### PR TITLE
Bun: Upgrade to Node JS 24

### DIFF
--- a/bun/Dockerfile
+++ b/bun/Dockerfile
@@ -5,7 +5,7 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG BUN_VERSION=1.3.5
 
 # See https://github.com/nodesource/distributions#installation-instructions
-ARG NODEJS_VERSION=20
+ARG NODEJS_VERSION=24
 
 # Install Node and bun
 RUN mkdir -p /etc/apt/keyrings \


### PR DESCRIPTION
### What are you trying to accomplish?

Upgrade NodeJS to 24 for Bun as Node 20 reached end of life on April 30, 2026. 

### Anything you want to highlight for special attention from reviewers?

This unblocks https://github.com/dependabot/dependabot-core/pull/14963 for the bun ecosystem

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

The build passes and all the existing tests continue to work

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
