### PR TITLE
Fix ARM64 local Docker builds by making base image overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,11 @@ flowchart LR
 Changes to the docker files for any of these images requires building one or more of the images locally in order to be reflected in the development shell.
 
 The simple but slow way is to delete any existing images and then run `bin/docker-dev-shell` which automatically builds
-missing images.
+missing images. On ARM, pass `DOCKER_BUILD_ARGS="--no-cache"` for the first build to avoid reusing cached AMD64 layers:
+
+```shell
+$ DOCKER_BUILD_ARGS="--no-cache" bin/docker-dev-shell go_modules --rebuild
+```
 
 The faster way is to pull all the pre-built images that are dependencies of the image you actually need to build.
 To (re)build a specific one:
@@ -177,7 +181,7 @@ To (re)build a specific one:
 
   ```shell
   $ docker pull ghcr.io/dependabot/dependabot-updater-core # OR
-  $ docker build -f Dockerfile.updater-core . --tag=dependabot-manual-build/updater-core # recommended on ARM
+  $ docker build --no-cache -f Dockerfile.updater-core --tag ghcr.io/dependabot/dependabot-updater-core . # recommended on ARM
   ```
 
 Each language/ecosystem sits on top of the core image. You need to rebuild whichever one you’re working on so it picks up your new core bits. For instance, if you’re working on **Go Modules**:
@@ -185,18 +189,7 @@ Each language/ecosystem sits on top of the core image. You need to rebuild which
 - The Updater ecosystem image:
 
   ```shell
-  $ docker pull ghcr.io/dependabot/dependabot-updater-gomod # OR
-  $ script/build go_modules # recommended on ARM
-  ```
-
-  Or explicitly:
-  ```shell
-  $ docker build \
-  --platform linux/amd64 \
-  --file go_modules/Dockerfile \
-  --build-arg UPDATER_CORE_IMAGE=dependabot-manual-build/updater-core \
-  --tag dependabot-manual-build/updater-gomod \
-  .
+  $ script/build go_modules
   ```
 
 - Spin-up the development container using the `--rebuild` flag:

--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 
 USER root

--- a/bun/Dockerfile
+++ b/bun/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 # Check for updates at https://github.com/oven-sh/bun/releases
 ARG BUN_VERSION=1.3.5

--- a/bundler/Dockerfile
+++ b/bundler/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 USER dependabot
 

--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker.io/docker/dockerfile:1.20
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
 FROM docker.io/library/rust:1.94.0-bookworm AS rust
 
-FROM ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 USER root
 

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 # This isn't a real ecosystem, adding it to make CI work easily.
 # If you don't like this, it might be a good idea to move

--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG COMPOSER_V2_VERSION=2.9.5
 ARG PHP_VERSION=8.4
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 
 # Install minimal conda for conda search functionality

--- a/deno/Dockerfile
+++ b/deno/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 ARG DENO_VERSION=2.1.0
 

--- a/devcontainers/Dockerfile
+++ b/devcontainers/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 
 # OS dependencies

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker.io/docker/dockerfile:1.20
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
 # From https://github.com/sigstore/cosign/releases
 FROM ghcr.io/sigstore/cosign/cosign:v3.0.5 AS cosign
 # From https://github.com/regclient/regclient/releases
 FROM ghcr.io/regclient/regctl:v0.11.2 AS regctl
 
-FROM ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 ENV PATH=/opt/bin:$PATH
 COPY --from=regctl /regctl /opt/bin/regctl

--- a/dotnet_sdk/Dockerfile
+++ b/dotnet_sdk/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 USER dependabot
 

--- a/elm/Dockerfile
+++ b/elm/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 # Install Elm
 # This is currently amd64 only, see:

--- a/git_submodules/Dockerfile
+++ b/git_submodules/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 USER dependabot
 

--- a/github_actions/Dockerfile
+++ b/github_actions/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 USER dependabot
 

--- a/go_modules/Dockerfile
+++ b/go_modules/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker.io/docker/dockerfile:1.20
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
 FROM docker.io/library/golang:1.26.1-bookworm AS go
 
-FROM ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 
 USER root

--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -5,9 +5,10 @@
 # If you perform a manual update, make sure to update the tag as well.
 # Including the tag with the digest is for documentation purposes, as Docker ignores the tag when a digest is provided
 # It is useful because mapping tags to digests is challenging without OCI metadata, and many images do not provide this metadata.
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
 FROM docker.io/gradle:9.2.1-jdk21-ubi-minimal@sha256:9049dc0698f42c2c1cd5c45a8e8a34f86602e7dd9a217e65da899e5077be3c21 AS gradle
 
-FROM ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openjdk-21-jdk-headless \

--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 
 # Install regctl. See https://github.com/regclient/regclient/releases for updates

--- a/hex/Dockerfile
+++ b/hex/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 USER root
 

--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,8 +1,9 @@
 # syntax=docker.io/docker/dockerfile:1.20
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
 # This cannot be inlined below (e.g., COPY --from=maven:...) because Dependabot does not support that syntax yet
 FROM maven:3.9.14 as maven
 
-FROM ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openjdk-21-jdk-headless \

--- a/nix/Dockerfile
+++ b/nix/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker.io/docker/dockerfile:1.20
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
 FROM docker.io/nixos/nix:2.34.7 AS nix
 
-FROM ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 # Copy Nix from the official image
 COPY --from=nix --chown=dependabot:dependabot /nix /nix

--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 # Check for updates at https://github.com/nodejs/corepack/releases
 ARG COREPACK_VERSION=0.34.6

--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 ARG TARGETARCH
 

--- a/opentofu/Dockerfile
+++ b/opentofu/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 
 # See https://github.com/opentofu/opentofu/releases

--- a/pre_commit/Dockerfile
+++ b/pre_commit/Dockerfile
@@ -2,9 +2,13 @@
 
 # Import pre-built ecosystem images to avoid code duplication
 # These images contain all the native helpers and tools already built
-FROM ghcr.io/dependabot/dependabot-updater-gomod:latest AS go_modules
-FROM ghcr.io/dependabot/dependabot-updater-bundler:latest AS bundler
-FROM ghcr.io/dependabot/dependabot-updater-pub:latest AS pub
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_GOMOD_IMAGE=ghcr.io/dependabot/dependabot-updater-gomod:latest
+ARG UPDATER_BUNDLER_IMAGE=ghcr.io/dependabot/dependabot-updater-bundler:latest
+ARG UPDATER_PUB_IMAGE=ghcr.io/dependabot/dependabot-updater-pub:latest
+FROM ${UPDATER_GOMOD_IMAGE} AS go_modules
+FROM ${UPDATER_BUNDLER_IMAGE} AS bundler
+FROM ${UPDATER_PUB_IMAGE} AS pub
 
 # Create an intermediate stage that combines both ecosystems into a single layer
 FROM scratch AS combined-helpers
@@ -15,7 +19,7 @@ COPY --from=pub /opt/dart /opt/dart
 COPY --from=pub /opt/pub /opt/pub
 
 # Final stage - copy all helpers in a single layer from the combined stage
-FROM ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 USER root
 

--- a/pub/Dockerfile
+++ b/pub/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 # Install Dart
 ENV PUB_CACHE=/opt/dart/pub-cache \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -12,7 +12,8 @@ ARG PY_3_9=3.9.24
 # https://github.com/pyenv/pyenv/releases
 ARG PYENV_VERSION=v2.6.16
 
-FROM ghcr.io/dependabot/dependabot-updater-core AS python-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE} AS python-core
 ARG PY_3_14
 ARG PY_3_13
 ARG PY_3_12

--- a/rust_toolchain/Dockerfile
+++ b/rust_toolchain/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 USER dependabot
 

--- a/sbt/Dockerfile
+++ b/sbt/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 # Install JDK for Coursier and Maven repository interaction
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/script/_common
+++ b/script/_common
@@ -116,12 +116,34 @@ function docker_build() {
   # We don't sign the updater image with Notary, so disable Docker Content Trust for remaining builds
   unset DOCKER_CONTENT_TRUST
 
-  # pre_commit depends on go_modules and bundler images, so build them first
+  # Retag the locally-built core image under a local-only name so BuildKit
+  # resolves FROM via the local daemon instead of contacting the registry.
+  local LOCAL_CORE_IMAGE="dependabot-local/updater-core"
+  docker tag "$UPDATER_CORE_IMAGE" "$LOCAL_CORE_IMAGE"
+
+  # pre_commit depends on go_modules, bundler, and pub images, so build them first
   # Use a guard variable to prevent infinite recursion when called recursively
+  local EXTRA_BUILD_ARGS=()
   if [[ "$ECOSYSTEM" == "pre_commit" && -z "$BUILDING_DEPENDENCY" ]]; then
-    echo "Building pre_commit dependencies: go_modules and bundler..."
+    echo "Building pre_commit dependencies: go_modules, bundler, and pub..."
     BUILDING_DEPENDENCY=1 docker_build "go_modules"
+    local LOCAL_GOMOD_IMAGE="dependabot-local/updater-gomod"
+    docker tag "${UPDATER_IMAGE}gomod" "$LOCAL_GOMOD_IMAGE"
+
     BUILDING_DEPENDENCY=1 docker_build "bundler"
+    local LOCAL_BUNDLER_IMAGE="dependabot-local/updater-bundler"
+    docker tag "${UPDATER_IMAGE}bundler" "$LOCAL_BUNDLER_IMAGE"
+
+    BUILDING_DEPENDENCY=1 docker_build "pub"
+    local LOCAL_PUB_IMAGE="dependabot-local/updater-pub"
+    docker tag "${UPDATER_IMAGE}pub" "$LOCAL_PUB_IMAGE"
+
+    EXTRA_BUILD_ARGS=(
+      --build-arg "UPDATER_GOMOD_IMAGE=$LOCAL_GOMOD_IMAGE"
+      --build-arg "UPDATER_BUNDLER_IMAGE=$LOCAL_BUNDLER_IMAGE"
+      --build-arg "UPDATER_PUB_IMAGE=$LOCAL_PUB_IMAGE"
+    )
+
     # Restore ecosystem and tag for pre_commit
     ECOSYSTEM="pre_commit"
     set_tag
@@ -136,6 +158,10 @@ function docker_build() {
   # shellcheck disable=SC2086  # word-splitting is intentional for build args
   $ECOSYSTEM_BUILD \
     $DOCKER_BUILD_ARGS \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --build-arg "UPDATER_CORE_IMAGE=$LOCAL_CORE_IMAGE" \
+    "${EXTRA_BUILD_ARGS[@]}" \
+    --cache-from "$UPDATER_IMAGE_NAME" \
     -t "$UPDATER_IMAGE_NAME" \
     -f "$DOCKERFILE_PATH" \
     .

--- a/silent/Dockerfile
+++ b/silent/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 USER dependabot
 

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 
 ENV PATH="${PATH}:/opt/swift/usr/bin"

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 ARG TARGETARCH
 
 # See https://github.com/hashicorp/terraform/releases or https://releases.hashicorp.com/terraform/

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -11,10 +11,11 @@ ARG PY_3_9=3.9.24
 # https://github.com/pyenv/pyenv/releases
 ARG PYENV_VERSION=v2.6.16
 
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
 # This cannot be inlined below (e.g., COPY --from=...) because Dependabot does not support that syntax yet
 FROM ghcr.io/astral-sh/uv:0.11.8 AS uv
 
-FROM ghcr.io/dependabot/dependabot-updater-core AS python-core
+FROM ${UPDATER_CORE_IMAGE} AS python-core
 ARG PY_3_14
 ARG PY_3_13
 ARG PY_3_12

--- a/vcpkg/Dockerfile
+++ b/vcpkg/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM ghcr.io/dependabot/dependabot-updater-core
+ARG UPDATER_CORE_IMAGE=ghcr.io/dependabot/dependabot-updater-core
+FROM ${UPDATER_CORE_IMAGE}
 
 # Install VCPKG and dependencies
 USER root


### PR DESCRIPTION
### What are you trying to accomplish?

Fix local Docker builds on ARM64 (Apple Silicon) hosts. Previously, even when building locally with `--pull=false`, BuildKit would contact the remote registry to resolve the canonical digest for `FROM ghcr.io/dependabot/dependabot-updater-core`, causing AMD64 layers to be pulled and used on ARM64 machines.

The fix adds `ARG UPDATER_CORE_IMAGE` to all ecosystem Dockerfiles so the base image can be overridden via `--build-arg`, and wires this through `script/_common` by retagging the locally-built core image under a local-only name (`dependabot-local/updater-core`). BuildKit resolves `FROM` references that look like local tags without contacting the registry.

### Anything you want to highlight for special attention from reviewers?

The retag approach (rather than e.g. `--platform`) is the minimal change that reliably prevents BuildKit from doing a remote manifest lookup. The `UPDATER_CORE_IMAGE` ARG defaults to the existing `ghcr.io/...` value, so CI and anyone not using `script/build` is completely unaffected.

`pre_commit` is slightly different since it pulls from three upstream images, each gets its own ARG.

### How will you know you've accomplished your goal?

Running `script/build go_modules` (or any ecosystem) on an ARM64 Mac should produce a native ARM64 image without requiring `--no-cache` or manual `--platform` flags. The README documents the updated workflow.

### Checklist

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
