### PR TITLE
Gradle: applying `git add --renormalize` on updated files

### DIFF
--- a/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
@@ -94,6 +94,16 @@ module Dependabot
                 SharedHelpers.run_shell_command(command, cwd: cwd, env: env) # retry via local wrapper
               end
 
+              # Apply `.gitattributes` to the updated files to prevent unnecessary diff changes on newline terminators
+              existing_files = @target_files.select { |f| File.exist?(File.join(cwd, f)) }
+              begin
+                SharedHelpers.run_shell_command("git add --renormalize " + existing_files.join(" "), cwd: cwd)
+              rescue SharedHelpers::HelperSubprocessFailed => e
+                Dependabot.logger.warn(
+                  "Failed to GIT renormalize Gradle updated files #{existing_files.join(', ')}: #{e.message}"
+                )
+              end
+
               # Restore previous validateDistributionUrl option if it existed
               override_validate_distribution_url_option(properties_file, validate_distribution)
 


### PR DESCRIPTION
### What are you trying to accomplish?
Patches the native Gradle updater, to make sure `.gitattributes` rules are honoured, preventing unnecessary diffs when committing the update. 

### Anything you want to highlight for special attention from reviewers?
I've following the documentation at https://docs.github.com/en/get-started/git-basics/configuring-git-to-handle-line-endings, by basically running a final `git add --renormalize .` after updating the files.

### How will you know you've accomplished your goal?
TBD: Didn't managed to reproduce this locally to write a test for it. But I've observed the behavior of git updating the `gradlew.bat` right after a bump PR is merged.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
