### PR TITLE
Bump toml-rb from 4.1.0 to 4.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -457,7 +457,7 @@ GEM
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
-    toml-rb (4.1.0)
+    toml-rb (4.2.0)
       citrus (~> 3.0, > 3.0)
       racc (~> 1.7)
     tsort (0.2.0)
@@ -674,7 +674,7 @@ CHECKSUMS
   tapioca (0.17.10) sha256=880a682ca8314f798dd09e9f104134fbf1a713c13be51f7dd4741dd434e6471b
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
-  toml-rb (4.1.0) sha256=14456ec4549e4703881bf04b83a56f3264ef99884880092d83c98a2058d95846
+  toml-rb (4.2.0) sha256=10a48c91613e20cf63483a7a776767dfb3cd7d70e9327c0237443da601e13776
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   turbo_tests (2.2.5) sha256=3fa31497d12976d11ccc298add29107b92bda94a90d8a0a5783f06f05102509f
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42

--- a/cargo/spec/dependabot/cargo/file_parser_edge_cases_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_edge_cases_spec.rb
@@ -279,5 +279,44 @@ RSpec.describe Dependabot::Cargo::FileParser do
         expect(dependencies.map(&:name)).not_to include("version", "authors")
       end
     end
+
+    # Regression test for https://github.com/emancu/toml-rb/issues/161
+    # Multi-line inline tables are valid TOML 1.1 syntax and are commonly used
+    # in Cargo.toml files. toml-rb < 4.2 raised TomlRB::ParseError on these.
+    context "with multi-line inline tables in Cargo.toml" do
+      let(:files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "Cargo.toml",
+            content: <<~TOML
+              [package]
+              name = "multi-line-inline"
+              version = "0.1.0"
+
+              [dependencies]
+              windows-sys = {
+                  version = "0.61.2",
+                  features = [
+                      "Win32_System_Environment",
+                      "Win32_Storage_FileSystem",
+                      "Win32_System_Memory"
+                      ]
+                  }
+            TOML
+          )
+        ]
+      end
+
+      it "parses multi-line inline tables without raising" do
+        expect { parser.parse }.not_to raise_error
+      end
+
+      it "extracts the dependency and its requirement" do
+        dependencies = parser.parse
+
+        expect(dependencies.map(&:name)).to eq(["windows-sys"])
+        expect(dependencies.first.requirements.first[:requirement]).to eq("0.61.2")
+      end
+    end
   end
 end

--- a/sorbet/rbi/gems/toml-rb@4.2.0.rbi
+++ b/sorbet/rbi/gems/toml-rb@4.2.0.rbi
@@ -223,7 +223,7 @@ class TomlRB::Keyvalue
   def accept_visitor(parser); end
 
   # source://toml-rb//lib/toml-rb/keyvalue.rb#13
-  def assign(hash, fully_defined_keys, symbolize_keys = T.unsafe(nil)); end
+  def assign(hash, fully_defined_paths, symbolize_keys = T.unsafe(nil)); end
 
   # source://toml-rb//lib/toml-rb/keyvalue.rb#35
   def dotted_key_merge(hash, update); end

--- a/updater/Gemfile.lock
+++ b/updater/Gemfile.lock
@@ -567,7 +567,7 @@ GEM
     stringio (3.2.0)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
-    toml-rb (4.1.0)
+    toml-rb (4.2.0)
       citrus (~> 3.0, > 3.0)
       racc (~> 1.7)
     tsort (0.2.0)
@@ -853,7 +853,7 @@ CHECKSUMS
   stackprof (0.2.28) sha256=4ec2ace02f386012b40ca20ef80c030ad711831f59511da12e83b34efb0f9a04
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
-  toml-rb (4.1.0) sha256=14456ec4549e4703881bf04b83a56f3264ef99884880092d83c98a2058d95846
+  toml-rb (4.2.0) sha256=10a48c91613e20cf63483a7a776767dfb3cd7d70e9327c0237443da601e13776
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   turbo_tests (2.2.5) sha256=3fa31497d12976d11ccc298add29107b92bda94a90d8a0a5783f06f05102509f
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42


### PR DESCRIPTION
### What are you trying to accomplish?

Bump `toml-rb` from `4.1.0` to `4.2.0`

Fixes: https://github.com/dependabot/dependabot-core/issues/14746

### Anything you want to highlight for special attention from reviewers?

Reference: https://github.com/emancu/toml-rb/issues/161

### How will you know you've accomplished your goal?

- `toml-rb` is updated from `4.1.0` to `4.2.0` in `Gemfile.lock`.
- bundle install succeeds and the existing test suite passes, confirming no regressions from the bump.
- A new regression spec covers **TOML 1.1 multi-line inline tables** and passes on 4.2.0.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
