### PR TITLE
simplify line indent detection

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -1748,6 +1748,85 @@ public class XmlFileWriterTests : FileWriterTestsBase
     }
 
     [Fact]
+    public async Task FormattingIsPreserved_InMiddleOfItemGroup_HonorsIndentation()
+    {
+        await TestAsync(
+            files: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net10.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Package.A" Version="2.0.0" />
+                        <PackageReference Include="Package.B" Version="2.0.0" />
+                        <PackageReference Include="Package.D" Version="2.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Package.C/1.0.0"],
+            requiredDependencyStrings: ["Package.C/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net10.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Package.A" Version="2.0.0" />
+                        <PackageReference Include="Package.B" Version="2.0.0" />
+                        <PackageReference Include="Package.C" Version="1.1.0" />
+                        <PackageReference Include="Package.D" Version="2.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task FormattingIsPreserved_InMiddleOfItemGroup_HonorsIndentation_EvenWithWhitespaceOnlyLine()
+    {
+        // note that the blank line after Package.A isn't actually blank; it has two leading spaces
+        await TestAsync(
+            files: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net10.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Package.A" Version="2.0.0" />
+                          
+                        <PackageReference Include="Package.B" Version="2.0.0" />
+                        <PackageReference Include="Package.D" Version="2.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Package.C/1.0.0"],
+            requiredDependencyStrings: ["Package.C/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net10.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Package.A" Version="2.0.0" />
+                          
+                        <PackageReference Include="Package.B" Version="2.0.0" />
+                        <PackageReference Include="Package.C" Version="1.1.0" />
+                        <PackageReference Include="Package.D" Version="2.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
     public async Task UpdateOfSdkManagedPackageCanOccurDespiteVersionReplacements()
     {
         // To avoid a unit test that's tightly coupled to the installed SDK, A list of SDK-managed packages is faked.

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -201,32 +201,24 @@ public class XmlFileWriter : IFileWriter
                     var lastPriorElement = elementsBeforeNew.LastOrDefault();
                     if (lastPriorElement is not null)
                     {
-                        // find line number of last prior element
-                        // find the offset of the first token on each newline
-                        var firstOffsetForLine = new List<int>();
-                        foreach (var tr in filesAndContents[projectRelativePath].DescendantTrivia(descendIntoChildren: _ => true, descendIntoTrivia: true))
+                        // find line indent of the prior element and mimic it
+                        var lastPriorElementIndent = string.Empty;
+                        for (int i = elementsBeforeNew.Length - 1; i >= 0; i--)
                         {
-                            if (tr.Kind == SyntaxKind.EndOfLineTrivia)
+                            var elementIndent = elementsBeforeNew[i].GetLeadingTrivia().ToFullString();
+                            var lastNewlineIndex = elementIndent.LastIndexOf('\n');
+                            if (lastNewlineIndex < 0)
                             {
-                                firstOffsetForLine.Add(tr.SpanStart);
+                                // prior element is on the same line as its prior sibling so keep walking backwards
+                                continue;
                             }
 
-                            if (tr.SpanStart >= lastPriorElement.SpanStart)
-                            {
-                                break;
-                            }
+                            var elementLineIndent = elementIndent[(lastNewlineIndex + 1)..];
+                            lastPriorElementIndent = elementLineIndent;
+                            break;
                         }
 
-                        var lastPriorElementLineNumber = firstOffsetForLine.Count(o => o < lastPriorElement.SpanStart);
-                        var lastElementAtStartOfLine = lastPriorElement.Parent.ChildNodes
-                            .First(n => firstOffsetForLine.Count(o => o < n.SpanStart) >= lastPriorElementLineNumber);
-                        var trivia = lastElementAtStartOfLine.GetLeadingTrivia().ToList();
-                        var priorEolIndex = trivia.FindLastIndex(t => t.Kind == SyntaxKind.EndOfLineTrivia);
-                        var indentTrivia = trivia
-                            .Skip(priorEolIndex + 1)
-                            .Select(t => SyntaxFactory.WhitespaceTrivia(t.ToFullString()))
-                            .ToArray();
-                        var newTrivia = new SyntaxTriviaList([SyntaxFactory.EndOfLineTrivia("\n"), .. indentTrivia]);
+                        var newTrivia = new SyntaxTriviaList([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia(lastPriorElementIndent)]);
                         newElement = (IXmlElementSyntax)newElement.AsNode.WithLeadingTrivia(newTrivia);
                         var replacementParent = lastPriorElement.Parent.InsertNodesAfter(lastPriorElement, [newElement.AsNode]);
                         var actualReplacementParent = ReplaceNode(projectRelativePath, lastPriorElement.Parent, replacementParent);


### PR DESCRIPTION
When adding a `<PackageReference>` element to a file we look at the previous `<PackageReference>` element and mimic its line indentation.  That code was overly complex and didn't handle multiple blank lines propely.

This fixes and simplifies it by starting at the prior element and walking backwards.  For that element it gets the leading trivia (which is usually a newline followed by indentation characters) and checks for the newline character.  If the newline isn't present, go to the prior element and try again.  Once we have an element where the previous one _does_ have a newline, then we strip off that newline and everything before it to get the correct visual single line indentation.