### PR TITLE
Fix uv grapher crash on directories without pyproject.toml

### DIFF
--- a/uv/lib/dependabot/uv/dependency_grapher.rb
+++ b/uv/lib/dependabot/uv/dependency_grapher.rb
@@ -35,6 +35,10 @@ module Dependabot
         return T.must(uv_lock) if uv_lock
         return T.must(pyproject_toml) if pyproject_toml
 
+        # Fall back to requirements files (.txt/.in) when no pyproject.toml or uv.lock is present
+        req_file = dependency_files.find { |f| f.name.end_with?(".txt", ".in") }
+        return req_file if req_file
+
         raise DependabotError, "No uv.lock or pyproject.toml present."
       end
 

--- a/uv/spec/dependabot/uv/dependency_grapher_spec.rb
+++ b/uv/spec/dependabot/uv/dependency_grapher_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Dependabot::Uv::DependencyGrapher do
         expect(grapher.relevant_dependency_file).to eql(uv_lock_file)
       end
     end
+
+    context "when only requirements.txt files are present" do
+      let(:requirements_txt) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "flask==3.1.3\nrequests==2.32.5\n",
+          directory: "/"
+        )
+      end
+
+      let(:dependency_files) { [requirements_txt] }
+
+      it "falls back to the requirements file" do
+        expect(grapher.relevant_dependency_file).to eql(requirements_txt)
+      end
+    end
   end
 
   describe "#resolved_dependencies" do


### PR DESCRIPTION
### What are you trying to accomplish?

When processing multi-directory jobs (`package-ecosystem: uv`), directories that only contain `requirements.txt`/`.in` files (e.g. `/pip`, `/pip-compile`) cause the uv dependency grapher to crash with `No uv.lock or pyproject.toml present`.

This happens because `relevant_dependency_file` only checks for `uv.lock` and `pyproject.toml`. The uv file parser already supports requirements files, but the grapher did not consider them as a fallback.

The crash kills the entire directory submission instead of allowing it to proceed as degraded.

Fixes github/dependabot-updates#13455

### Anything you want to highlight for special attention from reviewers?

The uv file parser already parses `requirements.txt`/`.in` and produces dependencies from them. This change only adds them as a fallback in `relevant_dependency_file` so the submission can proceed (with degraded status from subdependency errors) instead of crashing.

### How will you know you have accomplished your goal?

- New spec verifies `relevant_dependency_file` returns `requirements.txt` when no `pyproject.toml` or `uv.lock` is present.
- Multi-directory jobs with `/pip` or `/pip-compile` directories should no longer crash the grapher.
- Full validation: `bin/test uv spec/dependabot/uv/dependency_grapher_spec.rb`

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.