### PR TITLE
fix(cargo): fetch workspace root and siblings when job runs in subdir

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -49,12 +49,17 @@ module Dependabot
         fetched_files << T.must(cargo_lock) if cargo_lock
         fetched_files << T.must(cargo_config) if cargo_config
         fetched_files << T.must(rust_toolchain) if rust_toolchain
-        fetched_files += fetch_path_dependency_and_workspace_files
+
         parsed_manifest = parsed_file(cargo_toml)
+        workspace_root = T.let(nil, T.nilable(DependencyFile))
         if uses_workspace_dependencies?(parsed_manifest) || workspace_member?(parsed_manifest)
           workspace_root = find_workspace_root(cargo_toml)
-          fetched_files << workspace_root if workspace_root && !fetched_files.include?(workspace_root)
         end
+
+        manifest_inputs = T.let([cargo_toml], T::Array[DependencyFile])
+        manifest_inputs << workspace_root if workspace_root
+        fetched_files += fetch_path_dependency_and_workspace_files(manifest_inputs)
+
         fetched_files.reject do |file|
           Dependabot::FileFiltering.should_exclude_path?(file.name, "file from final collection", @exclude_paths)
         end.uniq
@@ -267,9 +272,13 @@ module Dependabot
       end
 
       # See if this Cargo manifest inherits any property from a workspace
-      # (e.g. edition = { workspace = true }).
+      # (e.g. edition = { workspace = true }) or explicitly points at a
+      # workspace root via `[package] workspace = "<path>"`.
       sig { params(hash: T::Hash[T.untyped, T.untyped]).returns(T::Boolean) }
       def workspace_member?(hash)
+        package_workspace = hash.dig("package", "workspace")
+        return true if package_workspace.is_a?(String) && !package_workspace.empty?
+
         hash.each do |key, value|
           if key == "workspace" && value == true
             return true
@@ -291,8 +300,9 @@ module Dependabot
 
         workspace_root_dir = parsed_file(workspace_member).dig("package", "workspace")
         unless workspace_root_dir.nil?
+          base_dir = current_dir.empty? ? workspace_root_dir : File.join(current_dir, workspace_root_dir)
           workspace_root = fetch_file_from_host(
-            File.join(current_dir, workspace_root_dir, "Cargo.toml"),
+            File.join(base_dir, "Cargo.toml"),
             fetch_submodules: true
           )
           return workspace_root if parsed_file(workspace_root)["workspace"]
@@ -303,7 +313,7 @@ module Dependabot
 
         parent_dirs = current_dir.scan("/").length
         while parent_dirs >= 0
-          current_dir = File.join(current_dir, "..")
+          current_dir = current_dir.empty? ? ".." : File.join(current_dir, "..")
           begin
             parent_manifest = fetch_file_from_host(
               File.join(current_dir, "Cargo.toml"),

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -1371,9 +1371,11 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
           cargo_toml: main_cargo_file,
           cargo_lock: nil,
           cargo_config: nil,
-          rust_toolchain: nil,
-          fetch_path_dependency_and_workspace_files: []
+          rust_toolchain: nil
         )
+        allow(file_fetcher_instance).to receive(:fetch_path_dependency_and_workspace_files) do |files = nil|
+          files || []
+        end
         allow(file_fetcher_instance).to receive(:find_workspace_root)
           .with(main_cargo_file)
           .and_return(workspace_root_file)
@@ -1581,6 +1583,601 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
         expect(files[0].name).to eq("Cargo.toml")
         expect(files[1].name).to eq("subdir/Cargo.toml")
       end
+    end
+  end
+
+  describe "subdirectory job inside a parent workspace with sibling members" do
+    let(:repo) { "dependabot-fixtures/cargo-workspace-example" }
+    let(:inner_pkg_dir_listing) do
+      [
+        { name: "Cargo.toml", path: "inner-pkg/Cargo.toml", type: "file", size: 1 }
+      ].to_json
+    end
+    let(:root_dir_listing) do
+      [
+        { name: "Cargo.toml", path: "Cargo.toml", type: "file", size: 1 },
+        { name: "inner-pkg", path: "inner-pkg", type: "dir", size: 0 },
+        { name: "shared-pkg", path: "shared-pkg", type: "dir", size: 0 }
+      ].to_json
+    end
+    let(:url) { "https://api.github.com/repos/#{repo}/contents/" }
+    let(:source) do
+      Dependabot::Source.new(
+        provider: "github",
+        repo: repo,
+        directory: "/inner-pkg"
+      )
+    end
+
+    let(:root_workspace_toml) do
+      <<~TOML
+        [workspace]
+        members = ["inner-pkg", "shared-pkg"]
+
+        [workspace.dependencies]
+        anyhow = "1.0"
+      TOML
+    end
+
+    let(:inner_pkg_toml) do
+      <<~TOML
+        [package]
+        name = "inner-pkg"
+        version = "0.1.0"
+
+        [dependencies]
+        anyhow = { workspace = true }
+      TOML
+    end
+
+    let(:shared_pkg_toml) do
+      <<~TOML
+        [package]
+        name = "shared-pkg"
+        version = "0.1.0"
+
+        [dependencies]
+        anyhow = { workspace = true }
+      TOML
+    end
+
+    def encoded_contents(path, content)
+      {
+        name: File.basename(path),
+        path: path,
+        type: "file",
+        size: content.bytesize,
+        content: Base64.encode64(content),
+        encoding: "base64"
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, url + "inner-pkg/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("inner-pkg/Cargo.toml", inner_pkg_toml),
+          headers: json_header
+        )
+
+      stub_request(:get, url + "Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("Cargo.toml", root_workspace_toml),
+          headers: json_header
+        )
+
+      stub_request(:get, url + "shared-pkg/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("shared-pkg/Cargo.toml", shared_pkg_toml),
+          headers: json_header
+        )
+
+      # Directory listings (used by fetch_file_if_present for support files)
+      stub_request(:get, url + "inner-pkg?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: inner_pkg_dir_listing, headers: json_header)
+
+      stub_request(:get, url + "?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: root_dir_listing, headers: json_header)
+
+      # No lockfile, no .cargo config, no rust-toolchain at any level
+      [
+        "inner-pkg/Cargo.lock",
+        "inner-pkg/.cargo",
+        "inner-pkg/.cargo/config.toml",
+        "inner-pkg/rust-toolchain",
+        "inner-pkg/rust-toolchain.toml",
+        ".cargo",
+        ".cargo/config.toml",
+        ".cargo/config"
+      ].each do |missing|
+        stub_request(:get, url + "#{missing}?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 404, headers: json_header)
+      end
+    end
+
+    it "fetches the workspace root sibling members so cargo can resolve the workspace" do
+      files = file_fetcher_instance.files
+      file_names = files.map(&:name)
+
+      expect(file_names).to include("Cargo.toml")
+      expect(file_names).to include("../Cargo.toml")
+      expect(file_names).to include("../shared-pkg/Cargo.toml")
+
+      # Regression check: the workspace_root must be fetched with a name that
+      # escapes the job directory, not collapsed to the same name as the inner
+      # manifest. We must not produce two files both called "Cargo.toml".
+      cargo_toml_named_files = files.select { |f| f.name == "Cargo.toml" }
+      expect(cargo_toml_named_files.length).to eq(1)
+
+      root_workspace_file = files.find { |f| f.name == "../Cargo.toml" }
+      expect(root_workspace_file&.content).to eq(root_workspace_toml)
+    end
+  end
+
+  describe "subdirectory job whose package.workspace points at a sibling workspace root" do
+    let(:repo) { "dependabot-fixtures/cargo-workspace-example" }
+    let(:inner_pkg_dir_listing) do
+      [
+        { name: "Cargo.toml", path: "inner-pkg/Cargo.toml", type: "file", size: 1 }
+      ].to_json
+    end
+    let(:root_dir_listing) do
+      [
+        { name: "Cargo.toml", path: "Cargo.toml", type: "file", size: 1 },
+        { name: "inner-pkg", path: "inner-pkg", type: "dir", size: 0 },
+        { name: "shared-pkg", path: "shared-pkg", type: "dir", size: 0 }
+      ].to_json
+    end
+    let(:url) { "https://api.github.com/repos/#{repo}/contents/" }
+    let(:source) do
+      Dependabot::Source.new(
+        provider: "github",
+        repo: repo,
+        directory: "/inner-pkg"
+      )
+    end
+
+    let(:root_workspace_toml) do
+      <<~TOML
+        [workspace]
+        members = ["inner-pkg", "shared-pkg"]
+      TOML
+    end
+
+    let(:inner_pkg_toml) do
+      <<~TOML
+        [package]
+        name = "inner-pkg"
+        version = "0.1.0"
+        workspace = ".."
+
+        [dependencies]
+        anyhow = "1.0"
+      TOML
+    end
+
+    let(:shared_pkg_toml) do
+      <<~TOML
+        [package]
+        name = "shared-pkg"
+        version = "0.1.0"
+
+        [dependencies]
+        anyhow = "1.0"
+      TOML
+    end
+
+    def encoded_contents(path, content)
+      {
+        name: File.basename(path),
+        path: path,
+        type: "file",
+        size: content.bytesize,
+        content: Base64.encode64(content),
+        encoding: "base64"
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, url + "inner-pkg/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("inner-pkg/Cargo.toml", inner_pkg_toml),
+          headers: json_header
+        )
+
+      stub_request(:get, url + "Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("Cargo.toml", root_workspace_toml),
+          headers: json_header
+        )
+
+      stub_request(:get, url + "shared-pkg/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("shared-pkg/Cargo.toml", shared_pkg_toml),
+          headers: json_header
+        )
+
+      stub_request(:get, url + "inner-pkg?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: inner_pkg_dir_listing, headers: json_header)
+
+      stub_request(:get, url + "?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: root_dir_listing, headers: json_header)
+
+      [
+        "inner-pkg/Cargo.lock",
+        "inner-pkg/.cargo",
+        "inner-pkg/.cargo/config.toml",
+        "inner-pkg/rust-toolchain",
+        "inner-pkg/rust-toolchain.toml",
+        ".cargo",
+        ".cargo/config.toml",
+        ".cargo/config"
+      ].each do |missing|
+        stub_request(:get, url + "#{missing}?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 404, headers: json_header)
+      end
+    end
+
+    it "fetches the workspace root with a name that escapes the job directory" do
+      files = file_fetcher_instance.files
+      file_names = files.map(&:name)
+
+      expect(file_names).to include("Cargo.toml")
+      expect(file_names).to include("../Cargo.toml")
+      expect(file_names).to include("../shared-pkg/Cargo.toml")
+
+      cargo_toml_named_files = files.select { |f| f.name == "Cargo.toml" }
+      expect(cargo_toml_named_files.length).to eq(1)
+    end
+  end
+
+  describe "workspace member backed by a directory symlink to a sibling crate" do
+    let(:repo) { "dependabot-fixtures/cargo-workspace-example" }
+    let(:symlink_response) do
+      {
+        name: "shared-pkg",
+        path: "inner-pkg/shared-pkg",
+        type: "symlink",
+        target: "../shared-pkg",
+        size: 0
+      }.to_json
+    end
+    let(:root_dir_listing) do
+      [
+        { name: "Cargo.toml", path: "Cargo.toml", type: "file", size: 1 },
+        { name: "inner-pkg", path: "inner-pkg", type: "dir", size: 0 },
+        { name: "shared-pkg", path: "shared-pkg", type: "dir", size: 0 }
+      ].to_json
+    end
+    let(:shared_pkg_dir_listing) do
+      [
+        { name: "Cargo.toml", path: "shared-pkg/Cargo.toml", type: "file", size: 1 }
+      ].to_json
+    end
+    let(:url) { "https://api.github.com/repos/#{repo}/contents/" }
+    let(:source) do
+      Dependabot::Source.new(
+        provider: "github",
+        repo: repo,
+        directory: "/"
+      )
+    end
+
+    let(:nested_workspace_toml) do
+      <<~TOML
+        [workspace]
+        members = ["shared-pkg"]
+      TOML
+    end
+
+    let(:shared_pkg_toml) do
+      <<~TOML
+        [package]
+        name = "shared-pkg"
+        version = "0.1.0"
+
+        [dependencies]
+        anyhow = "1.0"
+      TOML
+    end
+
+    let(:root_workspace_toml) do
+      <<~TOML
+        [workspace]
+        members = ["inner-pkg"]
+      TOML
+    end
+
+    def encoded_contents(path, content)
+      {
+        name: File.basename(path),
+        path: path,
+        type: "file",
+        size: content.bytesize,
+        content: Base64.encode64(content),
+        encoding: "base64"
+      }.to_json
+    end
+
+    before do
+      # Top-level Cargo.toml: workspace including the nested workspace dir
+      stub_request(:get, url + "Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("Cargo.toml", root_workspace_toml),
+          headers: json_header
+        )
+
+      # inner-pkg/Cargo.toml: a nested workspace with shared-pkg as a member
+      stub_request(:get, url + "inner-pkg/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("inner-pkg/Cargo.toml", nested_workspace_toml),
+          headers: json_header
+        )
+
+      # The path-through-the-symlink is not directly fetchable; the parent
+      # directory of the file is itself a symlink to ../shared-pkg.
+      stub_request(:get, url + "inner-pkg/shared-pkg/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 404, headers: json_header)
+
+      # Querying the symlinked dir itself returns a symlink record (single
+      # object response, which the base file fetcher treats as Octokit::NotFound
+      # after registering the linked path).
+      stub_request(:get, url + "inner-pkg/shared-pkg?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: symlink_response,
+          headers: json_header
+        )
+
+      # The resolved sibling crate's directory listing (after symlink resolution).
+      stub_request(:get, url + "shared-pkg?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: shared_pkg_dir_listing,
+          headers: json_header
+        )
+
+      # The resolved sibling crate's Cargo.toml.
+      stub_request(:get, url + "shared-pkg/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("shared-pkg/Cargo.toml", shared_pkg_toml),
+          headers: json_header
+        )
+
+      # Top-level dir listing
+      stub_request(:get, url + "?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: root_dir_listing, headers: json_header)
+
+      # Inner package dir listing (parent directory of Cargo.toml inside the
+      # nested workspace, used by fetch_file_if_present for support files).
+      stub_request(:get, url + "inner-pkg?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: [
+            { name: "Cargo.toml", path: "inner-pkg/Cargo.toml", type: "file", size: 1 },
+            { name: "shared-pkg", path: "inner-pkg/shared-pkg", type: "symlink", size: 0 }
+          ].to_json,
+          headers: json_header
+        )
+
+      # No lockfile, no .cargo, no rust-toolchain
+      [
+        "Cargo.lock",
+        ".cargo",
+        ".cargo/config.toml",
+        "rust-toolchain",
+        "rust-toolchain.toml"
+      ].each do |missing|
+        stub_request(:get, url + "#{missing}?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 404, headers: json_header)
+      end
+    end
+
+    it "fetches the symlinked workspace member's Cargo.toml under its symlink path" do
+      files = file_fetcher_instance.files
+      file_names = files.map(&:name)
+
+      expect(file_names).to include("Cargo.toml")
+      expect(file_names).to include("inner-pkg/Cargo.toml")
+      expect(file_names).to include("inner-pkg/shared-pkg/Cargo.toml")
+
+      symlinked = files.find { |f| f.name == "inner-pkg/shared-pkg/Cargo.toml" }
+      expect(symlinked.content).to include('name = "shared-pkg"')
+    end
+
+    it "marks the symlinked workspace member as a non-support manifest so cargo can use it" do
+      files = file_fetcher_instance.files
+      symlinked = files.find { |f| f.name == "inner-pkg/shared-pkg/Cargo.toml" }
+
+      expect(symlinked).not_to be_support_file
+    end
+  end
+
+  describe "subdirectory job whose own Cargo.toml is a workspace with a symlinked member" do
+    let(:repo) { "dependabot-fixtures/cargo-workspace-example" }
+    let(:nested_symlink_response) do
+      {
+        name: "nested",
+        path: "inner-pkg/nested",
+        type: "symlink",
+        target: "../nested",
+        size: 0
+      }.to_json
+    end
+    let(:nested_dir_listing) do
+      [
+        { name: "Cargo.toml", path: "nested/Cargo.toml", type: "file", size: 1 }
+      ].to_json
+    end
+    let(:inner_pkg_dir_listing) do
+      [
+        { name: "Cargo.toml", path: "inner-pkg/Cargo.toml", type: "file", size: 1 },
+        { name: "nested", path: "inner-pkg/nested", type: "symlink", size: 0 }
+      ].to_json
+    end
+    let(:url) { "https://api.github.com/repos/#{repo}/contents/" }
+    let(:source) do
+      Dependabot::Source.new(
+        provider: "github",
+        repo: repo,
+        directory: "/inner-pkg"
+      )
+    end
+
+    let(:inner_workspace_toml) do
+      <<~TOML
+        [workspace]
+        members = ["nested"]
+      TOML
+    end
+
+    let(:nested_pkg_toml) do
+      <<~TOML
+        [package]
+        name = "nested"
+        version = "0.1.0"
+
+        [dependencies]
+        anyhow = "1.0"
+      TOML
+    end
+
+    def encoded_contents(path, content)
+      {
+        name: File.basename(path),
+        path: path,
+        type: "file",
+        size: content.bytesize,
+        content: Base64.encode64(content),
+        encoding: "base64"
+      }.to_json
+    end
+
+    before do
+      # The job's own manifest is itself a workspace with one member: nested.
+      stub_request(:get, url + "inner-pkg/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("inner-pkg/Cargo.toml", inner_workspace_toml),
+          headers: json_header
+        )
+
+      # The workspace member's path lookup fails because `nested` is a symlink.
+      stub_request(:get, url + "inner-pkg/nested/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 404, headers: json_header)
+
+      # Fetching the parent dir of the failing path returns the symlink object,
+      # which the base file fetcher uses to populate @linked_paths.
+      stub_request(:get, url + "inner-pkg/nested?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: nested_symlink_response,
+          headers: json_header
+        )
+
+      # After symlink resolution, the contents of the resolved sibling dir.
+      stub_request(:get, url + "nested?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: nested_dir_listing,
+          headers: json_header
+        )
+
+      # The resolved sibling crate manifest.
+      stub_request(:get, url + "nested/Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: encoded_contents("nested/Cargo.toml", nested_pkg_toml),
+          headers: json_header
+        )
+
+      # No root Cargo.toml.
+      stub_request(:get, url + "Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 404, headers: json_header)
+
+      # Inner-pkg dir listing (used by fetch_file_if_present for support files).
+      stub_request(:get, url + "inner-pkg?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: inner_pkg_dir_listing, headers: json_header)
+
+      stub_request(:get, url + "?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: [
+            { name: "inner-pkg", path: "inner-pkg", type: "dir", size: 0 },
+            { name: "nested", path: "nested", type: "dir", size: 0 }
+          ].to_json,
+          headers: json_header
+        )
+
+      [
+        "inner-pkg/Cargo.lock",
+        "inner-pkg/.cargo",
+        "inner-pkg/.cargo/config.toml",
+        "inner-pkg/rust-toolchain",
+        "inner-pkg/rust-toolchain.toml",
+        ".cargo",
+        ".cargo/config.toml",
+        ".cargo/config",
+        "rust-toolchain",
+        "rust-toolchain.toml",
+        "Cargo.lock"
+      ].each do |missing|
+        stub_request(:get, url + "#{missing}?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 404, headers: json_header)
+      end
+    end
+
+    it "fetches the symlinked workspace member under its symlinked path" do
+      file_names = file_fetcher_instance.files.map(&:name)
+
+      expect(file_names).to include("Cargo.toml")
+      expect(file_names).to include("nested/Cargo.toml")
+    end
+
+    it "marks the symlinked workspace member as a non-support manifest" do
+      member = file_fetcher_instance.files.find { |f| f.name == "nested/Cargo.toml" }
+
+      expect(member).not_to be_nil
+      expect(member).not_to be_support_file
+      expect(member.content).to include('name = "nested"')
     end
   end
 end


### PR DESCRIPTION
## Summary

When a Cargo job runs in a subdirectory whose `Cargo.toml` is a workspace member, the file fetcher discovers the parent workspace root but never fetches the root's other members. Cargo then fails at runtime with:

```
error: failed to load manifest for workspace member `X`
referenced by workspace at `Y`
Caused by: failed to read `<...>/X/Cargo.toml`
Caused by: No such file or directory (os error 2)
```

This trips for two real-world setups:

1. The job's manifest declares `anyhow = { workspace = true }` and the parent workspace has sibling members listed in `[workspace] members = [...]`.
2. The job's manifest sets `[package] workspace = "<path>"` to point explicitly at the workspace root.

## Root causes

Three issues compound to produce the failure:

1. **`fetch_files` ordering** — the workspace root was appended to the fetched list *after* the recursive `fetch_path_dependency_and_workspace_files` call, so its sibling members were never visited. The fix passes `[cargo_toml, workspace_root]` into the recursion. Lock/config/toolchain files are deliberately excluded from the recursion input because it calls `parsed_file`, which would crash on plain-text files like `rust-toolchain`.
2. **Path collapse in `find_workspace_root`** — `File.join("", "..")` yields `"/.."` (leading slash). The cargo override of `fetch_file_from_host` strips leading slashes, collapsing the workspace root's name to `"Cargo.toml"` (colliding with the inner package's manifest). Both branches of `find_workspace_root` (explicit `package.workspace` and parent-walking) now handle empty `current_dir` by using the literal `".."`, so the workspace root is named relative to the job dir (e.g. `"../Cargo.toml"`).
3. **`workspace_member?` missed `[package] workspace = "<path>"`** — only the dependency-level `{ workspace = true }` form was detected. The string form is now also recognised, making the explicit-workspace branch in `find_workspace_root` reachable.

## Tests

Added four describe blocks in `cargo/spec/dependabot/cargo/file_fetcher_spec.rb`:

- subdirectory job inside a parent workspace with sibling members (the reported failure)
- subdirectory job whose `package.workspace` points at the parent workspace root
- workspace member backed by a directory symlink (regression check that the existing symlink retry path remains intact)
- subdir job whose own manifest is a workspace with a symlinked member

All 543 cargo specs pass; rubocop is clean.

## Validation

- `bundle exec rspec spec/dependabot/cargo/file_fetcher_spec.rb` — 66 examples, 0 failures
- Full cargo gem suite — 543 examples, 0 failures
- `bin/rubocop` clean

## Notes

- Two minor pre-existing issues are noted but not addressed here, as they don't cause regressions and are tangential to the reported failure: `expand_workspaces` resolves glob members against the job directory rather than the file's location, and the workspace root recursion may double-fetch the inner manifest under a different name (identical content, no on-disk collision).
- The fix is purely additive at the fetcher layer; downstream `LockfileUpdater.write_temporary_*` already handles `../`-prefixed file names correctly via `Pathname`-relative writes, so no downstream changes are needed for cargo to resolve the workspace at update time.
