### PR TITLE
Nix: reject input names Nix's CLI can't parse

### DIFF
--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -14,6 +14,10 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
+      # Nix's CLI restricts flake input attribute path elements to this regex.
+      # see `flakeIdRegex` in nix/src/libflake/include/nix/flake/flakeref.hh
+      FLAKE_ID_REGEX = /\A[a-zA-Z][a-zA-Z0-9_-]*\z/
+
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
       def updated_dependency_files
         updated_files = []
@@ -54,6 +58,13 @@ module Dependabot
 
       sig { params(updated_nix_content: T.nilable(String)).returns(String) }
       def update_flake_lock(updated_nix_content)
+        unless dependency.name.match?(FLAKE_ID_REGEX)
+          raise Dependabot::DependencyFileNotResolvable,
+                "Cannot update flake input '#{dependency.name}': Nix only " \
+                "permits input names matching #{FLAKE_ID_REGEX.source}. " \
+                "Rename the input in flake.nix to update it via Dependabot."
+        end
+
         SharedHelpers.in_a_temporary_repo_directory(
           flake_lock.directory,
           repo_contents_path

--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -60,8 +60,9 @@ module Dependabot
       def update_flake_lock(updated_nix_content)
         unless dependency.name.match?(FLAKE_ID_REGEX)
           raise Dependabot::DependencyFileNotResolvable,
-                "Cannot update flake input '#{dependency.name}': Nix only " \
-                "permits input names matching #{FLAKE_ID_REGEX.source}. " \
+                "Cannot update flake input '#{dependency.name}': Nix requires input names to start " \
+                "with a letter and contain only letters, digits, underscores, or hyphens " \
+                "(pattern: [a-zA-Z][a-zA-Z0-9_-]*). " \
                 "Rename the input in flake.nix to update it via Dependabot."
         end
 

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -116,6 +116,45 @@ RSpec.describe Dependabot::Nix::FileUpdater do
       end
     end
 
+    context "with an input name Nix's CLI can't parse" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "_1password-shell-plugins",
+          version: "new_sha_abc123",
+          previous_version: "old_sha_abc123",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "git",
+              url: "https://github.com/1Password/shell-plugins",
+              branch: nil,
+              ref: "main"
+            },
+            groups: []
+          }],
+          previous_requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "git",
+              url: "https://github.com/1Password/shell-plugins",
+              branch: nil,
+              ref: "main"
+            },
+            groups: []
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      it "raises DependencyFileNotResolvable with a clear message" do
+        expect { updated_files }
+          .to raise_error(Dependabot::DependencyFileNotResolvable, /_1password-shell-plugins/)
+        expect(Dependabot::SharedHelpers).not_to have_received(:run_shell_command)
+      end
+    end
+
     context "with a tag-pinned input (ref changed)" do
       let(:flake_nix_content) { fixture("flake_with_tag.nix") }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Some `flake.nix` files use input names like `_1password-shell-plugins`. Nix itself accepts these in the manifest, but `nix flake update <name>` rejects them because the CLI's `flakeIdRegex` requires names to start with a letter (`[a-zA-Z][a-zA-Z0-9_-]*`). There's no escape mechanism — quoting doesn't help.

Today this surfaces as a confusing `HelperSubprocessFailed` with `invalid flake input attribute path element`. Example: https://github.com/donaldgifford/nix-config/actions/runs/25744488138.

This change validates the input name up front and raises `DependencyFileNotResolvable` with a message that explains the limitation and suggests renaming the input.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
I tried to fix this by quoting the name in the shell command first. It doesn't work. Nix has no escape for invalid identifiers. The validation regex matches Nix's own `flakeIdRegex` from `src/libflake/include/nix/flake/flakeref.hh`.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->
Reproduced locally with a `_1foo` input. Nix rejects every quoting variant. With this change, Dependabot returns a clear error instead of a subprocess failure.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
