### PR TITLE
Enable `pipe-operators`, `fetch-closure`, and `parse-toml-timestamps` for Nix

### DIFF
--- a/nix/Dockerfile
+++ b/nix/Dockerfile
@@ -6,9 +6,14 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 # Copy Nix from the official image
 COPY --from=nix --chown=dependabot:dependabot /nix /nix
 
-# Configure Nix for single-user mode with flakes enabled
+# Configure Nix for single-user mode with flakes enabled.
+# Additional language-level experimental features are enabled so user flakes
+# that opt into them can still be evaluated when updating flake.lock:
+#   - pipe-operators: |> and <| operators
+#   - fetch-closure: builtins.fetchClosure
+#   - parse-toml-timestamps: timestamp parsing in builtins.fromTOML
 RUN mkdir -p /etc/nix \
-  && echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf \
+  && echo "experimental-features = nix-command flakes pipe-operators fetch-closure parse-toml-timestamps" > /etc/nix/nix.conf \
   && echo "sandbox = false" >> /etc/nix/nix.conf
 
 ENV PATH="/nix/var/nix/profiles/default/bin:${PATH}"


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #14983. Flakes that use `pipe-operators` (`|>` / `<|`) can't be locked today because the Nix container only enables `nix-command` and `flakes`. While here, I also enabled `fetch-closure` and `parse-toml-timestamps` so flakes using those builtins evaluate as well.

### Anything you want to highlight for special attention from reviewers?

I only enabled language-level features. Store, builder, and daemon features (`ca-derivations`, `recursive-nix`, `cgroups`, etc.) are deliberately left off since we only evaluate flakes to refresh `flake.lock` and never build derivations.

### How will you know you've accomplished your goal?

A flake using `|>` should now update cleanly.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
