### PR TITLE
Bump NuGet.Client to release/7.6.x and pin dotnet-core to v10.0.8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,8 @@
 [submodule "nuget/helpers/lib/NuGet.Client"]
 	path = nuget/helpers/lib/NuGet.Client
 	url = https://github.com/NuGet/NuGet.Client
-	branch = release-6.14.x
+	branch = release/7.6.x
 [submodule "nuget/helpers/lib/dotnet-core"]
 	path = nuget/helpers/lib/dotnet-core
 	url = https://github.com/dotnet/core
+	branch = v10.0.8

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/CompatibilityCheckerFacts.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/CompatibilityCheckerFacts.cs
@@ -7,6 +7,8 @@ namespace NuGetUpdater.Core.Test.FrameworkChecker;
 public class CompatibilityCheckerFacts
 {
     [Theory]
+    [InlineData("net11.0", "net11.0")]
+    [InlineData("net11.0", "net10.0")]
     [InlineData("net10.0", "net10.0")]
     [InlineData("net10.0", "net9.0")]
     [InlineData("net9.0", "net9.0")]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/FrameworkCompatibilityServiceFacts.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/FrameworkCompatibilityServiceFacts.cs
@@ -99,7 +99,7 @@ public class FrameworkCompatibilityServiceFacts
     }
 
     [Theory]
-    [InlineData("net6.0-windows7.0", "net6.0-windows", "net6.0-windows7.0", "net7.0-windows", "net7.0-windows7.0", "net8.0-windows", "net8.0-windows7.0", "net9.0-windows", "net9.0-windows7.0", "net10.0-windows", "net10.0-windows7.0", "net11.0-windows", "net11.0-windows7.0")]
+    [InlineData("net6.0-windows7.0", "net6.0-windows", "net6.0-windows7.0", "net7.0-windows", "net7.0-windows7.0", "net8.0-windows", "net8.0-windows7.0", "net9.0-windows", "net9.0-windows7.0", "net10.0-windows", "net10.0-windows7.0")]
     public void WindowsPlatformVersionsShouldContainAllSpecifiedFrameworks(string windowsDefaultVersionFramework, params string[] windowsProjectFrameworks)
     {
         var packageFramework = NuGetFramework.Parse(windowsDefaultVersionFramework);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/FrameworkCompatibilityServiceFacts.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/FrameworkChecker/FrameworkCompatibilityServiceFacts.cs
@@ -99,7 +99,7 @@ public class FrameworkCompatibilityServiceFacts
     }
 
     [Theory]
-    [InlineData("net6.0-windows7.0", "net6.0-windows", "net6.0-windows7.0", "net7.0-windows", "net7.0-windows7.0", "net8.0-windows", "net8.0-windows7.0", "net9.0-windows", "net9.0-windows7.0", "net10.0-windows", "net10.0-windows7.0")]
+    [InlineData("net6.0-windows7.0", "net6.0-windows", "net6.0-windows7.0", "net7.0-windows", "net7.0-windows7.0", "net8.0-windows", "net8.0-windows7.0", "net9.0-windows", "net9.0-windows7.0", "net10.0-windows", "net10.0-windows7.0", "net11.0-windows", "net11.0-windows7.0")]
     public void WindowsPlatformVersionsShouldContainAllSpecifiedFrameworks(string windowsDefaultVersionFramework, params string[] windowsProjectFrameworks)
     {
         var packageFramework = NuGetFramework.Parse(windowsDefaultVersionFramework);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
@@ -75,6 +75,7 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework Net100Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "windows", EmptyVersion);
 
         public static readonly NuGetFramework Net110 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version11);
+        public static readonly NuGetFramework Net110Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version11, "windows", EmptyVersion);
 
         public static readonly NuGetFramework NetCore = new NuGetFramework(FrameworkIdentifiers.NetCore, EmptyVersion);
         public static readonly NuGetFramework NetMf = new NuGetFramework(FrameworkIdentifiers.NetMicro, EmptyVersion);
@@ -90,6 +91,7 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework Net80Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "windows", Version7);
         public static readonly NuGetFramework Net90Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9, "windows", Version7);
         public static readonly NuGetFramework Net100Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "windows", Version7);
+        public static readonly NuGetFramework Net110Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version11, "windows", Version7);
 
         public static readonly IReadOnlyList<NuGetFramework> AllSupportedNuGetFrameworks;
 
@@ -106,7 +108,7 @@ namespace NuGetGallery.Frameworks
                 Net80, Net80Android, Net80Browser, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows, Net80Windows7,
                 Net90, Net90Android, Net90Browser, Net90Ios, Net90MacCatalyst, Net90MacOs, Net90TvOs, Net90Windows, Net90Windows7,
                 Net100, Net100Android, Net100Browser, Net100Ios, Net100MacCatalyst, Net100MacOs, Net100TvOs, Net100Windows, Net100Windows7,
-                Net110,
+                Net110, Net110Windows, Net110Windows7,
                 NetCore, NetCore45, NetCore451,
                 NetCoreApp10, NetCoreApp11, NetCoreApp20, NetCoreApp21, NetCoreApp22, NetCoreApp30, NetCoreApp31,
                 NetMf,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
@@ -75,7 +75,6 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework Net100Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "windows", EmptyVersion);
 
         public static readonly NuGetFramework Net110 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version11);
-        public static readonly NuGetFramework Net110Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version11, "windows", EmptyVersion);
 
         public static readonly NuGetFramework NetCore = new NuGetFramework(FrameworkIdentifiers.NetCore, EmptyVersion);
         public static readonly NuGetFramework NetMf = new NuGetFramework(FrameworkIdentifiers.NetMicro, EmptyVersion);
@@ -91,7 +90,6 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework Net80Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "windows", Version7);
         public static readonly NuGetFramework Net90Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version9, "windows", Version7);
         public static readonly NuGetFramework Net100Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "windows", Version7);
-        public static readonly NuGetFramework Net110Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version11, "windows", Version7);
 
         public static readonly IReadOnlyList<NuGetFramework> AllSupportedNuGetFrameworks;
 
@@ -108,7 +106,7 @@ namespace NuGetGallery.Frameworks
                 Net80, Net80Android, Net80Browser, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows, Net80Windows7,
                 Net90, Net90Android, Net90Browser, Net90Ios, Net90MacCatalyst, Net90MacOs, Net90TvOs, Net90Windows, Net90Windows7,
                 Net100, Net100Android, Net100Browser, Net100Ios, Net100MacCatalyst, Net100MacOs, Net100TvOs, Net100Windows, Net100Windows7,
-                Net110, Net110Windows, Net110Windows7,
+                Net110,
                 NetCore, NetCore45, NetCore451,
                 NetCoreApp10, NetCoreApp11, NetCoreApp20, NetCoreApp21, NetCoreApp22, NetCoreApp30, NetCoreApp31,
                 NetMf,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/FrameworkChecker/SupportedFrameworks.cs
@@ -23,6 +23,7 @@ namespace NuGetGallery.Frameworks
         public static readonly Version Version8 = new Version(8, 0, 0, 0);
         public static readonly Version Version9 = new Version(9, 0, 0, 0);
         public static readonly Version Version10 = new Version(10, 0, 0, 0);
+        public static readonly Version Version11 = new Version(11, 0, 0, 0);
 
         public static readonly NuGetFramework MonoAndroid = new NuGetFramework(FrameworkIdentifiers.MonoAndroid, EmptyVersion);
         public static readonly NuGetFramework MonoTouch = new NuGetFramework(FrameworkIdentifiers.MonoTouch, EmptyVersion);
@@ -73,6 +74,8 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework Net100TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "tvos", EmptyVersion);
         public static readonly NuGetFramework Net100Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version10, "windows", EmptyVersion);
 
+        public static readonly NuGetFramework Net110 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version11);
+
         public static readonly NuGetFramework NetCore = new NuGetFramework(FrameworkIdentifiers.NetCore, EmptyVersion);
         public static readonly NuGetFramework NetMf = new NuGetFramework(FrameworkIdentifiers.NetMicro, EmptyVersion);
         public static readonly NuGetFramework UAP = new NuGetFramework(FrameworkIdentifiers.UAP, EmptyVersion);
@@ -103,6 +106,7 @@ namespace NuGetGallery.Frameworks
                 Net80, Net80Android, Net80Browser, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows, Net80Windows7,
                 Net90, Net90Android, Net90Browser, Net90Ios, Net90MacCatalyst, Net90MacOs, Net90TvOs, Net90Windows, Net90Windows7,
                 Net100, Net100Android, Net100Browser, Net100Ios, Net100MacCatalyst, Net100MacOs, Net100TvOs, Net100Windows, Net100Windows7,
+                Net110,
                 NetCore, NetCore45, NetCore451,
                 NetCoreApp10, NetCoreApp11, NetCoreApp20, NetCoreApp21, NetCoreApp22, NetCoreApp30, NetCoreApp31,
                 NetMf,


### PR DESCRIPTION
### What are you trying to accomplish?

Refresh the NuGet submodules. NuGet renamed their release branches to `release/X.Y.x`, so we move from `release-6.14.x` to `release/7.6.x` (the latest released line per the [7.6 notes](https://learn.microsoft.com/en-us/nuget/release-notes/nuget-7.6)). dotnet/core was floating on `main`; I pinned it to the `v10.0.8` tag so builds aren't moving targets.

### Anything you want to highlight for special attention from reviewers?

`.gitmodules` has `branch = v10.0.8` for dotnet-core. Git accepts a tag there. It only matters for `git submodule update --remote` (normal clones just use the recorded SHA).

### How will you know you've accomplished your goal?

CI green on the nuget ecosystem.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.