### PR TITLE
Cache image builds with Buildx GHA cache backend

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -109,6 +109,12 @@ jobs:
 
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Expose GitHub Actions cache to Buildx
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+
       - name: Prepare tag
         run: echo "DEPENDABOT_UPDATER_VERSION=${{ github.sha }}" >> $GITHUB_ENV
         if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review'
@@ -135,6 +141,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ecosystem image
+        env:
+          BUILDX_GHA_CACHE: "1"
         run: script/build ${{ matrix.suite.name }}
 
       - name: Push branch image

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -81,8 +81,16 @@ jobs:
 
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Expose GitHub Actions cache to Buildx
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+
       - name: Build the dependabot-updater-<ecosystem> image
         # despite the script input being $NAME, the resulting image is dependabot-updater-${ECOSYSTEM}
+        env:
+          BUILDX_GHA_CACHE: "1"
         run: script/build ${NAME}
 
       - name: Tag the images with the SHA, `latest`, and the date version

--- a/script/_common
+++ b/script/_common
@@ -63,6 +63,27 @@ function get_dockerfile_path() {
     esac
 }
 
+function _build_cmd_and_cache_args() {
+  # Outputs (via stdout) the build command followed by cache-related flags for
+  # the given cache scope. When BUILDX_GHA_CACHE=1, uses `docker buildx build`
+  # with the GitHub Actions cache backend (https://docs.docker.com/build/cache/backends/gha/).
+  # Otherwise falls back to the legacy `docker build` with registry inline cache.
+  local scope="$1"
+  local image="$2"
+  if [[ -n "$BUILDX_GHA_CACHE" ]]; then
+    # --load is required so the resulting image is available to the local
+    # docker daemon for subsequent tag/push/cosign steps.
+    echo "docker buildx build --load" \
+         "--cache-from type=gha,scope=${scope}" \
+         "--cache-to type=gha,mode=max,scope=${scope}" \
+         "--cache-from ${image}"
+  else
+    echo "docker build" \
+         "--build-arg BUILDKIT_INLINE_CACHE=1" \
+         "--cache-from ${image}"
+  fi
+}
+
 function docker_build() {
   [[ -n "$SKIP_BUILD" ]] && return
   ensure_compatible_docker_api_version
@@ -80,14 +101,14 @@ function docker_build() {
   # shellcheck disable=SC2034 # Used implicitly in docker build
   DOCKER_CONTENT_TRUST=1
 
-  # shellcheck disable=SC2086  # as $DOCKER_BUILD_ARGS relies on word-splitting
-  docker build \
+  CORE_BUILD=$(_build_cmd_and_cache_args "updater-core" "$UPDATER_CORE_IMAGE")
+
+  # shellcheck disable=SC2086  # word-splitting is intentional for build args
+  $CORE_BUILD \
     $DOCKER_BUILD_ARGS \
-    --build-arg BUILDKIT_INLINE_CACHE=1 \
     --build-arg USER_UID=$DEPENDABOT_USER_UID \
     --build-arg USER_GID=$DEPENDABOT_USER_GID \
     --build-arg DEPENDABOT_UPDATER_VERSION=$DEPENDABOT_UPDATER_VERSION \
-    --cache-from "$UPDATER_CORE_IMAGE" \
     -t "$UPDATER_CORE_IMAGE" \
     -f Dockerfile.updater-core \
     .
@@ -110,11 +131,11 @@ function docker_build() {
 
   DOCKERFILE_PATH=$(get_dockerfile_path)
 
-  # shellcheck disable=SC2086  # as $DOCKER_BUILD_ARGS relies on word-splitting
-  docker build \
+  ECOSYSTEM_BUILD=$(_build_cmd_and_cache_args "$ECOSYSTEM" "$UPDATER_IMAGE_NAME")
+
+  # shellcheck disable=SC2086  # word-splitting is intentional for build args
+  $ECOSYSTEM_BUILD \
     $DOCKER_BUILD_ARGS \
-    --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --cache-from "$UPDATER_IMAGE_NAME" \
     -t "$UPDATER_IMAGE_NAME" \
     -f "$DOCKERFILE_PATH" \
     .


### PR DESCRIPTION
### What are you trying to accomplish?

The `Branch images` workflow rebuilds ~30 ecosystem images from scratch on every PR. It's slow and regularly gets rate-limited.

Switches both the per-PR and main-branch builds to `docker buildx` with the [GitHub Actions cache backend](https://docs.docker.com/build/cache/backends/gha/), with a per-ecosystem cache scope. The registry image is kept as a `--cache-from` fallback so cold builds (e.g. forks) still work.

### Anything you want to highlight for special attention from reviewers?

The `script/_common` change is gated on `BUILDX_GHA_CACHE=1`, so local dev workflows are untouched. I went with `mode=max` to cache intermediate layers; if we blow past the 10 GB per-repo cache limit we can drop to `mode=min`. `images-latest.yml` is updated too so PR builds can pull from a cache that `main` populates.

### How will you know you've accomplished your goal?

Once `main` runs once to seed the cache, subsequent PR builds should skip most layers. I'll keep an eye on the next handful of PR runs.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.