### PR TITLE
Implement sbt file updater and fix issues in file parser

### DIFF
--- a/gradle/lib/dependabot/gradle/file_updater/property_value_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/property_value_updater.rb
@@ -5,81 +5,22 @@ require "sorbet-runtime"
 
 require "dependabot/gradle/file_updater"
 require "dependabot/gradle/file_parser/property_value_finder"
+require "dependabot/maven/shared/shared_property_value_updater"
 
 module Dependabot
   module Gradle
     class FileUpdater
-      class PropertyValueUpdater
+      class PropertyValueUpdater < Dependabot::Maven::Shared::SharedPropertyValueUpdater
         extend T::Sig
-
-        sig { params(dependency_files: T::Array[DependencyFile]).void }
-        def initialize(dependency_files:)
-          @dependency_files = dependency_files
-          @property_value_finder = T.let(nil, T.nilable(Gradle::FileParser::PropertyValueFinder))
-        end
-
-        sig do
-          params(
-            property_name: String,
-            callsite_buildfile: DependencyFile,
-            previous_value: String,
-            updated_value: String
-          )
-            .returns(T::Array[DependencyFile])
-        end
-        def update_files_for_property_change(
-          property_name:,
-          callsite_buildfile:,
-          previous_value:,
-          updated_value:
-        )
-          declaration_details = T.must(
-            property_value_finder.property_details(
-              property_name: property_name,
-              callsite_buildfile: callsite_buildfile
-            )
-          )
-          declaration_string = declaration_details.fetch(:declaration_string)
-          filename = declaration_details.fetch(:file)
-
-          file_to_update = T.must(dependency_files.find { |f| f.name == filename })
-          updated_content = T.must(file_to_update.content).sub(
-            declaration_string,
-            declaration_string.sub(
-              previous_value_regex(previous_value),
-              updated_value
-            )
-          )
-
-          updated_files = dependency_files.dup
-          updated_files[T.must(updated_files.index(file_to_update))] =
-            update_file(file: file_to_update, content: updated_content)
-
-          updated_files
-        end
 
         private
 
-        sig { returns(T::Array[DependencyFile]) }
-        attr_reader :dependency_files
-
-        sig { returns(Gradle::FileParser::PropertyValueFinder) }
+        sig { override.returns(Gradle::FileParser::PropertyValueFinder) }
         def property_value_finder
-          @property_value_finder ||=
-            Gradle::FileParser::PropertyValueFinder
-            .new(dependency_files: dependency_files)
-        end
-
-        sig { params(file: DependencyFile, content: String).returns(DependencyFile) }
-        def update_file(file:, content:)
-          updated_file = file.dup
-          updated_file.content = content
-          updated_file
-        end
-
-        sig { params(previous_value: String).returns(Regexp) }
-        def previous_value_regex(previous_value)
-          /(?<=['"])#{Regexp.quote(previous_value)}(?=['"])/
+          @property_value_finder ||= T.let(
+            Gradle::FileParser::PropertyValueFinder.new(dependency_files: dependency_files),
+            T.nilable(Gradle::FileParser::PropertyValueFinder)
+          )
         end
       end
     end

--- a/maven/lib/dependabot/maven/shared/shared_property_value_updater.rb
+++ b/maven/lib/dependabot/maven/shared/shared_property_value_updater.rb
@@ -1,0 +1,85 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/dependency_file"
+
+module Dependabot
+  module Maven
+    module Shared
+      # Shared base for text-based property value updaters (Gradle, SBT).
+      # Subclasses must override `property_value_finder` to return the
+      # ecosystem-specific PropertyValueFinder instance.
+      #
+      # Maven's PropertyValueUpdater is XML-based and does not share this class.
+      class SharedPropertyValueUpdater
+        extend T::Sig
+        extend T::Helpers
+
+        abstract!
+
+        sig { params(dependency_files: T::Array[DependencyFile]).void }
+        def initialize(dependency_files:)
+          @dependency_files = T.let(dependency_files, T::Array[DependencyFile])
+        end
+
+        sig do
+          params(
+            property_name: String,
+            callsite_buildfile: DependencyFile,
+            previous_value: String,
+            updated_value: String
+          ).returns(T::Array[DependencyFile])
+        end
+        def update_files_for_property_change(
+          property_name:,
+          callsite_buildfile:,
+          previous_value:,
+          updated_value:
+        )
+          declaration_details = property_value_finder.property_details(
+            property_name: property_name,
+            callsite_buildfile: callsite_buildfile
+          )
+          declaration_string = T.let(declaration_details.fetch(:declaration_string), String)
+          filename = T.let(declaration_details.fetch(:file), String)
+
+          file_to_update = T.must(dependency_files.find { |f| f.name == filename })
+          updated_content = T.must(file_to_update.content).sub(
+            declaration_string,
+            declaration_string.sub(
+              previous_value_regex(previous_value),
+              updated_value
+            )
+          )
+
+          updated_files = dependency_files.dup
+          updated_files[T.must(updated_files.index(file_to_update))] =
+            update_file(file: file_to_update, content: updated_content)
+
+          updated_files
+        end
+
+        private
+
+        sig { returns(T::Array[DependencyFile]) }
+        attr_reader :dependency_files
+
+        sig { abstract.returns(T.untyped) }
+        def property_value_finder; end
+
+        sig { params(previous_value: String).returns(Regexp) }
+        def previous_value_regex(previous_value)
+          /(?<=['"])#{Regexp.quote(previous_value)}(?=['"])/
+        end
+
+        sig { params(file: DependencyFile, content: String).returns(DependencyFile) }
+        def update_file(file:, content:)
+          updated_file = file.dup
+          updated_file.content = content
+          updated_file
+        end
+      end
+    end
+  end
+end

--- a/maven/lib/dependabot/maven/shared/shared_property_value_updater.rb
+++ b/maven/lib/dependabot/maven/shared/shared_property_value_updater.rb
@@ -41,6 +41,8 @@ module Dependabot
             property_name: property_name,
             callsite_buildfile: callsite_buildfile
           )
+          raise "Property '#{property_name}' not found" unless declaration_details
+
           declaration_string = T.let(declaration_details.fetch(:declaration_string), String)
           filename = T.let(declaration_details.fetch(:file), String)
 

--- a/maven/spec/dependabot/maven/shared/shared_property_value_updater_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_property_value_updater_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Dependabot::Maven::Shared::SharedPropertyValueUpdater do
         @dependency_files = dependency_files
       end
 
-      def property_details(property_name:)
+      def property_details(property_name:, callsite_buildfile: nil) # rubocop:disable Lint/UnusedMethodArgument
         @dependency_files.each do |file|
           file.content&.scan(
             /(?:^|\s)(?:lazy\s+)?val\s+#{Regexp.quote(property_name)}(?:\s*:\s*String)?\s*=\s*"([^"]+)"/

--- a/maven/spec/dependabot/maven/shared/shared_property_value_updater_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_property_value_updater_spec.rb
@@ -1,0 +1,211 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/maven/shared/shared_property_value_updater"
+
+RSpec.describe Dependabot::Maven::Shared::SharedPropertyValueUpdater do
+  # Concrete subclass with a stub PropertyValueFinder for testing
+  let(:finder_class) do
+    Class.new do
+      def initialize(dependency_files:)
+        @dependency_files = dependency_files
+      end
+
+      def property_details(property_name:)
+        @dependency_files.each do |file|
+          file.content&.scan(
+            /(?:^|\s)(?:lazy\s+)?val\s+#{Regexp.quote(property_name)}(?:\s*:\s*String)?\s*=\s*"([^"]+)"/
+          ) do
+            declaration = Regexp.last_match.to_s.strip
+            return {
+              value: Regexp.last_match(1),
+              declaration_string: declaration,
+              file: file.name
+            }
+          end
+        end
+        nil
+      end
+    end
+  end
+
+  let(:updater_class) do
+    fc = finder_class
+    Class.new(described_class) do
+      define_method(:property_value_finder) do
+        @property_value_finder ||= fc.new(dependency_files: dependency_files)
+      end
+    end
+  end
+
+  let(:updater) { updater_class.new(dependency_files: dependency_files) }
+
+  describe "#update_files_for_property_change" do
+    subject(:updated_files) do
+      updater.update_files_for_property_change(
+        property_name: property_name,
+        callsite_buildfile: callsite_buildfile,
+        previous_value: previous_value,
+        updated_value: updated_value
+      )
+    end
+
+    context "when the property is in the callsite file" do
+      let(:buildfile) do
+        Dependabot::DependencyFile.new(
+          name: "build.sbt",
+          content: <<~SBT
+            val catsVersion = "2.10.0"
+
+            libraryDependencies += "org.typelevel" %% "cats-core" % catsVersion
+          SBT
+        )
+      end
+      let(:dependency_files) { [buildfile] }
+      let(:callsite_buildfile) { buildfile }
+      let(:property_name) { "catsVersion" }
+      let(:previous_value) { "2.10.0" }
+      let(:updated_value) { "2.11.0" }
+
+      it "returns an array of DependencyFile objects" do
+        expect(updated_files).to all(be_a(Dependabot::DependencyFile))
+      end
+
+      it "updates the val declaration" do
+        updated = updated_files.find { |f| f.name == "build.sbt" }
+        expect(updated.content).to include('val catsVersion = "2.11.0"')
+        expect(updated.content).not_to include('val catsVersion = "2.10.0"')
+      end
+
+      it "does not change the dependency reference line" do
+        updated = updated_files.find { |f| f.name == "build.sbt" }
+        expect(updated.content).to include('"org.typelevel" %% "cats-core" % catsVersion')
+      end
+
+      it "preserves the total number of files" do
+        expect(updated_files.length).to eq(dependency_files.length)
+      end
+    end
+
+    context "when the property is in a different file" do
+      let(:buildfile) do
+        Dependabot::DependencyFile.new(
+          name: "build.sbt",
+          content: <<~SBT
+            libraryDependencies += "org.typelevel" %% "cats-core" % catsVersion
+          SBT
+        )
+      end
+      let(:scala_file) do
+        Dependabot::DependencyFile.new(
+          name: "project/Dependencies.scala",
+          content: <<~SCALA
+            import sbt._
+
+            object Dependencies {
+              val catsVersion = "2.10.0"
+              val akkaVersion = "2.8.5"
+            }
+          SCALA
+        )
+      end
+      let(:dependency_files) { [buildfile, scala_file] }
+      let(:callsite_buildfile) { buildfile }
+      let(:property_name) { "catsVersion" }
+      let(:previous_value) { "2.10.0" }
+      let(:updated_value) { "2.11.0" }
+
+      it "updates the val in the Scala file" do
+        updated = updated_files.find { |f| f.name == "project/Dependencies.scala" }
+        expect(updated.content).to include('val catsVersion = "2.11.0"')
+        expect(updated.content).not_to include('val catsVersion = "2.10.0"')
+      end
+
+      it "does not modify the buildfile content" do
+        updated = updated_files.find { |f| f.name == "build.sbt" }
+        expect(updated.content).to eq(buildfile.content)
+      end
+
+      it "leaves other properties unchanged" do
+        updated = updated_files.find { |f| f.name == "project/Dependencies.scala" }
+        expect(updated.content).to include('val akkaVersion = "2.8.5"')
+      end
+    end
+
+    context "with a lazy val declaration" do
+      let(:buildfile) do
+        Dependabot::DependencyFile.new(
+          name: "build.sbt",
+          content: <<~SBT
+            lazy val guavaVersion = "33.0.0-jre"
+
+            libraryDependencies += "com.google.guava" % "guava" % guavaVersion
+          SBT
+        )
+      end
+      let(:dependency_files) { [buildfile] }
+      let(:callsite_buildfile) { buildfile }
+      let(:property_name) { "guavaVersion" }
+      let(:previous_value) { "33.0.0-jre" }
+      let(:updated_value) { "33.1.0-jre" }
+
+      it "updates the lazy val declaration" do
+        updated = updated_files.find { |f| f.name == "build.sbt" }
+        expect(updated.content).to include('lazy val guavaVersion = "33.1.0-jre"')
+        expect(updated.content).not_to include('"33.0.0-jre"')
+      end
+    end
+
+    context "with a typed val declaration" do
+      let(:buildfile) do
+        Dependabot::DependencyFile.new(
+          name: "build.sbt",
+          content: <<~SBT
+            val guavaVersion: String = "33.0.0-jre"
+
+            libraryDependencies += "com.google.guava" % "guava" % guavaVersion
+          SBT
+        )
+      end
+      let(:dependency_files) { [buildfile] }
+      let(:callsite_buildfile) { buildfile }
+      let(:property_name) { "guavaVersion" }
+      let(:previous_value) { "33.0.0-jre" }
+      let(:updated_value) { "33.1.0-jre" }
+
+      it "updates the typed val declaration" do
+        updated = updated_files.find { |f| f.name == "build.sbt" }
+        expect(updated.content).to include('val guavaVersion: String = "33.1.0-jre"')
+        expect(updated.content).not_to include('"33.0.0-jre"')
+      end
+    end
+
+    context "when the value appears in multiple places but only updates the declaration" do
+      let(:buildfile) do
+        Dependabot::DependencyFile.new(
+          name: "build.sbt",
+          content: <<~SBT
+            val akkaVersion = "2.8.5"
+
+            // akka is pinned to "2.8.5" for stability
+            libraryDependencies += "com.typesafe.akka" %% "akka-actor" % akkaVersion
+          SBT
+        )
+      end
+      let(:dependency_files) { [buildfile] }
+      let(:callsite_buildfile) { buildfile }
+      let(:property_name) { "akkaVersion" }
+      let(:previous_value) { "2.8.5" }
+      let(:updated_value) { "2.9.0" }
+
+      it "only updates the val declaration, not the comment" do
+        updated = updated_files.find { |f| f.name == "build.sbt" }
+        expect(updated.content).to include('val akkaVersion = "2.9.0"')
+        # The comment still has the old version since sub only replaces the first match
+        expect(updated.content).to include('// akka is pinned to "2.8.5" for stability')
+      end
+    end
+  end
+end

--- a/sbt/lib/dependabot/sbt/file_parser.rb
+++ b/sbt/lib/dependabot/sbt/file_parser.rb
@@ -23,6 +23,12 @@ module Dependabot
       BUILD_SBT_FILENAME = "build.sbt"
       BUILD_PROPERTIES_FILENAME = "project/build.properties"
 
+      # Matches a simple identifier or dotted reference (e.g. myVal, V.scala212)
+      IDENT_OR_DOTTED = T.let(
+        "[a-zA-Z_]\\w*(?:\\.[a-zA-Z_]\\w*)*",
+        String
+      )
+
       # "org" % "artifact" % "version"  or  "org" %% "artifact" % "version"
       # Optionally followed by % "scope" (e.g. % "test", % "provided")
       LIBRARY_DEP_REGEX = T.let(
@@ -46,7 +52,7 @@ module Dependabot
       # addSbtPlugin("org" % "name" % valName)
       # Also handles dotted references like Object.member
       PLUGIN_VAL_REF_REGEX = T.let(
-        /addSbtPlugin\(\s*"(?<group>[^"]+)"\s+%\s+"(?<artifact>[^"]+)"\s+%\s+(?<val_name>[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\)/,
+        /addSbtPlugin\(\s*"(?<group>[^"]+)"\s+%\s+"(?<artifact>[^"]+)"\s+%\s+(?<val_name>#{IDENT_OR_DOTTED})\s*\)/,
         Regexp
       )
 
@@ -65,7 +71,7 @@ module Dependabot
 
       # scalaVersion := valRef  or  scalaVersion in ThisBuild := V.scala212
       SCALA_VERSION_VAL_REGEX = T.let(
-        %r{(?:ThisBuild\s*/\s*)?(?:scalaVersion\s+in\s+ThisBuild|scalaVersion)\s*:=\s*(?<val_name>[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)},
+        %r{(?:ThisBuild\s*/\s*)?(?:scalaVersion\s+in\s+ThisBuild|scalaVersion)\s*:=\s*(?<val_name>#{IDENT_OR_DOTTED})},
         Regexp
       )
 
@@ -136,18 +142,8 @@ module Dependabot
       sig { returns(String) }
       def scala_full_version
         sbt_files.each do |file|
-          match = prepared_content(file).match(SCALA_VERSION_REGEX)
-          return T.must(match[:version]) if match
-
-          val_match = prepared_content(file).match(SCALA_VERSION_VAL_REGEX)
-          next unless val_match
-
-          val_name = T.must(val_match[:val_name])
-          resolved = property_value_finder.property_value(
-            property_name: val_name,
-            callsite_buildfile: file
-          )
-          return resolved if resolved
+          version = resolve_scala_version(file)
+          return version if version
         end
         "NOT-AVAILABLE"
       end
@@ -179,17 +175,12 @@ module Dependabot
 
           next unless Sbt::Version.correct?(version)
 
-          dependency_set << Dependency.new(
+          meta = cross_versioned ? { packaging_type: "cross-versioned" } : nil
+          dependency_set << new_dependency(
             name: dep_name,
             version: version,
-            requirements: [{
-              requirement: version,
-              file: buildfile.name,
-              source: nil,
-              groups: [],
-              metadata: cross_versioned ? { packaging_type: "cross-versioned" } : nil
-            }],
-            package_manager: "sbt"
+            file: buildfile.name,
+            metadata: meta
           )
         end
 
@@ -225,17 +216,11 @@ module Dependabot
           )
           metadata[:packaging_type] = "cross-versioned" if cross_versioned
 
-          dependency_set << Dependency.new(
+          dependency_set << new_dependency(
             name: dep_name,
             version: version,
-            requirements: [{
-              requirement: version,
-              file: buildfile.name,
-              source: nil,
-              groups: [],
-              metadata: metadata
-            }],
-            package_manager: "sbt"
+            file: buildfile.name,
+            metadata: metadata
           )
         end
 
@@ -254,17 +239,11 @@ module Dependabot
 
           next unless Sbt::Version.correct?(version)
 
-          dependency_set << Dependency.new(
+          dependency_set << new_dependency(
             name: "#{group}:#{artifact}",
             version: version,
-            requirements: [{
-              requirement: version,
-              file: buildfile.name,
-              source: nil,
-              groups: ["plugins"],
-              metadata: nil
-            }],
-            package_manager: "sbt"
+            file: buildfile.name,
+            groups: ["plugins"]
           )
         end
 
@@ -291,17 +270,13 @@ module Dependabot
           next unless version
           next unless Sbt::Version.correct?(version)
 
-          dependency_set << Dependency.new(
+          meta = { property_name: val_name, property_source: property_details[:file] }
+          dependency_set << new_dependency(
             name: "#{group}:#{artifact}",
             version: version,
-            requirements: [{
-              requirement: version,
-              file: buildfile.name,
-              source: nil,
-              groups: ["plugins"],
-              metadata: { property_name: val_name, property_source: property_details[:file] }
-            }],
-            package_manager: "sbt"
+            file: buildfile.name,
+            groups: ["plugins"],
+            metadata: meta
           )
         end
 
@@ -322,17 +297,11 @@ module Dependabot
           version = T.must(match[:version]).strip
           next unless Sbt::Version.correct?(version)
 
-          dependency_set << Dependency.new(
+          dependency_set << new_dependency(
             name: "org.scala-sbt:sbt",
             version: version,
-            requirements: [{
-              requirement: version,
-              file: properties_file.name,
-              source: nil,
-              groups: [],
-              metadata: { property_source: "build.properties" }
-            }],
-            package_manager: "sbt"
+            file: properties_file.name,
+            metadata: { property_source: "build.properties" }
           )
 
           break
@@ -354,17 +323,11 @@ module Dependabot
         # Scala 3 uses scala3-library, Scala 2 uses scala-library
         dep_name = version.start_with?("3") ? "org.scala-lang:scala3-library_3" : "org.scala-lang:scala-library"
 
-        dependency_set << Dependency.new(
+        dependency_set << new_dependency(
           name: dep_name,
           version: version,
-          requirements: [{
-            requirement: version,
-            file: buildfile.name,
-            source: nil,
-            groups: [],
-            metadata: { property_source: "scalaVersion" }
-          }],
-          package_manager: "sbt"
+          file: buildfile.name,
+          metadata: { property_source: "scalaVersion" }
         )
 
         dependency_set
@@ -395,27 +358,28 @@ module Dependabot
         files_to_check << root if root && root != buildfile
 
         files_to_check.each do |file|
-          # Try literal scalaVersion first
-          match = prepared_content(file).match(SCALA_VERSION_REGEX)
-          if match
-            full_version = T.must(match[:version])
-            return extract_scala_major(full_version)
-          end
-
-          # Try val-reference scalaVersion (e.g. scalaVersion := myVal or := V.scala212)
-          val_match = prepared_content(file).match(SCALA_VERSION_VAL_REGEX)
-          next unless val_match
-
-          val_name = T.must(val_match[:val_name])
-          resolved = property_value_finder.property_value(
-            property_name: val_name,
-            callsite_buildfile: file
-          )
-          return extract_scala_major(resolved) if resolved
+          version = resolve_scala_version(file)
+          return extract_scala_major(version) if version
         end
 
         # Default to 2.13 if scalaVersion is not declared
         "2.13"
+      end
+
+      # Resolves scalaVersion from a file, trying literal value first, then val reference.
+      sig { params(file: Dependabot::DependencyFile).returns(T.nilable(String)) }
+      def resolve_scala_version(file)
+        match = prepared_content(file).match(SCALA_VERSION_REGEX)
+        return T.must(match[:version]) if match
+
+        val_match = prepared_content(file).match(SCALA_VERSION_VAL_REGEX)
+        return nil unless val_match
+
+        val_name = T.must(val_match[:val_name])
+        property_value_finder.property_value(
+          property_name: val_name,
+          callsite_buildfile: file
+        )
       end
 
       sig { params(full_version: String).returns(String) }
@@ -467,6 +431,27 @@ module Dependabot
         @scala_build_files ||= T.let(
           dependency_files.select { |f| f.name.end_with?(".scala") && f.name.start_with?("project/") },
           T.nilable(T::Array[Dependabot::DependencyFile])
+        )
+      end
+
+      sig do
+        params(
+          name: String,
+          version: String,
+          file: String,
+          groups: T::Array[String],
+          metadata: T.nilable(T::Hash[Symbol, T.untyped])
+        ).returns(Dependabot::Dependency)
+      end
+      def new_dependency(name:, version:, file:, groups: [], metadata: nil)
+        Dependency.new(
+          name: name,
+          version: version,
+          requirements: [{
+            requirement: version, file: file,
+            source: nil, groups: groups, metadata: metadata
+          }],
+          package_manager: "sbt"
         )
       end
 

--- a/sbt/lib/dependabot/sbt/file_parser.rb
+++ b/sbt/lib/dependabot/sbt/file_parser.rb
@@ -31,8 +31,9 @@ module Dependabot
       )
 
       # "org" % "artifact" % valName  or  "org" %% "artifact" % valName
+      # Also handles dotted references like Object.member
       VAL_REF_DEP_REGEX = T.let(
-        /"(?<group>[^"]+)"\s+(?<op>%%?)\s+"(?<artifact>[^"]+)"\s+%\s+(?<val_name>[a-zA-Z_]\w*)/,
+        /"(?<group>[^"]+)"\s+(?<op>%%?)\s+"(?<artifact>[^"]+)"\s+%\s+(?<val_name>[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)/,
         Regexp
       )
 
@@ -43,8 +44,9 @@ module Dependabot
       )
 
       # addSbtPlugin("org" % "name" % valName)
+      # Also handles dotted references like Object.member
       PLUGIN_VAL_REF_REGEX = T.let(
-        /addSbtPlugin\(\s*"(?<group>[^"]+)"\s+%\s+"(?<artifact>[^"]+)"\s+%\s+(?<val_name>[a-zA-Z_]\w*)\s*\)/,
+        /addSbtPlugin\(\s*"(?<group>[^"]+)"\s+%\s+"(?<artifact>[^"]+)"\s+%\s+(?<val_name>[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\)/,
         Regexp
       )
 
@@ -55,8 +57,15 @@ module Dependabot
       )
 
       # scalaVersion := "2.13.12"  or  ThisBuild / scalaVersion := "2.13.12"
+      # Also: scalaVersion in ThisBuild := "2.13.12" (older SBT syntax)
       SCALA_VERSION_REGEX = T.let(
-        %r{(?:ThisBuild\s*/\s*)?scalaVersion\s*:=\s*"(?<version>[^"]+)"},
+        %r{(?:ThisBuild\s*/\s*)?(?:scalaVersion\s+in\s+ThisBuild|scalaVersion)\s*:=\s*"(?<version>[^"]+)"},
+        Regexp
+      )
+
+      # scalaVersion := valRef  or  scalaVersion in ThisBuild := V.scala212
+      SCALA_VERSION_VAL_REGEX = T.let(
+        %r{(?:ThisBuild\s*/\s*)?(?:scalaVersion\s+in\s+ThisBuild|scalaVersion)\s*:=\s*(?<val_name>[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)},
         Regexp
       )
 
@@ -129,6 +138,16 @@ module Dependabot
         sbt_files.each do |file|
           match = prepared_content(file).match(SCALA_VERSION_REGEX)
           return T.must(match[:version]) if match
+
+          val_match = prepared_content(file).match(SCALA_VERSION_VAL_REGEX)
+          next unless val_match
+
+          val_name = T.must(val_match[:val_name])
+          resolved = property_value_finder.property_value(
+            property_name: val_name,
+            callsite_buildfile: file
+          )
+          return resolved if resolved
         end
         "NOT-AVAILABLE"
       end
@@ -376,17 +395,33 @@ module Dependabot
         files_to_check << root if root && root != buildfile
 
         files_to_check.each do |file|
+          # Try literal scalaVersion first
           match = prepared_content(file).match(SCALA_VERSION_REGEX)
-          next unless match
+          if match
+            full_version = T.must(match[:version])
+            return extract_scala_major(full_version)
+          end
 
-          full_version = T.must(match[:version])
-          parts = full_version.split(".")
-          # Scala 2.x uses major.minor (e.g. 2.13), Scala 3.x uses just major (e.g. 3)
-          return parts[0] == "3" ? "3" : "#{parts[0]}.#{parts[1]}"
+          # Try val-reference scalaVersion (e.g. scalaVersion := myVal or := V.scala212)
+          val_match = prepared_content(file).match(SCALA_VERSION_VAL_REGEX)
+          next unless val_match
+
+          val_name = T.must(val_match[:val_name])
+          resolved = property_value_finder.property_value(
+            property_name: val_name,
+            callsite_buildfile: file
+          )
+          return extract_scala_major(resolved) if resolved
         end
 
         # Default to 2.13 if scalaVersion is not declared
         "2.13"
+      end
+
+      sig { params(full_version: String).returns(String) }
+      def extract_scala_major(full_version)
+        parts = full_version.split(".")
+        parts[0] == "3" ? "3" : "#{parts[0]}.#{parts[1]}"
       end
 
       sig { params(buildfile: Dependabot::DependencyFile).returns(String) }

--- a/sbt/lib/dependabot/sbt/file_parser/property_value_finder.rb
+++ b/sbt/lib/dependabot/sbt/file_parser/property_value_finder.rb
@@ -30,6 +30,11 @@ module Dependabot
             .returns(T.nilable(T::Hash[Symbol, String]))
         end
         def property_details(property_name:, callsite_buildfile:)
+          # Handle dotted references like "V.scalafixVersion" by looking up the member name
+          if property_name.include?(".")
+            return dotted_property_details(property_name: property_name, callsite_buildfile: callsite_buildfile)
+          end
+
           # Look in the callsite file first, then fall back to the root build.sbt,
           # then check project/*.scala build definition files
           all_files = [callsite_buildfile, top_level_buildfile].compact
@@ -54,6 +59,46 @@ module Dependabot
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         attr_reader :dependency_files
+
+        # Resolves dotted property references like "Versions.catsVersion" or "V.scala212".
+        # Searches for `val <member> = "..."` inside `object <ObjectName> { ... }` blocks
+        # across all dependency files.
+        sig do
+          params(property_name: String, callsite_buildfile: Dependabot::DependencyFile)
+            .returns(T.nilable(T::Hash[Symbol, String]))
+        end
+        def dotted_property_details(property_name:, callsite_buildfile:)
+          parts = property_name.split(".")
+          return nil unless parts.length == 2
+
+          object_name = T.must(parts.first)
+          member_name = T.must(parts.last)
+
+          all_files = [callsite_buildfile, top_level_buildfile].compact
+          all_files += project_scala_files
+          all_files.uniq!
+
+          all_files.each do |file|
+            content = prepared_content(file)
+            # Look for val <member> = "value" inside object <ObjectName>
+            object_regex = /object\s+#{Regexp.quote(object_name)}\b[^{]*\{(?<body>[^}]*)\}/m
+            content.scan(object_regex) do
+              body = T.must(Regexp.last_match).named_captures.fetch("body")
+              member_regex = /(?:^|\s)(?:lazy\s+)?val\s+#{Regexp.quote(member_name)}(?:\s*:\s*String)?\s*=\s*"(?<value>[^"]+)"/
+              member_match = body&.match(member_regex)
+              next unless member_match
+
+              declaration_string = member_match.to_s.strip
+              return {
+                value: T.must(member_match[:value]),
+                declaration_string: declaration_string,
+                file: file.name
+              }
+            end
+          end
+
+          nil
+        end
 
         sig { params(buildfile: Dependabot::DependencyFile).returns(T::Hash[String, T::Hash[Symbol, String]]) }
         def properties(buildfile)

--- a/sbt/lib/dependabot/sbt/file_parser/property_value_finder.rb
+++ b/sbt/lib/dependabot/sbt/file_parser/property_value_finder.rb
@@ -74,30 +74,55 @@ module Dependabot
           object_name = T.must(parts.first)
           member_name = T.must(parts.last)
 
+          # Resolve val aliases (e.g. "val V = BuildInfo" means V.x should look in object BuildInfo)
+          resolved_names = resolve_object_aliases(object_name, callsite_buildfile)
+
+          all_files = [callsite_buildfile, top_level_buildfile].compact
+          all_files += project_scala_files
+          all_files.uniq!
+
+          resolved_names.each do |resolved_name|
+            all_files.each do |file|
+              content = prepared_content(file)
+              object_regex = /object\s+#{Regexp.quote(resolved_name)}\b[^{]*\{(?<body>[^}]*)\}/m
+              content.scan(object_regex) do
+                body = T.must(Regexp.last_match).named_captures.fetch("body")
+                member_regex = /(?:^|\s)(?:lazy\s+)?val\s+#{Regexp.quote(member_name)}/
+                member_value_regex = /#{member_regex}(?:\s*:\s*String)?\s*=\s*"(?<value>[^"]+)"/
+                member_match = body&.match(member_value_regex)
+                next unless member_match
+
+                declaration_string = member_match.to_s.strip
+                return {
+                  value: T.must(member_match[:value]),
+                  declaration_string: declaration_string,
+                  file: file.name
+                }
+              end
+            end
+          end
+
+          nil
+        end
+
+        # Resolves val aliases like "val V = BuildInfo" → returns ["V", "BuildInfo"]
+        # so that dotted references like V.member can look in object BuildInfo.
+        sig { params(name: String, callsite_buildfile: Dependabot::DependencyFile).returns(T::Array[String]) }
+        def resolve_object_aliases(name, callsite_buildfile)
+          names = [name]
+
           all_files = [callsite_buildfile, top_level_buildfile].compact
           all_files += project_scala_files
           all_files.uniq!
 
           all_files.each do |file|
-            content = prepared_content(file)
-            # Look for val <member> = "value" inside object <ObjectName>
-            object_regex = /object\s+#{Regexp.quote(object_name)}\b[^{]*\{(?<body>[^}]*)\}/m
-            content.scan(object_regex) do
-              body = T.must(Regexp.last_match).named_captures.fetch("body")
-              member_regex = /(?:^|\s)(?:lazy\s+)?val\s+#{Regexp.quote(member_name)}(?:\s*:\s*String)?\s*=\s*"(?<value>[^"]+)"/
-              member_match = body&.match(member_regex)
-              next unless member_match
-
-              declaration_string = member_match.to_s.strip
-              return {
-                value: T.must(member_match[:value]),
-                declaration_string: declaration_string,
-                file: file.name
-              }
+            prepared_content(file).scan(/(?:^|\s)(?:lazy\s+)?val\s+#{Regexp.quote(name)}\s*=\s*(?<target>[A-Z]\w*)/) do
+              target = T.must(Regexp.last_match).named_captures.fetch("target")
+              names << T.must(target) unless names.include?(target)
             end
           end
 
-          nil
+          names
         end
 
         sig { params(buildfile: Dependabot::DependencyFile).returns(T::Hash[String, T::Hash[Symbol, String]]) }

--- a/sbt/lib/dependabot/sbt/file_updater.rb
+++ b/sbt/lib/dependabot/sbt/file_updater.rb
@@ -1,26 +1,33 @@
-# typed: strong
+# typed: strict
 # frozen_string_literal: true
+
+require "sorbet-runtime"
 
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
+require "dependabot/sbt/file_parser"
 
 module Dependabot
   module Sbt
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
+      require_relative "file_updater/property_value_updater"
+
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
       def updated_dependency_files
-        updated_files = []
+        updated_files = T.let(dependency_files.dup, T::Array[Dependabot::DependencyFile])
 
-        # TODO: Implement file update logic
-        # For each file that needs updating:
-        # 1. Get the original file content
-        # 2. Update it with new dependency versions
-        # 3. Add to updated_files array
-        # Example:
-        # manifest = dependency_files.find { |f| f.name == "manifest.json" }
-        # updated_files << updated_file(file: manifest, content: new_content)
+        dependencies.each do |dependency|
+          updated_files = update_files_for_dependency(
+            original_files: updated_files,
+            dependency: dependency
+          )
+        end
+
+        updated_files.reject! { |f| dependency_files.include?(f) }
+
+        raise "No files changed!" if updated_files.none?
 
         updated_files
       end
@@ -29,10 +36,180 @@ module Dependabot
 
       sig { override.void }
       def check_required_files
-        # TODO: Verify that all required files are present
-        # Example:
-        # return if get_original_file("manifest.json")
-        # raise "No manifest.json file found!"
+        raise "No build.sbt!" unless get_original_file("build.sbt")
+      end
+
+      sig do
+        params(
+          original_files: T::Array[Dependabot::DependencyFile],
+          dependency: Dependabot::Dependency
+        ).returns(T::Array[Dependabot::DependencyFile])
+      end
+      def update_files_for_dependency(original_files:, dependency:)
+        files = original_files.dup
+
+        reqs = dependency.requirements.zip(dependency.previous_requirements.to_a)
+                         .reject { |new_req, old_req| new_req == old_req }
+
+        reqs.each do |new_req, old_req|
+          raise "Bad req match" unless new_req[:file] == T.must(old_req)[:file]
+          next if new_req[:requirement] == T.must(old_req)[:requirement]
+
+          if new_req.dig(:metadata, :property_name)
+            files = update_files_for_property_change(files, T.must(old_req), new_req)
+          elsif T.let(new_req[:file], String).end_with?("build.properties")
+            files = update_build_properties(files, T.must(old_req), new_req)
+          elsif scala_version_requirement?(new_req)
+            file = T.must(files.find { |f| f.name == new_req[:file] })
+            files[T.must(files.index(file))] = update_scala_version(file, T.must(old_req), new_req)
+          else
+            file = T.must(files.find { |f| f.name == new_req[:file] })
+            files[T.must(files.index(file))] = update_version_in_buildfile(dependency, file, T.must(old_req), new_req)
+          end
+        end
+
+        files
+      end
+
+      sig do
+        params(
+          files: T::Array[Dependabot::DependencyFile],
+          old_req: T::Hash[Symbol, T.untyped],
+          new_req: T::Hash[Symbol, T.untyped]
+        ).returns(T::Array[Dependabot::DependencyFile])
+      end
+      def update_files_for_property_change(files, old_req, new_req)
+        property_name = T.let(new_req.dig(:metadata, :property_name), String)
+        callsite = T.must(files.find { |f| f.name == new_req[:file] })
+
+        PropertyValueUpdater.new(dependency_files: files)
+                            .update_files_for_property_change(
+                              property_name: property_name,
+                              callsite_buildfile: callsite,
+                              previous_value: T.let(old_req.fetch(:requirement), String),
+                              updated_value: T.let(new_req.fetch(:requirement), String)
+                            )
+      end
+
+      sig do
+        params(
+          files: T::Array[Dependabot::DependencyFile],
+          old_req: T::Hash[Symbol, T.untyped],
+          new_req: T::Hash[Symbol, T.untyped]
+        ).returns(T::Array[Dependabot::DependencyFile])
+      end
+      def update_build_properties(files, old_req, new_req)
+        file = T.must(files.find { |f| f.name == new_req[:file] })
+        old_version = T.let(old_req.fetch(:requirement), String)
+        new_version = T.let(new_req.fetch(:requirement), String)
+
+        updated_content = T.must(file.content).sub(
+          /(sbt\.version\s*=\s*)#{Regexp.quote(old_version)}/,
+          "\\1#{new_version}"
+        )
+
+        raise "Expected content to change!" if updated_content == file.content
+
+        updated_files = files.dup
+        updated_files[T.must(files.index(file))] =
+          updated_file(file: file, content: updated_content)
+        updated_files
+      end
+
+      sig do
+        params(
+          file: Dependabot::DependencyFile,
+          old_req: T::Hash[Symbol, T.untyped],
+          new_req: T::Hash[Symbol, T.untyped]
+        ).returns(Dependabot::DependencyFile)
+      end
+      def update_scala_version(file, old_req, new_req)
+        old_version = T.let(old_req.fetch(:requirement), String)
+        new_version = T.let(new_req.fetch(:requirement), String)
+
+        updated_content = T.must(file.content).sub(
+          %r{((?:ThisBuild\s*/\s*)?(?:scalaVersion\s+in\s+ThisBuild|scalaVersion)\s*:=\s*")#{Regexp.quote(old_version)}(")},
+          "\\1#{new_version}\\2"
+        )
+
+        raise "Expected content to change!" if updated_content == file.content
+
+        updated_file(file: file, content: updated_content)
+      end
+
+      sig do
+        params(
+          dependency: Dependabot::Dependency,
+          buildfile: Dependabot::DependencyFile,
+          previous_req: T::Hash[Symbol, T.untyped],
+          requirement: T::Hash[Symbol, T.untyped]
+        ).returns(Dependabot::DependencyFile)
+      end
+      def update_version_in_buildfile(dependency, buildfile, previous_req, requirement)
+        updated_content = T.must(buildfile.content.dup)
+
+        original_declarations = original_buildfile_declarations(dependency, previous_req)
+        original_declarations.each do |old_dec|
+          updated_content = updated_content.gsub(old_dec) do
+            updated_buildfile_declaration(old_dec, previous_req, requirement)
+          end
+        end
+
+        raise "Expected content to change!" if updated_content == buildfile.content
+
+        updated_file(file: buildfile, content: updated_content)
+      end
+
+      sig do
+        params(
+          dependency: Dependabot::Dependency,
+          requirement: T::Hash[Symbol, T.untyped]
+        ).returns(T::Array[String])
+      end
+      def original_buildfile_declarations(dependency, requirement)
+        buildfile = T.must(dependency_files.find { |f| f.name == T.let(requirement.fetch(:file), String) })
+        group, artifact = dependency_group_and_artifact(dependency)
+
+        T.must(buildfile.content).lines.select do |line|
+          next false unless line.include?(group)
+          next false unless line.include?(artifact)
+
+          line.include?(T.let(requirement.fetch(:requirement), String))
+        end
+      end
+
+      sig { params(dependency: Dependabot::Dependency).returns([String, String]) }
+      def dependency_group_and_artifact(dependency)
+        parts = dependency.name.split(":")
+        group = T.must(parts.first)
+        artifact = T.must(parts.last)
+
+        # Strip Scala version suffix for cross-versioned deps (e.g. cats-core_2.13 → cats-core)
+        artifact = artifact.sub(/_\d+(\.\d+)?$/, "")
+
+        [group, artifact]
+      end
+
+      sig do
+        params(
+          old_declaration: String,
+          previous_req: T::Hash[Symbol, T.untyped],
+          requirement: T::Hash[Symbol, T.untyped]
+        ).returns(String)
+      end
+      def updated_buildfile_declaration(old_declaration, previous_req, requirement)
+        original_req_string = T.let(previous_req.fetch(:requirement), String)
+        new_req_string = T.let(requirement.fetch(:requirement), String)
+
+        old_declaration.gsub(
+          /"#{Regexp.quote(original_req_string)}"/,
+          "\"#{new_req_string}\""
+        )
+      end
+
+      sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      def scala_version_requirement?(req)
+        req.dig(:metadata, :property_source) == "scalaVersion"
       end
     end
   end

--- a/sbt/lib/dependabot/sbt/file_updater.rb
+++ b/sbt/lib/dependabot/sbt/file_updater.rb
@@ -14,6 +14,14 @@ module Dependabot
 
       require_relative "file_updater/property_value_updater"
 
+      # Regex matching scalaVersion declarations in all supported SBT syntaxes
+      SCALA_VERSION_DECL = T.let(
+        "(?:ThisBuild\\s*/\\s*)?" \
+        "(?:scalaVersion\\s+in\\s+ThisBuild|scalaVersion)" \
+        '\\s*:=\\s*"',
+        String
+      )
+
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
       def updated_dependency_files
         updated_files = T.let(dependency_files.dup, T::Array[Dependabot::DependencyFile])
@@ -55,20 +63,34 @@ module Dependabot
           raise "Bad req match" unless new_req[:file] == T.must(old_req)[:file]
           next if new_req[:requirement] == T.must(old_req)[:requirement]
 
-          if new_req.dig(:metadata, :property_name)
-            files = update_files_for_property_change(files, T.must(old_req), new_req)
-          elsif T.let(new_req[:file], String).end_with?("build.properties")
-            files = update_build_properties(files, T.must(old_req), new_req)
-          elsif scala_version_requirement?(new_req)
-            file = T.must(files.find { |f| f.name == new_req[:file] })
-            files[T.must(files.index(file))] = update_scala_version(file, T.must(old_req), new_req)
-          else
-            file = T.must(files.find { |f| f.name == new_req[:file] })
-            files[T.must(files.index(file))] = update_version_in_buildfile(dependency, file, T.must(old_req), new_req)
-          end
+          files = apply_requirement_update(files, dependency, new_req, T.must(old_req))
         end
 
         files
+      end
+
+      sig do
+        params(
+          files: T::Array[Dependabot::DependencyFile],
+          dependency: Dependabot::Dependency,
+          new_req: T::Hash[Symbol, T.untyped],
+          old_req: T::Hash[Symbol, T.untyped]
+        ).returns(T::Array[Dependabot::DependencyFile])
+      end
+      def apply_requirement_update(files, dependency, new_req, old_req)
+        if new_req.dig(:metadata, :property_name)
+          update_files_for_property_change(files, old_req, new_req)
+        elsif T.let(new_req[:file], String).end_with?("build.properties")
+          update_build_properties(files, old_req, new_req)
+        elsif scala_version_requirement?(new_req)
+          file = T.must(files.find { |f| f.name == new_req[:file] })
+          idx = T.must(files.index(file))
+          files.dup.tap { |updated| updated[idx] = update_scala_version(file, old_req, new_req) }
+        else
+          file = T.must(files.find { |f| f.name == new_req[:file] })
+          idx = T.must(files.index(file))
+          files.dup.tap { |updated| updated[idx] = update_version_in_buildfile(dependency, file, old_req, new_req) }
+        end
       end
 
       sig do
@@ -128,7 +150,7 @@ module Dependabot
         new_version = T.let(new_req.fetch(:requirement), String)
 
         updated_content = T.must(file.content).sub(
-          %r{((?:ThisBuild\s*/\s*)?(?:scalaVersion\s+in\s+ThisBuild|scalaVersion)\s*:=\s*")#{Regexp.quote(old_version)}(")},
+          /(#{SCALA_VERSION_DECL})#{Regexp.quote(old_version)}(")/,
           "\\1#{new_version}\\2"
         )
 

--- a/sbt/lib/dependabot/sbt/file_updater/property_value_updater.rb
+++ b/sbt/lib/dependabot/sbt/file_updater/property_value_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/sbt/lib/dependabot/sbt/file_updater/property_value_updater.rb
+++ b/sbt/lib/dependabot/sbt/file_updater/property_value_updater.rb
@@ -1,0 +1,28 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/sbt/file_updater"
+require "dependabot/sbt/file_parser/property_value_finder"
+require "dependabot/maven/shared/shared_property_value_updater"
+
+module Dependabot
+  module Sbt
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class PropertyValueUpdater < Dependabot::Maven::Shared::SharedPropertyValueUpdater
+        extend T::Sig
+
+        private
+
+        sig { override.returns(Sbt::FileParser::PropertyValueFinder) }
+        def property_value_finder
+          @property_value_finder ||= T.let(
+            Sbt::FileParser::PropertyValueFinder.new(dependency_files: dependency_files),
+            T.nilable(Sbt::FileParser::PropertyValueFinder)
+          )
+        end
+      end
+    end
+  end
+end

--- a/sbt/spec/dependabot/sbt/file_parser_spec.rb
+++ b/sbt/spec/dependabot/sbt/file_parser_spec.rb
@@ -296,4 +296,59 @@ RSpec.describe Dependabot::Sbt::FileParser do
       )
     end
   end
+
+  context "with scalaVersion in ThisBuild syntax (older SBT)" do
+    let(:buildfile_fixture_name) { "in_this_build.sbt" }
+
+    it "correctly resolves the Scala version for cross-versioned deps" do
+      dependencies = parser.parse
+      cats_dep = dependencies.find { |d| d.name.start_with?("org.typelevel:cats_") }
+      expect(cats_dep).to be_a(Dependabot::Dependency)
+      expect(cats_dep.name).to eq("org.typelevel:cats_2.12")
+      expect(cats_dep.version).to eq("0.9.0")
+    end
+
+    it "parses scalaVersion as a dependency" do
+      dependencies = parser.parse
+      scala_dep = dependencies.find { |d| d.name == "org.scala-lang:scala-library" }
+      expect(scala_dep).to be_a(Dependabot::Dependency)
+      expect(scala_dep.version).to eq("2.12.18")
+    end
+  end
+
+  context "with dotted val references (Object.member)" do
+    let(:buildfile_fixture_name) { "dotted_val_build.sbt" }
+
+    let(:scala_build_file) do
+      Dependabot::DependencyFile.new(
+        name: "project/BuildInfo.scala",
+        content: fixture("buildfiles", "project/BuildInfo.scala")
+      )
+    end
+
+    let(:dependency_files) { [build_sbt, scala_build_file] }
+
+    it "resolves dotted val references for dependency versions" do
+      dependencies = parser.parse
+      scalafix_dep = dependencies.find { |d| d.name.start_with?("ch.epfl.scala:scalafix-core") }
+      expect(scalafix_dep).to be_a(Dependabot::Dependency)
+      expect(scalafix_dep.version).to eq("0.9.34")
+      expect(scalafix_dep.requirements.first[:metadata]).to include(
+        property_name: "V.scalafixVersion"
+      )
+    end
+
+    it "resolves dotted val references for scalaVersion" do
+      dependencies = parser.parse
+      cats_dep = dependencies.find { |d| d.name.start_with?("org.typelevel:cats_") }
+      expect(cats_dep).to be_a(Dependabot::Dependency)
+      expect(cats_dep.name).to eq("org.typelevel:cats_2.12")
+    end
+
+    it "still parses literal version deps correctly" do
+      dependencies = parser.parse
+      cats_dep = dependencies.find { |d| d.name.start_with?("org.typelevel:cats_") }
+      expect(cats_dep.version).to eq("0.9.0")
+    end
+  end
 end

--- a/sbt/spec/dependabot/sbt/file_updater_spec.rb
+++ b/sbt/spec/dependabot/sbt/file_updater_spec.rb
@@ -2,9 +2,499 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/dependency"
 require "dependabot/sbt/file_updater"
 require_common_spec "file_updaters/shared_examples_for_file_updaters"
 
 RSpec.describe Dependabot::Sbt::FileUpdater do
+  let(:dependency_files) { [buildfile] }
+  let(:dependencies) { [dependency] }
+  let(:updater) do
+    described_class.new(
+      dependency_files: dependency_files,
+      dependencies: dependencies,
+      credentials: [{
+        "type" => "git_source",
+        "host" => "github.com",
+        "username" => "x-access-token",
+        "password" => "token"
+      }]
+    )
+  end
+
+  let(:buildfile) do
+    Dependabot::DependencyFile.new(
+      name: "build.sbt",
+      content: fixture("buildfiles", buildfile_fixture_name)
+    )
+  end
+  let(:buildfile_fixture_name) { "basic_build.sbt" }
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "com.google.guava:guava",
+      version: "33.1.0-jre",
+      requirements: [{
+        file: "build.sbt",
+        requirement: "33.1.0-jre",
+        groups: [],
+        source: nil,
+        metadata: nil
+      }],
+      previous_requirements: [{
+        file: "build.sbt",
+        requirement: "33.0.0-jre",
+        groups: [],
+        source: nil,
+        metadata: nil
+      }],
+      previous_version: "33.0.0-jre",
+      package_manager: "sbt"
+    )
+  end
+
   it_behaves_like "a dependency file updater"
+
+  describe "#updated_dependency_files" do
+    subject(:updated_files) { updater.updated_dependency_files }
+
+    it "returns DependencyFile objects" do
+      expect(updated_files).to all(be_a(Dependabot::DependencyFile))
+    end
+
+    its(:length) { is_expected.to eq(1) }
+
+    context "with a basic build.sbt" do
+      let(:buildfile_fixture_name) { "basic_build.sbt" }
+
+      it "updates the version string" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('"com.google.guava" % "guava" % "33.1.0-jre"')
+        expect(updated_content).not_to include('"com.google.guava" % "guava" % "33.0.0-jre"')
+      end
+
+      it "preserves other dependencies" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('"org.typelevel" %% "cats-core" % "2.10.0"')
+        expect(updated_content).to include('"com.typesafe.akka" %% "akka-actor" % "2.8.5"')
+      end
+    end
+
+    context "with a cross-versioned dependency (%%)" do
+      let(:buildfile_fixture_name) { "basic_build.sbt" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.typelevel:cats-core_2.13",
+          version: "2.11.0",
+          requirements: [{
+            file: "build.sbt",
+            requirement: "2.11.0",
+            groups: [],
+            source: nil,
+            metadata: { packaging_type: "cross-versioned" }
+          }],
+          previous_requirements: [{
+            file: "build.sbt",
+            requirement: "2.10.0",
+            groups: [],
+            source: nil,
+            metadata: { packaging_type: "cross-versioned" }
+          }],
+          previous_version: "2.10.0",
+          package_manager: "sbt"
+        )
+      end
+
+      it "updates the cross-versioned dependency" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('"org.typelevel" %% "cats-core" % "2.11.0"')
+        expect(updated_content).not_to include('"org.typelevel" %% "cats-core" % "2.10.0"')
+      end
+    end
+
+    context "with a Seq-style dependency declaration" do
+      let(:buildfile_fixture_name) { "seq_build.sbt" }
+
+      it "updates the version in the Seq block" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('"com.google.guava" % "guava" % "33.1.0-jre"')
+        expect(updated_content).not_to include('"com.google.guava" % "guava" % "33.0.0-jre"')
+      end
+
+      it "preserves other Seq entries" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('"org.typelevel" %% "cats-core" % "2.10.0"')
+        expect(updated_content).to include('"com.typesafe.akka" %% "akka-actor" % "2.8.5"')
+      end
+    end
+
+    context "with a commented build file" do
+      let(:buildfile_fixture_name) { "commented_build.sbt" }
+
+      it "updates the real dependency, not the commented one" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('"com.google.guava" % "guava" % "33.1.0-jre"')
+        expect(updated_content).not_to include(
+          'libraryDependencies += "com.google.guava" % "guava" % "33.0.0-jre"'
+        )
+      end
+    end
+
+    context "with a multiproject build file" do
+      let(:buildfile_fixture_name) { "multiproject_build.sbt" }
+
+      it "updates all occurrences of the dependency" do
+        updated_content = updated_files.first.content
+        expect(updated_content.scan('"33.1.0-jre"').length).to eq(2)
+        expect(updated_content).not_to include('"33.0.0-jre"')
+      end
+    end
+
+    context "with a plugin dependency" do
+      let(:dependency_files) { [buildfile, plugins_file] }
+      let(:plugins_file) do
+        Dependabot::DependencyFile.new(
+          name: "project/plugins.sbt",
+          content: fixture("buildfiles", "plugins.sbt")
+        )
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "com.eed3si9n:sbt-assembly",
+          version: "2.2.0",
+          requirements: [{
+            file: "project/plugins.sbt",
+            requirement: "2.2.0",
+            groups: ["plugins"],
+            source: nil,
+            metadata: nil
+          }],
+          previous_requirements: [{
+            file: "project/plugins.sbt",
+            requirement: "2.1.5",
+            groups: ["plugins"],
+            source: nil,
+            metadata: nil
+          }],
+          previous_version: "2.1.5",
+          package_manager: "sbt"
+        )
+      end
+
+      it "updates the plugin version" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")')
+        expect(updated_content).not_to include('"2.1.5"')
+      end
+
+      it "preserves other plugins" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")')
+      end
+    end
+
+    context "with a val-based version" do
+      let(:buildfile_fixture_name) { "val_based_build.sbt" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.typelevel:cats-core_2.13",
+          version: "2.11.0",
+          requirements: [{
+            file: "build.sbt",
+            requirement: "2.11.0",
+            groups: [],
+            source: nil,
+            metadata: {
+              property_name: "catsVersion",
+              property_source: "build.sbt",
+              packaging_type: "cross-versioned"
+            }
+          }],
+          previous_requirements: [{
+            file: "build.sbt",
+            requirement: "2.10.0",
+            groups: [],
+            source: nil,
+            metadata: {
+              property_name: "catsVersion",
+              property_source: "build.sbt",
+              packaging_type: "cross-versioned"
+            }
+          }],
+          previous_version: "2.10.0",
+          package_manager: "sbt"
+        )
+      end
+
+      it "updates the val declaration" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('val catsVersion = "2.11.0"')
+        expect(updated_content).not_to include('val catsVersion = "2.10.0"')
+      end
+
+      it "does not change the dependency line referencing the val" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('"org.typelevel" %% "cats-core" % catsVersion')
+      end
+    end
+
+    context "with a val defined in a Scala file" do
+      let(:buildfile_fixture_name) { "scala_file_vals_build.sbt" }
+      let(:scala_file) do
+        Dependabot::DependencyFile.new(
+          name: "project/Dependencies.scala",
+          content: fixture("buildfiles", "project/Dependencies.scala"),
+          support_file: true
+        )
+      end
+      let(:dependency_files) { [buildfile, scala_file] }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.typelevel:cats-core_2.13",
+          version: "2.11.0",
+          requirements: [{
+            file: "build.sbt",
+            requirement: "2.11.0",
+            groups: [],
+            source: nil,
+            metadata: {
+              property_name: "catsVersion",
+              property_source: "project/Dependencies.scala",
+              packaging_type: "cross-versioned"
+            }
+          }],
+          previous_requirements: [{
+            file: "build.sbt",
+            requirement: "2.10.0",
+            groups: [],
+            source: nil,
+            metadata: {
+              property_name: "catsVersion",
+              property_source: "project/Dependencies.scala",
+              packaging_type: "cross-versioned"
+            }
+          }],
+          previous_version: "2.10.0",
+          package_manager: "sbt"
+        )
+      end
+
+      it "updates the val in the Scala file" do
+        scala_updated = updated_files.find { |f| f.name == "project/Dependencies.scala" }
+        expect(scala_updated).not_to be_nil
+        expect(scala_updated.content).to include('val catsVersion = "2.11.0"')
+        expect(scala_updated.content).not_to include('val catsVersion = "2.10.0"')
+      end
+    end
+
+    context "with an SBT version update in build.properties" do
+      let(:properties_file) do
+        Dependabot::DependencyFile.new(
+          name: "project/build.properties",
+          content: fixture("buildfiles", "build.properties")
+        )
+      end
+      let(:dependency_files) { [buildfile, properties_file] }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.scala-sbt:sbt",
+          version: "1.10.0",
+          requirements: [{
+            file: "project/build.properties",
+            requirement: "1.10.0",
+            groups: [],
+            source: nil,
+            metadata: { property_source: "build.properties" }
+          }],
+          previous_requirements: [{
+            file: "project/build.properties",
+            requirement: "1.9.8",
+            groups: [],
+            source: nil,
+            metadata: { property_source: "build.properties" }
+          }],
+          previous_version: "1.9.8",
+          package_manager: "sbt"
+        )
+      end
+
+      it "updates the SBT version in build.properties" do
+        properties_updated = updated_files.find { |f| f.name == "project/build.properties" }
+        expect(properties_updated).not_to be_nil
+        expect(properties_updated.content).to include("sbt.version=1.10.0")
+        expect(properties_updated.content).not_to include("sbt.version=1.9.8")
+      end
+    end
+
+    context "with a scalaVersion update" do
+      let(:buildfile_fixture_name) { "basic_build.sbt" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.scala-lang:scala-library",
+          version: "2.13.14",
+          requirements: [{
+            file: "build.sbt",
+            requirement: "2.13.14",
+            groups: [],
+            source: nil,
+            metadata: { property_source: "scalaVersion" }
+          }],
+          previous_requirements: [{
+            file: "build.sbt",
+            requirement: "2.13.12",
+            groups: [],
+            source: nil,
+            metadata: { property_source: "scalaVersion" }
+          }],
+          previous_version: "2.13.12",
+          package_manager: "sbt"
+        )
+      end
+
+      it "updates the scalaVersion declaration" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('scalaVersion := "2.13.14"')
+        expect(updated_content).not_to include('scalaVersion := "2.13.12"')
+      end
+    end
+
+    context "with a Scala 3 ThisBuild scalaVersion update" do
+      let(:buildfile_fixture_name) { "scala3_build.sbt" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.scala-lang:scala3-library_3",
+          version: "3.4.0",
+          requirements: [{
+            file: "build.sbt",
+            requirement: "3.4.0",
+            groups: [],
+            source: nil,
+            metadata: { property_source: "scalaVersion" }
+          }],
+          previous_requirements: [{
+            file: "build.sbt",
+            requirement: "3.3.1",
+            groups: [],
+            source: nil,
+            metadata: { property_source: "scalaVersion" }
+          }],
+          previous_version: "3.3.1",
+          package_manager: "sbt"
+        )
+      end
+
+      it "updates the ThisBuild scalaVersion declaration" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('ThisBuild / scalaVersion := "3.4.0"')
+        expect(updated_content).not_to include('ThisBuild / scalaVersion := "3.3.1"')
+      end
+    end
+
+    context "with scalaVersion in ThisBuild (older syntax)" do
+      let(:buildfile_fixture_name) { "in_this_build.sbt" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.scala-lang:scala-library",
+          version: "2.12.19",
+          requirements: [{
+            file: "build.sbt",
+            requirement: "2.12.19",
+            groups: [],
+            source: nil,
+            metadata: { property_source: "scalaVersion" }
+          }],
+          previous_requirements: [{
+            file: "build.sbt",
+            requirement: "2.12.18",
+            groups: [],
+            source: nil,
+            metadata: { property_source: "scalaVersion" }
+          }],
+          previous_version: "2.12.18",
+          package_manager: "sbt"
+        )
+      end
+
+      it "updates the scalaVersion in ThisBuild declaration" do
+        updated_content = updated_files.first.content
+        expect(updated_content).to include('scalaVersion in ThisBuild := "2.12.19"')
+        expect(updated_content).not_to include('scalaVersion in ThisBuild := "2.12.18"')
+      end
+    end
+
+    context "with a val-based plugin version" do
+      let(:dependency_files) { [buildfile, plugins_file] }
+      let(:plugins_file) do
+        Dependabot::DependencyFile.new(
+          name: "project/plugins.sbt",
+          content: fixture("buildfiles", "val_plugins.sbt")
+        )
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "com.eed3si9n:sbt-assembly",
+          version: "2.2.0",
+          requirements: [{
+            file: "project/plugins.sbt",
+            requirement: "2.2.0",
+            groups: ["plugins"],
+            source: nil,
+            metadata: {
+              property_name: "pluginVersion",
+              property_source: "project/plugins.sbt"
+            }
+          }],
+          previous_requirements: [{
+            file: "project/plugins.sbt",
+            requirement: "2.1.5",
+            groups: ["plugins"],
+            source: nil,
+            metadata: {
+              property_name: "pluginVersion",
+              property_source: "project/plugins.sbt"
+            }
+          }],
+          previous_version: "2.1.5",
+          package_manager: "sbt"
+        )
+      end
+
+      it "updates the val declaration for the plugin version" do
+        plugins_updated = updated_files.find { |f| f.name == "project/plugins.sbt" }
+        expect(plugins_updated).not_to be_nil
+        expect(plugins_updated.content).to include('val pluginVersion = "2.2.0"')
+        expect(plugins_updated.content).not_to include('val pluginVersion = "2.1.5"')
+      end
+    end
+
+    context "when no files change" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "com.google.guava:guava",
+          version: "33.0.0-jre",
+          requirements: [{
+            file: "build.sbt",
+            requirement: "33.0.0-jre",
+            groups: [],
+            source: nil,
+            metadata: nil
+          }],
+          previous_requirements: [{
+            file: "build.sbt",
+            requirement: "33.0.0-jre",
+            groups: [],
+            source: nil,
+            metadata: nil
+          }],
+          previous_version: "33.0.0-jre",
+          package_manager: "sbt"
+        )
+      end
+
+      it "raises an error" do
+        expect { updated_files }.to raise_error("No files changed!")
+      end
+    end
+  end
 end

--- a/sbt/spec/fixtures/buildfiles/dotted_val_build.sbt
+++ b/sbt/spec/fixtures/buildfiles/dotted_val_build.sbt
@@ -1,0 +1,8 @@
+val V = BuildInfo
+
+scalaVersion in ThisBuild := V.scala212
+
+libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "cats" % "0.9.0"
+)

--- a/sbt/spec/fixtures/buildfiles/in_this_build.sbt
+++ b/sbt/spec/fixtures/buildfiles/in_this_build.sbt
@@ -1,0 +1,5 @@
+scalaVersion in ThisBuild := "2.12.18"
+
+libraryDependencies ++= Seq(
+  "org.typelevel" %% "cats" % "0.9.0"
+)

--- a/sbt/spec/fixtures/buildfiles/multiproject_build.sbt
+++ b/sbt/spec/fixtures/buildfiles/multiproject_build.sbt
@@ -1,0 +1,11 @@
+scalaVersion := "2.13.12"
+
+libraryDependencies += "org.typelevel" %% "cats-core" % "2.10.0"
+libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.8.5"
+libraryDependencies += "com.google.guava" % "guava" % "33.0.0-jre"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+
+lazy val subproject = (project in file("sub"))
+  .settings(
+    libraryDependencies += "com.google.guava" % "guava" % "33.0.0-jre"
+  )

--- a/sbt/spec/fixtures/buildfiles/project/BuildInfo.scala
+++ b/sbt/spec/fixtures/buildfiles/project/BuildInfo.scala
@@ -1,0 +1,6 @@
+import sbt._
+
+object BuildInfo {
+  val scala212 = "2.12.18"
+  val scalafixVersion = "0.9.34"
+}

--- a/sbt/spec/fixtures/buildfiles/val_plugins.sbt
+++ b/sbt/spec/fixtures/buildfiles/val_plugins.sbt
@@ -1,0 +1,4 @@
+val pluginVersion = "2.1.5"
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % pluginVersion)
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
### What are you trying to accomplish?
This PR implements the SBT `FileUpdater` — responsible for rewriting version strings in SBT build files when Dependabot proposes a dependency update. It also fixes some issues where the `FileParser` was incorrectly resolving Scala cross-version suffixes when `scalaVersion` was declared using the older `scalaVersion in ThisBuild :=` syntax or via dotted val references like `V.scala212`. This caused dependencies to be looked up under `_2.13` (the default fallback) instead of their actual Scala version, leading to 404s on Maven Central and silent update failures. 

The `SharedPropertyValueUpdater` base class is created for the text-based "find a quoted val declaration and replace the version string" pattern, which was duplicated identically between Gradle and SBT. Gradle's existing `PropertyValueUpdater` now inherits from this shared base.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
The shared `SharedPropertyValueUpdater` lives in `maven/shared/` alongside the other shared classes (`SharedVersionFinder`, `SharedMetadataFinder`, etc.). Maven's own `PropertyValueUpdater` is XML-based (uses REXML) and intentionally does **not** inherit from this class — the shared base is specifically for text/regex-based ecosystems (Gradle, SBT).

The `dotted_property_details` method in `PropertyValueFinder` uses a simple regex to find `val member = "..."` inside `object Object { ... }` blocks. This works for locally-defined Scala objects but cannot resolve references to externally-generated code (e.g. `_root_.scalafix.sbt.BuildInfo` produced by `sbt-buildinfo` at compile time). This is an inherent limitation of static regex-based parsing and matches the approach taken by the Gradle ecosystem.

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- Comprehensive specs cover all SBT dependency declaration patterns: literal versions, `Seq(...)` blocks, cross-versioned `%%` deps, `addSbtPlugin`, val-based versions (including vals in `project/*.scala` files), `build.properties` SBT version, `scalaVersion` / `ThisBuild / scalaVersion` / `scalaVersion in ThisBuild`, and multi-occurrence updates.
- Dry-run against test repositories successfully detects and generates correct diffs for updates.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
