### PR TITLE
Handle pubspec validation errors gracefully

### DIFF
--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -295,7 +295,7 @@ module Dependabot
 
       sig { params(stderr: String).returns(T.noreturn) }
       def raise_error(stderr)
-        if stderr.include?("Failed parsing lock file") || stderr.include?("Unsupported operation")
+        if stderr.match?(/Failed parsing lock file|Unsupported operation|Duplicate mapping key|doesn't match expected name/) # rubocop:disable Layout/LineLength
           raise DependencyFileNotEvaluatable, "dependency_services failed: #{stderr}"
         elsif stderr.include?("Git error")
           raise Dependabot::InvalidGitAuthToken, "dependency_services failed: #{stderr}"

--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -295,7 +295,7 @@ module Dependabot
 
       sig { params(stderr: String).returns(T.noreturn) }
       def raise_error(stderr)
-        if stderr.match?(/Failed parsing lock file|Unsupported operation|Duplicate mapping key|doesn't match expected name/) # rubocop:disable Layout/LineLength
+        if stderr.match?(/Failed parsing lock file|Unsupported operation|Duplicate mapping key|"name" field/)
           raise DependencyFileNotEvaluatable, "dependency_services failed: #{stderr}"
         elsif stderr.include?("Git error")
           raise Dependabot::InvalidGitAuthToken, "dependency_services failed: #{stderr}"

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -825,6 +825,24 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         expect { checker.latest_version }.to raise_error(Dependabot::DependencyFileNotResolvable)
       end
     end
+
+    context "when pubspec.yaml has duplicate mapping keys" do
+      let(:stderr) { "Error on line 39, column 3 of pubspec.yaml: Duplicate mapping key." }
+
+      it "raises the correct error" do
+        expect { checker.latest_version }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
+      end
+    end
+
+    context "when pubspec.yaml name doesn't match expected name" do
+      let(:stderr) do
+        "Error on line 1, column 7: \"name\" field doesn't match expected name \"flutter_shortcuts\"."
+      end
+
+      it "raises the correct error" do
+        expect { checker.latest_version }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
+      end
+    end
   end
 
   context "with a git dependency" do

--- a/pub/spec/dependabot/pub/update_checker_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker_spec.rb
@@ -843,6 +843,16 @@ RSpec.describe Dependabot::Pub::UpdateChecker do
         expect { checker.latest_version }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
       end
     end
+
+    context "when pubspec.yaml name field is not a string" do
+      let(:stderr) do
+        "Error on line 1, column 7 of pubspec.yaml: \"name\" field must be a String."
+      end
+
+      it "raises the correct error" do
+        expect { checker.latest_version }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
+      end
+    end
   end
 
   context "with a git dependency" do


### PR DESCRIPTION
### What are you trying to accomplish?
Several user-facing `dependency_services` errors in the `pub` ecosystem were falling through to the generic `Dependabot::DependabotError` handler, causing unnecessary Sentry noise. These errors are caused by invalid user repository configurations, not internal failures:
1. **Duplicate mapping keys** — `Duplicate mapping key` in `pubspec.yaml`
2. **Package name mismatch** — `"name" field doesn't match expected name`

**Fix:**
Updated the `raise_error` method in `Dependabot::Pub::Helpers` to classify these errors appropriately:
- Pubspec validation errors → `DependencyFileNotEvaluatable`
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
**Changes:**
- **`pub/lib/dependabot/pub/helpers.rb`** — Added error pattern matching for pubspec validation failures
- **`pub/spec/dependabot/pub/update_checker_spec.rb`** — Added test cases for all new error scenarios
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
If the pubspec validation sentry error is fixed.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
