### PR TITLE
fix: do not cache EOF-backed Excon socket errors in RegistryClient

### DIFF
--- a/common/lib/dependabot/registry_client.rb
+++ b/common/lib/dependabot/registry_client.rb
@@ -36,7 +36,7 @@ module Dependabot
         retry_interval: 5
       )
     rescue Excon::Error::Timeout, Excon::Error::Socket => e
-      cache_error(url, e)
+      cache_error(url, e) if cacheable_error?(e)
       raise e
     end
 
@@ -57,7 +57,7 @@ module Dependabot
         **SharedHelpers.excon_defaults({ headers: headers }.merge(options))
       )
     rescue Excon::Error::Timeout, Excon::Error::Socket => e
-      cache_error(url, e)
+      cache_error(url, e) if cacheable_error?(e)
       raise e
     end
 
@@ -76,6 +76,18 @@ module Dependabot
     private_class_method def self.cached_error_for(url)
       host = URI(url).host
       @cached_errors.fetch(host, nil)
+    end
+
+    sig { params(error: CachedErrorType).returns(T::Boolean) }
+    private_class_method def self.cacheable_error?(error)
+      if error.is_a?(Excon::Error::Socket)
+        case error.socket_error
+        when EOFError
+          return false
+        end
+      end
+
+      true
     end
   end
 end

--- a/common/spec/dependabot/registry_client_spec.rb
+++ b/common/spec/dependabot/registry_client_spec.rb
@@ -157,11 +157,12 @@ RSpec.describe Dependabot::RegistryClient do
 
   describe "exception caching" do
     let(:unreachable_url) { "https://example.local" }
+    let(:escaped_unreachable_url) { Regexp.escape(unreachable_url) }
 
     before do
       described_class.clear_cache!
-      allow(Excon).to receive(:get).with(/#{unreachable_url}/, anything).and_raise(error)
-      allow(Excon).to receive(:head).with(/#{unreachable_url}/, anything).and_raise(error)
+      allow(Excon).to receive(:get).with(/#{escaped_unreachable_url}/, anything).and_raise(error)
+      allow(Excon).to receive(:head).with(/#{escaped_unreachable_url}/, anything).and_raise(error)
     end
 
     describe "when Excon times out internally" do
@@ -189,7 +190,7 @@ RSpec.describe Dependabot::RegistryClient do
         let(:error) { Excon::Error::Socket.new(EOFError.new) }
 
         it "does not cache get failures" do
-          expect(Excon).to receive(:get).with(/#{unreachable_url}/, anything).exactly(3).times
+          expect(Excon).to receive(:get).with(/#{escaped_unreachable_url}/, anything).exactly(3).times
 
           expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
           expect { described_class.get(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error::Socket)
@@ -197,7 +198,7 @@ RSpec.describe Dependabot::RegistryClient do
         end
 
         it "does not cache head failures" do
-          expect(Excon).to receive(:head).with(/#{unreachable_url}/, anything).exactly(3).times
+          expect(Excon).to receive(:head).with(/#{escaped_unreachable_url}/, anything).exactly(3).times
 
           expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
           expect { described_class.head(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error::Socket)
@@ -250,7 +251,7 @@ RSpec.describe Dependabot::RegistryClient do
           let(:error) { error_class.new(error_message) }
 
           it "does not cache anything" do
-            expect(Excon).to receive(:get).with(/#{unreachable_url}/, anything)
+            expect(Excon).to receive(:get).with(/#{escaped_unreachable_url}/, anything)
 
             expect { described_class.get(url: unreachable_url) }.to raise_error(error_class)
             expect { described_class.get(url: "#{unreachable_url}/foos") }.to raise_error(error_class)
@@ -264,7 +265,7 @@ RSpec.describe Dependabot::RegistryClient do
       let(:error) { Excon::Error.new("Boom!") }
 
       it "does not cache anything" do
-        expect(Excon).to receive(:get).with(/#{unreachable_url}/, anything)
+        expect(Excon).to receive(:get).with(/#{escaped_unreachable_url}/, anything)
 
         expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error)
         expect { described_class.get(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error)

--- a/common/spec/dependabot/registry_client_spec.rb
+++ b/common/spec/dependabot/registry_client_spec.rb
@@ -185,38 +185,60 @@ RSpec.describe Dependabot::RegistryClient do
     end
 
     describe "when Excon encounters a socket error" do
-      let(:error) { Excon::Error::Socket.new(EOFError.new) }
+      context "with EOFError" do
+        let(:error) { Excon::Error::Socket.new(EOFError.new) }
 
-      it "only attempts to reach it once via get and then plays back the first error" do
-        expect(Excon).to receive(:get).with(unreachable_url, anything).once
+        it "does not cache get failures" do
+          expect(Excon).to receive(:get).with(/#{unreachable_url}/, anything).exactly(3).times
 
-        expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
-        expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
-        expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+          expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+          expect { described_class.get(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error::Socket)
+          expect { described_class.get(url: "#{unreachable_url}/foos/bars") }.to raise_error(Excon::Error::Socket)
+        end
+
+        it "does not cache head failures" do
+          expect(Excon).to receive(:head).with(/#{unreachable_url}/, anything).exactly(3).times
+
+          expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+          expect { described_class.head(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error::Socket)
+          expect { described_class.head(url: "#{unreachable_url}/foos/bars") }.to raise_error(Excon::Error::Socket)
+        end
       end
 
-      it "replays the first get error for the host on any request path" do
-        expect(Excon).to receive(:get).with(unreachable_url, anything).once
+      context "with non-EOF socket errors" do
+        let(:error) { Excon::Error::Socket.new(SocketError.new("getaddrinfo failed")) }
 
-        expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
-        expect { described_class.get(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error::Socket)
-        expect { described_class.get(url: "#{unreachable_url}/foos/bars") }.to raise_error(Excon::Error::Socket)
-      end
+        it "only attempts to reach it once via get and then plays back the first error" do
+          expect(Excon).to receive(:get).with(unreachable_url, anything).once
 
-      it "only attempts to reach it once via head and then plays back the first error" do
-        expect(Excon).to receive(:head).with(unreachable_url, anything).once
+          expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+          expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+          expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+        end
 
-        expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
-        expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
-        expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
-      end
+        it "replays the first get error for the host on any request path" do
+          expect(Excon).to receive(:get).with(unreachable_url, anything).once
 
-      it "replays the first head error for the host on any request path" do
-        expect(Excon).to receive(:head).with(unreachable_url, anything).once
+          expect { described_class.get(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+          expect { described_class.get(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error::Socket)
+          expect { described_class.get(url: "#{unreachable_url}/foos/bars") }.to raise_error(Excon::Error::Socket)
+        end
 
-        expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
-        expect { described_class.head(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error::Socket)
-        expect { described_class.head(url: "#{unreachable_url}/foos/bars") }.to raise_error(Excon::Error::Socket)
+        it "only attempts to reach it once via head and then plays back the first error" do
+          expect(Excon).to receive(:head).with(unreachable_url, anything).once
+
+          expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+          expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+          expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+        end
+
+        it "replays the first head error for the host on any request path" do
+          expect(Excon).to receive(:head).with(unreachable_url, anything).once
+
+          expect { described_class.head(url: unreachable_url) }.to raise_error(Excon::Error::Socket)
+          expect { described_class.head(url: "#{unreachable_url}/foos") }.to raise_error(Excon::Error::Socket)
+          expect { described_class.head(url: "#{unreachable_url}/foos/bars") }.to raise_error(Excon::Error::Socket)
+        end
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

This change improves resilience of dependency update jobs when registry requests fail intermittently with `Excon::Error::Socket` caused by `EOFError`.

The goal is to prevent transient network hiccups from being treated as permanently unreachable hosts during a run. Previously, these EOF-backed socket errors were cached and replayed for the host, which could cause follow-up requests to fail immediately and abort otherwise recoverable update flows.

The approach keeps the existing fast-fail behavior for genuinely persistent connectivity failures (timeouts and non-EOF socket errors), but treats EOF socket failures as non-cacheable so subsequent requests can still proceed and recover naturally. Tests were updated to enforce this distinction and protect against regressions.


### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

Success is demonstrated by behavior-focused tests and local verification:
- The shared RegistryClient spec suite passes with assertions that EOF-backed socket errors are not cached, so repeated requests still attempt network calls instead of immediately replaying a cached failure.
- The same suite still proves that non-EOF socket errors and timeouts remain cached, preserving existing fast-fail behavior for persistently unreachable hosts.
- Sorbet type checking passes, confirming the new error classification logic is valid under current typing constraints.
- The practical outcome is that transient EOF failures no longer poison subsequent requests in the same run, which directly addresses the observed updater failure mode.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
