### PR TITLE
[bun] respect frozenLockfile = true projects by passing --no-frozen-l…

### DIFF
--- a/bun/lib/dependabot/bun/file_updater/bun_lockfile_updater.rb
+++ b/bun/lib/dependabot/bun/file_updater/bun_lockfile_updater.rb
@@ -93,15 +93,15 @@ module Dependabot
           end.join(" ")
 
           Helpers.run_bun_command(
-            "install #{dependency_updates} --save-text-lockfile --ignore-scripts",
-            fingerprint: "install <dependency_updates> --save-text-lockfile --ignore-scripts"
+            "install #{dependency_updates} --save-text-lockfile --ignore-scripts --no-frozen-lockfile",
+            fingerprint: "install <dependency_updates> --save-text-lockfile --ignore-scripts --no-frozen-lockfile"
           )
         end
 
         sig { void }
         def run_bun_install
           Helpers.run_bun_command(
-            "install --save-text-lockfile --ignore-scripts"
+            "install --save-text-lockfile --ignore-scripts --no-frozen-lockfile"
           )
         end
 

--- a/bun/spec/dependabot/bun/file_updater_spec.rb
+++ b/bun/spec/dependabot/bun/file_updater_spec.rb
@@ -182,19 +182,71 @@ RSpec.describe Dependabot::Bun::FileUpdater do
             .to include("etag@1.2.0")
         end
 
-        it "runs bun install commands with --ignore-scripts" do
+        it "runs bun install commands with --ignore-scripts and --no-frozen-lockfile" do
           allow(Dependabot::Bun::Helpers).to receive(:run_bun_command).and_call_original
 
           updated_files
 
           expect(Dependabot::Bun::Helpers).to have_received(:run_bun_command).with(
-            a_string_matching(/^install .+ --save-text-lockfile --ignore-scripts$/),
-            fingerprint: "install <dependency_updates> --save-text-lockfile --ignore-scripts"
+            a_string_matching(/^install .+ --save-text-lockfile --ignore-scripts --no-frozen-lockfile$/),
+            fingerprint: "install <dependency_updates> --save-text-lockfile --ignore-scripts --no-frozen-lockfile"
           )
           expect(Dependabot::Bun::Helpers).to have_received(:run_bun_command).with(
-            "install --save-text-lockfile --ignore-scripts"
+            "install --save-text-lockfile --ignore-scripts --no-frozen-lockfile"
           )
         end
+      end
+    end
+
+    context "with a bunfig.toml that sets frozenLockfile = true" do
+      let(:files) { project_dependency_files("bun/frozen_lockfile") }
+      let(:repo_contents_path) { build_tmp_repo("bun/frozen_lockfile", path: "projects") }
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "etag",
+            version: "1.2.0",
+            previous_version: "1.0.1",
+            requirements: [{
+              file: "package.json",
+              requirement: "^1.0.1",
+              groups: ["dependencies"],
+              source: nil
+            }],
+            previous_requirements: [{
+              file: "package.json",
+              requirement: "^1.0.1",
+              groups: ["dependencies"],
+              source: nil
+            }],
+            package_manager: "bun"
+          ),
+          Dependabot::Dependency.new(
+            name: "is-number",
+            version: "2.1.0",
+            previous_version: "2.0.0",
+            requirements: [{
+              file: "package.json",
+              requirement: "^2.0.0",
+              groups: ["dependencies"],
+              source: nil
+            }],
+            previous_requirements: [{
+              file: "package.json",
+              requirement: "^2.0.0",
+              groups: ["dependencies"],
+              source: nil
+            }],
+            package_manager: "bun"
+          )
+        ]
+      end
+
+      it "still updates the lockfile despite the frozen guard" do
+        expect { updated_files }.not_to raise_error
+        expect(updated_files.map(&:name)).to match_array(%w(bun.lock))
+        expect(updated_bun_lock.content).to include("etag@1.2.0")
+        expect(updated_bun_lock.content).to include("is-number@2.1.0")
       end
     end
 

--- a/bun/spec/fixtures/projects/bun/frozen_lockfile/bun.lock
+++ b/bun/spec/fixtures/projects/bun/frozen_lockfile/bun.lock
@@ -1,0 +1,39 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "example",
+      "dependencies": {
+        "etag": "^1.0.1",
+        "is-number": "^2.0.0"
+      },
+      "devDependencies": {
+        "@types/bun": "latest"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      }
+    }
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
+
+    "@types/node": ["@types/node@22.13.1", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew=="],
+
+    "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+
+    "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
+
+    "is-number": ["is-number@2.1.0", "", { "dependencies": { "kind-of": "^3.0.2" } }, "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg=="],
+
+    "kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
+
+    "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+
+    "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="]
+  }
+}

--- a/bun/spec/fixtures/projects/bun/frozen_lockfile/bunfig.toml
+++ b/bun/spec/fixtures/projects/bun/frozen_lockfile/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+frozenLockfile = true

--- a/bun/spec/fixtures/projects/bun/frozen_lockfile/package.json
+++ b/bun/spec/fixtures/projects/bun/frozen_lockfile/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+      "url": "https://github.com/waltfy/PROTO_TEST/issues"
+  },
+  "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+  "dependencies": {
+      "etag": "^1.0.1",
+      "is-number": "^2.0.0"
+  }
+}


### PR DESCRIPTION
…ockfile

When a project's `bunfig.toml` sets `[install].frozenLockfile = true`, bun refuses to mutate the lockfile on any `bun install`, even with `--save-text-lockfile`. Every Dependabot bun-ecosystem job in such a repo currently fails with:

    error: lockfile had changes, but lockfile is frozen
    note: try re-running without --frozen-lockfile and commit the updated lockfile

`frozenLockfile = true` is the bun-recommended supply-chain hardening pattern (defense against postinstall attacks like TanStack GHSA-g7cv-rxg3-hmpx, May 2026), so security-conscious users hit this on their first Dependabot run. There is no workaround besides removing the guard.

The updater's two `bun install` invocations are the only callsites whose purpose is to mutate the lockfile. Pass `--no-frozen-lockfile` explicitly on both so they override any project-level frozen guard, and update the spec that pins the command strings to match.

