### PR TITLE
npm_and_yarn: handle pnpm no-change lockfile updates

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -230,8 +230,8 @@ module Dependabot
               original_content = File.read(lockfile_name)
 
               Helpers.run_pnpm_command(
-                pnpm_update_command,
-                fingerprint: pnpm_update_fingerprint
+                "update #{dependency.name} --lockfile-only",
+                fingerprint: "update <dependency_name> --lockfile-only"
               )
 
               updated_content = File.read(lockfile_name)
@@ -248,16 +248,6 @@ module Dependabot
               { lockfile_name => updated_content }
             end
           end
-        end
-
-        sig { returns(String) }
-        def pnpm_update_command
-          "update #{dependency.name}@#{dependency.version} --lockfile-only --no-save -r"
-        end
-
-        sig { returns(String) }
-        def pnpm_update_fingerprint
-          "update <dependency_name>@<dependency_version> --lockfile-only --no-save -r"
         end
 
         # First-tier fallback: try `pnpm update --depth Infinity <dep>` to

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -252,12 +252,20 @@ module Dependabot
 
         sig { returns(String) }
         def pnpm_update_command
-          "update #{dependency.name}@#{dependency.version} --lockfile-only --no-save -r"
+          if latest_allowable_version
+            "update #{dependency.name}@#{latest_allowable_version} --lockfile-only --no-save -r"
+          else
+            "update #{dependency.name} --lockfile-only"
+          end
         end
 
         sig { returns(String) }
         def pnpm_update_fingerprint
-          "update <dependency_name>@<dependency_version> --lockfile-only --no-save -r"
+          if latest_allowable_version
+            "update <dependency_name>@<latest_allowable_version> --lockfile-only --no-save -r"
+          else
+            "update <dependency_name> --lockfile-only"
+          end
         end
 
         # First-tier fallback: try `pnpm update --depth Infinity <dep>` to

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -230,8 +230,8 @@ module Dependabot
               original_content = File.read(lockfile_name)
 
               Helpers.run_pnpm_command(
-                "update #{dependency.name} --lockfile-only",
-                fingerprint: "update <dependency_name> --lockfile-only"
+                pnpm_update_command,
+                fingerprint: pnpm_update_fingerprint
               )
 
               updated_content = File.read(lockfile_name)
@@ -248,6 +248,16 @@ module Dependabot
               { lockfile_name => updated_content }
             end
           end
+        end
+
+        sig { returns(String) }
+        def pnpm_update_command
+          "update #{dependency.name}@#{dependency.version} --lockfile-only --no-save -r"
+        end
+
+        sig { returns(String) }
+        def pnpm_update_fingerprint
+          "update <dependency_name>@<dependency_version> --lockfile-only --no-save -r"
         end
 
         # First-tier fallback: try `pnpm update --depth Infinity <dep>` to

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -198,6 +198,25 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       end
       let(:latest_allowable_version) { "3.10.2" }
 
+      it "uses the same pnpm update flags as the file updater" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).and_return("")
+        allow(Dependabot::NpmAndYarn::NativeHelpers)
+          .to receive_messages(run_pnpm_deep_update_command: "", run_pnpm_audit_fix_command: "")
+
+        expect(Dependabot::NpmAndYarn::Helpers)
+          .to receive(:run_pnpm_command)
+          .with(
+            "update lodash@3.10.1 --lockfile-only --no-save -r",
+            { fingerprint: "update <dependency_name>@<dependency_version> --lockfile-only --no-save -r" }
+          )
+        expect(Dependabot::NpmAndYarn::NativeHelpers)
+          .to receive(:run_pnpm_deep_update_command).once
+        expect(Dependabot::NpmAndYarn::NativeHelpers)
+          .to receive(:run_pnpm_audit_fix_command).once
+
+        latest_resolvable_version
+      end
+
       it "falls back to pnpm audit --fix when pnpm update is a no-op" do
         # Stub pnpm update to be a no-op (returns unchanged lockfile)
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).and_return("")

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       end
       let(:latest_allowable_version) { "3.10.2" }
 
-      it "uses the same pnpm update flags as the file updater" do
+      it "tries the pnpm update flow before its fallbacks" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).and_return("")
         allow(Dependabot::NpmAndYarn::NativeHelpers)
           .to receive_messages(run_pnpm_deep_update_command: "", run_pnpm_audit_fix_command: "")
@@ -206,8 +206,8 @@ RSpec.describe namespace::SubdependencyVersionResolver do
         expect(Dependabot::NpmAndYarn::Helpers)
           .to receive(:run_pnpm_command)
           .with(
-            "update lodash@3.10.1 --lockfile-only --no-save -r",
-            { fingerprint: "update <dependency_name>@<dependency_version> --lockfile-only --no-save -r" }
+            "update lodash --lockfile-only",
+            { fingerprint: "update <dependency_name> --lockfile-only" }
           )
         expect(Dependabot::NpmAndYarn::NativeHelpers)
           .to receive(:run_pnpm_deep_update_command).once

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       end
       let(:latest_allowable_version) { "3.10.2" }
 
-      it "uses the same pnpm update flags as the file updater" do
+      it "pins pnpm update to the latest allowable version" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).and_return("")
         allow(Dependabot::NpmAndYarn::NativeHelpers)
           .to receive_messages(run_pnpm_deep_update_command: "", run_pnpm_audit_fix_command: "")
@@ -206,8 +206,8 @@ RSpec.describe namespace::SubdependencyVersionResolver do
         expect(Dependabot::NpmAndYarn::Helpers)
           .to receive(:run_pnpm_command)
           .with(
-            "update lodash@3.10.1 --lockfile-only --no-save -r",
-            { fingerprint: "update <dependency_name>@<dependency_version> --lockfile-only --no-save -r" }
+            "update lodash@3.10.2 --lockfile-only --no-save -r",
+            { fingerprint: "update <dependency_name>@<latest_allowable_version> --lockfile-only --no-save -r" }
           )
         expect(Dependabot::NpmAndYarn::NativeHelpers)
           .to receive(:run_pnpm_deep_update_command).once

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       end
       let(:latest_allowable_version) { "3.10.2" }
 
-      it "tries the pnpm update flow before its fallbacks" do
+      it "uses the same pnpm update flags as the file updater" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).and_return("")
         allow(Dependabot::NpmAndYarn::NativeHelpers)
           .to receive_messages(run_pnpm_deep_update_command: "", run_pnpm_audit_fix_command: "")
@@ -206,8 +206,8 @@ RSpec.describe namespace::SubdependencyVersionResolver do
         expect(Dependabot::NpmAndYarn::Helpers)
           .to receive(:run_pnpm_command)
           .with(
-            "update lodash --lockfile-only",
-            { fingerprint: "update <dependency_name> --lockfile-only" }
+            "update lodash@3.10.1 --lockfile-only --no-save -r",
+            { fingerprint: "update <dependency_name>@<dependency_version> --lockfile-only --no-save -r" }
           )
         expect(Dependabot::NpmAndYarn::NativeHelpers)
           .to receive(:run_pnpm_deep_update_command).once


### PR DESCRIPTION
### What are you trying to accomplish?

This change fixes a false-positive `NoChangeError `when Dependabot updates pnpm-managed dependencies in cases where `pnpm update --lockfile-only` succeeds but does not rewrite the lockfile. That behavior can happen for valid dependency resolution flows, and treating it as a hard failure prevents Dependabot from completing updates it should consider successful.

The fix adjusts the pnpm update flow so we only treat the operation as failed when pnpm actually fails, rather than when the lockfile remains byte-for-byte unchanged after the command. This keeps Dependabot aligned with pnpm’s behavior while preserving the existing update flow for cases where a lockfile change is still expected.

### Anything you want to highlight for special attention from reviewers?

For reviewer context, the Sentry-reported error was successfully reproduced in [this workflow run](https://github.com/test-org-hari/pnpm-nochange-error-testing/actions/runs/25856827169/job/75976656356)
### How will you know you've accomplished your goal?

Before the fix, the reproduction fails with `No files were updated! Package manager: pnpm`, which bubbles up as an `unknown_error` for `@clerk/shared`.
```
updater | 2026/05/14 11:16:26 ERROR No files were updated! Package manager: pnpm
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:52:in 'Dependabot::NpmAndYarn::FileUpdater#updated_dependency_files'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater#_on_method_added'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:155:in 'Dependabot::DependencyChangeBuilder#generate_dependency_files'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::DependencyChangeBuilder#_on_method_added'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:74:in 'Dependabot::DependencyChangeBuilder#run'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::DependencyChangeBuilder#_on_method_added'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:44:in 'Dependabot::DependencyChangeBuilder.create_from'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::DependencyChangeBuilder._on_method_added'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:175:in 'Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#check_and_create_pull_request'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#_on_method_added'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:98:in 'Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#check_and_create_pr_with_error_handling'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#_on_method_added'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:71:in 'block in Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#perform'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:71:in 'Array#each'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:71:in 'Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#perform'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#_on_method_added'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:56:in 'Dependabot::Updater#run'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater#_on_method_added'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:53:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
updater | 2026/05/14 11:16:26 ERROR /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
updater | 2026/05/14 11:16:26 ERROR bin/update_files.rb:48:in '<main>'
  proxy | 2026/05/14 11:16:26 [768] POST http://host.docker.internal:36461/update_jobs/cli/record_ecosystem_meta
{"data":[{"ecosystem":{"name":"npm_and_yarn","package_manager":{"name":"pnpm","version":"10.16.0","raw_version":"10.16.0"},"language":{"name":"node","version":"24.15.0","raw_version":"24.15.0"}}}],"type":"record_ecosystem_meta"}
  proxy | 2026/05/14 11:16:26 [768] 200 http://host.docker.internal:36461/update_jobs/cli/record_ecosystem_meta
  proxy | 2026/05/14 11:16:26 [769] PATCH http://host.docker.internal:36461/update_jobs/cli/mark_as_processed
{"data":{"base-commit-sha":"a1e0908afc7f91ae4ca92ace7330019dfb4fd97b"},"type":"mark_as_processed"}
  proxy | 2026/05/14 11:16:26 [769] 200 http://host.docker.internal:36461/update_jobs/cli/mark_as_processed
updater | 2026/05/14 11:16:26 INFO Finished job processing
updater | 2026/05/14 11:16:26 INFO Results:
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +-----------------------------------------------+
updater | |         Dependencies failed to update         |
updater | +---------------+---------------+---------------+
updater | | Dependency    | Error Type    | Error Details |
updater | +---------------+---------------+---------------+
updater | | @clerk/shared | unknown_error | null          |
updater | +---------------+---------------+---------------+
```

**After the fix**, the same reproduction should no longer raise `Dependabot::NpmAndYarn::FileUpdater::NoChangeError`, and the update should proceed without hitting that false no-change failure
```
updater | +-----------------------------------------------------------------------------+
updater | |                                   Errors                                    |
updater | +------------------------------+----------------------------------------------+
updater | | Type                         | Details                                      |
updater | +------------------------------+----------------------------------------------+
updater | | security_update_not_possible | {                                            |
updater | |                              |   "dependency-name": "@clerk/shared",        |
updater | |                              |   "latest-resolvable-version": "3.23.0",     |
updater | |                              |   "lowest-non-vulnerable-version": "3.47.5", |
updater | |                              |   "conflicting-dependencies": []             |
updater | |                              | }                                            |
updater | +------------------------------+----------------------------------------------+
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
