### PR TITLE
fix(npm_and_yarn): avoid pnpm grouped security no-op updates causing NoChangeError

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -80,6 +80,12 @@ module Dependabot
               updated_lockfile
             end
 
+            # If every targeted lockfile remained byte-identical after running
+            # update + fallbacks, treat this as not resolvable. Returning a
+            # synthetic higher version here can cause FileUpdater to no-op and
+            # raise NoChangeError later in grouped security updates.
+            return nil unless lockfiles_changed?(updated_lockfiles)
+
             version_from_updated_lockfiles(updated_lockfiles)
           end
         rescue SharedHelpers::HelperSubprocessFailed
@@ -377,6 +383,14 @@ module Dependabot
             ).files_requiring_update,
             T.nilable(T::Array[Dependabot::DependencyFile])
           )
+        end
+
+        sig { params(updated_lockfiles: T::Array[Dependabot::DependencyFile]).returns(T::Boolean) }
+        def lockfiles_changed?(updated_lockfiles)
+          filtered_lockfiles.any? do |original|
+            updated = updated_lockfiles.find { |file| file.name == original.name }
+            updated && updated.content != original.content
+          end
         end
 
         sig { returns(Dependabot::NpmAndYarn::UpdateChecker::DependencyFilesBuilder) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -815,8 +815,8 @@ module Dependabot
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
               output = Helpers.run_pnpm_command(
-                "update #{dependency.name}@#{version} --lockfile-only",
-                fingerprint: "update <dependency_name>@<version> --lockfile-only"
+                "update #{dependency.name}@#{version} --lockfile-only --no-save -r",
+                fingerprint: "update <dependency_name>@<version> --lockfile-only --no-save -r"
               )
               if PNPM_PEER_DEP_ERROR_REGEX.match?(output)
                 raise SharedHelpers::HelperSubprocessFailed.new(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -243,9 +243,7 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       end
 
       it "returns nil when lockfiles are unchanged after update and fallbacks" do
-        allow(resolver).to receive(:update_subdependency_in_lockfile) do |lockfile|
-          lockfile.content
-        end
+        allow(resolver).to receive(:update_subdependency_in_lockfile) { |lockfile| lockfile.content }
 
         expect(resolver).not_to receive(:version_from_updated_lockfiles)
         expect(latest_resolvable_version).to be_nil

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -242,6 +242,15 @@ RSpec.describe namespace::SubdependencyVersionResolver do
         latest_resolvable_version
       end
 
+      it "returns nil when lockfiles are unchanged after update and fallbacks" do
+        allow(resolver).to receive(:update_subdependency_in_lockfile) do |lockfile|
+          lockfile.content
+        end
+
+        expect(resolver).not_to receive(:version_from_updated_lockfiles)
+        expect(latest_resolvable_version).to be_nil
+      end
+
       context "when pnpm audit --fix fails" do
         it "logs and continues without raising" do
           allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).and_return("")

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe namespace::SubdependencyVersionResolver do
       end
 
       it "returns nil when lockfiles are unchanged after update and fallbacks" do
-        allow(resolver).to receive(:update_subdependency_in_lockfile) { |lockfile| lockfile.content }
+        allow(resolver).to receive(:update_subdependency_in_lockfile, &:content)
 
         expect(resolver).not_to receive(:version_from_updated_lockfiles)
         expect(latest_resolvable_version).to be_nil

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -1038,14 +1038,16 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
         it "uses pnpm no-save recursive flags while checking resolvability" do
           allow(Dependabot::SharedHelpers).to receive(:with_git_configured).and_yield
           allow(Dir).to receive(:chdir).and_call_original
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).and_return("")
+
           expect(Dir).to receive(:chdir).with(".").and_yield
 
-          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).with(
+          resolver.send(:run_pnpm_checker, path: ".", version: latest_allowable_version)
+
+          expect(Dependabot::NpmAndYarn::Helpers).to have_received(:run_pnpm_command).with(
             "update left-pad@1.3.0 --lockfile-only --no-save -r",
             fingerprint: "update <dependency_name>@<version> --lockfile-only --no-save -r"
-          ).and_return("")
-
-          resolver.send(:run_pnpm_checker, path: ".", version: latest_allowable_version)
+          )
         end
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -1034,6 +1034,19 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
         end
 
         it { is_expected.to eq(latest_allowable_version) }
+
+        it "uses pnpm no-save recursive flags while checking resolvability" do
+          allow(Dependabot::SharedHelpers).to receive(:with_git_configured).and_yield
+          allow(Dir).to receive(:chdir).and_call_original
+          expect(Dir).to receive(:chdir).with(".").and_yield
+
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command).with(
+            "update left-pad@1.3.0 --lockfile-only --no-save -r",
+            fingerprint: "update <dependency_name>@<version> --lockfile-only --no-save -r"
+          ).and_return("")
+
+          resolver.send(:run_pnpm_checker, path: ".", version: latest_allowable_version)
+        end
       end
 
       describe "updating a dependency with a peer requirement" do


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes a pnpm grouped security update path where Dependabot could report a subdependency as updatable even when pnpm produced no lasting lockfile change, leading to a later NoChangeError in the file updater. The change brings the checker and updater behavior into closer alignment and treats unchanged lockfiles as “no update possible,” so grouped security runs fail less noisily and reflect pnpm’s real outcome more accurately.

### Anything you want to highlight for special attention from reviewers?

- before: checker said “yes, resolvable” even when pnpm had produced no durable diff
- now: checker says “no, not resolvable” if the update flow results in unchanged lockfiles


### How will you know you've accomplished your goal?

The fix is validated by reproducing the failure from [this workflow](https://github.com/theopensystemslab/planx-new/actions/runs/25870422179/job/76023884050) and confirming the grouped pnpm security update no longer reaches FileUpdater with a false-positive update candidate:


Before this change, the `UpdateChecker` identified **uuid as updatable**, but the pnpm update flow produced no persisted lockfile changes. That mismatch propagated into `FileUpdater`, which then raised `NoChangeError`:
```
2026/05/14 15:59:46 ERROR <job_1367811777> No files were updated! Package manager: pnpm
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:52:in 'Dependabot::NpmAndYarn::FileUpdater#updated_dependency_files'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater#_on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:155:in 'Dependabot::DependencyChangeBuilder#generate_dependency_files'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::DependencyChangeBuilder#_on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:74:in 'Dependabot::DependencyChangeBuilder#run'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::DependencyChangeBuilder#_on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:44:in 'Dependabot::DependencyChangeBuilder.create_from'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::DependencyChangeBuilder._on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:249:in 'Dependabot::Updater::GroupUpdateCreation#create_change_for'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::GroupUpdateCreation#_on_method_added'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:137:in 'block in Dependabot::Updater::GroupUpdateCreation#compile_all_dependency_changes_for'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:104:in 'Array#each'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/group_update_creation.rb:104:in 'Dependabot::Updater::GroupUpdateCreation#compile_all_dependency_changes_for'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::GroupUpdateCreation#_on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb:119:in 'block in Dependabot::Updater::Operations::CreateGroupUpdatePullRequest#dependency_change'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb:116:in 'Array#each'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb:116:in 'Enumerable#filter_map'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb:116:in 'Dependabot::Updater::Operations::CreateGroupUpdatePullRequest#dependency_change'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::CreateGroupUpdatePullRequest#_on_method_added'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb:63:in 'Dependabot::Updater::Operations::CreateGroupUpdatePullRequest#perform'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::CreateGroupUpdatePullRequest#_on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:120:in 'Dependabot::Updater::Operations::GroupUpdateAllVersions#run_grouped_update_for'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::GroupUpdateAllVersions#_on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:106:in 'block in Dependabot::Updater::Operations::GroupUpdateAllVersions#run_grouped_dependency_updates'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:105:in 'Array#each'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:105:in 'Dependabot::Updater::Operations::GroupUpdateAllVersions#run_grouped_dependency_updates'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::GroupUpdateAllVersions#_on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/group_update_all_versions.rb:62:in 'Dependabot::Updater::Operations::GroupUpdateAllVersions#perform'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::GroupUpdateAllVersions#_on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:56:in 'Dependabot::Updater#run'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater#_on_method_added'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:53:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
2026/05/14 15:59:46 ERROR <job_1367811777> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
2026/05/14 15:59:46 ERROR <job_1367811777> bin/update_files.rb:48:in '<main>'
2026/05/14 15:59:46 INFO <job_1367811777> Skipping uuid in group npm_and_yarn: No dependency change was created
updater | 2026/05/14 15:59:46 INFO <job_1367811777> Started process PID: 2311 with command: {} git reset --hard 97c7350893cc6b8524a158a3f8e0361329abb68e {}
```

After this change, the no-op is detected earlier in the update-checking flow, so the run correctly concludes that no resolvable update is available and does not call `FileUpdater` for that dependency:
```
updater | 2026/05/14 16:52:18 INFO pnpm audit --fix modified package.json (overrides) — reverting fallback
updater | 2026/05/14 16:52:18 INFO Requirements to unlock update_not_possible
updater | 2026/05/14 16:52:18 INFO Requirements update strategy bump_versions
updater | 2026/05/14 16:52:18 INFO No update possible for uuid 10.0.0
```


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
