### PR TITLE
NuGet: Add FindRootDirectory experiment to resolve root entry points

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/EntryPointFinderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/EntryPointFinderTests.cs
@@ -1,0 +1,430 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Test;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Discover;
+
+public class EntryPointFinderTests : TestBase
+{
+    [Fact]
+    public async Task SlnReferencingCsproj_MapsChildToParent()
+    {
+        // a .sln referencing a .csproj creates a child-to-parent mapping
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("app.sln", """
+                Microsoft Visual Studio Solution File, Format Version 12.00
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyApp", "src\MyApp\MyApp.csproj", "{00000000-0000-0000-0000-000000000000}"
+                EndProject
+                """),
+            ("src/MyApp/MyApp.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var entryPoints = EntryPointFinder.ScanForEntryPointFiles(temp.DirectoryPath);
+        Assert.Single(entryPoints);
+
+        var map = await EntryPointFinder.BuildChildToParentMapAsync(entryPoints, new TestLogger());
+        var csprojPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "MyApp", "MyApp.csproj"));
+        Assert.True(map.ContainsKey(csprojPath), $"Expected map to contain {csprojPath}");
+        var parents = map[csprojPath];
+        Assert.Single(parents);
+        Assert.EndsWith("app.sln", parents.First());
+    }
+
+    [Fact]
+    public async Task ProjWithProjectFile_MapsChildToParent()
+    {
+        // a .proj file using <ProjectFile> references maps children back to parent
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="src\MyApp\MyApp.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/MyApp/MyApp.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var entryPoints = EntryPointFinder.ScanForEntryPointFiles(temp.DirectoryPath);
+        Assert.Single(entryPoints);
+
+        var map = await EntryPointFinder.BuildChildToParentMapAsync(entryPoints, new TestLogger());
+        var csprojPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "MyApp", "MyApp.csproj"));
+        Assert.True(map.ContainsKey(csprojPath));
+        Assert.EndsWith("dirs.proj", map[csprojPath].First());
+    }
+
+    [Fact]
+    public async Task TransitiveChain_CollapsesToTopLevel()
+    {
+        // dirs.proj -> src/dirs.proj -> src/client/client.csproj
+        // walking from client.csproj should reach dirs.proj at the root
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="src\dirs.proj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="client\client.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/client/client.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var entryPoints = EntryPointFinder.ScanForEntryPointFiles(temp.DirectoryPath);
+        Assert.Equal(2, entryPoints.Length);
+
+        var map = await EntryPointFinder.BuildChildToParentMapAsync(entryPoints, new TestLogger());
+
+        var clientPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "client", "client.csproj"));
+        var roots = EntryPointFinder.WalkToRoots(clientPath, map);
+        Assert.Single(roots);
+        Assert.EndsWith("dirs.proj", roots.First());
+        // the root should be at the repo root, not src/dirs.proj
+        var rootDir = Path.GetDirectoryName(roots.First())!.NormalizePathToUnix();
+        Assert.False(rootDir.EndsWith("/src"), $"Expected root directory to not be under 'src', but was: {rootDir}");
+    }
+
+    [Fact]
+    public async Task NoParentFound_KeepsOriginalDirectory()
+    {
+        // a .csproj with no parent entry point keeps its directory
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("src/MyApp/MyApp.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var entryPoints = EntryPointFinder.ScanForEntryPointFiles(temp.DirectoryPath);
+        Assert.Empty(entryPoints);
+
+        var result = await EntryPointFinder.FindRootDirectoriesAsync(
+            ["/src/MyApp"],
+            temp.DirectoryPath,
+            new TestLogger());
+
+        Assert.Single(result);
+        Assert.Equal("/src/MyApp", result[0]);
+    }
+
+    [Fact]
+    public async Task MultipleDirectoriesConvergingToSameRoot()
+    {
+        // two directories both parented by the same .sln -> single root
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("app.sln", """
+                Microsoft Visual Studio Solution File, Format Version 12.00
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "src\client\client.csproj", "{00000000-0000-0000-0000-000000000001}"
+                EndProject
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server", "src\server\server.csproj", "{00000000-0000-0000-0000-000000000002}"
+                EndProject
+                """),
+            ("src/client/client.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"),
+            ("src/server/server.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var result = await EntryPointFinder.FindRootDirectoriesAsync(
+            ["/src/client", "/src/server"],
+            temp.DirectoryPath,
+            new TestLogger());
+
+        Assert.Single(result);
+        Assert.Equal("/", result[0]);
+    }
+
+    [Fact]
+    public async Task MixedDirectories_SomeWithParentsSomeWithout()
+    {
+        // /src/client has a parent .sln, /standalone does not
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("app.sln", """
+                Microsoft Visual Studio Solution File, Format Version 12.00
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "src\client\client.csproj", "{00000000-0000-0000-0000-000000000001}"
+                EndProject
+                """),
+            ("src/client/client.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"),
+            ("standalone/standalone.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var result = await EntryPointFinder.FindRootDirectoriesAsync(
+            ["/src/client", "/standalone"],
+            temp.DirectoryPath,
+            new TestLogger());
+
+        Assert.Equal(2, result.Length);
+        Assert.Contains("/", result);
+        Assert.Contains("/standalone", result);
+    }
+
+    [Fact]
+    public async Task AlreadyRootDirectory_RemainsUnchanged()
+    {
+        // job directory is already "/" and a .sln is at root
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("app.sln", """
+                Microsoft Visual Studio Solution File, Format Version 12.00
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyApp", "src\MyApp\MyApp.csproj", "{00000000-0000-0000-0000-000000000000}"
+                EndProject
+                """),
+            ("src/MyApp/MyApp.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var result = await EntryPointFinder.FindRootDirectoriesAsync(
+            ["/"],
+            temp.DirectoryPath,
+            new TestLogger());
+
+        Assert.Single(result);
+        Assert.Equal("/", result[0]);
+    }
+
+    [Fact]
+    public async Task DuplicateDirectories_AreDeduplicated()
+    {
+        // two projects in the same directory both parented by same .sln
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("app.sln", """
+                Microsoft Visual Studio Solution File, Format Version 12.00
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib1", "src\Lib1.csproj", "{00000000-0000-0000-0000-000000000001}"
+                EndProject
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib2", "src\Lib2.csproj", "{00000000-0000-0000-0000-000000000002}"
+                EndProject
+                """),
+            ("src/Lib1.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"),
+            ("src/Lib2.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var result = await EntryPointFinder.FindRootDirectoriesAsync(
+            ["/src"],
+            temp.DirectoryPath,
+            new TestLogger());
+
+        Assert.Single(result);
+        Assert.Equal("/", result[0]);
+    }
+
+    [Fact]
+    public void WalkToRoots_NoCycle_WithMultipleParents()
+    {
+        // file has two parents, both are roots
+        var map = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["/repo/src/app.csproj"] = new(StringComparer.OrdinalIgnoreCase) { "/repo/a.sln", "/repo/b.sln" },
+        };
+
+        var roots = EntryPointFinder.WalkToRoots("/repo/src/app.csproj", map);
+        Assert.Equal(2, roots.Count);
+        Assert.Contains("/repo/a.sln", roots);
+        Assert.Contains("/repo/b.sln", roots);
+    }
+
+    [Fact]
+    public void WalkToRoots_HandlesCycles()
+    {
+        // circular reference shouldn't infinite loop
+        var map = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["/repo/a.proj"] = new(StringComparer.OrdinalIgnoreCase) { "/repo/b.proj" },
+            ["/repo/b.proj"] = new(StringComparer.OrdinalIgnoreCase) { "/repo/a.proj" },
+        };
+
+        // should terminate without hanging; both files reference each other so neither is a "root"
+        // but the visited check prevents infinite loop, and neither has a non-cyclic parent
+        var roots = EntryPointFinder.WalkToRoots("/repo/a.proj", map);
+        Assert.Empty(roots);
+    }
+
+    [Fact]
+    public void WalkToRoots_FileNotInMap_ReturnsSelf()
+    {
+        var map = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var roots = EntryPointFinder.WalkToRoots("/repo/orphan.csproj", map);
+        Assert.Single(roots);
+        Assert.Contains("/repo/orphan.csproj", roots);
+    }
+
+    [Fact]
+    public async Task ProjWithRecursiveGlob_ExpandsAllMatchingProjects()
+    {
+        // a .proj file using a recursive glob should find all matching .csproj files
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="**\*.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/app/app.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"),
+            ("src/lib/lib.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"),
+            ("test/app.test/app.test.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var entryPoints = EntryPointFinder.ScanForEntryPointFiles(temp.DirectoryPath);
+        Assert.Single(entryPoints);
+
+        var map = await EntryPointFinder.BuildChildToParentMapAsync(entryPoints, new TestLogger());
+        Assert.Equal(3, map.Count);
+
+        var appPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "app", "app.csproj"));
+        var libPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "lib", "lib.csproj"));
+        var testPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "test", "app.test", "app.test.csproj"));
+
+        Assert.True(map.ContainsKey(appPath));
+        Assert.True(map.ContainsKey(libPath));
+        Assert.True(map.ContainsKey(testPath));
+
+        // all should map back to dirs.proj
+        foreach (var key in new[] { appPath, libPath, testPath })
+        {
+            Assert.Single(map[key]);
+            Assert.EndsWith("dirs.proj", map[key].First());
+        }
+    }
+
+    [Fact]
+    public async Task ProjWithSingleLevelGlob_ExpandsOnlyImmediateChildren()
+    {
+        // a .proj file using a single-level glob should only match files in the immediate subdirectory
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="src\*\*.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/app/app.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"),
+            ("src/lib/lib.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"),
+            ("test/other/other.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var entryPoints = EntryPointFinder.ScanForEntryPointFiles(temp.DirectoryPath);
+        Assert.Single(entryPoints);
+
+        var map = await EntryPointFinder.BuildChildToParentMapAsync(entryPoints, new TestLogger());
+        // only the two under src/ should match, not the one under test/
+        Assert.Equal(2, map.Count);
+
+        var appPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "app", "app.csproj"));
+        var libPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "lib", "lib.csproj"));
+        var testPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "test", "other", "other.csproj"));
+
+        Assert.True(map.ContainsKey(appPath));
+        Assert.True(map.ContainsKey(libPath));
+        Assert.False(map.ContainsKey(testPath));
+    }
+
+    [Fact]
+    public async Task ProjWithGlob_WalksToRoot()
+    {
+        // end-to-end: a recursive glob .proj is the root, and a job directory should resolve to it
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="**\*.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/app/app.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var result = await EntryPointFinder.FindRootDirectoriesAsync(
+            ["/src/app"],
+            temp.DirectoryPath,
+            new TestLogger());
+
+        Assert.Single(result);
+        Assert.Equal("/", result[0]);
+    }
+
+    [Fact]
+    public async Task ProjWithGlobAndExplicitRef_BothExpanded()
+    {
+        // a .proj file mixing a glob with an explicit reference should map both
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="src\**\*.csproj" />
+                    <ProjectFile Include="standalone\standalone.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/app/app.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"),
+            ("standalone/standalone.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var entryPoints = EntryPointFinder.ScanForEntryPointFiles(temp.DirectoryPath);
+        Assert.Single(entryPoints);
+
+        var map = await EntryPointFinder.BuildChildToParentMapAsync(entryPoints, new TestLogger());
+        Assert.Equal(2, map.Count);
+
+        var appPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "app", "app.csproj"));
+        var standalonePath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "standalone", "standalone.csproj"));
+
+        Assert.True(map.ContainsKey(appPath));
+        Assert.True(map.ContainsKey(standalonePath));
+    }
+
+    [Fact]
+    public async Task ProjWithMSBuildProperty_ExpandsPropertyInPath()
+    {
+        // $(MSBuildThisFileDirectory) resolves to the directory containing the .proj file
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="$(MSBuildThisFileDirectory)src\app\app.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/app/app.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var entryPoints = EntryPointFinder.ScanForEntryPointFiles(temp.DirectoryPath);
+        Assert.Single(entryPoints);
+
+        var map = await EntryPointFinder.BuildChildToParentMapAsync(entryPoints, new TestLogger());
+        var appPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "app", "app.csproj"));
+        Assert.True(map.ContainsKey(appPath), $"Expected map to contain {appPath}");
+        Assert.EndsWith("dirs.proj", map[appPath].First());
+    }
+
+    [Fact]
+    public async Task ProjWithMSBuildPropertyAndGlob_ExpandsBoth()
+    {
+        // $(MSBuildThisFileDirectory) combined with a glob should expand both the property and the glob
+        using var temp = await TemporaryDirectory.CreateWithContentsAsync(
+            ("dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="$(MSBuildThisFileDirectory)src\**\*.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/app/app.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"),
+            ("src/lib/lib.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />")
+        );
+
+        var entryPoints = EntryPointFinder.ScanForEntryPointFiles(temp.DirectoryPath);
+        Assert.Single(entryPoints);
+
+        var map = await EntryPointFinder.BuildChildToParentMapAsync(entryPoints, new TestLogger());
+        Assert.Equal(2, map.Count);
+
+        var appPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "app", "app.csproj"));
+        var libPath = Path.GetFullPath(Path.Combine(temp.DirectoryPath, "src", "lib", "lib.csproj"));
+        Assert.True(map.ContainsKey(appPath));
+        Assert.True(map.ContainsKey(libPath));
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
@@ -1381,6 +1381,234 @@ public class EndToEndTests
         Assert.Equal("2.1.0", resolvedInLibrary);
     }
 
+    [Fact]
+    public async Task FindRootDirectory_ExpandsDirectoryThroughProjChain()
+    {
+        // Job starts at /src/client, but a .proj chain leads up to the repo root.
+        // With FindRootDirectory enabled, the job should discover from "/" instead,
+        // which also picks up /test/client/client-test.csproj that would not be found
+        // if only /src/client were examined.
+        await RunAsync(
+            packages: [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "2.0.0", "net9.0"),
+            ],
+            job: new()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                    Directory = "/src/client",
+                }
+            },
+            files: [
+                ("Directory.Build.props", "<Project />"),
+                ("Directory.Build.targets", "<Project />"),
+                ("Directory.Packages.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+                      </PropertyGroup>
+                    </Project>
+                    """),
+                ("dirs.proj", """
+                    <Project>
+                      <ItemGroup>
+                        <ProjectFile Include="src\dirs.proj" />
+                        <ProjectFile Include="test\dirs.proj" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("src/dirs.proj", """
+                    <Project>
+                      <ItemGroup>
+                        <ProjectFile Include="client\client.csproj" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("test/dirs.proj", """
+                    <Project>
+                      <ItemGroup>
+                        <ProjectFile Include="client\client-test.csproj" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("src/client/client.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("test/client/client-test.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                        <ProjectReference Include="..\..\src\client\client.csproj" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+            ],
+            discoveryWorker: null,
+            analyzeWorker: null,
+            updaterWorker: null,
+            experimentsManager: new ExperimentsManager() { FindRootDirectory = true },
+            expectedApiMessages: [
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "group_update_all_versions"
+                    }
+                },
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/src/client/client.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/test/client/client-test.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                    ],
+                    DependencyFiles = [
+                        "/Directory.Build.props",
+                        "/Directory.Build.targets",
+                        "/Directory.Packages.props",
+                        "/src/client/client.csproj",
+                        "/test/client/client-test.csproj",
+                    ],
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "2.0.0",
+                                    File = "/src/client/client.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = null,
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/src/client/client.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "2.0.0",
+                                    File = "/test/client/client-test.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = null,
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/test/client/client-test.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src/client",
+                            Name = "client.csproj",
+                            Content = """
+                                <Project Sdk="Microsoft.NET.Sdk">
+                                  <PropertyGroup>
+                                    <TargetFramework>net9.0</TargetFramework>
+                                  </PropertyGroup>
+                                  <ItemGroup>
+                                    <PackageReference Include="Some.Package" Version="2.0.0" />
+                                  </ItemGroup>
+                                </Project>
+                                """
+                        },
+                        new()
+                        {
+                            Directory = "/test/client",
+                            Name = "client-test.csproj",
+                            Content = """
+                                <Project Sdk="Microsoft.NET.Sdk">
+                                  <PropertyGroup>
+                                    <TargetFramework>net9.0</TargetFramework>
+                                  </PropertyGroup>
+                                  <ItemGroup>
+                                    <PackageReference Include="Some.Package" Version="2.0.0" />
+                                    <ProjectReference Include="..\..\src\client\client.csproj" />
+                                  </ItemGroup>
+                                </Project>
+                                """
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = TestPullRequestCommitMessage,
+                    PrTitle = TestPullRequestTitle,
+                    PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA")
+            ]
+        );
+    }
+
     public const string TestPullRequestCommitMessage = "test-pull-request-commit-message";
     public const string TestPullRequestTitle = "test-pull-request-title";
     public const string TestPullRequestBody = "test-pull-request-body";

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/EntryPointFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/EntryPointFinder.cs
@@ -1,0 +1,258 @@
+using System.Collections.Immutable;
+
+using Microsoft.Build.Construction;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+
+using Microsoft.VisualStudio.SolutionPersistence.Serializer;
+
+using NuGetUpdater.Core.Utilities;
+
+namespace NuGetUpdater.Core.Discover;
+
+internal static class EntryPointFinder
+{
+    private static readonly string[] EntryPointExtensions = [".sln", ".slnx", ".proj"];
+    private static readonly string[] ProjectExtensions = [".csproj", ".vbproj", ".fsproj"];
+
+    /// <summary>
+    /// Given a set of job directories and a repo root, finds the minimal set of directories
+    /// that contain the ultimate parent entry point files (e.g., .sln, .proj) for all projects
+    /// found in the original directories.
+    /// </summary>
+    internal static async Task<ImmutableArray<string>> FindRootDirectoriesAsync(ImmutableArray<string> jobDirectories, string repoRootPath, ILogger logger)
+    {
+        var entryPointFiles = ScanForEntryPointFiles(repoRootPath);
+        if (entryPointFiles.Length == 0)
+        {
+            logger.Info("  No entry point files found; keeping original directories.");
+            return jobDirectories;
+        }
+
+        var childToParentMap = await BuildChildToParentMapAsync(entryPointFiles, logger);
+        if (childToParentMap.Count == 0)
+        {
+            logger.Info("  No parent relationships found; keeping original directories.");
+            return jobDirectories;
+        }
+
+        var rootDirectories = new HashSet<string>(PathComparer.Instance);
+
+        foreach (var directory in jobDirectories)
+        {
+            var fullDirectoryPath = PathHelper.GetFullPathFromRelative(repoRootPath, directory);
+            var projectFiles = FindProjectFilesInDirectory(fullDirectoryPath);
+
+            if (projectFiles.Length == 0)
+            {
+                // no project files in this directory; check if any entry point files exist here
+                var entryPointsHere = FindEntryPointFilesInDirectory(fullDirectoryPath);
+                if (entryPointsHere.Length == 0)
+                {
+                    rootDirectories.Add(directory);
+                    continue;
+                }
+
+                // walk these entry points up to their roots
+                foreach (var entryPoint in entryPointsHere)
+                {
+                    var roots = WalkToRoots(entryPoint, childToParentMap);
+                    foreach (var root in roots)
+                    {
+                        var rootDir = PathHelper.GetRelativeDirectoryOf(root, repoRootPath);
+                        rootDirectories.Add(rootDir);
+                    }
+                }
+            }
+            else
+            {
+                foreach (var projectFile in projectFiles)
+                {
+                    var roots = WalkToRoots(projectFile, childToParentMap);
+                    if (roots.Count == 0)
+                    {
+                        // no parent found; keep original directory
+                        rootDirectories.Add(directory);
+                    }
+                    else
+                    {
+                        foreach (var root in roots)
+                        {
+                            var rootDir = PathHelper.GetRelativeDirectoryOf(root, repoRootPath);
+                            rootDirectories.Add(rootDir);
+                        }
+                    }
+                }
+            }
+        }
+
+        var result = rootDirectories.OrderBy(d => d, StringComparer.OrdinalIgnoreCase).ToImmutableArray();
+        logger.Info($"  Resolved root directories: [{string.Join(", ", result)}]");
+        return result;
+    }
+
+    internal static ImmutableArray<string> ScanForEntryPointFiles(string repoRootPath)
+    {
+        var result = new List<string>();
+        foreach (var extension in EntryPointExtensions)
+        {
+            var files = Directory.EnumerateFiles(repoRootPath, $"*{extension}", SearchOption.AllDirectories);
+            result.AddRange(files.Select(f => Path.GetFullPath(f)));
+        }
+
+        return [.. result];
+    }
+
+    internal static async Task<Dictionary<string, HashSet<string>>> BuildChildToParentMapAsync(ImmutableArray<string> entryPointFiles, ILogger logger)
+    {
+        var childToParent = new Dictionary<string, HashSet<string>>(PathComparer.Instance);
+
+        foreach (var parentFile in entryPointFiles)
+        {
+            var children = await GetChildrenOfEntryPointAsync(parentFile, logger);
+            foreach (var child in children)
+            {
+                if (!childToParent.TryGetValue(child, out var parents))
+                {
+                    parents = new HashSet<string>(PathComparer.Instance);
+                    childToParent[child] = parents;
+                }
+
+                parents.Add(parentFile);
+            }
+        }
+
+        return childToParent;
+    }
+
+    internal static async Task<ImmutableArray<string>> GetChildrenOfEntryPointAsync(string entryPointPath, ILogger logger)
+    {
+        var extension = Path.GetExtension(entryPointPath).ToLowerInvariant();
+        try
+        {
+            return extension switch
+            {
+                ".sln" => GetChildrenOfSolution(entryPointPath),
+                ".slnx" => await GetChildrenOfSlnxAsync(entryPointPath),
+                ".proj" => GetChildrenOfProj(entryPointPath),
+                _ => [],
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.Info($"  Warning: failed to parse {entryPointPath}: {ex.Message}");
+            return [];
+        }
+    }
+
+    private static ImmutableArray<string> GetChildrenOfSolution(string solutionPath)
+    {
+        var solution = SolutionFile.Parse(solutionPath);
+        return solution.ProjectsInOrder
+            .Select(p => Path.GetFullPath(p.AbsolutePath))
+            .ToImmutableArray();
+    }
+
+    private static async Task<ImmutableArray<string>> GetChildrenOfSlnxAsync(string slnxPath)
+    {
+        var solution = await SolutionSerializers.SlnXml.OpenAsync(slnxPath, CancellationToken.None);
+        var solutionDir = Path.GetDirectoryName(slnxPath) ?? string.Empty;
+        return solution.SolutionProjects
+            .Select(p => PathHelper.GetFullPathFromRelative(solutionDir, p.FilePath))
+            .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Parses a .proj file using MSBuild evaluation to extract referenced projects.
+    /// MSBuild must be registered via <see cref="MSBuildHelper.RegisterMSBuild"/> before calling this method.
+    /// </summary>
+    private static ImmutableArray<string> GetChildrenOfProj(string projPath)
+    {
+        if (!File.Exists(projPath))
+        {
+            return [];
+        }
+
+        using var projectCollection = new ProjectCollection();
+        var project = Project.FromFile(projPath, new ProjectOptions
+        {
+            LoadSettings = ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports,
+            ProjectCollection = projectCollection,
+        });
+
+        var itemTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ProjectFile", "ProjectReference" };
+        var projectItems = project.Items.Where(i => itemTypes.Contains(i.ItemType)).ToList();
+        var projectDir = Path.GetDirectoryName(projPath)!;
+        var result = new HashSet<string>(PathComparer.Instance);
+
+        foreach (var item in projectItems)
+        {
+            var evaluatedInclude = item.EvaluatedInclude;
+            var normalizedPath = Path.IsPathRooted(evaluatedInclude)
+                ? Path.GetFullPath(evaluatedInclude)
+                : PathHelper.GetFullPathFromRelative(projectDir, evaluatedInclude);
+            result.Add(normalizedPath);
+        }
+
+        return [.. result];
+    }
+
+    /// <summary>
+    /// Walks from a file upward through the child-to-parent map until reaching files with no parents.
+    /// Returns the set of root files found.
+    /// </summary>
+    internal static HashSet<string> WalkToRoots(string startFile, Dictionary<string, HashSet<string>> childToParentMap)
+    {
+        var roots = new HashSet<string>(PathComparer.Instance);
+        var visited = new HashSet<string>(PathComparer.Instance);
+        var queue = new Queue<string>();
+        queue.Enqueue(startFile);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!visited.Add(current))
+            {
+                continue;
+            }
+
+            if (childToParentMap.TryGetValue(current, out var parents) && parents.Count > 0)
+            {
+                foreach (var parent in parents)
+                {
+                    queue.Enqueue(parent);
+                }
+            }
+            else
+            {
+                roots.Add(current);
+            }
+        }
+
+        return roots;
+    }
+
+    private static ImmutableArray<string> FindProjectFilesInDirectory(string directoryPath)
+        => FindFilesInDirectory(directoryPath, ProjectExtensions);
+
+    private static ImmutableArray<string> FindEntryPointFilesInDirectory(string directoryPath)
+        => FindFilesInDirectory(directoryPath, EntryPointExtensions);
+
+    private static ImmutableArray<string> FindFilesInDirectory(string directoryPath, string[] extensions)
+    {
+        if (!Directory.Exists(directoryPath))
+        {
+            return [];
+        }
+
+        var result = new List<string>();
+        foreach (var extension in extensions)
+        {
+            result.AddRange(
+                Directory.EnumerateFiles(directoryPath, $"*{extension}", SearchOption.TopDirectoryOnly)
+                    .Select(Path.GetFullPath));
+        }
+
+        return [.. result];
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -8,12 +8,14 @@ namespace NuGetUpdater.Core;
 public record ExperimentsManager
 {
     public bool GenerateSimplePrBody { get; init; } = false;
+    public bool FindRootDirectory { get; init; } = false;
 
     public Dictionary<string, object> ToDictionary()
     {
         return new()
         {
             ["nuget_generate_simple_pr_body"] = GenerateSimplePrBody,
+            ["nuget_find_root_directory"] = FindRootDirectory,
         };
     }
 
@@ -22,6 +24,7 @@ public record ExperimentsManager
         return new ExperimentsManager()
         {
             GenerateSimplePrBody = IsEnabled(experiments, "nuget_generate_simple_pr_body"),
+            FindRootDirectory = IsEnabled(experiments, "nuget_find_root_directory"),
         };
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobSource.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobSource.cs
@@ -1,6 +1,6 @@
 namespace NuGetUpdater.Core.Run.ApiModel;
 
-public sealed class JobSource
+public sealed record JobSource
 {
     public required string Provider { get; init; }
     public required string Repo { get; init; }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -51,8 +51,29 @@ public class RunWorker
 
     public async Task<int> RunAsync(Job job, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, ExperimentsManager experimentsManager)
     {
+        if (experimentsManager.FindRootDirectory)
+        {
+            _logger.Info("FindRootDirectory experiment is enabled; resolving root directories...");
+            MSBuildHelper.RegisterMSBuild(repoContentsPath.FullName, repoContentsPath.FullName, _logger);
+            job = await ResolveRootDirectoriesAsync(job, repoContentsPath.FullName);
+        }
+
         var result = await RunScenarioHandlersWithErrorHandlingAsync(job, repoContentsPath, caseInsensitiveRepoContentsPath, baseCommitSha, experimentsManager);
         return result;
+    }
+
+    internal async Task<Job> ResolveRootDirectoriesAsync(Job job, string repoRootPath)
+    {
+        var originalDirectories = job.GetAllDirectories(repoRootPath);
+        var rootDirectories = await EntryPointFinder.FindRootDirectoriesAsync(originalDirectories, repoRootPath, _logger);
+        if (rootDirectories.SequenceEqual(originalDirectories))
+        {
+            return job;
+        }
+
+        _logger.Info($"  Updated job directories from [{string.Join(", ", originalDirectories)}] to [{string.Join(", ", rootDirectories)}]");
+        var updatedSource = job.Source with { Directory = null, Directories = rootDirectories.ToArray() };
+        return job with { Source = updatedSource };
     }
 
     private static readonly ImmutableArray<IUpdateHandler> UpdateHandlers =

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
@@ -83,6 +83,18 @@ internal static class PathHelper
     public static string GetFullPathFromRelative(string rootPath, string relativePath)
         => Path.GetFullPath(JoinPath(rootPath, relativePath.NormalizePathToUnix()));
 
+    /// <summary>
+    /// Returns the directory of <paramref name="filePath"/> as a unix-style path relative to
+    /// <paramref name="rootPath"/>, prefixed with "/".  When the file is directly inside the
+    /// root, the result is "/".
+    /// </summary>
+    public static string GetRelativeDirectoryOf(string filePath, string rootPath)
+    {
+        var directory = Path.GetDirectoryName(filePath)!;
+        var relative = Path.GetRelativePath(rootPath, directory).NormalizePathToUnix();
+        return relative == "." ? "/" : "/" + relative;
+    }
+
     public static string[] GetAllDirectoriesToRoot(string initialDirectoryPath, string rootDirectoryPath)
     {
         var candidatePaths = new List<string>();


### PR DESCRIPTION
When the `nuget-find-root-directory` experiment flag is enabled, the RunWorker scans the repo for .sln, .slnx, and .proj files and builds a child-to-parent mapping. It then walks upward from each job directory's project files to find the ultimate root entry points, replacing the job's directory list with the minimal ancestor set.

This enables Dependabot to discover and update all projects reachable from a common root, even when the job is initially scoped to a single subdirectory.

Includes:
- EntryPointFinder utility with scanning, parent map building, and root walking
- MSBuild evaluation for .proj files supporting globs, properties like $(MSBuildThisFileDirectory), and explicit references
- Integration in RunWorker behind the experiment flag
- 17 unit tests covering explicit refs, globs, MSBuild properties, transitive chains, cycles, and edge cases
- 1 end-to-end test proving root directory expansion across a .proj chain with two projects in different directories
