### PR TITLE
fix(npm_and_yarn): avoid false-positive security updates when audit fallback makes no lockfile changes

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -113,6 +113,8 @@ module Dependabot
 
         sig { params(updated_lockfiles: T::Array[Dependabot::DependencyFile]).returns(T.nilable(Gem::Version)) }
         def version_from_updated_lockfiles(updated_lockfiles)
+          lockfile_changed = lockfiles_changed?(updated_lockfiles)
+
           updated_files = dependency_files -
                           dependency_files_builder.lockfiles +
                           updated_lockfiles
@@ -126,19 +128,21 @@ module Dependabot
 
           combined = version_class.new(parsed_dep.version)
           current_version = dependency.version ? version_class.new(dependency.version) : nil
-          audit_fix_version = audit_fix_best_version(parsed_dep, current_version)
+          audit_fix_version = audit_fix_best_version(parsed_dep, current_version, lockfile_changed)
           audit_fix_version || combined
         end
 
         sig do
           params(
             parsed_dep: Dependabot::Dependency,
-            current_version: T.nilable(Gem::Version)
+            current_version: T.nilable(Gem::Version),
+            lockfile_changed: T::Boolean
           ).returns(T.nilable(Gem::Version))
         end
-        def audit_fix_best_version(parsed_dep, current_version)
+        def audit_fix_best_version(parsed_dep, current_version, lockfile_changed)
           return unless Dependabot::Experiments.enabled?(:enable_audit_fix_fallback)
           return unless current_version
+          return unless lockfile_changed
 
           all_versions = parsed_dep.metadata[:all_versions]
           return unless all_versions&.any?
@@ -163,6 +167,17 @@ module Dependabot
             .filter_map { |d| version_class.new(d.version) if d.version }
             .select { |v| v > current_version && (allowable.nil? || v <= allowable) }
             .max
+        end
+
+        sig { params(updated_lockfiles: T::Array[Dependabot::DependencyFile]).returns(T::Boolean) }
+        def lockfiles_changed?(updated_lockfiles)
+          original_lockfile_contents = dependency_files_builder.lockfiles.to_h do |lockfile|
+            [lockfile.name, lockfile.content]
+          end
+
+          updated_lockfiles.any? do |lockfile|
+            lockfile.content != original_lockfile_contents[lockfile.name]
+          end
         end
 
         sig { params(path: String, lockfile_name: String).returns(T::Hash[String, String]) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver_spec.rb
@@ -421,6 +421,27 @@ RSpec.describe namespace::SubdependencyVersionResolver do
           end
         end
 
+        context "when fallback runs but lockfile content is unchanged" do
+          let(:parsed_dep) do
+            Dependabot::Dependency.new(
+              name: "acorn",
+              version: "5.5.3",
+              requirements: [],
+              package_manager: "npm_and_yarn",
+              metadata: { all_versions: all_version_deps }
+            )
+          end
+
+          before do
+            allow(Dependabot::NpmAndYarn::NativeHelpers)
+              .to receive_messages(run_npm8_subdependency_update_command: "", run_npm_audit_fix_command: "")
+          end
+
+          it "does not infer a newer resolvable version from all_versions alone" do
+            expect(latest_resolvable_version).to eq(Gem::Version.new("5.5.3"))
+          end
+        end
+
         context "when the experiment is disabled" do
           before do
             allow(Dependabot::Experiments).to receive(:enabled?)


### PR DESCRIPTION
### What are you trying to accomplish?

This change fixes a false-positive security update path in npm/yarn subdependency resolution when enable-audit-fix-fallback is enabled.

The issue was that Dependabot could conclude an update was available (from resolver metadata) even when fallback commands did not actually modify the lockfile. That mismatch led to `NoChangeError`: `UpdateChecker` reported an update, but `FileUpdater` had no concrete file diff to apply.

The approach is to make update detection reflect real lockfile state: fallback-derived version selection is now only trusted when the lockfile content actually changed. This keeps checker and updater behavior aligned, avoids raising no-change errors for no-op fallbacks, and preserves normal behavior when fallback genuinely produces a lockfile update.

### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

Validation run: https://github.com/theopensystemslab/planx-new/actions/runs/25870422179/job/76023884050

Before this fix, the run ended with a NoChangeError.

After this fix, Dependabot correctly reports that no update is possible for this case, instead of failing with a mismatch between update detection and file changes.

Key output from the successful behavior:
```
updater | 2026/05/15 13:12:24 INFO Requirements to unlock update_not_possible
updater | 2026/05/15 13:12:24 INFO Requirements update strategy bump_versions
updater | 2026/05/15 13:12:24 INFO No update possible for uuid 10.0.0
```


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
