### PR TITLE
Update OpenTelemetry packages to 1.15.3

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.14.2075" />
     <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
@@ -25,9 +25,9 @@
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.17" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NuGet.Core" Version="2.14.0" Aliases="CoreV2" />
-    <PackageVersion Include="OpenTelemetry" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.3" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="10.0.3" />


### PR DESCRIPTION
Update OpenTelemetry, OpenTelemetry.Exporter.Console, and OpenTelemetry.Exporter.OpenTelemetryProtocol from 1.12.0 to 1.15.3. Also update Microsoft.Extensions.Logging from 9.0.7 to 10.0.3 as required by the new OpenTelemetry version.