### PR TITLE
Fix NuGet lock file tracking when no lock file exists

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
@@ -151,6 +151,141 @@ public class EndToEndTests
     }
 
     [Fact]
+    public async Task WithPackageReferenceAndRestorePackagesWithLockFile_LockFileNotPresent()
+    {
+        await RunAsync(
+            packages: [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "2.0.0", "net9.0"),
+            ],
+            job: new()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                    Directory = "/",
+                }
+            },
+            files: [
+                ("Directory.Build.props", "<Project />"),
+                ("Directory.Build.targets", "<Project />"),
+                ("Directory.Packages.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+                      </PropertyGroup>
+                    </Project>
+                    """),
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+            ],
+            discoveryWorker: null, // use real worker
+            analyzeWorker: null, // use real worker
+            updaterWorker: null, // use real worker
+            expectedApiMessages: [
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "group_update_all_versions"
+                    }
+                },
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/project.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                    ],
+                    DependencyFiles = [
+                        "/Directory.Build.props",
+                        "/Directory.Build.targets",
+                        "/Directory.Packages.props",
+                        "/project.csproj",
+                    ],
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Some.Package",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "2.0.0",
+                                    File = "/project.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = null,
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/project.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/",
+                            Name = "project.csproj",
+                            Content = """
+                                <Project Sdk="Microsoft.NET.Sdk">
+                                  <PropertyGroup>
+                                    <TargetFramework>net9.0</TargetFramework>
+                                    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+                                  </PropertyGroup>
+                                  <ItemGroup>
+                                    <PackageReference Include="Some.Package" Version="2.0.0" />
+                                  </ItemGroup>
+                                </Project>
+                                """
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = TestPullRequestCommitMessage,
+                    PrTitle = TestPullRequestTitle,
+                    PrBody = TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA")
+            ]
+        );
+    }
+
+    [Fact]
     public async Task WithPackagesConfig()
     {
         await RunAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ModifiedFilesTrackerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ModifiedFilesTrackerTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Run;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run;
+
+public class ModifiedFilesTrackerTests
+{
+    [Fact]
+    public async Task LockFileCreatedByDiscoveryIsNotTracked()
+    {
+        // Simulates the scenario where RestorePackagesWithLockFile=true but no lock file is checked in.
+        // After discovery runs, a lock file is created. It should not be tracked.
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("project.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """)
+        );
+
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new TestLogger();
+
+        // Record initial lock files (none exist yet)
+        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
+        Assert.Empty(initialLockFiles);
+
+        // Simulate discovery creating a lock file (as restore would)
+        var lockFilePath = Path.Combine(tempDirectory.DirectoryPath, "packages.lock.json");
+        File.WriteAllText(lockFilePath, """{"version": 1, "dependencies": {}}""");
+
+        // Create discovery result that includes the lock file as an additional file
+        var discoveryResult = new WorkspaceDiscoveryResult()
+        {
+            Path = "/",
+            Projects = [
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = ["packages.lock.json"],
+                }
+            ],
+        };
+
+        // Create tracker with initial lock files (empty set)
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialLockFiles, logger);
+        await tracker.StartTrackingAsync(discoveryResult);
+
+        // The lock file should not be in the tracked contents
+        Assert.DoesNotContain("packages.lock.json", tracker.OriginalDependencyFileContents.Keys.Select(Path.GetFileName));
+
+        // Modify the lock file to simulate an update
+        File.WriteAllText(lockFilePath, """{"version": 1, "dependencies": {"net9.0": {"Some.Package": {"resolved": "2.0.0"}}}}""");
+
+        // Stop tracking - should NOT report the lock file as modified
+        var updatedFiles = await tracker.StopTrackingAsync();
+        Assert.Empty(updatedFiles);
+    }
+
+    [Fact]
+    public async Task ExistingLockFileIsTrackedAndReported()
+    {
+        // When a lock file IS checked in, it should be tracked and reported as modified after an update
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("project.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """),
+            ("packages.lock.json", """{"version": 1, "dependencies": {}}""")
+        );
+
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new TestLogger();
+
+        // Record initial lock files (the lock file exists)
+        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
+        Assert.Single(initialLockFiles);
+
+        // Create discovery result that includes the lock file
+        var discoveryResult = new WorkspaceDiscoveryResult()
+        {
+            Path = "/",
+            Projects = [
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = ["packages.lock.json"],
+                }
+            ],
+        };
+
+        // Create tracker with initial lock files
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialLockFiles, logger);
+        await tracker.StartTrackingAsync(discoveryResult);
+
+        // The lock file SHOULD be tracked
+        Assert.Contains("packages.lock.json", tracker.OriginalDependencyFileContents.Keys.Select(Path.GetFileName));
+
+        // Modify the lock file
+        var lockFilePath = Path.Combine(tempDirectory.DirectoryPath, "packages.lock.json");
+        File.WriteAllText(lockFilePath, """{"version": 1, "dependencies": {"net9.0": {"Some.Package": {"resolved": "2.0.0"}}}}""");
+
+        // Stop tracking - SHOULD report the lock file as modified
+        var updatedFiles = await tracker.StopTrackingAsync();
+        Assert.Single(updatedFiles);
+        Assert.Equal("packages.lock.json", updatedFiles[0].Name);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -86,7 +86,7 @@ public class UpdatedDependencyListTests
                 ]
             }
         };
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: temp.DirectoryPath, new TestLogger());
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: temp.DirectoryPath, new TestLogger(), ModifiedFilesTracker.GetExistingLockFiles(new DirectoryInfo(temp.DirectoryPath)));
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies =
@@ -210,7 +210,7 @@ public class UpdatedDependencyListTests
         };
 
         // act
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: tempDir.DirectoryPath, new TestLogger());
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: tempDir.DirectoryPath, new TestLogger(), ModifiedFilesTracker.GetExistingLockFiles(new DirectoryInfo(tempDir.DirectoryPath)));
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
@@ -18,15 +18,27 @@ public class ModifiedFilesTracker
     private readonly Dictionary<string, EOLType> _originalDependencyFileEOFs = [];
     private readonly Dictionary<string, bool> _originalDependencyFileBOMs = [];
     private string[] _nonProjectFiles = [];
+    private readonly HashSet<string> _initiallyExistingLockFiles;
 
     public IReadOnlyDictionary<string, string> OriginalDependencyFileContents => _originalDependencyFileContents;
     //public IReadOnlyDictionary<string, EOLType> OriginalDependencyFileEOFs => _originalDependencyFileEOFs;
     public IReadOnlyDictionary<string, bool> OriginalDependencyFileBOMs => _originalDependencyFileBOMs;
 
-    public ModifiedFilesTracker(DirectoryInfo repoContentsPath, ILogger logger)
+    public ModifiedFilesTracker(DirectoryInfo repoContentsPath, HashSet<string> initiallyExistingLockFiles, ILogger logger)
     {
         RepoContentsPath = repoContentsPath;
+        _initiallyExistingLockFiles = initiallyExistingLockFiles;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the set of lock file paths (relative to repo root, unix-style) that currently exist on disk.
+    /// </summary>
+    public static HashSet<string> GetExistingLockFiles(DirectoryInfo repoContentsPath)
+    {
+        return Directory.EnumerateFiles(repoContentsPath.FullName, ProjectHelper.PackagesLockJsonFileName, SearchOption.AllDirectories)
+            .Select(f => Path.GetRelativePath(repoContentsPath.FullName, f).NormalizePathToUnix())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     public async Task StartTrackingAsync(WorkspaceDiscoveryResult discoveryResult)
@@ -57,6 +69,11 @@ public class ModifiedFilesTracker
             foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
             {
                 var extraFilePath = Path.Join(projectDirectory, extraFile);
+                if (IsLockFileNotInitiallyPresent(Path.Join(_currentDiscoveryResult.Path, extraFilePath).NormalizePathToUnix()))
+                {
+                    continue;
+                }
+
                 await TrackOriginalContentsAsync(_currentDiscoveryResult.Path, extraFilePath);
             }
         }
@@ -126,6 +143,11 @@ public class ModifiedFilesTracker
             foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
             {
                 var extraFilePath = Path.Join(projectDirectory, extraFile);
+                if (IsLockFileNotInitiallyPresent(Path.Join(_currentDiscoveryResult.Path, extraFilePath).NormalizePathToUnix()))
+                {
+                    continue;
+                }
+
                 await AddUpdatedFileIfDifferentAsync(_currentDiscoveryResult.Path, extraFilePath);
             }
         }
@@ -149,6 +171,22 @@ public class ModifiedFilesTracker
         var repoFullPath = Path.Join(directory, fileName).FullyNormalizedRootedPath();
         var correctedRepoFullPath = RunWorker.EnsureCorrectFileCasing(repoFullPath, RepoContentsPath.FullName, _logger);
         return correctedRepoFullPath;
+    }
+
+    private bool IsLockFileNotInitiallyPresent(string repoRelativePath)
+    {
+        return IsLockFileNotInitiallyPresent(repoRelativePath, _initiallyExistingLockFiles);
+    }
+
+    public static bool IsLockFileNotInitiallyPresent(string repoRelativePath, HashSet<string> initiallyExistingLockFiles)
+    {
+        var normalizedPath = repoRelativePath.NormalizePathToUnix().NormalizeUnixPathParts().TrimStart('/');
+        if (!Path.GetFileName(normalizedPath).Equals(ProjectHelper.PackagesLockJsonFileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !initiallyExistingLockFiles.Contains(normalizedPath);
     }
 
     public static ImmutableArray<DependencyFile> MergeUpdatedFileSet(ImmutableArray<DependencyFile> setA, ImmutableArray<DependencyFile> setB)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -241,7 +241,7 @@ public class RunWorker
         return relativeResolvedName;
     }
 
-    internal static UpdatedDependencyList GetUpdatedDependencyListFromDiscovery(WorkspaceDiscoveryResult discoveryResult, string repoRoot, ILogger logger)
+    internal static UpdatedDependencyList GetUpdatedDependencyListFromDiscovery(WorkspaceDiscoveryResult discoveryResult, string repoRoot, ILogger logger, HashSet<string> initiallyExistingLockFiles)
     {
         string GetFullRepoPath(string path)
         {
@@ -265,6 +265,11 @@ public class RunWorker
             foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
             {
                 var extraFileFullPath = Path.Join(projectDirectory, extraFile);
+                if (ModifiedFilesTracker.IsLockFileNotInitiallyPresent(Path.Join(discoveryResult.Path, extraFileFullPath).NormalizePathToUnix(), initiallyExistingLockFiles))
+                {
+                    continue;
+                }
+
                 var extraFileRepoPath = GetFullRepoPath(extraFileFullPath);
                 auxiliaryFiles.Add(extraFileRepoPath);
             }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -31,6 +31,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
         var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -41,7 +42,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -61,7 +62,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
 
             logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -52,6 +52,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
     private async Task RunGroupedDependencyUpdates(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
+        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
         foreach (var group in job.DependencyGroups)
         {
             logger.Info($"Starting update for group {group.Name}");
@@ -69,10 +70,10 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     return;
                 }
 
-                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
+                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
                 await tracker.StartTrackingAsync(discoveryResult);
 
-                var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
+                var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
                 await apiHandler.UpdateDependencyList(updatedDependencyList);
 
                 var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
@@ -179,6 +180,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
     private async Task RunUngroupedDependencyUpdates(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
+        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -189,7 +191,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
 
             var updateOperationsToPerformByDependency = CollectUpdateOperationsByDependency(discoveryResult);
@@ -198,7 +200,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 logger.Info($"Starting dependency update for {sameDependencySet.Key}");
                 var updateOperationsPerformed = new List<UpdateOperationBase>();
                 var updatedDependencies = new List<ReportedDependency>();
-                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
+                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
                 await tracker.StartTrackingAsync(discoveryResult);
 
                 foreach (var (projectPath, dependency) in sameDependencySet)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -68,6 +68,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
         var updateOperationsPerformed = new List<UpdateOperationBase>();
         var updatedDependencies = new List<ReportedDependency>();
         var allUpdatedDependencyFiles = ImmutableArray.Create<DependencyFile>();
+        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -78,7 +79,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
 
             var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
@@ -89,7 +90,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.OrdinalIgnoreCase);
             logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -30,6 +30,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
         var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -41,7 +42,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -75,7 +76,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 continue;
             }
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -30,6 +30,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
         var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -40,7 +41,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -74,7 +75,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
 
             logger.Info($"Updating dependencies: {string.Join(", ", relevantUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, logger);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyUpdatesToPerform in relevantUpdateOperationsToPerform)
             {


### PR DESCRIPTION
When a project sets `<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>` but no lock file is checked in, the discovery restore creates a `packages.lock.json` that was incorrectly tracked and reported as a modified file.

This fix records which lock files exist before discovery runs and excludes any that weren't initially present from both file tracking and dependency file reporting.

Fixes #14059