### PR TITLE
(fix) Stabilize Poetry updates for PEP 735 dependency-groups

### DIFF
--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -167,6 +167,7 @@ module Dependabot
 
           # Freeze PEP 621 project.dependencies and project.optional-dependencies
           freeze_pep621_top_level_deps!(pyproject_object, excluded_names)
+          freeze_pep735_dependency_groups!(pyproject_object, excluded_names)
 
           TomlRB.dump(pyproject_object)
         end
@@ -218,6 +219,36 @@ module Dependabot
 
           project_object["optional-dependencies"]&.each_value do |opt_deps|
             freeze_pep621_dep_array!(opt_deps, excluded_names)
+          end
+        end
+
+        sig { params(pyproject_object: T::Hash[String, T.untyped], excluded_names: T::Array[String]).void }
+        def freeze_pep735_dependency_groups!(pyproject_object, excluded_names)
+          dependency_groups = pyproject_object["dependency-groups"]
+          return unless dependency_groups
+
+          dependency_groups.each_value do |dep_array|
+            freeze_pep735_dep_array!(dep_array, excluded_names)
+          end
+        end
+
+        sig { params(dep_array: T.nilable(T::Array[T.untyped]), excluded_names: T::Array[String]).void }
+        def freeze_pep735_dep_array!(dep_array, excluded_names)
+          return unless dep_array
+
+          dep_array.each_with_index do |entry, index|
+            next unless entry.is_a?(String)
+
+            match = entry.match(/\A([a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?)/i)
+            next unless match
+
+            dep_name = normalise(T.must(match[1]))
+            next if excluded_names.include?(dep_name)
+
+            locked_details = locked_details(dep_name)
+            next unless (locked_version = locked_details&.fetch("version"))
+
+            dep_array[index] = self.class.send(:pin_pep508_entry, entry, locked_version)
           end
         end
 

--- a/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
+++ b/python/lib/dependabot/python/file_updater/pyproject_preparer.rb
@@ -165,7 +165,7 @@ module Dependabot
             end
           end
 
-          # Freeze PEP 621 project.dependencies and project.optional-dependencies
+          # Freeze top-level PEP 621 dependencies and PEP 735 dependency-groups
           freeze_pep621_top_level_deps!(pyproject_object, excluded_names)
           freeze_pep735_dependency_groups!(pyproject_object, excluded_names)
 
@@ -239,10 +239,10 @@ module Dependabot
           dep_array.each_with_index do |entry, index|
             next unless entry.is_a?(String)
 
-            match = entry.match(/\A([a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?)/i)
+            match = entry.match(PEP508_PREFIX)
             next unless match
 
-            dep_name = normalise(T.must(match[1]))
+            dep_name = normalise(T.must(match[:name]))
             next if excluded_names.include?(dep_name)
 
             locked_details = locked_details(dep_name)
@@ -257,11 +257,10 @@ module Dependabot
           return unless dep_array
 
           dep_array.each_with_index do |entry, index|
-            # Extract dependency name from PEP 508 string
-            match = entry.match(/\A([a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?)/i)
+            match = entry.match(PEP508_PREFIX)
             next unless match
 
-            dep_name = normalise(T.must(match[1]))
+            dep_name = normalise(T.must(match[:name]))
             next if excluded_names.include?(dep_name)
 
             locked_details = locked_details(dep_name)

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -327,10 +327,7 @@ module Dependabot
             update_dependency_requirement(dependencies, updated_requirement)
           end
 
-          groups = poetry_object["group"]&.values || []
-          groups.each do |group_spec|
-            update_dependency_requirement(group_spec["dependencies"], updated_requirement)
-          end
+          update_group_dependency_requirements(poetry_object, updated_requirement)
 
           # If this is a sub-dependency, add the new requirement
           unless dependency.requirements.find { |r| r[:file] == T.must(pyproject).name }
@@ -339,6 +336,17 @@ module Dependabot
           end
 
           TomlRB.dump(pyproject_object)
+        end
+
+        sig { params(poetry_object: T::Hash[String, T.untyped], updated_requirement: String).void }
+        def update_group_dependency_requirements(poetry_object, updated_requirement)
+          groups = poetry_object["group"]&.values || []
+          groups.each do |group_spec|
+            group_dependencies = group_spec["dependencies"]
+            next unless group_dependencies.is_a?(Hash)
+
+            update_dependency_requirement(group_dependencies, updated_requirement)
+          end
         end
 
         sig { params(toml_node: T::Hash[String, T.untyped], requirement: String).void }

--- a/python/spec/dependabot/python/file_updater/pyproject_preparer_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pyproject_preparer_spec.rb
@@ -366,6 +366,7 @@ RSpec.describe Dependabot::Python::FileUpdater::PyprojectPreparer do
 
         groups = parsed["dependency-groups"]
         expect(groups["dev"]).to include("pytest==8.0.2", "black==24.2.0")
+        expect(groups["dev"]).to include("colorama==0.4.6 ; sys_platform == 'win32'")
         expect(groups["docs"]).to include("sphinx==7.2.6")
       end
     end

--- a/python/spec/dependabot/python/file_updater/pyproject_preparer_spec.rb
+++ b/python/spec/dependabot/python/file_updater/pyproject_preparer_spec.rb
@@ -350,5 +350,24 @@ RSpec.describe Dependabot::Python::FileUpdater::PyprojectPreparer do
         end
       end
     end
+
+    context "with PEP 735 dependency-groups" do
+      let(:dependencies) { [] }
+      let(:pyproject_fixture_name) { "poetry_v2_groups_markers.toml" }
+      let(:poetry_lock_fixture_name) { "poetry_v2_groups_markers.lock" }
+
+      it "freezes dependency-groups entries to their locked versions" do
+        result = freeze_top_level_dependencies_except
+        parsed = TomlRB.parse(result)
+
+        project_deps = parsed.dig("project", "dependencies")
+        requests_dep = project_deps.find { |d| d.start_with?("requests") }
+        expect(requests_dep).to eq("requests==2.31.0")
+
+        groups = parsed["dependency-groups"]
+        expect(groups["dev"]).to include("pytest==8.0.2", "black==24.2.0")
+        expect(groups["docs"]).to include("sphinx==7.2.6")
+      end
+    end
   end
 end

--- a/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/poetry_version_resolver_spec.rb
@@ -62,6 +62,34 @@ RSpec.describe namespace::PoetryVersionResolver do
     }]
   end
 
+  describe "#set_target_dependency_req" do
+    subject(:updated_pyproject_content) do
+      resolver.send(:set_target_dependency_req, pyproject_content, updated_requirement)
+    end
+
+    let(:updated_requirement) { ">=2.18.0,<=2.18.4" }
+
+    context "when a poetry group has no dependencies table" do
+      let(:pyproject_fixture_name) { "poetry_group_without_dependencies.toml" }
+      let(:dependency_name) { "requests" }
+      let(:dependency_version) { "2.31.0" }
+      let(:dependency_requirements) do
+        [{
+          file: "pyproject.toml",
+          requirement: "^2.31.0",
+          groups: ["dependencies"],
+          source: nil
+        }]
+      end
+
+      it "does not raise and updates the target requirement" do
+        expect { updated_pyproject_content }.not_to raise_error
+        parsed = TomlRB.parse(updated_pyproject_content)
+        expect(parsed.dig("tool", "poetry", "dependencies", "requests")).to eq(updated_requirement)
+      end
+    end
+  end
+
   describe "#latest_resolvable_version" do
     subject(:latest_resolvable_version) { resolver.latest_resolvable_version(requirement: updated_requirement) }
 

--- a/python/spec/fixtures/pyproject_files/poetry_v2_groups_markers.toml
+++ b/python/spec/fixtures/pyproject_files/poetry_v2_groups_markers.toml
@@ -15,6 +15,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "black>=23.0",
+    "colorama>=0.4.0 ; sys_platform == 'win32'",
 ]
 docs = [
     "sphinx>=6.0",


### PR DESCRIPTION
### What are you trying to accomplish?
Prevent Dependabot Poetry update runs from failing or drifting when pyproject.toml uses dependency-groups.
Two issues were addressed:
1. PEP 735 dependency-group entries were not being frozen before lockfile update steps.
2. Resolver logic could raise when a Poetry group entry existed without a dependencies hash.

### Anything you want to highlight for special attention from reviewers?
This keeps behavior narrowly aligned with existing PEP 621 freezing logic and avoids broader refactors.
The implementation now:
1. Freezes PEP 735 dependency-groups using the same safe PEP 508 parsing approach.
2. Preserves markers while pinning (for example platform markers in group entries).
3. Guards resolver updates for group entries that do not define dependencies, preventing nil crashes.

Regression coverage includes:
1. A Poetry v2 fixture with dependency-groups and marker-bearing entries to verify marker-preserving pinning.
2. A resolver spec for group-without-dependencies to verify no exception and correct requirement updates.

### How will you know you've accomplished your goal?
Success criteria:
1. Dependency-group entries are pinned to lockfile versions during preparer freeze, including marker-bearing entries.
2. Resolver no longer crashes on groups that omit dependencies.
3. Targeted specs pass and RuboCop is clean for touched files.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
