### PR TITLE
Remove NuGet.Core package dependency

### DIFF
--- a/.github/instructions/nuget-projects.instructions.md
+++ b/.github/instructions/nuget-projects.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "nuget/helpers/lib/NuGetUpdater/NuGetProjects/**"
+---
+
+# NuGetProjects Maintenance
+
+## Submodule Update Checklist
+
+When the `NuGet.Client` submodule is updated, all `*.cs` files under `NuGetProjects/` must be re-checked against their original files in the submodule to ensure they remain largely in line with the upstream content.
+
+## Rules for modified files
+
+1. **No references to `NuGet.Core`.** Remove all `extern alias CoreV2` usages and any other references to the legacy `NuGet.Core` (v2) package.
+2. **No .NET Framework-only APIs.** Remove or stub any APIs not compatible with .NET Core (e.g., `System.Data.Services`, WCF types, CoreV2's `PhysicalFileSystem`).
+3. **Preserve behavior where possible.** When removing or stubbing, keep surrounding logic intact so the project compiles and packages.config tests pass.
+4. **Document deviations.** If a file significantly diverges from upstream, add a comment at the top explaining what changed and why.

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -19,4 +19,12 @@ Open the solution file at `helpers/lib/NuGetUpdater/NuGetUpdater.slnx` in your p
    [dependabot-core-dev] ~ $ cd nuget && rspec
    ```
 
+### Known limitations
+
+#### Projects suppressing `NU1701`
+
+If a project explicitly includes `NU1701` in its `<NoWarn>` property, Dependabot will likely be unable to process updates for that project. The `NU1701` warning indicates that a package's target framework may not be compatible with the project's target framework, and suppressing it allows NuGet to restore packages that would otherwise be rejected.
+
+Dependabot cannot determine why or under what circumstances ignoring target framework compatibility is safe for a given project. As a result, the final package compatibility check will fail and Dependabot will err on the side of caution and not submit a pull request.
+
 [core-repo]: https://github.com/dependabot/dependabot-core

--- a/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Build.props
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <NoWarn>$(NoWarn);NU1701</NoWarn>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
@@ -24,7 +24,6 @@
     <PackageVersion Include="Microsoft.Web.Xdt" Version="3.2.3" />
     <PackageVersion Include="MSBuild.StructuredLogger" Version="2.3.17" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NuGet.Core" Version="2.14.0" Aliases="CoreV2" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
@@ -5,7 +5,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NoWarn>$(NoWarn);CA1305</NoWarn><!-- behavior of StringBuilder could vary based on user's locale -->
     <NoWarn>$(NoWarn);CA2022</NoWarn><!-- avoid inexact Stream.Read() -->
-    <NoWarn>$(NoWarn);NU1701</NoWarn><!-- package target framework may not be compatible -->
     <NoWarn>$(NoWarn);NU1903</NoWarn><!-- package has a known high severity vulnerability -->
     <NoWarn>$(NoWarn);SYSLIB0014</NoWarn><!-- obsolete -->
     <NuGetSourceLocation>$(MSBuildThisFileDirectory)..\..\NuGet.Client</NuGetSourceLocation>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/Command.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/Command.cs
@@ -1,0 +1,288 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Credentials;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Plugins;
+
+namespace NuGet.CommandLine
+{
+    public abstract class Command : ICommand
+    {
+        private const string CommandSuffix = "Command";
+        private CommandAttribute _commandAttribute;
+        private string _currentDirectory;
+
+        protected Command()
+        {
+            Arguments = new List<string>();
+        }
+
+        public IList<string> Arguments { get; private set; }
+
+        [Import]
+        public IConsole Console { get; set; }
+
+        [Import]
+        public HelpCommand HelpCommand { get; set; }
+
+        [Import]
+        public ICommandManager Manager { get; set; }
+
+        [Import]
+        public Configuration.IMachineWideSettings MachineWideSettings { get; set; }
+
+        [Option(typeof(NuGetCommand), "Option_Help", AltName = "?")]
+        public bool Help { get; set; }
+
+        [Option(typeof(NuGetCommand), "Option_Verbosity")]
+        public Verbosity Verbosity { get; set; }
+
+        [Option(typeof(NuGetCommand), "Option_NonInteractive")]
+        public bool NonInteractive { get; set; }
+
+        [Option(typeof(NuGetCommand), "Option_ConfigFile")]
+        public string ConfigFile { get; set; }
+
+        [Option(typeof(NuGetCommand), "Option_ForceEnglishOutput")]
+        public bool ForceEnglishOutput { get; set; }
+
+        protected Configuration.ICredentialService CredentialService { get; private set; }
+
+        public DeprecatedCommandAttribute DeprecatedCommandAttribute
+        {
+            get
+            {
+                var deprecatedAttrs = GetType().GetCustomAttributes(typeof(DeprecatedCommandAttribute), false);
+
+                if (deprecatedAttrs.Length > 0)
+                {
+                    return deprecatedAttrs[0] as DeprecatedCommandAttribute;
+                }
+
+                return null;
+            }
+        }
+
+        public string CurrentDirectory
+        {
+            get
+            {
+                return _currentDirectory ?? Directory.GetCurrentDirectory();
+            }
+            set
+            {
+                _currentDirectory = value;
+            }
+        }
+
+        protected internal Configuration.ISettings Settings { get; set; }
+
+        protected internal Configuration.IPackageSourceProvider SourceProvider { get; set; }
+
+        private Lazy<MsBuildToolset> MsBuildToolset
+        {
+            get
+            {
+                if (_defaultMsBuildToolset == null)
+                {
+                    _defaultMsBuildToolset = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(null, null, Console);
+
+                }
+                return _defaultMsBuildToolset;
+            }
+        }
+
+        private Lazy<MsBuildToolset> _defaultMsBuildToolset;
+
+        public CommandAttribute CommandAttribute
+        {
+            get
+            {
+                if (_commandAttribute == null)
+                {
+                    _commandAttribute = GetCommandAttribute();
+                }
+                return _commandAttribute;
+            }
+        }
+
+        public virtual bool IncludedInHelp(string optionName)
+        {
+            return true;
+        }
+
+        public void Execute()
+        {
+            if (Help)
+            {
+                if (DeprecatedCommandAttribute != null)
+                {
+                    var deprecationMessage = DeprecatedCommandAttribute.GetDeprecationMessage(CommandAttribute.CommandName);
+                    Console.WriteWarning(deprecationMessage);
+                }
+
+                HelpCommand.ViewHelpForCommand(CommandAttribute.CommandName);
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(ConfigFile))
+                {
+                    string configFileName = null;
+
+                    var packCommand = this as PackCommand;
+                    if (packCommand != null && !string.IsNullOrEmpty(packCommand.ConfigFile))
+                    {
+                        configFileName = packCommand.ConfigFile;
+                    }
+
+                    Settings = Configuration.Settings.LoadDefaultSettings(
+                        CurrentDirectory,
+                        configFileName: configFileName,
+                        machineWideSettings: MachineWideSettings);
+                }
+                else
+                {
+                    var configFileFullPath = Path.GetFullPath(ConfigFile);
+                    var directory = Path.GetDirectoryName(configFileFullPath);
+                    var configFileName = Path.GetFileName(configFileFullPath);
+                    Settings = Configuration.Settings.LoadDefaultSettings(
+                        directory,
+                        configFileName,
+                        MachineWideSettings);
+                }
+
+                SourceProvider = PackageSourceBuilder.CreateSourceProvider(Settings);
+
+                SetDefaultCredentialProvider();
+
+                UserAgent.SetUserAgentString(new UserAgentStringBuilder(CommandLineConstants.UserAgent));
+
+                if (DeprecatedCommandAttribute != null)
+                {
+                    var deprecationMessage = DeprecatedCommandAttribute.GetDeprecationMessage(CommandAttribute.CommandName);
+                    Console.WriteWarning(deprecationMessage);
+                }
+
+                OutputNuGetVersion();
+                ExecuteCommandAsync().GetAwaiter().GetResult();
+            }
+        }
+
+        /// <summary>
+        /// Outputs the current NuGet version (by default, only when vebosity is detailed).
+        /// </summary>
+        private void OutputNuGetVersion()
+        {
+            if (ShouldOutputNuGetVersion)
+            {
+                var assemblyName = typeof(Command).Assembly.GetName();
+                var assemblyLocation = typeof(Command).Assembly.Location;
+                var version = System.Diagnostics.FileVersionInfo.GetVersionInfo(assemblyLocation).FileVersion;
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    LocalizedResourceManager.GetString("OutputNuGetVersion"),
+                    assemblyName.Name,
+                    version);
+                Console.WriteLine(message);
+            }
+        }
+
+        protected virtual bool ShouldOutputNuGetVersion
+        {
+            get { return Console.Verbosity == Verbosity.Detailed; }
+        }
+
+        protected virtual void SetDefaultCredentialProvider()
+        {
+            SetDefaultCredentialProvider(MsBuildToolset);
+        }
+
+        /// <summary>
+        /// Set default credential provider for the HttpClient, which is used by V2 sources.
+        /// Also set up authenticated proxy handling for V3 sources.
+        /// </summary>
+        protected void SetDefaultCredentialProvider(Lazy<MsBuildToolset> msbuildDirectory)
+        {
+            PluginDiscoveryUtility.InternalPluginDiscoveryRoot = new Lazy<string>(() => PluginDiscoveryUtility.GetInternalPluginRelativeToMSBuildDirectory(msbuildDirectory.Value.Path));
+            CredentialService = new CredentialService(new AsyncLazy<IEnumerable<ICredentialProvider>>(() => GetCredentialProvidersAsync()), NonInteractive, handlesDefaultCredentials: PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders);
+
+            HttpHandlerResourceV3.CredentialService = new Lazy<Configuration.ICredentialService>(() => CredentialService);
+
+            HttpHandlerResourceV3.CredentialsSuccessfullyUsed = (uri, credentials) =>
+            {
+            };
+        }
+
+        private async Task<IEnumerable<ICredentialProvider>> GetCredentialProvidersAsync()
+        {
+            var extensionLocator = new ExtensionLocator();
+            var providers = new List<ICredentialProvider>();
+            var pluginProviders = new PluginCredentialProviderBuilder(extensionLocator, Settings, Console)
+                .BuildAll(Verbosity.ToString())
+                .ToList();
+            var securePluginProviders = await (new SecurePluginCredentialProviderBuilder(PluginManager.Instance, canShowDialog: true, logger: Console)).BuildAllAsync();
+
+            providers.Add(new SettingsCredentialProvider(SourceProvider, Console));
+            providers.AddRange(securePluginProviders);
+            providers.AddRange(pluginProviders);
+
+            if (pluginProviders.Any() || securePluginProviders.Any())
+            {
+                if (PreviewFeatureSettings.DefaultCredentialsAfterCredentialProviders)
+                {
+                    providers.Add(new DefaultNetworkCredentialsCredentialProvider());
+                }
+            }
+            providers.Add(new ConsoleCredentialProvider(Console));
+
+            return providers;
+        }
+
+        public virtual Task ExecuteCommandAsync()
+        {
+            ExecuteCommand();
+            return Task.CompletedTask;
+        }
+
+        public virtual void ExecuteCommand()
+        {
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "This method does quite a bit of processing.")]
+        public virtual CommandAttribute GetCommandAttribute()
+        {
+            var type = GetType();
+            var attributes = type.GetCustomAttributes(typeof(CommandAttribute), true);
+            var attribute = attributes.FirstOrDefault();
+            if (attribute != null)
+            {
+                return (CommandAttribute)attribute;
+            }
+
+            // Use the command name minus the suffix if present and default description
+            var name = type.Name;
+            var idx = name.LastIndexOf(CommandSuffix, StringComparison.OrdinalIgnoreCase);
+            if (idx >= 0)
+            {
+                name = name.Substring(0, idx);
+            }
+            if (!string.IsNullOrEmpty(name))
+            {
+                return new CommandAttribute(name, LocalizedResourceManager.GetString("DefaultCommandDescription"));
+            }
+            return null;
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -1,0 +1,1428 @@
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Xml.Linq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.PackageManagement;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using XElementExtensions = NuGet.Packaging.XElementExtensions;
+
+namespace NuGet.CommandLine
+{
+    public class ProjectFactory : IProjectFactory, IDisposable
+    {
+        private const string NUGET_ENABLE_LEGACY_CSPROJ_PACK = nameof(NUGET_ENABLE_LEGACY_CSPROJ_PACK);
+
+        // Its type is Microsoft.Build.Evaluation.Project
+        private dynamic _project;
+
+        private ILogger _logger;
+
+        private IEnvironmentVariableReader _environmentVariableReader;
+
+        // Files we want to always exclude from the resulting package
+        private static readonly HashSet<string> ExcludeFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+            NuGetConstants.PackageReferenceFile,
+            "Web.Debug.config",
+            "Web.Release.config"
+        };
+
+        private readonly Dictionary<string, string> _properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly MSBuildAssemblyResolver _msbuildAssemblyResolver;
+
+        // Packaging folders
+        private const string ContentFolder = "content";
+
+        private const string ReferenceFolder = "lib";
+        private const string ToolsFolder = "tools";
+        private const string SourcesFolder = "src";
+
+        // Common item types
+        private const string SourcesItemType = "Compile";
+
+        private const string ContentItemType = "Content";
+        private const string ProjectReferenceItemType = "ProjectReference";
+        private const string ReferenceOutputAssembly = "ReferenceOutputAssembly";
+        private const string TransformFileExtension = ".transform";
+
+        [Import]
+        public IMachineWideSettings MachineWideSettings { get; set; }
+
+        public static IProjectFactory ProjectCreator(PackArgs packArgs, string path)
+        {
+            return new ProjectFactory(packArgs.MsBuildDirectory.Value, path, packArgs.Properties)
+            {
+                IsTool = packArgs.Tool,
+                LogLevel = packArgs.LogLevel,
+                Logger = packArgs.Logger,
+                MachineWideSettings = packArgs.MachineWideSettings,
+                Build = packArgs.Build,
+                IncludeReferencedProjects = packArgs.IncludeReferencedProjects,
+                SymbolPackageFormat = packArgs.SymbolPackageFormat,
+                PackagesDirectory = packArgs.PackagesDirectory,
+                SolutionDirectory = packArgs.SolutionDirectory,
+            };
+        }
+
+        public ProjectFactory(string msbuildDirectory, string path, IDictionary<string, string> projectProperties)
+        {
+            _environmentVariableReader = EnvironmentVariableWrapper.Instance;
+
+            _msbuildAssemblyResolver = new MSBuildAssemblyResolver(msbuildDirectory);
+
+            var project = Activator.CreateInstance(
+                    _msbuildAssemblyResolver.ProjectType,
+                    path,
+                    projectProperties,
+                    null);
+            Initialize(project);
+        }
+
+        public ProjectFactory(string msbuildDirectory, dynamic project)
+        {
+            Initialize(project);
+            _environmentVariableReader = EnvironmentVariableWrapper.Instance;
+        }
+
+        private ProjectFactory(
+            MSBuildAssemblyResolver msbuildAssemblyResolver,
+            dynamic project,
+            IEnvironmentVariableReader environmentVariableReader)
+        {
+            _msbuildAssemblyResolver = msbuildAssemblyResolver;
+            _environmentVariableReader = environmentVariableReader;
+            Initialize(project);
+        }
+
+        private void Initialize(dynamic project)
+        {
+            _project = project;
+            ProjectProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            AddSolutionDir();
+            // Get the target framework of the project
+            string targetFrameworkMoniker = _project.GetPropertyValue("TargetFrameworkMoniker");
+            if (!string.IsNullOrEmpty(targetFrameworkMoniker))
+            {
+                TargetFramework = NuGetFramework.Parse(targetFrameworkMoniker);
+            }
+
+            // This happens before we obtain warning properties, so this Logger is still IConsole.
+            IConsole console = Logger as IConsole;
+            switch (LogLevel)
+            {
+                case LogLevel.Verbose:
+                    {
+                        console.Verbosity = Verbosity.Detailed;
+                        break;
+                    }
+                case LogLevel.Information:
+                    {
+                        console.Verbosity = Verbosity.Normal;
+                        break;
+                    }
+                case LogLevel.Minimal:
+                    {
+                        console.Verbosity = Verbosity.Quiet;
+                        break;
+                    }
+            }
+        }
+
+        public WarningProperties GetWarningPropertiesForProject()
+        {
+            var treatWarningsAsErrors = GetPropertyValue("TreatWarningsAsErrors");
+            return WarningProperties.GetWarningProperties(treatWarningsAsErrors: string.IsNullOrEmpty(treatWarningsAsErrors) ? "false" : treatWarningsAsErrors,
+                warningsAsErrors: GetPropertyValue("WarningsAsErrors"),
+                noWarn: GetPropertyValue("NoWarn"),
+                warningsNotAsErrors: GetPropertyValue("WarningsNotAsErrors"));
+        }
+
+        private string TargetPath
+        {
+            get;
+            set;
+        }
+
+        private NuGetFramework TargetFramework
+        {
+            get;
+            set;
+        }
+
+        public void SetIncludeSymbols(bool includeSymbols)
+        {
+            IncludeSymbols = includeSymbols;
+        }
+        public bool IncludeSymbols { get; set; }
+
+        public bool IncludeReferencedProjects { get; set; }
+        public bool Build { get; set; }
+
+        public Dictionary<string, string> GetProjectProperties()
+        {
+            return ProjectProperties;
+        }
+        public Dictionary<string, string> ProjectProperties { get; private set; }
+
+        public bool IsTool { get; set; }
+
+        public LogLevel LogLevel { get; set; }
+
+        public SymbolPackageFormat SymbolPackageFormat { get; set; }
+
+        public string PackagesDirectory { get; set; }
+
+        public string SolutionDirectory { get; set; }
+
+        public ILogger Logger
+        {
+            get
+            {
+                return _logger ?? Common.NullLogger.Instance;
+            }
+            set
+            {
+                _logger = value;
+            }
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We want to continue regardless of any error we encounter extracting metadata.")]
+        public PackageBuilder CreateBuilder(string basePath, NuGetVersion version, string suffix, bool buildIfNeeded, PackageBuilder builder = null)
+        {
+            if (buildIfNeeded)
+            {
+                BuildProject();
+            }
+
+            if (!string.IsNullOrEmpty(TargetPath))
+            {
+                Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
+                        CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString("PackagingFilesFromOutputPath"),
+                        Path.GetFullPath(Path.GetDirectoryName(TargetPath))), LogLevel.Minimal));
+            }
+
+            string usingNETSDK = _project.GetPropertyValue("UsingMicrosoftNETSDK");
+            if (!string.IsNullOrEmpty(usingNETSDK)) // NuGet.exe cannot correctly pack SDK based projects.
+            {
+                _ = bool.TryParse(_environmentVariableReader.GetEnvironmentVariable(NUGET_ENABLE_LEGACY_CSPROJ_PACK),
+                    out bool enableLegacyCsprojPack);
+
+                if (!enableLegacyCsprojPack)
+                {
+                    Logger.Log(PackagingLogMessage.CreateError(string.Format(NuGetResources.Error_AttemptingToPackSDKproject, NUGET_ENABLE_LEGACY_CSPROJ_PACK, CultureInfo.CurrentCulture), NuGetLogCode.NU5049));
+                    return null;
+                }
+            }
+
+            builder = new PackageBuilder(false, Logger);
+
+            try
+            {
+                ExtractMetadata(builder);
+            }
+            catch (PackagingException packex) when (packex.AsLogMessage().Code.Equals(NuGetLogCode.NU5133))
+            {
+                ExceptionUtilities.LogException(packex, Logger);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log(PackagingLogMessage.CreateError(string.Format(
+                        CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString("UnableToExtractAssemblyMetadata"),
+                        Path.GetFileName(TargetPath)), NuGetLogCode.NU5011));
+                if (LogLevel == LogLevel.Verbose)
+                {
+                    Logger.Log(PackagingLogMessage.CreateError(ex.ToString(), NuGetLogCode.NU5011));
+                }
+                else
+                {
+                    Logger.Log(PackagingLogMessage.CreateError(ex.Message, NuGetLogCode.NU5011));
+                }
+
+                return null;
+            }
+
+            var projectAuthor = InitializeProperties(builder);
+
+            // Set version based on version argument from console?
+            if (version != null)
+            {
+                // make sure the $version$ placeholder gets populated correctly
+                _properties["version"] = version.ToFullString();
+
+                builder.Version = version;
+            }
+
+            // Only override properties from assembly extracted metadata if they haven't
+            // been specified also at construction time for the factory (that is,
+            // console properties always take precedence.
+            foreach ((var key, var value) in builder.Properties)
+            {
+                if (!_properties.ContainsKey(key) &&
+                    !ProjectProperties.ContainsKey(key))
+                {
+                    _properties.Add(key, value);
+                }
+            }
+
+            // If the package contains a nuspec file then use it for metadata
+            Manifest manifest = ProcessNuspec(builder, basePath);
+
+            // Remove the extra author
+            if (builder.Authors.Count > 1)
+            {
+                builder.Authors.Remove(projectAuthor);
+            }
+
+            // Add output files
+            ApplyAction(p => p.AddOutputFiles(builder));
+
+            // Add content files if there are any. They could come from a project or nuspec file
+            // In order to be compliant with the documented behavior, if the nuspec file has an
+            // empty <files> element, we do not add any content files at all. If the <files> element
+            // has one or more files specified, then those files are added to the package along with
+            // any files of type Content from the csproj file.
+            if (manifest == null || !manifest.HasFilesNode || manifest.Files.Count > 0)
+            {
+                ApplyAction(p => p.AddFiles(builder, ContentItemType, ContentFolder));
+            }
+
+            // Add sources if this is a symbol package
+            if (IncludeSymbols)
+            {
+                if (SymbolPackageFormat == SymbolPackageFormat.SymbolsNupkg)
+                {
+                    ApplyAction(p => p.AddFiles(builder, SourcesItemType, SourcesFolder));
+                }
+
+            }
+
+            ProcessDependencies(builder);
+
+            // Set defaults if some required fields are missing
+            if (string.IsNullOrEmpty(builder.Description))
+            {
+                builder.Description = "Description";
+                Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
+                        CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString("Warning_UnspecifiedField"),
+                        "Description",
+                        "Description"), NuGetLogCode.NU5115));
+            }
+
+            if (!builder.Authors.Any())
+            {
+                builder.Authors.Add(Environment.UserName);
+                Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
+                        CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString("Warning_UnspecifiedField"),
+                        "Author",
+                        Environment.UserName), NuGetLogCode.NU5115));
+            }
+
+            return builder;
+        }
+
+        public string InitializeProperties(Packaging.IPackageMetadata metadata)
+        {
+            // Set the properties that were resolved from the assembly/project so they can be
+            // resolved by name if the nuspec contains tokens
+            _properties.Clear();
+
+            // Allow Id to be overridden by cmd line properties
+            if (ProjectProperties.TryGetValue("Id", out var id))
+            {
+                _properties.Add("Id", id);
+            }
+            else
+            {
+                _properties.Add("Id", metadata.Id);
+            }
+
+            _properties.Add("Version", metadata.Version.ToFullString());
+
+            if (!string.IsNullOrEmpty(metadata.Title))
+            {
+                _properties.Add("Title", metadata.Title);
+            }
+
+            if (!string.IsNullOrEmpty(metadata.Description))
+            {
+                _properties.Add("Description", metadata.Description);
+            }
+
+            if (!string.IsNullOrEmpty(metadata.Copyright))
+            {
+                _properties.Add("Copyright", metadata.Copyright);
+            }
+
+            string projectAuthor = metadata.Authors.FirstOrDefault();
+            if (!string.IsNullOrEmpty(projectAuthor))
+            {
+                _properties.Add("Author", projectAuthor);
+            }
+            return projectAuthor;
+        }
+
+        public string GetPropertyValue(string propertyName)
+        {
+            string value;
+            if (!_properties.TryGetValue(propertyName, out value) &&
+                !ProjectProperties.TryGetValue(propertyName, out value))
+            {
+                dynamic property = _project.GetProperty(propertyName);
+                if (property != null)
+                {
+                    value = property.EvaluatedValue;
+                }
+            }
+
+            return value;
+        }
+
+        private void BuildProject()
+        {
+            if (Build)
+            {
+                if (TargetFramework != null)
+                {
+                    Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
+                            CultureInfo.CurrentCulture,
+                            LocalizedResourceManager.GetString("BuildingProjectTargetingFramework"),
+                            _project.FullPath,
+                            TargetFramework), LogLevel.Minimal));
+                }
+
+                BuildProjectWithMsbuild();
+            }
+            else
+            {
+                TargetPath = ResolveTargetPath();
+
+                // Make if the target path doesn't exist, fail
+                if (!Directory.Exists(TargetPath) && !File.Exists(TargetPath))
+                {
+                    throw new PackagingException(NuGetLogCode.NU5012, string.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString("UnableToFindBuildOutput"), TargetPath));
+                }
+            }
+        }
+
+        private void BuildProjectWithMsbuild()
+        {
+            string properties = string.Empty;
+            foreach (var property in ProjectProperties)
+            {
+                string escapedValue = MsBuildUtility.Escape(property.Value);
+                properties += $" /p:{property.Key}={escapedValue}";
+            }
+
+            int result = MsBuildUtility.Build(_msbuildAssemblyResolver.MSBuildDirectory, $"\"{_project.FullPath}\" {properties} /toolsversion:{_project.ToolsVersion}");
+
+            if (0 != result) // 0 is msbuild.exe success code
+            {
+                // If the build fails, report the error
+                var error = string.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString("FailedToBuildProject"), Path.GetFileName(_project.FullPath));
+                throw new PackagingException(NuGetLogCode.NU5013, error);
+            }
+
+            TargetPath = ResolveTargetPath();
+        }
+
+        private string ResolveTargetPath()
+        {
+            // Set the project properties
+            foreach (var property in ProjectProperties)
+            {
+                var existingProperty = _project.GetProperty(property.Key);
+                if (existingProperty == null || !IsGlobalProperty(existingProperty))
+                {
+                    // Only set the property if it's not already defined as a global property
+                    // (which those passed in via the ctor are) as trying to set global properties
+                    // with this method throws.
+                    _project.SetProperty(property.Key, property.Value);
+                }
+            }
+
+            // Re-evaluate the project so that the new property values are applied
+            _project.ReevaluateIfNecessary();
+
+            // Return the new target path
+            string targetPath = _project.GetPropertyValue("TargetPath");
+
+            if (string.IsNullOrEmpty(targetPath))
+            {
+                string outputPath = _project.GetPropertyValue("OutputPath");
+                string configuration = _project.GetPropertyValue("Configuration");
+                string projectName = Path.GetFileName(Path.GetDirectoryName(_project.FullPath));
+                targetPath = PathUtility.EnsureTrailingSlash(Path.Combine(outputPath, projectName, "bin", configuration));
+            }
+
+            return targetPath;
+        }
+
+        // The type of projectProperty is Microsoft.Build.Evaluation.ProjectProperty
+        private static bool IsGlobalProperty(object projectProperty)
+        {
+            // This property isn't available on xbuild (mono)
+            var property = projectProperty.GetType().GetProperty("IsGlobalProperty", BindingFlags.Public | BindingFlags.Instance);
+            if (property != null)
+            {
+                return (bool)property.GetValue(projectProperty, null);
+            }
+
+            // REVIEW: Maybe there's something better we can do on mono
+            // Just return false if the property isn't there
+            return false;
+        }
+
+        private void ExtractMetadataFromProject(Packaging.PackageBuilder builder)
+        {
+            builder.Id = builder.Id ??
+                        _project.GetPropertyValue("AssemblyName") ??
+                        Path.GetFileNameWithoutExtension(_project.FullPath);
+
+            string version = _project.GetPropertyValue("Version");
+            if (builder.Version == null)
+            {
+                NuGetVersion parsedVersion;
+
+                if (NuGetVersion.TryParse(version, out parsedVersion))
+                {
+                    builder.Version = parsedVersion;
+                }
+                else
+                {
+                    builder.Version = new NuGetVersion(1, 0, 0);
+                }
+            }
+        }
+
+        private static IEnumerable<string> GetFiles(string path, ISet<string> fileNames, SearchOption searchOption)
+        {
+            return Directory.EnumerateFiles(path, "*", searchOption)
+                .Where(filePath => fileNames.Contains(Path.GetFileName(filePath)));
+        }
+
+        private void ApplyAction(Action<ProjectFactory> action)
+        {
+            if (IncludeReferencedProjects)
+            {
+                RecursivelyApply(action);
+            }
+            else
+            {
+                action(this);
+            }
+        }
+
+        /// <summary>
+        /// Recursively execute the specified action on the current project and
+        /// projects referenced by the current project.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        private void RecursivelyApply(Action<ProjectFactory> action)
+        {
+            var projectCollection = Activator.CreateInstance(_msbuildAssemblyResolver.ProjectCollectionType) as IDisposable;
+            using (projectCollection)
+            {
+                RecursivelyApply(action, projectCollection);
+            }
+        }
+
+        /// <summary>
+        /// Recursively execute the specified action on the current project and
+        /// projects referenced by the current project.
+        /// </summary>
+        /// <param name="action">The action to be executed.</param>
+        /// <param name="alreadyAppliedProjects">The collection of projects that have been processed.
+        /// It is used to avoid processing the same project more than once.</param>
+        private void RecursivelyApply(Action<ProjectFactory> action, dynamic alreadyAppliedProjects)
+        {
+            action(this);
+            foreach (var item in _project.GetItems(ProjectReferenceItemType))
+            {
+                if (ShouldExcludeItem(item))
+                {
+                    continue;
+                }
+
+                string fullPath = item.GetMetadataValue("FullPath");
+                if (!string.IsNullOrEmpty(fullPath) &&
+                    !NuspecFileExists(fullPath) &&
+                    !File.Exists(ProjectJsonPathUtilities.GetProjectConfigPath(Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))) &&
+                    alreadyAppliedProjects.GetLoadedProjects(fullPath).Count == 0)
+                {
+                    dynamic project = Activator.CreateInstance(
+                        _msbuildAssemblyResolver.ProjectType,
+                        fullPath,
+                        null,
+                        null,
+                        alreadyAppliedProjects);
+                    var referencedProject = new ProjectFactory(_msbuildAssemblyResolver, project, _environmentVariableReader);
+                    referencedProject.Logger = _logger;
+                    referencedProject.IncludeSymbols = IncludeSymbols;
+                    referencedProject.Build = Build;
+                    referencedProject.IncludeReferencedProjects = IncludeReferencedProjects;
+                    referencedProject.ProjectProperties = ProjectProperties;
+                    referencedProject.TargetFramework = TargetFramework;
+                    referencedProject.BuildProject();
+                    referencedProject.SymbolPackageFormat = SymbolPackageFormat;
+                    referencedProject.RecursivelyApply(action, alreadyAppliedProjects);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Should the project item be excluded based on the Reference output assembly metadata
+        /// </summary>
+        /// <param name="item">Dynamic item which is a project item</param>
+        /// <returns>true, if the item should be excluded. false, otherwise.</returns>
+        private static bool ShouldExcludeItem(dynamic item)
+        {
+            if (item == null)
+            {
+                return true;
+            }
+
+            if (item.HasMetadata(ReferenceOutputAssembly))
+            {
+                bool result;
+                if (bool.TryParse(item.GetMetadataValue("ReferenceOutputAssembly"), out result))
+                {
+                    if (!result)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns whether a project file has a corresponding nuspec file.
+        /// </summary>
+        /// <param name="projectFileFullName">The name of the project file.</param>
+        /// <returns>True if there is a corresponding nuspec file.</returns>
+        private static bool NuspecFileExists(string projectFileFullName)
+        {
+            var nuspecFile = Path.ChangeExtension(projectFileFullName, NuGetConstants.ManifestExtension);
+            return File.Exists(nuspecFile);
+        }
+
+        /// <summary>
+        /// Adds referenced projects that have corresponding nuspec files as dependencies.
+        /// </summary>
+        /// <param name="dependencies">The dependencies collection where the new dependencies
+        /// are added into.</param>
+        private void AddProjectReferenceDependencies(Dictionary<string, Packaging.Core.PackageDependency> dependencies)
+        {
+            var processedProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var projectsToProcess = new Queue<object>();
+            dynamic projectCollection = Activator.CreateInstance(_msbuildAssemblyResolver.ProjectCollectionType);
+            using ((IDisposable)projectCollection)
+            {
+                projectsToProcess.Enqueue(_project);
+                while (projectsToProcess.Count > 0)
+                {
+                    dynamic project = projectsToProcess.Dequeue();
+                    processedProjects.Add(project.FullPath);
+
+                    foreach (var projectReference in project.GetItems(ProjectReferenceItemType))
+                    {
+                        if (ShouldExcludeItem(projectReference))
+                        {
+                            continue;
+                        }
+
+                        string fullPath = projectReference.GetMetadataValue("FullPath");
+                        if (string.IsNullOrEmpty(fullPath) ||
+                            processedProjects.Contains(fullPath))
+                        {
+                            continue;
+                        }
+
+                        var loadedProjects = projectCollection.GetLoadedProjects(fullPath);
+                        var referencedProject = loadedProjects.Count > 0 ?
+                            loadedProjects[0] :
+                            Activator.CreateInstance(
+                                _msbuildAssemblyResolver.ProjectType,
+                                fullPath,
+                                project.GlobalProperties,
+                                null,
+                                projectCollection);
+
+                        if (NuspecFileExists(fullPath) || File.Exists(ProjectJsonPathUtilities.GetProjectConfigPath(Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))))
+                        {
+                            var dependency = CreateDependencyFromProject(referencedProject, dependencies);
+                            dependencies[dependency.Id] = dependency;
+                        }
+                        else
+                        {
+                            projectsToProcess.Enqueue(referencedProject);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Creates a package dependency from the given project, which has a corresponding
+        // nuspec file.
+        private PackageDependency CreateDependencyFromProject(dynamic project, Dictionary<string, Packaging.Core.PackageDependency> dependencies)
+        {
+            try
+            {
+                var projectFactory = new ProjectFactory(_msbuildAssemblyResolver, project, EnvironmentVariableWrapper.Instance);
+                projectFactory.Build = Build;
+                projectFactory.ProjectProperties = ProjectProperties;
+                projectFactory.SymbolPackageFormat = SymbolPackageFormat;
+                projectFactory.BuildProject();
+                var builder = new PackageBuilder();
+
+                projectFactory.ExtractMetadata(builder);
+                projectFactory.InitializeProperties(builder);
+                projectFactory.ProcessNuspec(builder, null);
+
+                VersionRange versionRange = null;
+                if (dependencies.TryGetValue(builder.Id, out PackageDependency dependency))
+                {
+                    VersionRange nuspecVersion = dependency.VersionRange;
+                    if (nuspecVersion != null)
+                    {
+                        versionRange = nuspecVersion;
+                    }
+                }
+
+                if (versionRange == null)
+                {
+                    versionRange = VersionRange.Parse(builder.Version.ToString());
+                }
+
+                return new Packaging.Core.PackageDependency(
+                    builder.Id,
+                    versionRange);
+            }
+            catch (Exception ex)
+            {
+                var message = string.Format(
+                    CultureInfo.InvariantCulture,
+                    LocalizedResourceManager.GetString("Error_ProcessingNuspecFile"),
+                    project.FullPath,
+                    ex.Message);
+                throw new PackagingException(NuGetLogCode.NU5014, message, ex);
+            }
+        }
+
+        private void ExtractMetadata(Packaging.PackageBuilder builder)
+        {
+            // If building an xproj, then TargetPath points to the folder where the framework folders will be
+            // instead of to a single dll. Skip trying to ExtractMetadata from the dll and instead
+            // use only metadata from the project and json file.
+            if (!Directory.Exists(TargetPath))
+            {
+                // If building a project targeting netstandard, assembly metadata extraction fails
+                // because it tries to load system.runtime version 4.1.0 which is not present in the local
+                // path or the gac. In this case, we should just skip it and extract metadata from the project.
+                try
+                {
+                    new AssemblyMetadataExtractor(Logger).ExtractMetadata(builder, TargetPath);
+                }
+                catch (PackagingException packex) when (packex.AsLogMessage().Code.Equals(NuGetLogCode.NU5133))
+                {
+                    // Reflection loading error for sandboxed assembly, rethrow it to fail packing.
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log(PackagingLogMessage.CreateMessage(ex.Message, LogLevel.Verbose));
+                    ExtractMetadataFromProject(builder);
+                }
+            }
+            else
+            {
+                ExtractMetadataFromProject(builder);
+            }
+        }
+
+        private void AddOutputFiles(Packaging.PackageBuilder builder)
+        {
+            // Get the target framework of the project
+            NuGetFramework nugetFramework = TargetFramework;
+
+            var projectOutputDirectory = Path.GetDirectoryName(TargetPath);
+            string targetFileName;
+
+            if (Directory.Exists(TargetPath))
+            {
+                targetFileName = builder.Id;
+            }
+            else
+            {
+                targetFileName = Path.GetFileNameWithoutExtension(TargetPath);
+            }
+
+            var outputFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                $"{targetFileName}.dll",
+                $"{targetFileName}.exe",
+                $"{targetFileName}.xml",
+                $"{targetFileName}.winmd"
+            };
+
+            if (IncludeSymbols)
+            {
+                // if this is a snupkg package, we don't want any files other than symbol files.
+                if (SymbolPackageFormat == SymbolPackageFormat.Snupkg)
+                {
+                    outputFileNames.Clear();
+                    outputFileNames.Add($"{targetFileName}.pdb");
+                }
+                else
+                {
+                    outputFileNames.Add($"{targetFileName}.pdb");
+                    outputFileNames.Add($"{targetFileName}.dll.mdb");
+                    outputFileNames.Add($"{targetFileName}.exe.mdb");
+                }
+            }
+
+            foreach (var file in GetFiles(projectOutputDirectory, outputFileNames, SearchOption.AllDirectories))
+            {
+                string targetFolder;
+
+                if (IsTool)
+                {
+                    targetFolder = ToolsFolder;
+                }
+                else
+                {
+                    if (Directory.Exists(TargetPath))
+                    {
+                        targetFolder = Path.Combine(ReferenceFolder, Path.GetDirectoryName(file.Replace(TargetPath, string.Empty)));
+                    }
+                    else if (nugetFramework == null)
+                    {
+                        targetFolder = ReferenceFolder;
+                    }
+                    else
+                    {
+                        string shortFolderName = nugetFramework.GetShortFolderName();
+                        targetFolder = Path.Combine(ReferenceFolder, shortFolderName);
+                    }
+                }
+                var packageFile = new Packaging.PhysicalPackageFile
+                {
+                    SourcePath = file,
+                    TargetPath = Path.Combine(targetFolder, Path.GetFileName(file))
+                };
+                AddFileToBuilder(builder, packageFile);
+            }
+        }
+
+        private void ProcessDependencies(Packaging.PackageBuilder builder)
+        {
+            // get all packages and dependencies, including the ones in project references
+            var packagesAndDependencies = new Dictionary<string, Tuple<PackageReaderBase, Packaging.Core.PackageDependency>>();
+            ApplyAction(p => p.AddDependencies(packagesAndDependencies));
+
+            // list of all dependency packages
+            var packages = packagesAndDependencies.Values.Select(t => t.Item1).ToList();
+
+            // Add the transform file to the package builder
+            ProcessTransformFiles(builder, packages.SelectMany(GetTransformFiles));
+
+            var dependencies = builder.DependencyGroups.SelectMany(d => d.Packages)
+                .ToDictionary(d => d.Id, StringComparer.OrdinalIgnoreCase);
+
+            // Reduce the set of packages we want to include as dependencies to the minimal set.
+            // Normally, packages.config has the full closure included, we only add top level
+            // packages, i.e. packages with in-degree 0
+            foreach (var package in packages)
+            {
+                // Don't add duplicate dependencies
+                var packageIdentity = package.GetIdentity();
+                if (dependencies.ContainsKey(packageIdentity.Id) ||
+                    !FindDependency(packageIdentity, packagesAndDependencies.Values))
+                {
+                    continue;
+                }
+
+                var dependency = packagesAndDependencies[packageIdentity.Id].Item2;
+                dependencies[dependency.Id] = dependency;
+            }
+
+            DisposePackageReaders(packagesAndDependencies);
+
+            if (IncludeReferencedProjects)
+            {
+                AddProjectReferenceDependencies(dependencies);
+            }
+
+            builder.DependencyGroups.Clear();
+
+            var targetFramework = TargetFramework ?? NuGetFramework.AnyFramework;
+            builder.DependencyGroups.Add(new PackageDependencyGroup(targetFramework, new HashSet<PackageDependency>(dependencies.Values)));
+        }
+
+        private bool FindDependency(PackageIdentity projectPackage, IEnumerable<Tuple<PackageReaderBase, Packaging.Core.PackageDependency>> packagesAndDependencies)
+        {
+            // returns true if the dependency should be added to the package
+            // This happens if the dependency is not a dependency of a dependency
+            // Or if the project dependency version is != the dependency's dependency version
+            bool found = false;
+            foreach (var reader in packagesAndDependencies)
+            {
+                foreach (var set in reader.Item1.GetPackageDependencies())
+                {
+                    foreach (var dependency in set.Packages)
+                    {
+                        if (dependency.Id.Equals(projectPackage.Id, StringComparison.OrdinalIgnoreCase))
+                        {
+                            found = true;
+
+                            if (dependency.VersionRange.MinVersion < projectPackage.Version ||
+                                (!dependency.VersionRange.IsMinInclusive &&
+                                dependency.VersionRange.MinVersion == projectPackage.Version))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return !found;
+        }
+
+        private void AddDependencies(Dictionary<string, Tuple<PackageReaderBase, Packaging.Core.PackageDependency>> packagesAndDependencies)
+        {
+            Dictionary<string, object> props = new Dictionary<string, object>();
+
+            foreach (var property in _project.Properties)
+            {
+                props.Add(property.Name, property.EvaluatedValue);
+            }
+
+            if (!props.ContainsKey(NuGetProjectMetadataKeys.TargetFramework))
+            {
+                props.Add(NuGetProjectMetadataKeys.TargetFramework, TargetFramework);
+            }
+            if (!props.ContainsKey(NuGetProjectMetadataKeys.Name))
+            {
+                props.Add(NuGetProjectMetadataKeys.Name, Path.GetFileNameWithoutExtension(_project.FullPath));
+            }
+
+            PackagesConfigNuGetProject packagesProject = new PackagesConfigNuGetProject(_project.DirectoryPath, props);
+
+            if (!packagesProject.PackagesConfigExists())
+            {
+                return;
+            }
+            Logger.Log(PackagingLogMessage.CreateMessage(LocalizedResourceManager.GetString("UsingPackagesConfigForDependencies"), LogLevel.Minimal));
+
+            var references = packagesProject.GetInstalledPackagesAsync(CancellationToken.None).Result;
+
+            string packagesFolderPath;
+            if (!string.IsNullOrEmpty(PackagesDirectory))
+            {
+                packagesFolderPath = PackagesDirectory;
+            }
+            else
+            {
+                var solutionDir = GetSolutionDir();
+                if (solutionDir == null)
+                {
+                    packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(_project.DirectoryPath, ReadSettings(_project.DirectoryPath));
+                }
+                else
+                {
+                    packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(solutionDir, ReadSettings(solutionDir));
+                }
+            }
+
+            var findLocalPackagesResource = Repository
+                .Factory
+                .GetCoreV3(packagesFolderPath)
+                .GetResource<FindLocalPackagesResource>(CancellationToken.None);
+
+            // Collect all packages
+            IDictionary<PackageIdentity, PackageReference> packageReferences =
+                references
+                .Where(r => !r.IsDevelopmentDependency)
+                .ToDictionary(r => r.PackageIdentity);
+
+            // add all packages and create an associated dependency to the dictionary
+            foreach (PackageReference reference in packageReferences.Values)
+            {
+                var packageReference = references.FirstOrDefault(r => r.PackageIdentity == reference.PackageIdentity);
+                if (packageReference != null && !packagesAndDependencies.ContainsKey(packageReference.PackageIdentity.Id))
+                {
+                    VersionRange range;
+                    if (packageReference.HasAllowedVersions)
+                    {
+                        range = packageReference.AllowedVersions;
+                    }
+                    else
+                    {
+                        range = new VersionRange(packageReference.PackageIdentity.Version);
+                    }
+
+                    var localPackageInfo = findLocalPackagesResource.GetPackage(
+                        packageReference.PackageIdentity,
+                        _logger,
+                        CancellationToken.None);
+
+                    var reader = localPackageInfo?.GetReader();
+                    if (reader != null)
+                    {
+                        try
+                        {
+                            var dependency = new PackageDependency(packageReference.PackageIdentity.Id, range);
+                            packagesAndDependencies.Add(packageReference.PackageIdentity.Id, Tuple.Create<PackageReaderBase, PackageDependency>(reader, dependency));
+                        }
+                        catch (Exception)
+                        {
+                            DisposePackageReaders(packagesAndDependencies);
+                            reader.Dispose();
+
+                            throw;
+                        }
+                    }
+                    else
+                    {
+                        DisposePackageReaders(packagesAndDependencies);
+
+                        var packageName = $"{packageReference.PackageIdentity.Id}.{packageReference.PackageIdentity.Version}";
+                        throw new PackagingException(NuGetLogCode.NU5012, string.Format(CultureInfo.CurrentCulture, NuGetResources.UnableToFindBuildOutput, $"{packageName}.nupkg"));
+                    }
+                }
+            }
+        }
+
+        private static void DisposePackageReaders(Dictionary<string, Tuple<PackageReaderBase, PackageDependency>> packagesAndDependencies)
+        {
+            // Release the open file handles
+            foreach (var package in packagesAndDependencies)
+            {
+                package.Value.Item1.Dispose();
+            }
+        }
+
+        private ISettings ReadSettings(string solutionDirectory)
+        {
+            // Read the solution-level settings
+            var solutionSettingsFile = Path.Combine(
+                solutionDirectory,
+                NuGetConstants.NuGetSolutionSettingsFolder);
+
+            return Settings.LoadDefaultSettings(
+                solutionSettingsFile,
+                configFileName: null,
+                machineWideSettings: MachineWideSettings);
+        }
+
+        private static void ProcessTransformFiles(PackageBuilder builder, IEnumerable<IPackageFile> transformFiles)
+        {
+            // Group transform by target file
+            var transformGroups = transformFiles.GroupBy(file => RemoveExtension(file.Path), StringComparer.OrdinalIgnoreCase);
+            var fileLookup = builder.Files.ToDictionary(file => file.Path, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var transformGroup in transformGroups)
+            {
+                IPackageFile file;
+                if (fileLookup.TryGetValue(transformGroup.Key, out file))
+                {
+                    // Replace the original file with a file that removes the transforms
+                    builder.Files.Remove(file);
+                    builder.Files.Add(new ReverseTransformFormFile(file, transformGroup));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes a file extension keeping the full path intact
+        /// </summary>
+        private static string RemoveExtension(string path)
+        {
+            return Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path));
+        }
+
+        private IEnumerable<IPackageFile> GetTransformFiles(PackageReaderBase package)
+        {
+            var groups = package.GetContentItems();
+            return groups.SelectMany(g => g.Items).Where(IsTransformFile).Select(f =>
+            {
+                var element = XElement.Load(package.GetStream(f));
+                var memStream = new MemoryStream();
+                element.Save(memStream);
+                memStream.Seek(0, SeekOrigin.Begin);
+
+                var file = new PhysicalPackageFile(memStream)
+                {
+                    TargetPath = f
+                };
+                return file;
+            }
+        );
+        }
+
+        private static bool IsTransformFile(string file)
+        {
+            return Path.GetExtension(file).Equals(TransformFileExtension, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void AddSolutionDir()
+        {
+            // Add the solution dir to the list of properties
+            string solutionDir = GetSolutionDir();
+
+            // Add a path separator for Visual Studio macro compatibility
+            solutionDir += Path.DirectorySeparatorChar;
+
+            if (!string.IsNullOrEmpty(solutionDir))
+            {
+                if (ProjectProperties.ContainsKey("SolutionDir"))
+                {
+                    Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
+                            CultureInfo.CurrentCulture,
+                            LocalizedResourceManager.GetString("Warning_DuplicatePropertyKey"),
+                            "SolutionDir"), NuGetLogCode.NU5114));
+                }
+
+                ProjectProperties["SolutionDir"] = solutionDir;
+            }
+        }
+
+        private string GetSolutionDir()
+        {
+            if (!string.IsNullOrEmpty(SolutionDirectory))
+            {
+                return SolutionDirectory;
+            }
+            return ProjectHelper.GetSolutionDir(_project.DirectoryPath);
+        }
+
+        private Packaging.Manifest ProcessNuspec(Packaging.PackageBuilder builder, string basePath)
+        {
+            string nuspecFile = GetNuspec();
+
+            if (string.IsNullOrEmpty(nuspecFile))
+            {
+                return null;
+            }
+
+            Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
+                    CultureInfo.CurrentCulture,
+                    LocalizedResourceManager.GetString("UsingNuspecForMetadata"),
+                    Path.GetFileName(nuspecFile)), LogLevel.Minimal));
+
+            using (Stream stream = File.OpenRead(nuspecFile))
+            {
+                // Don't validate the manifest since this might be a partial manifest
+                // The bulk of the metadata might be coming from the project.
+                Packaging.Manifest manifest = Packaging.Manifest.ReadFrom(stream, GetPropertyValue, validateSchema: true);
+                builder.Populate(manifest.Metadata);
+
+                if (manifest.HasFilesNode)
+                {
+                    basePath = string.IsNullOrEmpty(basePath) ? Path.GetDirectoryName(nuspecFile) : basePath;
+                    builder.PopulateFiles(basePath, manifest.Files);
+                }
+
+                return manifest;
+            }
+        }
+
+        private string GetNuspec()
+        {
+            return GetNuspecPaths().FirstOrDefault(File.Exists);
+        }
+
+        private IEnumerable<string> GetNuspecPaths()
+        {
+            // Check for a nuspec in the project file
+            yield return GetContentOrNone(file => Path.GetExtension(file).Equals(NuGetConstants.ManifestExtension, StringComparison.OrdinalIgnoreCase));
+            // Check for a nuspec named after the project
+            yield return Path.Combine(_project.DirectoryPath, Path.GetFileNameWithoutExtension(_project.FullPath) + NuGetConstants.ManifestExtension);
+        }
+
+        private string GetContentOrNone(Func<string, bool> matcher)
+        {
+            return GetFiles("Content").Concat(GetFiles("None")).FirstOrDefault(matcher);
+        }
+
+        private IEnumerable<string> GetFiles(string itemType)
+        {
+            foreach (dynamic item in _project.GetItems(itemType))
+            {
+                // the type of item is ProjectItem
+                var fullPath = item.GetMetadataValue("FullPath") as string;
+                yield return fullPath;
+            }
+        }
+
+        private void AddFiles(Packaging.PackageBuilder builder, string itemType, string targetFolder)
+        {
+            // Skip files that are added by dependency packages
+            ProjectManagement.FolderNuGetProject project = new ProjectManagement.FolderNuGetProject(_project.FullPath);
+            var referencesTask = project.GetInstalledPackagesAsync(new CancellationToken());
+            referencesTask.Wait();
+            var references = referencesTask.Result;
+
+            string projectName = Path.GetFileNameWithoutExtension(_project.FullPath);
+
+            var contentFilesInDependencies = new List<FrameworkSpecificGroup>();
+            if (references.Any())
+            {
+                contentFilesInDependencies = references
+                    .Select(reference => new PackageArchiveReader(project.GetInstalledPackageFilePath(reference.PackageIdentity)))
+                    .SelectMany(a => a.GetContentItems())
+                    .ToList();
+            }
+
+            // Get the content files from the project
+            foreach (var item in _project.GetItems(itemType))
+            {
+                string fullPath = item.GetMetadataValue("FullPath");
+                if (ExcludeFiles.Contains(Path.GetFileName(fullPath)))
+                {
+                    continue;
+                }
+
+                if (IncludeSymbols &&
+                    SymbolPackageFormat == SymbolPackageFormat.Snupkg &&
+                    !string.Equals(Path.GetExtension(fullPath), ".pdb", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                string targetFilePath = GetTargetPath(item);
+
+                if (!File.Exists(fullPath))
+                {
+                    Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
+                            CultureInfo.CurrentCulture,
+                            LocalizedResourceManager.GetString("Warning_FileDoesNotExist"),
+                            targetFilePath), NuGetLogCode.NU5116));
+                    continue;
+                }
+
+                // Skip target file paths containing msbuild variables since we do not offer a way to install files with variable paths.
+                // These are show up in shared files found in universal apps.
+                if (targetFilePath.IndexOf("$(MSBuild", StringComparison.OrdinalIgnoreCase) > -1)
+                {
+                    Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
+                            CultureInfo.CurrentCulture,
+                            LocalizedResourceManager.GetString("Warning_UnresolvedFilePath"),
+                            targetFilePath), NuGetLogCode.NU5117));
+                    continue;
+                }
+
+                // if IncludeReferencedProjects is true and we are adding source files,
+                // add projectName as part of the target to avoid file conflicts.
+                string targetPath = IncludeReferencedProjects && itemType == SourcesItemType ?
+                    Path.Combine(targetFolder, projectName, targetFilePath) :
+                    Path.Combine(targetFolder, targetFilePath);
+
+                // Check that file is added by dependency
+                var targetFile = contentFilesInDependencies.SelectMany(f => f.Items).FirstOrDefault(a => a.Equals(targetPath, StringComparison.OrdinalIgnoreCase));
+                if (targetFile != null)
+                {
+                    // Compare contents as well
+                    var isEqual = ContentEquals(targetFile, fullPath);
+                    if (isEqual)
+                    {
+                        Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
+                                CultureInfo.CurrentCulture,
+                                LocalizedResourceManager.GetString("PackageCommandFileFromDependencyIsNotChanged"),
+                                targetFilePath), LogLevel.Minimal));
+                        continue;
+                    }
+
+                    Logger.Log(PackagingLogMessage.CreateMessage(string.Format(
+                            CultureInfo.CurrentCulture,
+                            LocalizedResourceManager.GetString("PackageCommandFileFromDependencyIsChanged"),
+                            targetFilePath), LogLevel.Minimal));
+                }
+
+                var packageFile = new PhysicalPackageFile
+                {
+                    SourcePath = fullPath,
+                    TargetPath = targetPath
+                };
+                AddFileToBuilder(builder, packageFile);
+            }
+        }
+
+        private void AddFileToBuilder(PackageBuilder builder, PhysicalPackageFile packageFile)
+        {
+            if (!builder.Files.Any(p => packageFile.Path.Equals(p.Path, StringComparison.OrdinalIgnoreCase)))
+            {
+                WriteDetail(LocalizedResourceManager.GetString("AddFileToPackage"), packageFile.SourcePath, packageFile.TargetPath);
+                builder.Files.Add(packageFile);
+            }
+            else
+            {
+                Logger.Log(PackagingLogMessage.CreateWarning(string.Format(
+                        CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString("FileNotAddedToPackage"),
+                        packageFile.SourcePath,
+                        packageFile.TargetPath), NuGetLogCode.NU5118));
+            }
+        }
+
+        private void WriteDetail(string format, params object[] args)
+        {
+            if (LogLevel == LogLevel.Verbose)
+            {
+                Logger.Log(PackagingLogMessage.CreateMessage(string.Format(CultureInfo.CurrentCulture, format, args), LogLevel.Verbose));
+            }
+        }
+
+        public static bool ContentEquals(string targetFile, string fullPath)
+        {
+            bool isEqual;
+            using (var dependencyFileStream = File.OpenRead(targetFile))
+            using (var fileContentStream = File.OpenRead(fullPath))
+            {
+                isEqual = StreamUtility.ContentEquals(dependencyFileStream, fileContentStream);
+            }
+            return isEqual;
+        }
+
+        private string GetTargetPath(dynamic item)
+        {
+            string path = item.EvaluatedInclude;
+            if (item.HasMetadata("Link"))
+            {
+                path = item.GetMetadataValue("Link");
+            }
+            return Normalize(path);
+        }
+
+        private string Normalize(string path)
+        {
+            string projectDirectoryPath = PathUtility.EnsureTrailingSlash(_project.DirectoryPath);
+            string fullPath = PathUtility.GetAbsolutePath(projectDirectoryPath, path);
+
+            // If the file is under the project root then remove the project root
+            if (fullPath.StartsWith(projectDirectoryPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return fullPath.Substring(_project.DirectoryPath.Length).TrimStart(Path.DirectorySeparatorChar);
+            }
+
+            // Otherwise the file is probably a shortcut so just take the file name
+            return Path.GetFileName(fullPath);
+        }
+
+        public void Dispose()
+        {
+            _msbuildAssemblyResolver.Dispose();
+        }
+
+        private class ReverseTransformFormFile : Packaging.IPackageFile
+        {
+            private readonly Lazy<Func<Stream>> _streamFactory;
+            private readonly string _effectivePath;
+            private DateTimeOffset _lastWriteTime = DateTimeOffset.UtcNow;
+
+            public ReverseTransformFormFile(Packaging.IPackageFile file, IEnumerable<Packaging.IPackageFile> transforms)
+            {
+                Path = file.Path + ".transform";
+                _streamFactory = new Lazy<Func<Stream>>(() => ReverseTransform(file, transforms), isThreadSafe: false);
+                NuGetFramework = NuGet.Packaging.FrameworkNameUtility.ParseNuGetFrameworkFromFilePath(Path, out _effectivePath);
+                if (NuGetFramework != null && NuGetFramework.Version.Major < 5)
+                {
+                    TargetFramework = new FrameworkName(NuGetFramework.DotNetFrameworkName);
+                }
+            }
+
+            public string Path
+            {
+                get;
+                private set;
+            }
+
+            public string EffectivePath
+            {
+                get
+                {
+                    return _effectivePath;
+                }
+            }
+
+            public Stream GetStream()
+            {
+                return _streamFactory.Value();
+            }
+
+            public DateTimeOffset LastWriteTime
+            {
+                get
+                {
+                    return _lastWriteTime;
+                }
+            }
+
+            [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "We need to return the MemoryStream for use.")]
+            private static Func<Stream> ReverseTransform(Packaging.IPackageFile file, IEnumerable<Packaging.IPackageFile> transforms)
+            {
+                // Get the original
+                XElement element = GetElement(file);
+
+                // Remove all the transforms
+                foreach (var transformFile in transforms)
+                {
+                    XElementExtensions.Except(element, GetElement(transformFile));
+                }
+
+                // Create the stream with the transformed content
+                var ms = new MemoryStream();
+                element.Save(ms);
+                ms.Seek(0, SeekOrigin.Begin);
+                byte[] buffer = ms.ToArray();
+                return () => new MemoryStream(buffer);
+            }
+
+            private static XElement GetElement(Packaging.IPackageFile file)
+            {
+                using (Stream stream = file.GetStream())
+                {
+                    return XElement.Load(stream);
+                }
+            }
+
+            public FrameworkName TargetFramework
+            {
+                get;
+                private set;
+            }
+
+            public NuGetFramework NuGetFramework
+            {
+                get;
+                private set;
+            }
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -1,0 +1,539 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.PackageManagement;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.PackageExtraction;
+using NuGet.Packaging.Signing;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+using NuGet.Versioning;
+
+namespace NuGet.CommandLine
+{
+    [Command(typeof(NuGetCommand), "update", "UpdateCommandDescription", UsageSummary = "<packages.config|solution|project>",
+        UsageExampleResourceName = "UpdateCommandUsageExamples")]
+    public class UpdateCommand : Command
+    {
+        [Option(typeof(NuGetCommand), "UpdateCommandSourceDescription")]
+        public ICollection<string> Source { get; } = new List<string>();
+
+        [Option(typeof(NuGetCommand), "UpdateCommandIdDescription")]
+        public ICollection<string> Id { get; } = new List<string>();
+
+        [Option(typeof(NuGetCommand), "UpdateCommandVersionDescription")]
+        public string Version { get; set; }
+
+        [Option(typeof(NuGetCommand), "UpdateCommandDependencyVersion")]
+        public string DependencyVersion { get; set; }
+
+        [Option(typeof(NuGetCommand), "UpdateCommandRepositoryPathDescription")]
+        public string RepositoryPath { get; set; }
+
+        [Option(typeof(NuGetCommand), "UpdateCommandSafeDescription")]
+        public bool Safe { get; set; }
+
+        [Option(typeof(NuGetCommand), "UpdateCommandSelfDescription")]
+        public bool Self { get; set; }
+
+        [Option(typeof(NuGetCommand), "UpdateCommandVerboseDescription")]
+        public bool Verbose { get; set; }
+
+        [Option(typeof(NuGetCommand), "UpdateCommandPrerelease")]
+        public bool Prerelease { get; set; }
+
+        [Option(typeof(NuGetCommand), "UpdateCommandFileConflictAction")]
+        public ProjectManagement.FileConflictAction FileConflictAction { get; set; }
+
+        [Option(typeof(NuGetCommand), "CommandMSBuildVersion")]
+        public string MSBuildVersion { get; set; }
+
+        [Option(typeof(NuGetCommand), "CommandMSBuildPath")]
+        public string MSBuildPath { get; set; }
+
+        // The directory that contains msbuild
+        private string _msbuildDirectory;
+
+        public override async Task ExecuteCommandAsync()
+        {
+            // update with self as parameter
+            if (Self)
+            {
+                await UpdateSelfAsync();
+                return;
+            }
+
+            string inputFile = GetInputFile();
+
+            if (string.IsNullOrEmpty(inputFile))
+            {
+                throw new CommandException(NuGetResources.InvalidFile);
+            }
+
+            _msbuildDirectory = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(MSBuildPath, MSBuildVersion, Console).Value.Path;
+            var context = new UpdateConsoleProjectContext(Console, FileConflictAction);
+
+            var logger = new LoggerAdapter(context);
+            var clientPolicyContext = ClientPolicyContext.GetClientPolicy(Settings, logger);
+
+            context.PackageExtractionContext = new PackageExtractionContext(
+                PackageSaveMode.Defaultv2,
+                PackageExtractionBehavior.XmlDocFileSaveMode,
+                clientPolicyContext,
+                logger);
+
+            string inputFileName = Path.GetFileName(inputFile);
+            // update with packages.config as parameter
+            if (CommandLineUtility.IsValidConfigFileName(inputFileName))
+            {
+                await UpdatePackagesAsync(inputFile, context);
+                return;
+            }
+
+            // update with project file as parameter
+            if (ProjectHelper.SupportedProjectExtensions.Contains(Path.GetExtension(inputFile)))
+            {
+                if (!File.Exists(inputFile))
+                {
+                    throw new CommandException(NuGetResources.UnableToFindProject, inputFile);
+                }
+
+                var projectSystem = new MSBuildProjectSystem(
+                    _msbuildDirectory,
+                    inputFile,
+                    context);
+                await UpdatePackagesAsync(projectSystem, GetRepositoryPath(projectSystem.ProjectFullPath));
+                return;
+            }
+
+            if (!File.Exists(inputFile))
+            {
+                throw new CommandException(NuGetResources.UnableToFindSolution, inputFile);
+            }
+
+            // update with solution as parameter
+            string solutionDir = Path.GetDirectoryName(inputFile);
+            await UpdateAllPackages(solutionDir, context);
+        }
+
+        private async Task UpdateSelfAsync()
+        {
+            PackageSource targetSource;
+            switch (Source.Count)
+            {
+                case 0:
+                    targetSource = new PackageSource(NuGetConstants.V3FeedUrl);
+                    break;
+                case 1:
+                    // Use the package source from the load config to preload any creds that might be needed for authentication.
+                    var availableSources = SourceProvider.LoadPackageSources().Where(source => source.IsEnabled);
+                    targetSource = Common.PackageSourceProviderExtensions.ResolveSource(availableSources, Source.Single());
+                    break;
+                default:
+                    throw new CommandException(NuGetResources.Error_UpdateSelf_Source);
+            }
+            var selfUpdater = new SelfUpdater(Console);
+            await selfUpdater.UpdateSelfAsync(Prerelease, targetSource);
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        private async Task UpdateAllPackages(string solutionDir, INuGetProjectContext projectContext)
+        {
+            Console.WriteLine(LocalizedResourceManager.GetString("ScanningForProjects"));
+
+            // Search recursively for all packages.xxx.config files
+            string[] packagesConfigFiles = Directory.GetFiles(
+                solutionDir, "*.config", SearchOption.AllDirectories);
+
+            var projects = packagesConfigFiles.Where(s => Path.GetFileName(s).StartsWith("packages.", StringComparison.OrdinalIgnoreCase))
+                                              .Select(s => GetProject(s, projectContext))
+                                              .Where(p => p != null)
+                                              .Distinct()
+                                              .ToList();
+
+            if (projects.Count == 0)
+            {
+                Console.WriteLine(LocalizedResourceManager.GetString("NoProjectsFound"));
+                return;
+            }
+
+            if (projects.Count == 1)
+            {
+                Console.WriteLine(LocalizedResourceManager.GetString("FoundProject"), projects.Single().ProjectName);
+            }
+            else
+            {
+                Console.WriteLine(LocalizedResourceManager.GetString("FoundProjects"), projects.Count, String.Join(", ", projects.Select(p => p.ProjectName)));
+            }
+
+            string repositoryPath = GetRepositoryPathFromSolution(solutionDir);
+
+            foreach (var project in projects)
+            {
+                try
+                {
+                    await UpdatePackagesAsync(project, repositoryPath);
+                    if (Verbose)
+                    {
+                        Console.WriteLine();
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (Console.Verbosity == Verbosity.Detailed || ExceptionLogger.Instance.ShowStack)
+                    {
+                        Console.WriteWarning(e.ToString());
+                    }
+                    else
+                    {
+                        Console.WriteWarning(ExceptionUtilities.DisplayMessage(e));
+                    }
+                }
+            }
+        }
+
+        private MSBuildProjectSystem GetProject(string path, INuGetProjectContext projectContext)
+        {
+            try
+            {
+                return GetMSBuildProject(path, projectContext);
+            }
+            catch (CommandException e)
+            {
+                if (Console.Verbosity == Verbosity.Detailed || ExceptionLogger.Instance.ShowStack)
+                {
+                    Console.WriteWarning(e.ToString());
+                }
+                else
+                {
+                    Console.WriteWarning(ExceptionUtilities.DisplayMessage(e));
+                }
+            }
+
+            return null;
+        }
+
+        private string GetInputFile()
+        {
+            if (Arguments.Any())
+            {
+                string path = Arguments[0];
+                string extension = Path.GetExtension(path) ?? string.Empty;
+
+                if (extension.Equals(".config", StringComparison.OrdinalIgnoreCase))
+                {
+                    return GetPackagesConfigPath(path);
+                }
+
+                if (path.IsSolutionFile())
+                {
+                    return Path.GetFullPath(path);
+                }
+
+                if (ProjectHelper.SupportedProjectExtensions.Contains(extension))
+                {
+                    return Path.GetFullPath(path);
+                }
+            }
+
+            return null;
+        }
+
+        private static string GetPackagesConfigPath(string path)
+        {
+            if (CommandLineUtility.IsValidConfigFileName(Path.GetFileName(path)))
+            {
+                return Path.GetFullPath(path);
+            }
+
+            return null;
+        }
+
+        private IReadOnlyCollection<PackageSource> GetPackageSources()
+        {
+            var availableSources = SourceProvider.LoadPackageSources().Where(source => source.IsEnabled).ToList();
+            var packageSources = new List<PackageSource>();
+            foreach (var source in Source)
+            {
+                packageSources.Add(Common.PackageSourceProviderExtensions.ResolveSource(availableSources, source));
+            }
+
+            if (packageSources.Count == 0)
+            {
+                packageSources.AddRange(availableSources);
+            }
+
+            return packageSources;
+        }
+
+        private Task UpdatePackagesAsync(string packagesConfigPath, INuGetProjectContext projectContext)
+        {
+            var project = GetMSBuildProject(packagesConfigPath, projectContext);
+            var packagesDirectory = GetRepositoryPath(project.ProjectFullPath);
+            return UpdatePackagesAsync(project, packagesDirectory);
+        }
+
+        private async Task UpdatePackagesAsync(MSBuildProjectSystem project, string packagesDirectory)
+        {
+            var sourceRepositoryProvider = GetSourceRepositoryProvider();
+            var packageManager = new NuGetPackageManager(sourceRepositoryProvider, Settings, packagesDirectory);
+            var nugetProject = new MSBuildNuGetProject(project, packagesDirectory, project.ProjectFullPath);
+            if (!nugetProject.PackagesConfigNuGetProject.PackagesConfigExists())
+            {
+                throw new CommandException(LocalizedResourceManager.GetString("NoPackagesConfig"));
+            }
+
+            var versionConstraints = Safe ?
+                VersionConstraints.ExactMajor | VersionConstraints.ExactMinor :
+                VersionConstraints.None;
+
+            var projectActions = new List<NuGetProjectAction>();
+
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var dependencyBehavior = DependencyBehaviorHelper.GetDependencyBehavior(DependencyBehavior.Highest, DependencyVersion, Settings);
+                var resolutionContext = new ResolutionContext(
+                               dependencyBehavior,
+                               Prerelease,
+                               includeUnlisted: false,
+                               versionConstraints: versionConstraints,
+                               gatherCache: new GatherCache(),
+                               sourceCacheContext: sourceCacheContext);
+
+                var packageSources = GetPackageSources();
+
+                Console.PrintPackageSources(packageSources);
+
+                var sourceRepositories = packageSources.Select(sourceRepositoryProvider.CreateRepository);
+                if (Id.Count > 0)
+                {
+                    var targetIds = new HashSet<string>(Id, StringComparer.OrdinalIgnoreCase);
+
+                    var installed = await nugetProject.GetInstalledPackagesAsync(CancellationToken.None);
+
+                    // If -Id has been specified and has exactly one package, use the explicit version requested
+                    var targetVersion = Version != null && Id != null && Id.Count == 1 ? new NuGetVersion(Version) : null;
+
+                    var targetIdentities = installed
+                        .Select(pr => pr.PackageIdentity.Id)
+                        .Where(id => targetIds.Contains(id))
+                        .Select(id => new PackageIdentity(id, targetVersion))
+                        .ToList();
+
+                    if (targetIdentities.Any())
+                    {
+                        var actions = await packageManager.PreviewUpdatePackagesAsync(
+                            targetIdentities,
+                            new[] { nugetProject },
+                            resolutionContext,
+                            project.NuGetProjectContext,
+                            sourceRepositories,
+                            Enumerable.Empty<SourceRepository>(),
+                            CancellationToken.None);
+
+                        projectActions.AddRange(actions);
+                    }
+                }
+                else
+                {
+                    var actions = await packageManager.PreviewUpdatePackagesAsync(
+                            new[] { nugetProject },
+                            resolutionContext,
+                            project.NuGetProjectContext,
+                            sourceRepositories,
+                            Enumerable.Empty<SourceRepository>(),
+                            CancellationToken.None);
+                    projectActions.AddRange(actions);
+                }
+
+                await packageManager.ExecuteNuGetProjectActionsAsync(
+                    nugetProject,
+                    projectActions,
+                    project.NuGetProjectContext,
+                    sourceCacheContext,
+                    CancellationToken.None);
+            }
+
+            project.Save();
+        }
+
+        private CommandLineSourceRepositoryProvider GetSourceRepositoryProvider()
+        {
+            var sourceRepositoryProvider = new CommandLineSourceRepositoryProvider(SourceProvider);
+            return sourceRepositoryProvider;
+        }
+
+        private string GetRepositoryPath(string projectRoot)
+        {
+            string packagesDir = RepositoryPath;
+
+            if (String.IsNullOrEmpty(packagesDir))
+            {
+                packagesDir = SettingsUtility.GetRepositoryPath(Settings);
+                if (String.IsNullOrEmpty(packagesDir))
+                {
+                    // Try to resolve the packages directory from the project
+                    string projectDir = Path.GetDirectoryName(projectRoot);
+                    string solutionDir = ProjectHelper.GetSolutionDir(projectDir);
+
+                    return GetRepositoryPathFromSolution(solutionDir);
+                }
+            }
+
+            return GetPackagesDirectory(packagesDir);
+        }
+
+        private string GetRepositoryPathFromSolution(string solutionDir)
+        {
+            string packagesDir = RepositoryPath;
+
+            if (String.IsNullOrEmpty(packagesDir))
+            {
+                // Try and get the packages folder from the nuget.config file otherwise full back to assuming it's <solution>\'packages'.
+                packagesDir = SettingsUtility.GetRepositoryPath(Settings);
+                if (String.IsNullOrEmpty(packagesDir) &&
+                    !String.IsNullOrEmpty(solutionDir))
+                {
+                    packagesDir = Path.Combine(solutionDir, CommandLineConstants.PackagesDirectoryName);
+                }
+            }
+
+            return GetPackagesDirectory(packagesDir);
+        }
+
+        private string GetPackagesDirectory(string packagesDir)
+        {
+            if (!String.IsNullOrEmpty(packagesDir))
+            {
+                // Get the full path to the packages directory
+                packagesDir = Path.GetFullPath(packagesDir);
+
+                // REVIEW: Do we need to check for existence?
+                if (Directory.Exists(packagesDir))
+                {
+                    string relativePath =
+                        PathUtility.GetRelativePath(
+                            PathUtility.EnsureTrailingSlash(CurrentDirectory), packagesDir);
+                    Console.LogVerbose(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            LocalizedResourceManager.GetString("LookingForInstalledPackages"),
+                            relativePath));
+                    return packagesDir;
+                }
+            }
+
+            throw new CommandException(LocalizedResourceManager.GetString("UnableToLocatePackagesFolder"));
+        }
+
+        private MSBuildProjectSystem GetMSBuildProject(string packageReferenceFilePath, INuGetProjectContext projectContext)
+        {
+            // Try to locate the project file associated with this packages.config file
+            var directory = Path.GetDirectoryName(packageReferenceFilePath);
+            var projectFiles = ProjectHelper.GetProjectFiles(directory).Take(2).ToArray();
+
+            if (projectFiles.Length == 0)
+            {
+                throw new CommandException(LocalizedResourceManager.GetString("UnableToLocateProjectFile"), packageReferenceFilePath);
+            }
+
+            if (projectFiles.Length > 1)
+            {
+                throw new CommandException(LocalizedResourceManager.GetString("MultipleProjectFilesFound"), packageReferenceFilePath);
+            }
+
+            return new MSBuildProjectSystem(_msbuildDirectory, projectFiles[0], projectContext);
+        }
+
+
+        private class UpdateConsoleProjectContext : ConsoleProjectContext
+        {
+            private readonly IConsole _console;
+            private readonly ProjectManagement.FileConflictAction FileConflictAction;
+            private bool _overwriteAll;
+            private bool _ignoreAll;
+
+            public UpdateConsoleProjectContext(
+                IConsole console,
+                ProjectManagement.FileConflictAction conflictAction)
+                : base(console)
+            {
+                _console = console;
+                FileConflictAction = conflictAction;
+            }
+
+            public override ProjectManagement.FileConflictAction ResolveFileConflict(string message)
+            {
+                // the -FileConflictAction is set to Overwrite or user has chosen Overwrite All previously
+                if (FileConflictAction == ProjectManagement.FileConflictAction.Overwrite || _overwriteAll)
+                {
+                    return ProjectManagement.FileConflictAction.Overwrite;
+                }
+
+                // the -FileConflictAction is set to Ignore or user has chosen Ignore All previously
+                if (FileConflictAction == ProjectManagement.FileConflictAction.Ignore || _ignoreAll)
+                {
+                    return ProjectManagement.FileConflictAction.Ignore;
+                }
+
+                // otherwise, prompt user for choice, unless we're in non-interactive mode
+                if (_console != null && !_console.IsNonInteractive)
+                {
+                    var resolution = GetUserInput(message);
+                    _overwriteAll = resolution == ProjectManagement.FileConflictAction.OverwriteAll;
+                    _ignoreAll = resolution == ProjectManagement.FileConflictAction.IgnoreAll;
+                    return resolution;
+                }
+
+                return ProjectManagement.FileConflictAction.Ignore;
+            }
+
+            private ProjectManagement.FileConflictAction GetUserInput(string message)
+            {
+                // make the question stand out from previous text
+                _console.WriteLine();
+
+                _console.WriteLine(ConsoleColor.Yellow, "File Conflict.");
+                _console.WriteLine(message);
+
+                // Yes - Yes To All - No - No To All
+                var acceptedAnswers = new List<string> { "Y", "A", "N", "L" };
+                var choices = new[]
+                {
+                    ProjectManagement.FileConflictAction.Overwrite,
+                    ProjectManagement.FileConflictAction.OverwriteAll,
+                    ProjectManagement.FileConflictAction.Ignore,
+                    ProjectManagement.FileConflictAction.IgnoreAll
+                };
+
+                while (true)
+                {
+                    _console.Write(LocalizedResourceManager.GetString("FileConflictChoiceText"));
+                    string answer = _console.ReadLine();
+                    if (!String.IsNullOrEmpty(answer))
+                    {
+                        int index = acceptedAnswers.FindIndex(a => a.Equals(answer, StringComparison.OrdinalIgnoreCase));
+                        if (index > -1)
+                        {
+                            return choices[index];
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" ExcludeAssets="runtime" />
-    <PackageReference Include="NuGet.Core" Aliases="CoreV2" PrivateAssets="All" />
     <PackageReference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 
@@ -24,6 +23,18 @@
     directory contains a copy of that file with that method replaced by a stub.
     -->
     <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Clients\NuGet.CommandLine\Commands\Pack\AssemblyMetadataExtractor.cs" />
+    <!--
+    The following files depend on the NuGet.Core (v2) package via the CoreV2 extern alias. This directory contains
+    replacement files with the CoreV2 dependencies removed or stubbed.
+    -->
+    <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Clients\NuGet.CommandLine\Program.cs" />
+    <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Clients\NuGet.CommandLine\Commands\Command.cs" />
+    <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Clients\NuGet.CommandLine\Commands\ProjectFactory.cs" />
+    <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Clients\NuGet.CommandLine\Commands\UpdateCommand.cs" />
+    <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Clients\NuGet.CommandLine\Common\CommandLineRepositoryFactory.cs" />
+    <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Clients\NuGet.CommandLine\Credentials\CredentialProviderAdapter.cs" />
+    <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Clients\NuGet.CommandLine\Credentials\CredentialServiceAdapter.cs" />
+    <Compile Remove="$(NuGetSourceLocation)\src\NuGet.Clients\NuGet.CommandLine\SettingsCredentialProvider.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Program.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Program.cs
@@ -1,0 +1,495 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using Microsoft.Win32;
+using NuGet.Common;
+using NuGet.PackageManagement;
+
+namespace NuGet.CommandLine
+{
+    public class Program
+    {
+        private const string Utf8Option = "-utf8";
+        private const string ForceEnglishOutputOption = "-forceEnglishOutput";
+#if DEBUG
+        private const string DebugOption = "--debug";
+#endif
+        private const string OSVersionRegistryKey = @"SOFTWARE\Microsoft\Windows NT\CurrentVersion";
+        private const string FilesystemRegistryKey = @"SYSTEM\CurrentControlSet\Control\FileSystem";
+        private const string DotNetSetupRegistryKey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\";
+        private const int Net462ReleasedVersion = 394802;
+
+        internal static readonly Assembly NuGetExeAssembly = typeof(Program).Assembly;
+        private static readonly string ThisExecutableName = NuGetExeAssembly.GetName().Name;
+
+        [Import]
+        public HelpCommand HelpCommand { get; set; }
+
+        [ImportMany]
+        public IEnumerable<ICommand> Commands { get; set; }
+
+        [Import]
+        public ICommandManager Manager { get; set; }
+
+        /// <summary>
+        /// Flag meant for unit tests that prevents command line extensions from being loaded.
+        /// </summary>
+        public static bool IgnoreExtensions { get; set; }
+
+        public static int Main(string[] args)
+        {
+            AppContext.SetSwitch("Switch.System.IO.UseLegacyPathHandling", false);
+            AppContext.SetSwitch("Switch.System.IO.BlockLongPaths", false);
+
+#if DEBUG
+            if (args.Contains(DebugOption, StringComparer.OrdinalIgnoreCase))
+            {
+                args = args.Where(arg => !string.Equals(arg, DebugOption, StringComparison.OrdinalIgnoreCase)).ToArray();
+                System.Diagnostics.Debugger.Launch();
+            }
+#endif
+
+            NuGet.Common.Migrations.MigrationRunner.Run();
+
+#if IS_DESKTOP
+            // Find any response files and resolve the args
+            if (!RuntimeEnvironmentHelper.IsMono)
+            {
+                args = CommandLineResponseFile.ParseArgsResponseFiles(args);
+            }
+#endif
+            return MainCore(Directory.GetCurrentDirectory(), args, EnvironmentVariableWrapper.Instance);
+        }
+
+        public static int MainCore(string workingDirectory, string[] args, IEnvironmentVariableReader environmentVariableReader)
+        {
+            var console = new Console();
+
+            // First, optionally disable localization in resources.
+            if (args.Any(arg => string.Equals(arg, ForceEnglishOutputOption, StringComparison.OrdinalIgnoreCase)))
+            {
+                CultureUtility.DisableLocalization();
+            }
+            else
+            {
+                UILanguageOverride.Setup(console);
+            }
+
+            // set output encoding to UTF8 if -utf8 is specified
+            var oldOutputEncoding = System.Console.OutputEncoding;
+            if (args.Any(arg => string.Equals(arg, Utf8Option, StringComparison.OrdinalIgnoreCase)))
+            {
+                args = args.Where(arg => !string.Equals(arg, Utf8Option, StringComparison.OrdinalIgnoreCase)).ToArray();
+                SetConsoleOutputEncoding(Encoding.UTF8);
+            }
+
+            // Increase the maximum number of connections per server.
+            if (!RuntimeEnvironmentHelper.IsMono)
+            {
+                ServicePointManager.DefaultConnectionLimit = 64;
+            }
+            else
+            {
+                // Keep mono limited to a single download to avoid issues.
+                ServicePointManager.DefaultConnectionLimit = 1;
+            }
+
+            try
+            {
+                // Remove NuGet.exe.old
+                RemoveOldFile();
+
+                // Import Dependencies
+                var p = new Program();
+                p.Initialize(console);
+
+                // Add commands to the manager
+                foreach (var cmd in p.Commands)
+                {
+                    p.Manager.RegisterCommand(cmd);
+                }
+
+                var parser = new CommandLineParser(p.Manager);
+
+                // Parse the command
+                var command = parser.ParseCommandLine(args) ?? p.HelpCommand;
+                command.CurrentDirectory = workingDirectory;
+                if (command is DownloadCommandBase downloadCommandBase && downloadCommandBase.NoCache)
+                {
+                    // NoCache option is deprecated. Users should use NoHttpCache instead.
+                    console.LogInformation(NuGetCommand.Log_RestoreNoCacheInformation);
+                }
+
+                if (command is Command commandImpl)
+                {
+                    console.Verbosity = commandImpl.Verbosity;
+                }
+
+                // Fallback on the help command if we failed to parse a valid command
+                if (!ArgumentCountValid(command))
+                {
+                    // Get the command name and add it to the argument list of the help command
+                    var commandName = command.CommandAttribute.CommandName;
+
+                    // Print invalid arguments command error message in stderr
+                    console.WriteError(LocalizedResourceManager.GetString("InvalidArguments"), commandName);
+
+                    // then show help
+                    p.HelpCommand.ViewHelpForCommand(commandName);
+
+                    return 1;
+                }
+                else
+                {
+                    if (command is Command baseCommand)
+                    {
+                        SetConsoleInteractivity(console, baseCommand, environmentVariableReader);
+                    }
+
+                    try
+                    {
+                        command.Execute();
+                    }
+                    catch (CommandLineArgumentCombinationException e)
+                    {
+                        var commandName = command.CommandAttribute.CommandName;
+
+                        console.WriteLine($"{string.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString("InvalidArguments"), commandName)} {e.Message}");
+
+                        p.HelpCommand.ViewHelpForCommand(commandName);
+
+                        return 1;
+                    }
+                }
+            }
+            catch (AggregateException exception)
+            {
+                var unwrappedEx = ExceptionUtility.Unwrap(exception);
+
+                LogException(unwrappedEx, console);
+                return 1;
+            }
+            catch (ExitCodeException e)
+            {
+                return e.ExitCode;
+            }
+            catch (PathTooLongException e)
+            {
+                LogException(e, console);
+                if (RuntimeEnvironmentHelper.IsWindows)
+                {
+                    LogHelperMessageForPathTooLongException(console);
+                }
+                return 1;
+            }
+            catch (Exception exception)
+            {
+                LogException(exception, console);
+                return 1;
+            }
+            finally
+            {
+                SetConsoleOutputEncoding(oldOutputEncoding);
+            }
+
+            return 0;
+        }
+
+        private void Initialize(IConsole console)
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+            AppDomain.CurrentDomain.ResourceResolve += CurrentDomain_ResourceResolve;
+
+            using (var catalog = new AggregateCatalog(new AssemblyCatalog(GetType().Assembly)))
+            {
+                if (!IgnoreExtensions)
+                {
+                    AddExtensionsToCatalog(catalog, console);
+                }
+
+                try
+                {
+                    using (var container = new CompositionContainer(catalog))
+                    {
+                        container.ComposeExportedValue(console);
+                        container.ComposeParts(this);
+                    }
+                }
+                catch (ReflectionTypeLoadException ex) when (ex?.LoaderExceptions.Length > 0)
+                {
+                    throw new AggregateException(ex.LoaderExceptions);
+                }
+            }
+        }
+
+        private Assembly CurrentDomain_ResourceResolve(object sender, ResolveEventArgs args)
+        {
+            Assembly returnedResource = null;
+
+            // We want to intercept NuGet.Resources resources and redirect it to nuget.exe assembly
+            if (!args.Name.StartsWith("NuGet.CommandLine", StringComparison.OrdinalIgnoreCase) && args.Name.StartsWith("NuGet", StringComparison.OrdinalIgnoreCase) && string.Equals("NuGet.Resources", args.RequestingAssembly.GetName().Name, StringComparison.OrdinalIgnoreCase))
+            {
+                ManifestResourceInfo resource = NuGetExeAssembly.GetManifestResourceInfo(args.Name);
+                if (resource != null)
+                {
+                    // Return nuget.exe assembly, since it contains the requested resource by NuGet.Resources assembly
+                    returnedResource = NuGetExeAssembly;
+                }
+            }
+
+            return returnedResource;
+        }
+
+        // This method acts as a binding redirect
+        private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            AssemblyName name = new AssemblyName(args.Name);
+            Assembly customLoadedAssembly = null;
+
+            if (string.Equals(name.Name, ThisExecutableName, StringComparison.OrdinalIgnoreCase))
+            {
+                customLoadedAssembly = NuGetExeAssembly;
+            }
+            // .NET Framework 4.x now triggers AssemblyResolve event for resource assemblies
+            // We want to catch failed NuGet.resources.dll assembly load to look for it in embedded resources
+            else if (name.Name == "NuGet.resources")
+            {
+                // Load satellite resource assembly from embedded resources
+                customLoadedAssembly = GetNuGetResourcesAssembly(name.Name, name.CultureInfo);
+            }
+
+            return customLoadedAssembly;
+        }
+
+        private static Assembly GetNuGetResourcesAssembly(string name, CultureInfo culture)
+        {
+            string resourceName = $"NuGet.CommandLine.{culture.Name}.{name}.dll";
+            Assembly resourceAssembly = LoadAssemblyFromEmbeddedResources(resourceName);
+            if (resourceAssembly == null)
+            {
+                // Sometimes, embedded assembly names have dashes replaced by underscores
+                string altResourceName = $"NuGet.CommandLine.{culture.Name.Replace("-", "_")}.{name}.dll";
+                resourceAssembly = LoadAssemblyFromEmbeddedResources(altResourceName);
+            }
+
+            return resourceAssembly;
+        }
+
+        private static Assembly LoadAssemblyFromEmbeddedResources(string resourceName)
+        {
+            Assembly resourceAssembly = null;
+            using (var stream = NuGetExeAssembly.GetManifestResourceStream(resourceName))
+            {
+                if (stream != null)
+                {
+                    byte[] assemblyData = new byte[stream.Length];
+                    stream.Read(assemblyData, offset: 0, assemblyData.Length);
+                    try
+                    {
+                        resourceAssembly = Assembly.Load(assemblyData);
+                    }
+                    catch (BadImageFormatException)
+                    {
+                        resourceAssembly = null;
+                    }
+                }
+            }
+
+            return resourceAssembly;
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We don't want to block the exe from usage if anything failed")]
+        internal static void RemoveOldFile()
+        {
+            var oldFile = NuGetExeAssembly.Location + ".old";
+            try
+            {
+                if (File.Exists(oldFile))
+                {
+                    File.Delete(oldFile);
+                }
+            }
+            catch
+            {
+                // We don't want to block the exe from usage if anything failed
+            }
+        }
+
+        public static bool ArgumentCountValid(ICommand command)
+        {
+            var attribute = command.CommandAttribute;
+            return command.Arguments.Count >= attribute.MinArgs &&
+                   command.Arguments.Count <= attribute.MaxArgs;
+        }
+
+        private static void AddExtensionsToCatalog(AggregateCatalog catalog, IConsole console)
+        {
+            var extensionLocator = new ExtensionLocator();
+            var files = extensionLocator.FindExtensions();
+            RegisterExtensions(catalog, files, console);
+        }
+
+        private static void RegisterExtensions(AggregateCatalog catalog, IEnumerable<string> enumerateFiles, IConsole console)
+        {
+            foreach (var item in enumerateFiles)
+            {
+                AssemblyCatalog assemblyCatalog = null;
+                try
+                {
+                    assemblyCatalog = new AssemblyCatalog(item);
+
+                    // get the parts - throw if something went wrong
+                    var parts = assemblyCatalog.Parts;
+
+                    // load all the types - throw if assembly cannot load (missing dependencies is a good example)
+                    var assembly = Assembly.LoadFile(item);
+                    assembly.GetTypes();
+
+                    catalog.Catalogs.Add(assemblyCatalog);
+                }
+                catch (BadImageFormatException ex)
+                {
+                    if (assemblyCatalog != null)
+                    {
+                        assemblyCatalog.Dispose();
+                    }
+
+                    // Ignore if the dll wasn't a valid assembly
+                    console.WriteWarning(ex.Message);
+                }
+                catch (FileLoadException ex)
+                {
+                    // Ignore if we couldn't load the assembly.
+
+                    if (assemblyCatalog != null)
+                    {
+                        assemblyCatalog.Dispose();
+                    }
+
+                    var message =
+                        string.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString(nameof(NuGetResources.FailedToLoadExtension)),
+                                      item);
+
+                    console.WriteWarning(message);
+                    console.WriteWarning(ex.Message);
+                }
+                catch (ReflectionTypeLoadException rex)
+                {
+                    // ignore if the assembly is missing dependencies
+
+                    var resource =
+                        LocalizedResourceManager.GetString(nameof(NuGetResources.FailedToLoadExtensionDuringMefComposition));
+
+                    var perAssemblyError = string.Empty;
+
+                    if (rex?.LoaderExceptions.Length > 0)
+                    {
+                        var builder = new StringBuilder();
+
+                        builder.AppendLine(string.Empty);
+
+                        var errors = rex.LoaderExceptions.Select(e => e.Message).Distinct(StringComparer.Ordinal);
+
+                        foreach (var error in errors)
+                        {
+                            builder.AppendLine(error);
+                        }
+
+                        perAssemblyError = builder.ToString();
+                    }
+
+                    var warning = string.Format(CultureInfo.CurrentCulture, resource, item, perAssemblyError);
+
+                    console.WriteWarning(warning);
+                }
+            }
+        }
+
+        private static void SetConsoleInteractivity(IConsole console, Command command, IEnvironmentVariableReader environmentVariableReader)
+        {
+            // Apply command setting
+            console.IsNonInteractive = command.NonInteractive;
+
+            // Global environment variable to prevent the exe for prompting for credentials
+            if (!string.IsNullOrEmpty(environmentVariableReader.GetEnvironmentVariable("NUGET_EXE_NO_PROMPT")))
+            {
+                console.IsNonInteractive = true;
+            }
+
+            // Disable non-interactive if force is set.
+            var forceInteractive = environmentVariableReader.GetEnvironmentVariable("FORCE_NUGET_EXE_INTERACTIVE");
+            if (!string.IsNullOrEmpty(forceInteractive))
+            {
+                console.IsNonInteractive = false;
+            }
+        }
+
+        private static void SetConsoleOutputEncoding(System.Text.Encoding encoding)
+        {
+            try
+            {
+                System.Console.OutputEncoding = encoding;
+            }
+            catch (IOException)
+            {
+            }
+        }
+
+        private static void LogException(Exception exception, IConsole console)
+        {
+            var logStackAsError = console.Verbosity == Verbosity.Detailed;
+
+            ExceptionUtilities.LogException(exception, console, logStackAsError);
+        }
+
+        private static void LogHelperMessageForPathTooLongException(Console logger)
+        {
+            if (!IsWindows10(logger))
+            {
+                logger.WriteWarning(LocalizedResourceManager.GetString(nameof(NuGetResources.Warning_LongPath_UnsupportedOS)));
+            }
+            else if (!IsSupportLongPathEnabled(logger))
+            {
+                logger.WriteWarning(LocalizedResourceManager.GetString(nameof(NuGetResources.Warning_LongPath_DisabledPolicy)));
+            }
+            else if (!IsRuntimeGreaterThanNet462(logger))
+            {
+                logger.WriteWarning(LocalizedResourceManager.GetString(nameof(NuGetResources.Warning_LongPath_UnsupportedNetFramework)));
+            }
+        }
+
+        private static bool IsWindows10(ILogger logger)
+        {
+            var productName = (string)RegistryKeyUtility.GetValueFromRegistryKey("ProductName", OSVersionRegistryKey, Registry.LocalMachine, logger);
+
+            return productName != null && productName.StartsWith("Windows 10", StringComparison.Ordinal);
+        }
+
+        private static bool IsSupportLongPathEnabled(ILogger logger)
+        {
+            var longPathsEnabled = RegistryKeyUtility.GetValueFromRegistryKey("LongPathsEnabled", FilesystemRegistryKey, Registry.LocalMachine, logger);
+
+            return longPathsEnabled != null && (int)longPathsEnabled > 0;
+        }
+
+        private static bool IsRuntimeGreaterThanNet462(ILogger logger)
+        {
+            var release = RegistryKeyUtility.GetValueFromRegistryKey("Release", DotNetSetupRegistryKey, Registry.LocalMachine, logger);
+
+            return release != null && (int)release >= Net462ReleasedVersion;
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/SettingsCredentialProvider.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/SettingsCredentialProvider.cs
@@ -1,0 +1,103 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Credentials;
+
+namespace NuGet.CommandLine
+{
+    public class SettingsCredentialProvider : ICredentialProvider
+    {
+        private readonly IPackageSourceProvider _packageSourceProvider;
+        private readonly Common.ILogger _logger;
+
+        public SettingsCredentialProvider(IPackageSourceProvider packageSourceProvider)
+            : this(packageSourceProvider, Common.NullLogger.Instance)
+        {
+        }
+
+        public SettingsCredentialProvider(IPackageSourceProvider packageSourceProvider, Common.ILogger logger)
+        {
+            _packageSourceProvider = packageSourceProvider ?? throw new ArgumentNullException(nameof(packageSourceProvider));
+            _logger = logger;
+            Id = $"{nameof(SettingsCredentialProvider)}_{Guid.NewGuid()}";
+        }
+
+        public string Id { get; }
+
+        public Task<CredentialResponse> GetAsync(
+            Uri uri,
+            IWebProxy proxy,
+            CredentialRequestType type,
+            string message,
+            bool isRetry,
+            bool nonInteractive,
+            CancellationToken cancellationToken)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // If we are retrying, the stored credentials must be invalid.
+            if (!isRetry && type == CredentialRequestType.Unauthorized && TryGetCredentials(uri, out var credentials, out var username))
+            {
+                _logger.LogMinimal(string.Format(
+                    System.Globalization.CultureInfo.CurrentCulture,
+                    NuGetResources.SettingsCredentials_UsingSavedCredentials,
+                    username,
+                    uri.OriginalString));
+
+                return Task.FromResult(new CredentialResponse(credentials));
+            }
+
+            return Task.FromResult(new CredentialResponse(CredentialStatus.ProviderNotApplicable));
+        }
+
+        private bool TryGetCredentials(Uri uri, out ICredentials? credentials, out string? username)
+        {
+            credentials = null;
+            username = null;
+
+            var source = _packageSourceProvider.LoadPackageSources()
+                .FirstOrDefault(p =>
+                {
+                    Uri sourceUri;
+                    return p.Credentials != null
+                        && p.Credentials.IsValid()
+                        && Uri.TryCreate(p.Source, UriKind.Absolute, out sourceUri)
+                        && UriEquals(IsHttpSource(sourceUri) ? sourceUri : new Uri(p.Source), uri);
+                });
+
+            if (source == null)
+            {
+                return false;
+            }
+
+            credentials = new NetworkCredential(source.Credentials.Username, source.Credentials.Password);
+            username = source.Credentials.Username;
+            return true;
+        }
+
+        private static bool IsHttpSource(Uri uri)
+        {
+            return uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps;
+        }
+
+        private static bool UriEquals(Uri uri1, Uri uri2)
+        {
+            // Compare the scheme, host, port, and path (case-insensitive for host)
+            return uri1.Scheme == uri2.Scheme
+                && string.Equals(uri1.Host, uri2.Host, StringComparison.OrdinalIgnoreCase)
+                && uri1.Port == uri2.Port
+                && string.Equals(uri1.AbsolutePath.TrimEnd('/'), uri2.AbsolutePath.TrimEnd('/'), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/README.md
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/README.md
@@ -1,1 +1,14 @@
-TODO:
+# NuGetProjects
+
+This directory contains locally-compiled versions of projects from the [NuGet.Client](https://github.com/NuGet/NuGet.Client) submodule. The `*.cs` files here are either copied directly from or are modified replacements of files in the vendored submodule source.
+
+## Maintenance: Submodule Updates
+
+Whenever the `NuGet.Client` submodule is updated, **all `*.cs` files under this directory must be re-checked** against their corresponding originals in the submodule to ensure they remain largely in line with the upstream content.
+
+### Rules for modified files
+
+1. **No references to the `NuGet.Core` package.** All `extern alias CoreV2` usages and any other references to the legacy `NuGet.Core` (v2) package must be removed.
+2. **No .NET Framework-only APIs.** Any APIs that are not compatible with .NET Core / modern .NET (e.g., `System.Data.Services`, WCF types, `PhysicalFileSystem` from CoreV2) must be removed or stubbed.
+3. **Keep behavior parity where possible.** When removing or stubbing functionality, preserve the surrounding logic so that the project continues to compile and the packages.config update tests continue to pass.
+4. **Document deviations.** If a file diverges significantly from its upstream counterpart, add a comment at the top of the file explaining what was changed and why.

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/StreamExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/StreamExtensions.cs
@@ -1,0 +1,16 @@
+namespace NuGetUpdater.Core.Test;
+
+internal static class StreamExtensions
+{
+    public static byte[] ReadAllBytes(this Stream stream)
+    {
+        if (stream is MemoryStream memoryStream)
+        {
+            return memoryStream.ToArray();
+        }
+
+        using var ms = new MemoryStream();
+        stream.CopyTo(ms);
+        return ms.ToArray();
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/NuGetUpdater.Core.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="MSBuild.StructuredLogger" />
-    <PackageReference Include="NuGet.Core" Aliases="CoreV2" />
     <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/AssemblyBinding.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/AssemblyBinding.cs
@@ -1,0 +1,141 @@
+using System.Xml.Linq;
+
+namespace NuGetUpdater.Core.Updater;
+
+internal class AssemblyBinding : IEquatable<AssemblyBinding>
+{
+    private const string Namespace = "urn:schemas-microsoft-com:asm.v1";
+    private string? _oldVersion;
+    private string? _culture;
+
+    internal AssemblyBinding()
+    {
+    }
+
+    public AssemblyBinding(IAssembly assembly)
+    {
+        Name = assembly.Name;
+        PublicKeyToken = assembly.PublicKeyToken;
+        NewVersion = assembly.Version.ToString();
+        AssemblyNewVersion = assembly.Version;
+        Culture = assembly.Culture;
+    }
+
+    public string Name { get; private set; } = string.Empty;
+
+    public string Culture
+    {
+        get => _culture ?? "neutral";
+        set => _culture = value;
+    }
+
+    public string PublicKeyToken { get; private set; } = string.Empty;
+
+    public string? ProcessorArchitecture { get; private set; }
+
+    public string NewVersion { get; private set; } = string.Empty;
+
+    public string OldVersion
+    {
+        get => _oldVersion ?? "0.0.0.0-" + NewVersion;
+        set => _oldVersion = value;
+    }
+
+    public Version? AssemblyNewVersion { get; private set; }
+
+    public string? CodeBaseHref { get; private set; }
+    public string? CodeBaseVersion { get; private set; }
+    public string? PublisherPolicy { get; private set; }
+
+    public XElement ToXElement()
+    {
+        var dependentAssembly = new XElement(GetQualifiedName("dependentAssembly"),
+            new XElement(GetQualifiedName("assemblyIdentity"),
+                new XAttribute("name", Name),
+                new XAttribute("publicKeyToken", PublicKeyToken),
+                new XAttribute("culture", Culture),
+                new XAttribute("processorArchitecture", ProcessorArchitecture ?? string.Empty)),
+            new XElement(GetQualifiedName("bindingRedirect"),
+                new XAttribute("oldVersion", OldVersion),
+                new XAttribute("newVersion", NewVersion)));
+
+        if (!string.IsNullOrEmpty(PublisherPolicy))
+        {
+            dependentAssembly.Add(new XElement(GetQualifiedName("publisherPolicy"),
+                new XAttribute("apply", PublisherPolicy)));
+        }
+
+        if (!string.IsNullOrEmpty(CodeBaseHref))
+        {
+            dependentAssembly.Add(new XElement(GetQualifiedName("codeBase"),
+                new XAttribute("href", CodeBaseHref),
+                new XAttribute("version", CodeBaseVersion ?? string.Empty)));
+        }
+
+        // Remove empty attributes
+        foreach (var attr in dependentAssembly.Descendants().Attributes().Where(a => string.IsNullOrEmpty(a.Value)).ToList())
+        {
+            attr.Remove();
+        }
+
+        return dependentAssembly;
+    }
+
+    public static AssemblyBinding Parse(XContainer dependentAssembly)
+    {
+        ArgumentNullException.ThrowIfNull(dependentAssembly);
+
+        var binding = new AssemblyBinding();
+
+        var assemblyIdentity = dependentAssembly.Element(GetQualifiedName("assemblyIdentity"));
+        if (assemblyIdentity != null)
+        {
+            binding.Name = assemblyIdentity.Attribute("name")?.Value ?? string.Empty;
+            binding.Culture = assemblyIdentity.Attribute("culture")?.Value!;
+            binding.PublicKeyToken = assemblyIdentity.Attribute("publicKeyToken")?.Value ?? string.Empty;
+            binding.ProcessorArchitecture = assemblyIdentity.Attribute("processorArchitecture")?.Value;
+        }
+
+        var bindingRedirect = dependentAssembly.Element(GetQualifiedName("bindingRedirect"));
+        if (bindingRedirect != null)
+        {
+            binding.OldVersion = bindingRedirect.Attribute("oldVersion")?.Value!;
+            binding.NewVersion = bindingRedirect.Attribute("newVersion")?.Value ?? string.Empty;
+        }
+
+        var codeBase = dependentAssembly.Element(GetQualifiedName("codeBase"));
+        if (codeBase != null)
+        {
+            binding.CodeBaseHref = codeBase.Attribute("href")?.Value;
+            binding.CodeBaseVersion = codeBase.Attribute("version")?.Value;
+        }
+
+        var publisherPolicy = dependentAssembly.Element(GetQualifiedName("publisherPolicy"));
+        if (publisherPolicy != null)
+        {
+            binding.PublisherPolicy = publisherPolicy.Attribute("apply")?.Value;
+        }
+
+        return binding;
+    }
+
+    public static XName GetQualifiedName(string name)
+    {
+        return XName.Get(name, Namespace);
+    }
+
+    public bool Equals(AssemblyBinding? other)
+    {
+        if (other is null) return false;
+        return string.Equals(Name, other.Name, StringComparison.Ordinal) &&
+               string.Equals(PublicKeyToken, other.PublicKeyToken, StringComparison.Ordinal) &&
+               string.Equals(Culture, other.Culture, StringComparison.Ordinal) &&
+               string.Equals(ProcessorArchitecture, other.ProcessorArchitecture, StringComparison.Ordinal);
+    }
+
+    public override bool Equals(object? obj) => obj is AssemblyBinding other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(Name, PublicKeyToken, Culture, ProcessorArchitecture);
+
+    public override string ToString() => ToXElement().ToString();
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
@@ -1,9 +1,5 @@
-extern alias CoreV2;
-
 using System.Collections.Immutable;
 using System.Xml.Linq;
-
-using CoreV2::NuGet.Runtime;
 
 using Microsoft.Language.Xml;
 
@@ -11,8 +7,6 @@ using NuGet.ProjectManagement;
 
 using NuGetUpdater.Core.Updater;
 using NuGetUpdater.Core.Utilities;
-
-using Runtime_AssemblyBinding = CoreV2::NuGet.Runtime.AssemblyBinding;
 
 namespace NuGetUpdater.Core;
 
@@ -151,7 +145,7 @@ internal static class BindingRedirectManager
         return new ConfigurationFile(configFilePath, configFileContents, false);
     }
 
-    private static string AddBindingRedirects(ConfigurationFile configFile, IEnumerable<(Runtime_AssemblyBinding Binding, string AssemblyPath)> bindingRedirectsAndAssemblyPaths, string assemblyPathPrefix)
+    private static string AddBindingRedirects(ConfigurationFile configFile, IEnumerable<(AssemblyBinding Binding, string AssemblyPath)> bindingRedirectsAndAssemblyPaths, string assemblyPathPrefix)
     {
         // Do nothing if there are no binding redirects to add, bail out
         if (!bindingRedirectsAndAssemblyPaths.Any())
@@ -245,7 +239,7 @@ internal static class BindingRedirectManager
 
         static void UpdateBindingRedirectElement(
             XElement existingDependentAssemblyElement,
-            Runtime_AssemblyBinding newBindingRedirect)
+            AssemblyBinding newBindingRedirect)
         {
             var existingBindingRedirectElement = existingDependentAssemblyElement.Element(BindingRedirectName);
             // Since we've successfully parsed this node, it has to be valid and this child must exist.
@@ -273,7 +267,7 @@ internal static class BindingRedirectManager
             // We're going to need to know which element is associated with what binding for removal
             var assemblyElementPairs = dependencyAssemblyElements.Select(dependentAssemblyElement => new
             {
-                Binding = Runtime_AssemblyBinding.Parse(dependentAssemblyElement),
+                Binding = AssemblyBinding.Parse(dependentAssemblyElement),
                 Element = dependentAssemblyElement
             });
 
@@ -302,7 +296,7 @@ internal static class BindingRedirectManager
         }
     }
 
-    internal sealed record AssemblyIdentity(string Name, string PublicKeyToken);
+    internal sealed record AssemblyIdentity(string? Name, string? PublicKeyToken);
 
     // Case-insensitive comparer. This helps avoid creating duplicate binding redirects when there is a case form mismatch between assembly identities.
     // Especially important for PublicKeyToken which is typically lowercase (using NuGet.exe), but can also be uppercase when using other tools (e.g. Visual Studio auto-resolve assembly conflicts feature).

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectResolver.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectResolver.cs
@@ -55,7 +55,7 @@ internal static partial class BindingRedirectResolver
     private static readonly Regex IncludesRegex = IncludesPattern();
 
     /// <summary>
-    /// Wraps system <see cref="IAssembly"/> interface to interop with nuget apis
+    /// Wraps the system <see cref="IAssembly"/> interface for interoperability with NuGet APIs.
     /// </summary>
     private class AssemblyWrapper : IAssembly
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectResolver.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectResolver.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Text.RegularExpressions;
 
 using NuGetUpdater.Core.Updater;
@@ -56,7 +55,7 @@ internal static partial class BindingRedirectResolver
     private static readonly Regex IncludesRegex = IncludesPattern();
 
     /// <summary>
-    /// Wraps system<see cref="Assembly"/> type in the nuget interface <see cref="NuGet.Runtime.IAssembly"/> to interop with nuget apis
+    /// Wraps system <see cref="IAssembly"/> interface to interop with nuget apis
     /// </summary>
     private class AssemblyWrapper : IAssembly
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectResolver.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectResolver.cs
@@ -1,17 +1,14 @@
-extern alias CoreV2;
-
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
-using Runtime_AssemblyBinding = CoreV2::NuGet.Runtime.AssemblyBinding;
-using Runtime_IAssembly = CoreV2::NuGet.Runtime.IAssembly;
+using NuGetUpdater.Core.Updater;
 
 namespace NuGetUpdater.Core;
 
-public static partial class BindingRedirectResolver
+internal static partial class BindingRedirectResolver
 {
-    public static IEnumerable<Runtime_AssemblyBinding> GetBindingRedirects(string projectPath, IEnumerable<string> includes)
+    public static IEnumerable<AssemblyBinding> GetBindingRedirects(string projectPath, IEnumerable<string> includes)
     {
         var directoryPath = Path.GetDirectoryName(projectPath);
         if (directoryPath is null)
@@ -23,7 +20,7 @@ public static partial class BindingRedirectResolver
         {
             if (TryParseIncludesString(include, out var assemblyInfo))
             {
-                yield return new Runtime_AssemblyBinding(assemblyInfo);
+                yield return new AssemblyBinding(assemblyInfo);
             }
         }
 
@@ -61,7 +58,7 @@ public static partial class BindingRedirectResolver
     /// <summary>
     /// Wraps system<see cref="Assembly"/> type in the nuget interface <see cref="NuGet.Runtime.IAssembly"/> to interop with nuget apis
     /// </summary>
-    private class AssemblyWrapper : Runtime_IAssembly
+    private class AssemblyWrapper : IAssembly
     {
         public AssemblyWrapper(string name, Version version, string publicKeyToken, string culture)
         {
@@ -75,7 +72,7 @@ public static partial class BindingRedirectResolver
         public Version Version { get; }
         public string PublicKeyToken { get; }
         public string Culture { get; }
-        public IEnumerable<Runtime_IAssembly> ReferencedAssemblies { get; } = Enumerable.Empty<AssemblyWrapper>();
+        public IEnumerable<IAssembly> ReferencedAssemblies { get; } = Enumerable.Empty<AssemblyWrapper>();
     }
 
     [GeneratedRegex("(?<key>\\w+)=(?<value>[^,]+)")]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/IAssembly.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/IAssembly.cs
@@ -1,0 +1,10 @@
+namespace NuGetUpdater.Core.Updater;
+
+internal interface IAssembly
+{
+    string Name { get; }
+    Version Version { get; }
+    string PublicKeyToken { get; }
+    string Culture { get; }
+    IEnumerable<IAssembly> ReferencedAssemblies { get; }
+}


### PR DESCRIPTION
This PR will allow dependabot to update dependabot again :)

Replace all usages of the NuGet.Core (v2) package with local implementations.  That package is a transitive dependency of the `NuGet.Client` submodule and the assembly targets `net40-Client` which is technically incompatible with the target framework used by dependabot.  Because of that, `<NoWarn>NU1701</NoWarn>` was present telling NuGet to ignore target framework compatibility checks.  This was a very specific case where the few types necessary from that assembly were compatible with .NET Core, but by having that suppression, it made it so that dependabot couldn't update dependabot because when determining package compatibility, we do not take into consideration `NU1701` because we have no way of knowing what packages that was for or in what circumstances it would be considered OK so we have to consider any target framework incompatibility as fatal.

Various documents were updated to help future maintainers and bots understand the limitations.