### PR TITLE
fix(opentofu): strip v prefix in cooldown version comparison

### DIFF
--- a/opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb
@@ -74,9 +74,9 @@ module Dependabot
 
           # sort the allowed version tags by name in descending order
           select_tags_which_in_cooldown_from_provider&.each do |tag_name|
-            # Iterate through versions and filter out those matching the tag_name
+            normalized_tag = tag_name.sub(/^v/, "")
             versions.reject! do |version|
-              version.to_s == tag_name
+              version.to_s == normalized_tag
             end
           end
           Dependabot.logger.info(
@@ -100,9 +100,9 @@ module Dependabot
 
           # sort the allowed version tags by name in descending order
           select_tags_which_in_cooldown_from_module&.each do |tag_name|
-            # Iterate through versions and filter out those matching the tag_name
+            normalized_tag = tag_name.sub(/^v/, "")
             versions.reject! do |version|
-              version.to_s == tag_name
+              version.to_s == normalized_tag
             end
           end
           Dependabot.logger.info(

--- a/opentofu/spec/dependabot/opentofu/update_checker/latest_version_resolver_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/update_checker/latest_version_resolver_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Dependabot::Opentofu::UpdateChecker::LatestVersionResolver do
   describe "#filter_versions_in_cooldown_period_from_provider" do
     let(:versions) do
       [
-        instance_double(Dependabot::Version, to_s: "v1.0.0"),
-        instance_double(Dependabot::Version, to_s: "v0.9.0")
+        instance_double(Dependabot::Version, to_s: "1.0.0"),
+        instance_double(Dependabot::Version, to_s: "0.9.0")
       ]
     end
 
@@ -60,23 +60,23 @@ RSpec.describe Dependabot::Opentofu::UpdateChecker::LatestVersionResolver do
       allow(resolver).to receive(:select_tags_which_in_cooldown_from_provider).and_return(["v0.9.0"])
     end
 
-    it "filters out versions in cooldown period" do
+    it "filters out versions in cooldown period despite v prefix mismatch" do
       result = resolver.filter_versions_in_cooldown_period_from_provider(versions)
-      expect(result.map(&:to_s)).to eq(["v1.0.0"])
+      expect(result.map(&:to_s)).to eq(["1.0.0"])
     end
 
     it "returns all versions if an error occurs" do
       allow(resolver).to receive(:select_tags_which_in_cooldown_from_provider).and_raise(StandardError)
       result = resolver.filter_versions_in_cooldown_period_from_provider(versions)
-      expect(result.map(&:to_s)).to eq(["v1.0.0", "v0.9.0"])
+      expect(result.map(&:to_s)).to eq(["1.0.0", "0.9.0"])
     end
   end
 
   describe "#filter_versions_in_cooldown_period_from_module" do
     let(:versions) do
       [
-        instance_double(Dependabot::Version, to_s: "v1.0.0"),
-        instance_double(Dependabot::Version, to_s: "v0.9.0")
+        instance_double(Dependabot::Version, to_s: "1.0.0"),
+        instance_double(Dependabot::Version, to_s: "0.9.0")
       ]
     end
 
@@ -84,15 +84,15 @@ RSpec.describe Dependabot::Opentofu::UpdateChecker::LatestVersionResolver do
       allow(resolver).to receive(:select_tags_which_in_cooldown_from_module).and_return(["v0.9.0"])
     end
 
-    it "filters out versions in cooldown period" do
+    it "filters out versions in cooldown period despite v prefix mismatch" do
       result = resolver.filter_versions_in_cooldown_period_from_module(versions)
-      expect(result.map(&:to_s)).to eq(["v1.0.0"])
+      expect(result.map(&:to_s)).to eq(["1.0.0"])
     end
 
     it "returns all versions if an error occurs" do
       allow(resolver).to receive(:select_tags_which_in_cooldown_from_module).and_raise(StandardError)
       result = resolver.filter_versions_in_cooldown_period_from_module(versions)
-      expect(result.map(&:to_s)).to eq(["v1.0.0", "v0.9.0"])
+      expect(result.map(&:to_s)).to eq(["1.0.0", "0.9.0"])
     end
   end
 


### PR DESCRIPTION
## Summary

- Fixes cooldown being silently ignored for all OpenTofu provider and module dependencies
- The OpenTofu docs API (`api.opentofu.org/registry/docs/providers/.../index.json`) returns version IDs with a `v` prefix (e.g., `v6.43.0`), while `RegistryClient` creates `Version` objects from the providers.v1 API which returns bare versions (e.g., `6.43.0`)
- The cooldown filter compared these strings directly (`version.to_s == tag_name`), so `"6.43.0" == "v6.43.0"` was always `false` — no versions were ever filtered, making cooldown a complete no-op

OpenTofu API:  https://api.opentofu.org/registry/docs/providers/hashicorp/aws/index.json

```
...
"versions": [
    {
      "id": "v6.45.0",
      "published": "2026-05-13T18:31:04Z"
    },
...
```

Registry API: https://registry.opentofu.org/v1/providers/hashicorp/aws/versions

```
...
"versions": [
    {
      "version": "6.45.0",
...
```

## Fix

Strip the leading `v` from the tag before comparison in both `filter_versions_in_cooldown_period_from_provider` and `filter_versions_in_cooldown_period_from_module`.

## Test plan

- [x] Updated existing specs to reflect real-world version formats (versions without `v` prefix, tags with `v` prefix)
- [x] Verify with a real OpenTofu repo that cooldown now correctly delays PRs

Fixes #14903