### PR TITLE
Detect NoWarn NU1701 in SDK project discovery and warn during report

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/LoggerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/LoggerTests.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using NuGetUpdater.Core.Discover;
+
 using Xunit;
 using Xunit.Sdk;
 
@@ -56,5 +58,47 @@ public class LoggerTests
         Assert.Contains(testMessage2, output);
     }
 
+    [Fact]
+    public void ReportDiscovery_LogsWarningForProjectsWithNU1701()
+    {
+        var logger = new StringLogger();
+        var discoveryResult = new WorkspaceDiscoveryResult()
+        {
+            Path = "/src",
+            Projects = [
+                new()
+                {
+                    FilePath = "zebra.csproj",
+                    Dependencies = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
+                    HasNoWarnNU1701 = true,
+                },
+                new()
+                {
+                    FilePath = "middle.csproj",
+                    Dependencies = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
+                    HasNoWarnNU1701 = false,
+                },
+                new()
+                {
+                    FilePath = "alpha.csproj",
+                    Dependencies = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
+                    HasNoWarnNU1701 = true,
+                },
+            ]
+        };
 
+        logger.ReportDiscovery(discoveryResult);
+
+        var warnings = logger.Messages.Where(m => m.Contains("has NoWarn property containing NU1701; package compatibility checks may be inaccurate.")).ToList();
+        Assert.Equal(2, warnings.Count);
+        Assert.Contains("/src/alpha.csproj", warnings[0]);
+        Assert.Contains("/src/zebra.csproj", warnings[1]);
+        Assert.DoesNotContain(logger.Messages, m => m.Contains("Project [/src/middle.csproj] has NoWarn property containing NU1701; package compatibility checks may be inaccurate."));
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/ProjectDiscoveryResult.cs
@@ -16,4 +16,5 @@ public record ProjectDiscoveryResult : IDiscoveryResultWithDependencies
     public required ImmutableArray<string> ImportedFiles { get; init; }
     public required ImmutableArray<string> AdditionalFiles { get; init; }
     public required ImmutableArray<Dependency> Dependencies { get; init; }
+    public bool HasNoWarnNU1701 { get; init; } = false;
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -674,6 +674,18 @@ internal static class SdkProjectDiscovery
                 packageManagementKind = PackageManagementKind.Default;
             }
 
+            // check for NoWarn containing NU1701
+            var noWarnValue = GetStringPropertyFromProjectProperties(projectProperties, "NoWarn");
+            var hasNoWarnNU1701 = false;
+            if (noWarnValue is not null)
+            {
+                var noWarnCodes = noWarnValue.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (noWarnCodes.Contains("NU1701", StringComparer.OrdinalIgnoreCase))
+                {
+                    hasNoWarnNU1701 = true;
+                }
+            }
+
             var projectDiscoveryResult = new ProjectDiscoveryResult()
             {
                 FilePath = projectRelativePath,
@@ -684,6 +696,7 @@ internal static class SdkProjectDiscovery
                 AdditionalFiles = additional,
                 PackageManagementKind = packageManagementKind,
                 PackageManagementSpecialFileRelativePath = packageManagementFile,
+                HasNoWarnNU1701 = hasNoWarnNU1701,
             };
             projectDiscoveryResults.Add(projectDiscoveryResult);
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ILogger.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/ILogger.cs
@@ -24,6 +24,16 @@ public static class LoggerExtensions
 
     public static void ReportDiscovery(this ILogger logger, WorkspaceDiscoveryResult discoveryResult)
     {
+        var nu1701Projects = discoveryResult.Projects
+            .Where(p => p.HasNoWarnNU1701)
+            .Select(p => PathHelper.JoinPath(discoveryResult.Path, p.FilePath).FullyNormalizedRootedPath())
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        foreach (var projectPath in nu1701Projects)
+        {
+            logger.Warn($"Project [{projectPath}] has NoWarn property containing NU1701; package compatibility checks may be inaccurate.");
+        }
+
         logger.Info("Discovery JSON content:");
         logger.Info(JsonSerializer.Serialize(discoveryResult, DiscoveryWorker.SerializerOptions));
     }


### PR DESCRIPTION
Add HasNoWarnNU1701 property to ProjectDiscoveryResult that is set during SDK project discovery when the NoWarn property contains NU1701. The warning is reported once per project during ReportDiscovery using a fully normalized rooted path in sorted order.

The NU1701 warning is used to indicate that a project's target framework isn't compatible with the frameworks supported by the given package.  An example might be a package that only explicitly supports `net48` but a project that targets `net10.0`.  A developer might do this if they have very specific knowledge about how a package is used and what may or may not work at runtime, but there is no granularity offered and dependabot has no way of knowing under what circumstances the differing target frameworks will matter or not.  The likely result is that dependabot will fail to produce an update because during the compatibility checks it will find an "unsupported" package and abandon everything.  With this approach we at least surface a warning so the user can easily see why no PR was generated.

I initially attempted to detect the bad package pairings before the update and not re-check those later, but that opens a huge can of worms around understanding exactly why the developer added NU1701 to NoWarn to begin with and we still have no way of knowing what other interactions might cause problems or not.

Eventually we can try to improve this behavior, but with this PR there is no functional change, just more reporting about why nothing happened.