### PR TITLE
fix(go_modules): preserve unrelated go.mod checksums in go.sum

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -10,6 +10,7 @@ require "dependabot/go_modules/file_updater"
 require "dependabot/go_modules/go_work_parser"
 require "dependabot/go_modules/replace_stubber"
 require "dependabot/go_modules/resolvability_errors"
+require "dependabot/go_modules/version"
 
 module Dependabot
   module GoModules
@@ -222,10 +223,12 @@ module Dependabot
               substitute_all(substitutions.invert)
             end
 
-            updated_go_sum = original_go_sum ? File.read("go.sum") : nil
             updated_go_mod = File.read("go.mod")
 
-            { go_mod: updated_go_mod, go_sum: updated_go_sum }
+            result = T.let({ go_mod: updated_go_mod }, T::Hash[Symbol, String])
+            result[:go_sum] = reconcile_go_sum(original_go_sum, File.read("go.sum")) if original_go_sum
+
+            result
           end
         end
 
@@ -415,6 +418,172 @@ module Dependabot
             FileUtils.touch(File.join(stub_path, "go.mod"))
             FileUtils.touch(File.join(stub_path, "main.go"))
           end
+        end
+
+        sig { params(original_go_sum: String, updated_go_sum: String).returns(String) }
+        def reconcile_go_sum(original_go_sum, updated_go_sum)
+          original_lines = original_go_sum.lines(chomp: true).reject(&:empty?)
+          updated_lines = updated_go_sum.lines(chomp: true).reject(&:empty?)
+          updated_set = updated_lines.to_set
+          updated_modules = extract_module_path_versions(updated_lines)
+
+          restored_lines = find_restorable_go_mod_lines(original_lines, updated_set, updated_modules)
+          return updated_go_sum if restored_lines.empty?
+
+          (updated_lines + restored_lines).sort! { |a, b| go_sum_line_compare(a, b) }.join("\n") + "\n"
+        end
+
+        sig do
+          params(
+            original_lines: T::Array[String],
+            updated_set: T::Set[String],
+            updated_modules: T::Hash[String, T::Set[String]]
+          ).returns(T::Array[String])
+        end
+        def find_restorable_go_mod_lines(original_lines, updated_set, updated_modules)
+          original_zip_versions = build_original_zip_versions(original_lines)
+
+          original_lines.filter_map do |line|
+            next unless go_mod_checksum_line?(line)
+            next if updated_set.include?(line)
+            next unless restorable_line?(line, updated_modules, original_zip_versions)
+
+            line
+          end
+        end
+
+        sig do
+          params(
+            line: String,
+            updated_modules: T::Hash[String, T::Set[String]],
+            original_zip_versions: T::Hash[String, T::Set[String]]
+          ).returns(T::Boolean)
+        end
+        def restorable_line?(line, updated_modules, original_zip_versions)
+          module_path = go_sum_module_path(line)
+          return false unless module_path
+          return false if updated_dependency_names.include?(module_path)
+
+          module_version = extract_module_version_from_go_mod_line(line)
+          return false unless module_version
+
+          version = T.must(module_version.split(/\s+/, 2).last)
+          has_zip_in_original = original_zip_versions.fetch(module_path, nil)&.include?(version)
+
+          if has_zip_in_original
+            module_version_still_relevant?(module_path, module_version, updated_modules)
+          else
+            updated_modules.key?(module_path)
+          end
+        end
+
+        # Builds a map of module_path → Set[versions] for entries that have a
+        # zip hash (non /go.mod lines) in the original go.sum.
+        sig { params(lines: T::Array[String]).returns(T::Hash[String, T::Set[String]]) }
+        def build_original_zip_versions(lines)
+          lines.each_with_object(Hash.new { |h, k| h[k] = Set.new }) do |line, map|
+            next if go_mod_checksum_line?(line)
+
+            parts = line.split(/\s+/, 3)
+            next unless parts.length >= 2
+
+            path = T.must(parts[0])
+            version = T.must(parts[1])
+            map[path].add(version)
+          end
+        end
+
+        sig { params(line: String).returns(T::Boolean) }
+        def go_mod_checksum_line?(line)
+          line.include?("/go.mod h1:")
+        end
+
+        sig { params(line: String).returns(T.nilable(String)) }
+        def go_sum_module_path(line)
+          line.split(/\s+/, 2).first
+        end
+
+        # Extracts "module/path vX.Y.Z" from a /go.mod checksum line
+        sig { params(line: String).returns(T.nilable(String)) }
+        def extract_module_version_from_go_mod_line(line)
+          match = line.match(%r{^(\S+)\s+(\S+)/go\.mod\s})
+          return nil unless match
+
+          "#{match[1]} #{match[2]}"
+        end
+
+        # Builds a map of module_path → Set[versions] from all lines in go.sum
+        sig { params(lines: T::Array[String]).returns(T::Hash[String, T::Set[String]]) }
+        def extract_module_path_versions(lines)
+          lines.each_with_object(Hash.new { |h, k| h[k] = Set.new }) do |line, map|
+            parts = line.split(/\s+/, 3)
+            next unless parts.length >= 2
+
+            path = T.must(parts[0])
+            version = T.must(parts[1]).sub(%r{/go\.mod$}, "")
+            map[path].add(version)
+          end
+        end
+
+        # A module+version is still relevant if it still has an entry in the
+        # updated go.sum (zip hash or another /go.mod line for the same version).
+        # If the module path has no entry for this version, it was removed from
+        # the graph (e.g., a transitive dep that was upgraded to a newer version).
+        sig do
+          params(
+            module_path: String,
+            module_version: String,
+            updated_modules: T::Hash[String, T::Set[String]]
+          ).returns(T::Boolean)
+        end
+        def module_version_still_relevant?(module_path, module_version, updated_modules)
+          versions = updated_modules.fetch(module_path, nil)
+          return false unless versions
+
+          version = module_version.split(/\s+/, 2).last
+          return false unless version
+
+          versions.include?(version)
+        end
+
+        sig { returns(T::Set[String]) }
+        def updated_dependency_names
+          @updated_dependency_names ||= T.let(dependencies.to_set(&:name), T.nilable(T::Set[String]))
+        end
+
+        # Compares two go.sum lines using Go's module-aware sort order:
+        # sort by module path, then semver version, then /go.mod suffix last.
+        sig { params(line_a: String, line_b: String).returns(Integer) }
+        def go_sum_line_compare(line_a, line_b)
+          path_a, version_rest_a = line_a.split(/\s+/, 2)
+          path_b, version_rest_b = line_b.split(/\s+/, 2)
+
+          path_cmp = T.must((path_a || "") <=> (path_b || ""))
+          return path_cmp unless path_cmp.zero?
+
+          compare_go_versions(version_rest_a || "", version_rest_b || "")
+        end
+
+        # Compares version+suffix portions of go.sum lines using GoModules::Version.
+        sig { params(ver_a: String, ver_b: String).returns(Integer) }
+        def compare_go_versions(ver_a, ver_b)
+          a_is_gomod = ver_a.include?("/go.mod")
+          b_is_gomod = ver_b.include?("/go.mod")
+
+          # Extract raw version token (e.g., "v0.6.0" from "v0.6.0/go.mod h1:...")
+          raw_a = ver_a.split(%r{(/go\.mod)?\s}, 2).first || ""
+          raw_b = ver_b.split(%r{(/go\.mod)?\s}, 2).first || ""
+
+          ver_cmp = go_version_compare(raw_a, raw_b)
+          return ver_cmp unless ver_cmp.zero?
+
+          # Same version: zip hash line sorts before /go.mod line
+          (a_is_gomod ? 1 : 0) <=> (b_is_gomod ? 1 : 0)
+        end
+
+        sig { params(ver_a: String, ver_b: String).returns(Integer) }
+        def go_version_compare(ver_a, ver_b)
+          T.must(Dependabot::GoModules::Version.new(ver_a) <=> Dependabot::GoModules::Version.new(ver_b))
         end
 
         # Given a go.mod file, find all `replace` directives pointing to a path

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -258,22 +258,126 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
         end
 
         context "with a go.sum" do
-          subject(:updated_go_mod_content) { updater.updated_go_sum_content }
+          subject(:updated_go_sum_content) { updater.updated_go_sum_content }
 
           let(:project_name) { "go_sum" }
 
           it "adds new entries to the go.sum" do
-            expect(updated_go_mod_content)
+            expect(updated_go_sum_content)
               .to include(%(rsc.io/quote v1.5.2 h1:))
-            expect(updated_go_mod_content)
+            expect(updated_go_sum_content)
               .to include(%(rsc.io/quote v1.5.2/go.mod h1:))
           end
 
           it "removes old entries from the go.sum" do
-            expect(updated_go_mod_content)
+            expect(updated_go_sum_content)
               .not_to include(%(rsc.io/quote v1.4.0 h1:))
-            expect(updated_go_mod_content)
+            expect(updated_go_sum_content)
               .not_to include(%(rsc.io/quote v1.4.0/go.mod h1:))
+          end
+
+          context "when go tooling removes an unrelated go.mod checksum line" do
+            let(:removed_line) do
+              "gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E="
+            end
+            let(:zip_line) do
+              "gonum.org/v1/gonum v0.16.0 h1:JKbmSgVMFkFMDpGCixMRJCMEMmNhrsJuJqVDPMGPnQY="
+            end
+
+            it "restores the unrelated checksum line" do
+              allow(File).to receive(:read).and_call_original
+
+              original_go_sum = fixture("projects", project_name, "go.sum") +
+                                "#{zip_line}\n#{removed_line}\n"
+              updated_go_sum = original_go_sum.lines.reject { |line| line.chomp == removed_line }.join
+
+              allow(File).to receive(:read).with("go.sum").and_return(original_go_sum, updated_go_sum)
+
+              expect(updated_go_sum_content).to include(removed_line)
+            end
+          end
+
+          context "when the removed checksum belongs to the updated dependency" do
+            let(:removed_line) { "rsc.io/quote v1.4.0/go.mod h1:somethingoldchecksum=" }
+
+            it "does not restore the removed checksum line" do
+              allow(File).to receive(:read).and_call_original
+
+              original_go_sum = <<~GOSUM
+                rsc.io/quote v1.4.0 h1:oldchecksum=
+                #{removed_line}
+                rsc.io/sampler v1.3.0/go.mod h1:anexistingchecksum=
+              GOSUM
+
+              updated_go_sum = <<~GOSUM
+                rsc.io/quote v1.5.2 h1:newchecksum=
+                rsc.io/quote v1.5.2/go.mod h1:newgomodchecksum=
+                rsc.io/sampler v1.3.0/go.mod h1:anexistingchecksum=
+              GOSUM
+
+              allow(File).to receive(:read).with("go.sum").and_return(original_go_sum, updated_go_sum)
+
+              expect(updated_go_sum_content).not_to include(removed_line)
+            end
+          end
+
+          context "when a transitive dependency version is legitimately upgraded" do
+            let(:removed_line) { "golang.org/x/sys v0.0.0-20200116001909/go.mod h1:oldtransitivechecksum=" }
+
+            it "does not restore the removed checksum line" do
+              allow(File).to receive(:read).and_call_original
+
+              original_go_sum = <<~GOSUM
+                golang.org/x/sys v0.0.0-20200116001909 h1:oldziphash=
+                #{removed_line}
+                rsc.io/quote v1.4.0 h1:oldchecksum=
+                rsc.io/quote v1.4.0/go.mod h1:oldgomod=
+              GOSUM
+
+              updated_go_sum = <<~GOSUM
+                golang.org/x/sys v0.0.0-20220731174439 h1:newziphash=
+                golang.org/x/sys v0.0.0-20220731174439/go.mod h1:newtransitivechecksum=
+                rsc.io/quote v1.5.2 h1:newchecksum=
+                rsc.io/quote v1.5.2/go.mod h1:newgomodchecksum=
+              GOSUM
+
+              allow(File).to receive(:read).with("go.sum").and_return(original_go_sum, updated_go_sum)
+
+              expect(updated_go_sum_content).not_to include(removed_line)
+            end
+          end
+
+          context "when a go.mod-only entry (no zip hash) is pruned" do
+            let(:removed_line) do
+              "golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ="
+            end
+
+            it "restores the go.mod-only checksum line" do
+              allow(File).to receive(:read).and_call_original
+
+              original_go_sum = <<~GOSUM
+                golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+                golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+                golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+                rsc.io/quote v1.4.0 h1:oldchecksum=
+                rsc.io/quote v1.4.0/go.mod h1:oldgomod=
+              GOSUM
+
+              updated_go_sum = <<~GOSUM
+                golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+                golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+                golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+                rsc.io/quote v1.5.2 h1:newchecksum=
+                rsc.io/quote v1.5.2/go.mod h1:newgomodchecksum=
+              GOSUM
+
+              # Simulate go tooling pruning the go.mod-only line
+              pruned_go_sum = updated_go_sum.lines.reject { |line| line.chomp == removed_line }.join
+
+              allow(File).to receive(:read).with("go.sum").and_return(original_go_sum, pruned_go_sum)
+
+              expect(updated_go_sum_content).to include(removed_line)
+            end
           end
 
           describe "a non-existent dependency with a pseudo-version" do
@@ -322,16 +426,16 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             end
 
             it "adds new entries to the go.sum" do
-              expect(updated_go_mod_content)
+              expect(updated_go_sum_content)
                 .to include(%(rsc.io/quote v1.5.2 h1:))
-              expect(updated_go_mod_content)
+              expect(updated_go_sum_content)
                 .to include(%(rsc.io/quote v1.5.2/go.mod h1:))
             end
 
             it "removes old entries from the go.sum" do
-              expect(updated_go_mod_content)
+              expect(updated_go_sum_content)
                 .not_to include(%(rsc.io/quote v1.4.0 h1:))
-              expect(updated_go_mod_content)
+              expect(updated_go_sum_content)
                 .not_to include(%(rsc.io/quote v1.4.0/go.mod h1:))
             end
 


### PR DESCRIPTION
When Go tooling (go get, go mod tidy) runs during a dependency update, it can prune go.mod checksum entries for indirect/transitive dependencies that aren't strictly needed for building. This causes Dependabot PRs to unexpectedly remove hash entries from go.sum that go mod tidy would keep.

Add reconcile_go_sum to detect go.mod checksum lines that were removed for modules NOT being updated, and restore them in sorted order.

Fixes #14872

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
