### PR TITLE
Fix gradle cooldown nil-poisoning for plugin coordinates against private mirrors

### DIFF
--- a/gradle/lib/dependabot/gradle/package/release_date_extractor.rb
+++ b/gradle/lib/dependabot/gradle/package/release_date_extractor.rb
@@ -119,12 +119,6 @@ module Dependabot
             next unless version
 
             next unless version_class.correct?(version)
-            # Skip if we already have a real release date for this version. We intentionally
-            # do NOT use `key?` here: an earlier repository (e.g. the Gradle Plugin Portal HTML
-            # listing, which has no dates) may have recorded a nil placeholder. Allowing a
-            # later repository (e.g. a private Artifactory/Nexus mirror) with real dates to
-            # overwrite that placeholder fixes the cooldown filter falsely filtering every
-            # version (see issue #14271).
             next if release_date_info.dig(version, :release_date)
 
             release_date = extract_release_date_from_link(link, version)
@@ -153,8 +147,6 @@ module Dependabot
           latest_version = metadata_xml.at_xpath("//metadata/versioning/latest")&.text&.strip
 
           return unless latest_version && version_class.correct?(latest_version)
-          # See note in `parse_maven_central_releases`: use `dig` so a real date from another
-          # repository overwrites any nil placeholder previously recorded for `latest_version`.
           return if release_date_info.dig(latest_version, :release_date)
 
           release_date = parse_gradle_timestamp(last_updated)

--- a/gradle/lib/dependabot/gradle/package/release_date_extractor.rb
+++ b/gradle/lib/dependabot/gradle/package/release_date_extractor.rb
@@ -119,7 +119,13 @@ module Dependabot
             next unless version
 
             next unless version_class.correct?(version)
-            next if release_date_info.key?(version)
+            # Skip if we already have a real release date for this version. We intentionally
+            # do NOT use `key?` here: an earlier repository (e.g. the Gradle Plugin Portal HTML
+            # listing, which has no dates) may have recorded a nil placeholder. Allowing a
+            # later repository (e.g. a private Artifactory/Nexus mirror) with real dates to
+            # overwrite that placeholder fixes the cooldown filter falsely filtering every
+            # version (see issue #14271).
+            next if release_date_info.dig(version, :release_date)
 
             release_date = extract_release_date_from_link(link, version)
             release_date_info[version] = { release_date: release_date }
@@ -147,7 +153,9 @@ module Dependabot
           latest_version = metadata_xml.at_xpath("//metadata/versioning/latest")&.text&.strip
 
           return unless latest_version && version_class.correct?(latest_version)
-          return if release_date_info.key?(latest_version)
+          # See note in `parse_maven_central_releases`: use `dig` so a real date from another
+          # repository overwrites any nil placeholder previously recorded for `latest_version`.
+          return if release_date_info.dig(latest_version, :release_date)
 
           release_date = parse_gradle_timestamp(last_updated)
           Dependabot.logger.info(

--- a/gradle/spec/dependabot/gradle/package/release_date_extractor_spec.rb
+++ b/gradle/spec/dependabot/gradle/package/release_date_extractor_spec.rb
@@ -182,5 +182,108 @@ RSpec.describe Dependabot::Gradle::Package::ReleaseDateExtractor do
         expect(extract_release_dates).to eq({})
       end
     end
+
+    # Regression test for https://github.com/dependabot/dependabot-core/issues/14271.
+    # When a Gradle plugin coordinate is updated against a private Maven mirror,
+    # `plugins.gradle.org` is always prepended to the repository list (even with
+    # `replaces-base: true`). The Plugin Portal HTML listing has no per-version
+    # release dates, so it used to write nil placeholders for every version and
+    # the `key?` guard prevented the real dates from the private mirror (which
+    # *does* expose them) from ever being recorded. Every version then looked
+    # like it was missing a date and the cooldown filter filtered them all out,
+    # leaving "Latest version is" empty in the logs.
+    context "with Gradle Plugin Portal HTML (no dates) followed by a private mirror (with dates)" do
+      let(:repositories) do
+        [
+          { "url" => "https://plugins.gradle.org/m2", "auth_headers" => {} },
+          { "url" => "https://artifactory.example.com/artifactory/maven", "auth_headers" => {} }
+        ]
+      end
+      let(:plugin_portal_html) do
+        <<~HTML
+          <html><body>
+            <pre><a href="2.3.10/">2.3.10/</a></pre>
+            <pre><a href="2.3.20/">2.3.20/</a></pre>
+            <pre><a href="2.3.21/">2.3.21/</a></pre>
+          </body></html>
+        HTML
+      end
+      let(:private_mirror_html) do
+        <<~HTML
+          <html><body>
+            <pre><a href="../">../</a>
+            <a href="2.3.10/">2.3.10/</a>   2026-01-10 12:00    -
+            <a href="2.3.20/">2.3.20/</a>   2026-03-15 09:30    -
+            <a href="2.3.21/">2.3.21/</a>   2026-04-02 16:45    -
+            </pre>
+          </body></html>
+        HTML
+      end
+      let(:plugin_portal_url) { "https://plugins.gradle.org/m2" }
+      let(:release_info_metadata_fetcher) do
+        lambda do |repo|
+          html = repo.fetch("url") == plugin_portal_url ? plugin_portal_html : private_mirror_html
+          Nokogiri::HTML(html)
+        end
+      end
+
+      it "lets real dates from the private mirror overwrite nil dates from the Plugin Portal" do
+        result = extract_release_dates
+
+        expect(result["2.3.10"]).to eq({ release_date: Time.parse("2026-01-10 12:00") })
+        expect(result["2.3.20"]).to eq({ release_date: Time.parse("2026-03-15 09:30") })
+        expect(result["2.3.21"]).to eq({ release_date: Time.parse("2026-04-02 16:45") })
+      end
+    end
+
+    # Regression test for the Gradle Plugin Portal maven-metadata.xml path of the
+    # same bug: when the Plugin Portal reports its `latest` version with a real
+    # `lastUpdated` timestamp, a private mirror processed afterwards must not
+    # be allowed to clobber it with nil; conversely, when the Plugin Portal
+    # XML is missing/empty and only the private mirror has the date, the mirror's
+    # date must win.
+    context "when the Plugin Portal XML latest has no date but a later mirror does" do
+      let(:repositories) do
+        [
+          { "url" => "https://plugins.gradle.org/m2", "auth_headers" => {} },
+          { "url" => "https://artifactory.example.com/artifactory/maven", "auth_headers" => {} }
+        ]
+      end
+      let(:plugin_portal_xml) do
+        <<~XML
+          <metadata>
+            <versioning>
+              <latest>2.3.21</latest>
+              <lastUpdated></lastUpdated>
+            </versioning>
+          </metadata>
+        XML
+      end
+      let(:private_mirror_html) do
+        <<~HTML
+          <html><body>
+            <pre><a href="2.3.21/">2.3.21/</a>   2026-04-02 16:45    -</pre>
+          </body></html>
+        HTML
+      end
+      let(:plugin_portal_url) { "https://plugins.gradle.org/m2" }
+      let(:dependency_metadata_fetcher) do
+        lambda do |repo|
+          xml = repo.fetch("url") == plugin_portal_url ? plugin_portal_xml : ""
+          Nokogiri::XML(xml)
+        end
+      end
+      let(:release_info_metadata_fetcher) do
+        lambda do |repo|
+          html = repo.fetch("url") == plugin_portal_url ? "" : private_mirror_html
+          Nokogiri::HTML(html)
+        end
+      end
+
+      it "uses the mirror's real date for the latest version" do
+        result = extract_release_dates
+        expect(result["2.3.21"]).to eq({ release_date: Time.parse("2026-04-02 16:45") })
+      end
+    end
   end
 end

--- a/gradle/spec/dependabot/gradle/package/release_date_extractor_spec.rb
+++ b/gradle/spec/dependabot/gradle/package/release_date_extractor_spec.rb
@@ -229,47 +229,50 @@ RSpec.describe Dependabot::Gradle::Package::ReleaseDateExtractor do
     end
 
     # Regression test for https://github.com/dependabot/dependabot-core/issues/14271.
-    context "when the Plugin Portal XML latest has no date but a later mirror does" do
+    # Specifically covers the XML guard: an earlier repository's HTML listing
+    # records a nil placeholder, and a later repository's maven-metadata.xml
+    # supplies the real `lastUpdated` for the same version.
+    context "when an earlier HTML listing records nil and a later XML metadata has a real date" do
       let(:repositories) do
         [
           { "url" => "https://plugins.gradle.org/m2", "auth_headers" => {} },
           { "url" => "https://artifactory.example.com/artifactory/maven", "auth_headers" => {} }
         ]
       end
-      let(:plugin_portal_xml) do
+      let(:plugin_portal_url) { "https://plugins.gradle.org/m2" }
+      let(:plugin_portal_html) do
+        <<~HTML
+          <html><body>
+            <pre><a href="2.3.21/">2.3.21/</a></pre>
+          </body></html>
+        HTML
+      end
+      let(:mirror_xml) do
         <<~XML
           <metadata>
             <versioning>
               <latest>2.3.21</latest>
-              <lastUpdated></lastUpdated>
+              <lastUpdated>20260402164500</lastUpdated>
             </versioning>
           </metadata>
         XML
       end
-      let(:private_mirror_html) do
-        <<~HTML
-          <html><body>
-            <pre><a href="2.3.21/">2.3.21/</a>   2026-04-02 16:45    -</pre>
-          </body></html>
-        HTML
-      end
-      let(:plugin_portal_url) { "https://plugins.gradle.org/m2" }
       let(:dependency_metadata_fetcher) do
         lambda do |repo|
-          xml = repo.fetch("url") == plugin_portal_url ? plugin_portal_xml : ""
+          xml = repo.fetch("url") == plugin_portal_url ? "" : mirror_xml
           Nokogiri::XML(xml)
         end
       end
       let(:release_info_metadata_fetcher) do
         lambda do |repo|
-          html = repo.fetch("url") == plugin_portal_url ? "" : private_mirror_html
+          html = repo.fetch("url") == plugin_portal_url ? plugin_portal_html : ""
           Nokogiri::HTML(html)
         end
       end
 
-      it "uses the mirror's real date for the latest version" do
+      it "lets the later XML lastUpdated overwrite the earlier nil placeholder" do
         result = extract_release_dates
-        expect(result["2.3.21"]).to eq({ release_date: Time.parse("2026-04-02 16:45") })
+        expect(result["2.3.21"]).to eq({ release_date: Time.utc(2026, 4, 2, 16, 45, 0) })
       end
     end
   end

--- a/gradle/spec/dependabot/gradle/package/release_date_extractor_spec.rb
+++ b/gradle/spec/dependabot/gradle/package/release_date_extractor_spec.rb
@@ -184,14 +184,6 @@ RSpec.describe Dependabot::Gradle::Package::ReleaseDateExtractor do
     end
 
     # Regression test for https://github.com/dependabot/dependabot-core/issues/14271.
-    # When a Gradle plugin coordinate is updated against a private Maven mirror,
-    # `plugins.gradle.org` is always prepended to the repository list (even with
-    # `replaces-base: true`). The Plugin Portal HTML listing has no per-version
-    # release dates, so it used to write nil placeholders for every version and
-    # the `key?` guard prevented the real dates from the private mirror (which
-    # *does* expose them) from ever being recorded. Every version then looked
-    # like it was missing a date and the cooldown filter filtered them all out,
-    # leaving "Latest version is" empty in the logs.
     context "with Gradle Plugin Portal HTML (no dates) followed by a private mirror (with dates)" do
       let(:repositories) do
         [
@@ -236,12 +228,7 @@ RSpec.describe Dependabot::Gradle::Package::ReleaseDateExtractor do
       end
     end
 
-    # Regression test for the Gradle Plugin Portal maven-metadata.xml path of the
-    # same bug: when the Plugin Portal reports its `latest` version with a real
-    # `lastUpdated` timestamp, a private mirror processed afterwards must not
-    # be allowed to clobber it with nil; conversely, when the Plugin Portal
-    # XML is missing/empty and only the private mirror has the date, the mirror's
-    # date must win.
+    # Regression test for https://github.com/dependabot/dependabot-core/issues/14271.
     context "when the Plugin Portal XML latest has no date but a later mirror does" do
       let(:repositories) do
         [


### PR DESCRIPTION
## Summary

Fixes #14271.

When a Gradle plugin coordinate (`*.gradle.plugin`) is updated against a private Maven mirror, `plugins.gradle.org` is always prepended to the repository list — even with `replaces-base: true`. The Plugin Portal HTML directory listing has no per-version release dates, so `ReleaseDateExtractor` recorded `{ release_date: nil }` for every version. The subsequent `key?` guards then prevented the private mirror's real per-version dates from ever being recorded, and the cooldown filter saw every version as "release date not available" and filtered them all out, leaving `Latest version is ` empty in logs.

This is a regression that #14938 inadvertently exposed (by making `parse_maven_central_releases` able to read Artifactory-style `<a href="X/">` listings, the Plugin Portal HTML now matches first and writes nil placeholders for every concrete version). #15006 added a lazy POM `Last-Modified` fallback that helps in many cases but does not address the in-memory bug here.

## Changes

- Switch the guards in both `parse_maven_central_releases` and `parse_gradle_plugin_portal_release` from `key?` to checking whether we already have a real (non-nil) date via `release_date_info.dig(version, :release_date)`. This lets a subsequent repository with real dates overwrite the earlier nil placeholder, while still avoiding redundant re-parsing for versions whose date is already known.
- Add two regression tests:
  1. Plugin Portal HTML (no dates) followed by an Artifactory-style mirror with real dates — all versions end up with the mirror's dates.
  2. Plugin Portal `maven-metadata.xml` with an empty `<lastUpdated>` followed by a mirror HTML with a date — the latest version ends up with the mirror's date.

## Why this is safe

- For the existing `with both repository styles` test, the XML records a real date for the latest version first; the new guard prevents the later HTML entry (also a real date but matching the same version) from overwriting it, so behaviour is unchanged for that case.
- Versions that only ever have nil dates continue to land as `{ release_date: nil }` exactly as before.
- The change is local to the extractor; no public API changes.

## Verification

- Syntax-checked both files with `ruby -c`.
- Added two RSpec contexts that reproduce the failure mode described in the issue's last comment and assert the fixed behaviour. (Per CONTRIBUTING, the full RSpec suite runs in the docker dev shell and will exercise these in CI.)