### PR TITLE
fix(uv): prefer uv.lock versions in parser output

### DIFF
--- a/uv/lib/dependabot/uv/file_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser.rb
@@ -25,6 +25,7 @@ module Dependabot
 
       require_relative "file_parser/pyproject_files_parser"
       require_relative "file_parser/python_requirement_parser"
+      require_relative "file_parser/lock_file_dependency_parser"
 
       DEPENDENCY_GROUP_KEYS = T.let(
         [
@@ -57,7 +58,7 @@ module Dependabot
         dependency_set += uv_lock_file_dependencies
         dependency_set += requirement_dependencies if requirement_files.any?
 
-        dependency_set.dependencies
+        lock_file_dependency_parser.prefer_lockfile_versions(dependency_set.dependencies)
       end
 
       sig { override.returns(Ecosystem) }
@@ -188,34 +189,17 @@ module Dependabot
         dependency_files.select { |f| f.name.end_with?(".txt", ".in") }
       end
 
-      sig { returns(T::Array[DependencyFile]) }
-      def uv_lock_files
-        dependency_files.select { |f| f.name == "uv.lock" }
+      sig { returns(LockFileDependencyParser) }
+      def lock_file_dependency_parser
+        @lock_file_dependency_parser ||= T.let(
+          LockFileDependencyParser.new(dependency_files: dependency_files),
+          T.nilable(LockFileDependencyParser)
+        )
       end
 
       sig { returns(DependencySet) }
       def uv_lock_file_dependencies
-        dependency_set = DependencySet.new
-
-        uv_lock_files.each do |file|
-          lockfile_content = TomlRB.parse(file.content)
-          packages = lockfile_content.fetch("package", [])
-
-          packages.each do |package_data|
-            next unless package_data.is_a?(Hash) && package_data["name"] && package_data["version"]
-
-            dependency_set << Dependency.new(
-              name: normalised_name(package_data["name"]),
-              version: package_data["version"],
-              requirements: [], # Lock files don't contain requirements
-              package_manager: "uv"
-            )
-          end
-        rescue StandardError => e
-          Dependabot.logger.warn("Error parsing uv.lock: #{e.message}")
-        end
-
-        dependency_set
+        lock_file_dependency_parser.dependency_set
       end
 
       sig { returns(DependencySet) }

--- a/uv/lib/dependabot/uv/file_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser.rb
@@ -58,7 +58,7 @@ module Dependabot
         dependency_set += uv_lock_file_dependencies
         dependency_set += requirement_dependencies if requirement_files.any?
 
-        lock_file_dependency_parser.prefer_lockfile_versions(dependency_set.dependencies)
+        lock_file_dependency_parser.override_with_lockfile_versions(dependency_set.dependencies)
       end
 
       sig { override.returns(Ecosystem) }

--- a/uv/lib/dependabot/uv/file_parser/lock_file_dependency_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser/lock_file_dependency_parser.rb
@@ -30,36 +30,44 @@ module Dependabot
           )
         end
 
-        # uv.lock is the resolved source of truth for installed versions. When a
-        # package also appears in a (possibly stale) requirements.txt/.in file,
-        # prefer the lockfile version while preserving requirements so the file
-        # updater can still operate on those files.
+        # `DependencySet#combined_version` can pick a stale `requirements.txt`
+        # version over `uv.lock` when both list the same package — `uv.lock`
+        # entries have empty requirements (so `top_level?` is false) and lose
+        # the merge. Override the merged version with the lockfile version for
+        # any package present in `uv.lock`, keeping the merged requirements so
+        # the file updater can still operate on the requirements files.
         sig do
           params(dependencies: T::Array[Dependabot::Dependency])
             .returns(T::Array[Dependabot::Dependency])
         end
-        def prefer_lockfile_versions(dependencies)
-          return dependencies if versions_by_name.empty?
+        def override_with_lockfile_versions(dependencies)
+          return dependencies if lockfile_versions.empty?
 
-          dependencies.map do |dep|
-            lock_version = versions_by_name[dep.name]
-            next dep if lock_version.nil? || dep.version == lock_version
-
-            Dependabot::Dependency.new(
-              name: dep.name,
-              version: lock_version,
-              requirements: dep.requirements,
-              package_manager: dep.package_manager,
-              subdependency_metadata: dep.subdependency_metadata,
-              metadata: dep.metadata
-            )
-          end
+          dependencies.map { |dep| override_version(dep, lockfile_versions[dep.name]) }
         end
 
         private
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         attr_reader :dependency_files
+
+        sig do
+          params(dep: Dependabot::Dependency, lock_version: T.nilable(String))
+            .returns(Dependabot::Dependency)
+        end
+        def override_version(dep, lock_version)
+          return dep if lock_version.nil? # not in uv.lock
+          return dep if dep.version == lock_version # merged version already correct
+
+          Dependabot::Dependency.new(
+            name: dep.name,
+            version: lock_version,
+            requirements: dep.requirements,
+            package_manager: dep.package_manager,
+            subdependency_metadata: dep.subdependency_metadata,
+            metadata: dep.metadata
+          )
+        end
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         def uv_lock_files
@@ -92,8 +100,8 @@ module Dependabot
         end
 
         sig { returns(T::Hash[String, String]) }
-        def versions_by_name
-          @versions_by_name ||= T.let(
+        def lockfile_versions
+          @lockfile_versions ||= T.let(
             dependency_set.dependencies.each_with_object({}) do |dep, hash|
               version = dep.version
               hash[dep.name] = version if version

--- a/uv/lib/dependabot/uv/file_parser/lock_file_dependency_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser/lock_file_dependency_parser.rb
@@ -1,0 +1,107 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "toml-rb"
+
+require "dependabot/dependency"
+require "dependabot/file_parsers/base/dependency_set"
+require "dependabot/uv/file_parser"
+require "dependabot/uv/name_normaliser"
+
+module Dependabot
+  module Uv
+    class FileParser
+      # Parses dependencies out of uv.lock files and provides a helper for
+      # preferring lockfile-resolved versions over any (potentially stale)
+      # versions discovered in requirements.txt/.in or pyproject.toml.
+      class LockFileDependencyParser
+        extend T::Sig
+
+        sig { params(dependency_files: T::Array[Dependabot::DependencyFile]).void }
+        def initialize(dependency_files:)
+          @dependency_files = dependency_files
+        end
+
+        sig { returns(Dependabot::FileParsers::Base::DependencySet) }
+        def dependency_set
+          @dependency_set ||= T.let(
+            build_dependency_set,
+            T.nilable(Dependabot::FileParsers::Base::DependencySet)
+          )
+        end
+
+        # uv.lock is the resolved source of truth for installed versions. When a
+        # package also appears in a (possibly stale) requirements.txt/.in file,
+        # prefer the lockfile version while preserving requirements so the file
+        # updater can still operate on those files.
+        sig do
+          params(dependencies: T::Array[Dependabot::Dependency])
+            .returns(T::Array[Dependabot::Dependency])
+        end
+        def prefer_lockfile_versions(dependencies)
+          return dependencies if versions_by_name.empty?
+
+          dependencies.map do |dep|
+            lock_version = versions_by_name[dep.name]
+            next dep if lock_version.nil? || dep.version == lock_version
+
+            Dependabot::Dependency.new(
+              name: dep.name,
+              version: lock_version,
+              requirements: dep.requirements,
+              package_manager: dep.package_manager,
+              subdependency_metadata: dep.subdependency_metadata,
+              metadata: dep.metadata
+            )
+          end
+        end
+
+        private
+
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        attr_reader :dependency_files
+
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        def uv_lock_files
+          dependency_files.select { |f| f.name == "uv.lock" }
+        end
+
+        sig { returns(Dependabot::FileParsers::Base::DependencySet) }
+        def build_dependency_set
+          set = Dependabot::FileParsers::Base::DependencySet.new
+
+          uv_lock_files.each do |file|
+            lockfile_content = TomlRB.parse(file.content)
+            packages = lockfile_content.fetch("package", [])
+
+            packages.each do |package_data|
+              next unless package_data.is_a?(Hash) && package_data["name"] && package_data["version"]
+
+              set << Dependabot::Dependency.new(
+                name: NameNormaliser.normalise(package_data["name"]),
+                version: package_data["version"],
+                requirements: [], # Lock files don't contain requirements
+                package_manager: "uv"
+              )
+            end
+          rescue StandardError => e
+            Dependabot.logger.warn("Error parsing uv.lock: #{e.message}")
+          end
+
+          set
+        end
+
+        sig { returns(T::Hash[String, String]) }
+        def versions_by_name
+          @versions_by_name ||= T.let(
+            dependency_set.dependencies.each_with_object({}) do |dep, hash|
+              version = dep.version
+              hash[dep.name] = version if version
+            end,
+            T.nilable(T::Hash[String, String])
+          )
+        end
+      end
+    end
+  end
+end

--- a/uv/spec/dependabot/uv/file_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser_spec.rb
@@ -945,6 +945,45 @@ RSpec.describe Dependabot::Uv::FileParser do
           end
         end
       end
+
+      context "when a requirements.txt with stale versions is also present" do
+        let(:files) { [pyproject, uv_lock, stale_requirements] }
+        let(:stale_requirements) do
+          Dependabot::DependencyFile.new(
+            name: "third-party/requirements.txt",
+            content: "requests==2.28.0\n"
+          )
+        end
+
+        it "uses the version from uv.lock, not requirements.txt" do
+          requests_dep = dependencies.find { |d| d.name == "requests" }
+          expect(requests_dep.version).to eq("2.32.3")
+        end
+
+        it "preserves the requirements.txt entry so the file updater can still update it" do
+          requests_dep = dependencies.find { |d| d.name == "requests" }
+          req_files = requests_dep.requirements.map { |r| r[:file] }
+          expect(req_files).to include("third-party/requirements.txt")
+        end
+      end
+
+      context "when a requirements.txt contains a package that is not in uv.lock" do
+        let(:files) { [pyproject, uv_lock, extra_requirements] }
+        let(:extra_requirements) do
+          Dependabot::DependencyFile.new(
+            name: "third-party/requirements.txt",
+            content: "some-tool==1.0.0\n"
+          )
+        end
+
+        it "parses the dependency from requirements.txt" do
+          extra_dep = dependencies.find { |d| d.name == "some-tool" }
+          expect(extra_dep).not_to be_nil
+          expect(extra_dep.version).to eq("1.0.0")
+          expect(extra_dep.requirements.map { |r| r[:file] })
+            .to include("third-party/requirements.txt")
+        end
+      end
     end
 
     context "with uv workspace member pyprojects" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fix the underlying bug from #14954 (which I had to roll back because it broke the file updater). Credit to @jmcgrath-tractian for the original report and fixture.

When both `uv.lock` and a `requirements.txt` / `.in` file list the same package, `Dependabot::Uv::FileParser#parse` previously returned the `requirements.txt` version. `DependencySet#combined_version` prefers the entry whose `top_level?` is `true`, and `uv.lock` entries always have empty `requirements: []`, so the `requirements.txt` entry wins — even when it is stale.

Result: the dependency graph reports the stale version, and Dependabot security alerts don't auto-dismiss after `uv lock` has already shipped the patched version.

### What changed

Follows @v-HaripriyaC's suggestion on #14954 to move the fix out of "skip the requirements parser entirely" and into dependency selection:

- Build the full dependency set as before (`pyproject` + `uv.lock` + `requirements.*`)
- Then post-process it: any package that also appears in `uv.lock` takes the lockfile-resolved version, while keeping the requirements collected from other files
- Lift `uv.lock` parsing into a dedicated `FileParser::LockFileDependencyParser` helper

Net effect:
- The dependency graph gets the correct `uv.lock` version
- The `FileUpdater` still sees the `requirements.txt` entry in `dep.requirements`, so it can update those files when needed — no spike in `Expected lockfile to change!` from `LockFileUpdater#fetch_updated_dependency_files`
- Packages that appear only in `requirements.txt` (no `uv.lock` entry) are unaffected

### Tests

Three new specs in `uv/spec/dependabot/uv/file_parser_spec.rb`:
- stale `requirements.txt` + `uv.lock` → parser returns the `uv.lock` version
- same scenario → `requirements.txt` is still listed in the dep's `requirements` (so the file updater path still works)
- package only in `requirements.txt` (not in `uv.lock`) → still parsed normally

Verified all 70 `file_parser_spec` examples plus `dependency_grapher_spec` and `file_updater_spec` pass. The one workspace-member failure that shows up is pre-existing on `main`.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
