### PR TITLE
[Graph Job] Do not treat `Dependabot::UnexpectedExternalCode` as a hard failure

### DIFF
--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -76,7 +76,7 @@ module Dependabot
     attr_reader :error_handler
 
     sig { params(branch: String, directory: String).void }
-    def process_directory(branch:, directory:)
+    def process_directory(branch:, directory:) # rubocop:disable Metrics/MethodLength
       directory_source = create_source_for(directory)
       directory_dependency_files = dependency_files_for(directory)
 

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -93,6 +93,36 @@ module Dependabot
 
       Dependabot.logger.info("Dependency submission payload:\n#{JSON.pretty_generate(submission.payload)}")
       service.create_dependency_submission(dependency_submission: submission)
+    rescue Dependabot::UnexpectedExternalCode
+      # If this has been raised, then the directory is trying to use a private registry with an ecosystem
+      # that requires the `insecure-external-code-execution: allow` flag.
+      #
+      # The default policy is denied, so this outcome represent misconfiguration for the directory - we
+      # should record this failure with allow other directories in the job to try as they may not be
+      # misconfigured.
+      Dependabot.logger.info(<<~LOG)
+        Skipping directory #{directory} — Dependabot refused to execute external code
+
+        This directory is configured to use a private registry but does not allow insecure code execution via your Dependabot configuration.
+
+        Please set `insecure-external-code-execution: allow` in the config if you trust your dependencies'
+        supply chain or remove the private registry from this directory.
+      LOG
+      service.record_update_job_error(
+        error_type: "unexpected_external_code",
+        error_details: { message: "Cannot process directory #{directory} without external code execution" }
+      )
+
+      return unless Dependabot::Environment.github_actions?
+
+      service.create_dependency_submission(
+        dependency_submission: empty_submission(
+          branch,
+          T.must(directory_source),
+          GithubApi::DependencySubmission::SnapshotStatus::FAILED,
+          "unexpected_external_code"
+        )
+      )
     rescue Dependabot::ApiError, Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
       # If the submission API is down, we should raise this as a specific error type for visibility.
       error_handler.handle_job_error(

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -97,9 +97,9 @@ module Dependabot
       # If this has been raised, then the directory is trying to use a private registry with an ecosystem
       # that requires the `insecure-external-code-execution: allow` flag.
       #
-      # The default policy is denied, so this outcome represent misconfiguration for the directory - we
-      # should record this failure with allow other directories in the job to try as they may not be
-      # misconfigured.
+      # The default policy is denied, so this outcome represents a misconfiguration for the directory.
+      # We should record this failure and allow other directories in the job to continue, as they may
+      # not be misconfigured.
       Dependabot.logger.info(<<~LOG)
         Skipping directory #{directory} — Dependabot refused to execute external code
 

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -791,4 +791,99 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       update_graph_processor.run
     end
   end
+
+  context "when external code execution is rejected" do
+    let(:directories) { [dir1, dir2] }
+    let(:dir1) { "/" }
+    let(:dir2) { "/subproject" }
+    let(:repo_contents_path) { build_tmp_repo("bundler/original", path: "") }
+
+    let(:dependency_files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "Gemfile",
+          content: fixture("bundler/original/Gemfile"),
+          directory: dir1
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: fixture("bundler/original/Gemfile.lock"),
+          directory: dir1
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile",
+          content: fixture("bundler/original/Gemfile"),
+          directory: dir2
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: fixture("bundler/original/Gemfile.lock"),
+          directory: dir2
+        )
+      ]
+    end
+
+    before do
+      allow(Dependabot::FileParsers).to receive(:for_package_manager)
+        .and_raise(Dependabot::UnexpectedExternalCode)
+    end
+
+    context "when executing standalone" do
+      before do
+        allow(Dependabot::Environment).to receive(:github_actions?).and_return(false)
+      end
+
+      it "records an error for each directory" do
+        expect(service).to receive(:record_update_job_error).with(
+          error_type: "unexpected_external_code",
+          error_details: { message: "Cannot process directory / without external code execution" }
+        )
+        expect(service).to receive(:record_update_job_error).with(
+          error_type: "unexpected_external_code",
+          error_details: { message: "Cannot process directory /subproject without external code execution" }
+        )
+
+        update_graph_processor.run
+      end
+
+      it "does not send any dependency submissions" do
+        expect(service).not_to receive(:create_dependency_submission)
+
+        update_graph_processor.run
+      end
+
+      it "does not halt processing of remaining directories" do
+        call_count = 0
+        allow(service).to receive(:record_update_job_error) { call_count += 1 }
+
+        update_graph_processor.run
+
+        expect(call_count).to eq(2)
+      end
+    end
+
+    context "when executing in GitHub Actions" do
+      before do
+        allow(Dependabot::Environment).to receive(:github_actions?).and_return(true)
+      end
+
+      it "sends a FAILED empty submission for each directory" do
+        expect(service).to receive(:create_dependency_submission).twice do |args|
+          payload = args[:dependency_submission].payload
+          expect(payload[:metadata][:status]).to eql(
+            GithubApi::DependencySubmission::SnapshotStatus::FAILED.serialize
+          )
+          expect(payload[:metadata][:reason]).to eql("unexpected_external_code")
+        end
+
+        update_graph_processor.run
+      end
+
+      it "records an error for each directory" do
+        expect(service).to receive(:record_update_job_error).twice
+
+        update_graph_processor.run
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

We recently shipped the Python ecosystem and it is the first ecosystem where we can encounter `Dependabot::UnexpectedExternalCode` if a user has:
- Checked in a `dependabot.yaml` file for the python directory
- Added private registry access to the config for the python directory
- Failed to set `insecure-external-code-execution: allow` so Python tools are allowed to use the secrets

This error code is currently being treated as unexpected which means we i/ kill the entire run ii/ do not report the error to the backend service so we can display guidelines on how to fix the problem on Dependency Insights and Dependabot Alerts screen(s).

#### Changes

This PR does three things:

1. Rescue `Dependabot::UnexpectedExternalCode` so it no longer kills the entire run
2. Return the error to the backend in addition to an empty snapshot so we can display info to the user
3. Uses `info` level logging to output remediation inline as part of the job

### Anything you want to highlight for special attention from reviewers?

This is a fairly straightforward change to address the problem at hand but I am looking at our error handling more generally as I'm seeing a few other cases where we could present degraded states with more information in the logs, but I'll address that separately.

### How will you know you've accomplished your goal?

If I use a project setup as described, I will stop seeing the job bail out with a hard failure and instead see information on Dependency Insights on how to fix it.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
