### PR TITLE
Recategorise lockfile generation errors as known types

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator.rb
@@ -4,6 +4,7 @@
 require "sorbet-runtime"
 
 require "dependabot/dependency_file"
+require "dependabot/errors"
 require "dependabot/shared_helpers"
 require "dependabot/npm_and_yarn/helpers"
 require "dependabot/npm_and_yarn/package_manager"
@@ -14,6 +15,12 @@ module Dependabot
     class DependencyGrapher < Dependabot::DependencyGraphers::Base
       class LockfileGenerator
         extend T::Sig
+
+        # URL extraction patterns
+        GENERIC_URL_REGEX = T.let(%r{(https?://[^\s"']+)}, Regexp)
+        NETWORK_ERROR_HOST_REGEX = T.let(/E(?:NOTFOUND|TIMEDOUT)\s+(\S+)/i, Regexp)
+
+        FALLBACK_SOURCE = "a private registry"
 
         sig do
           params(
@@ -202,20 +209,48 @@ module Dependabot
             "Failed to generate lockfile with #{package_manager}: #{error.message}"
           )
 
-          # Log more details for debugging
           if error.message.include?("ERESOLVE")
             Dependabot.logger.error(
               "Dependency resolution failed. This may be due to conflicting peer dependencies."
             )
+            raise Dependabot::DependencyFileNotResolvable,
+                  "Could not resolve dependencies. This may be due to conflicting peer dependencies."
           elsif error.message.include?("ENOTFOUND") || error.message.include?("ETIMEDOUT")
             Dependabot.logger.error(
               "Network error while generating lockfile. Registry may be unreachable."
             )
-          elsif error.message.include?("401") || error.message.include?("403")
+            raise Dependabot::PrivateSourceTimedOut, extract_network_error_host(error.message)
+          elsif authentication_error?(error.message)
             Dependabot.logger.error(
               "Authentication error. Check that credentials are configured correctly."
             )
+            raise Dependabot::PrivateSourceAuthenticationFailure, extract_url(error.message)
           end
+        end
+
+        sig { params(message: String).returns(T::Boolean) }
+        def authentication_error?(message)
+          message.include?("401") ||
+            message.include?("403") ||
+            message.include?(NpmAndYarn::AUTHENTICATION_TOKEN_NOT_PROVIDED) ||
+            message.include?(NpmAndYarn::AUTHENTICATION_IS_NOT_CONFIGURED) ||
+            message.include?(NpmAndYarn::AUTHENTICATION_HEADER_NOT_PROVIDED) ||
+            message.match?(NpmAndYarn::AUTH_REQUIRED_ERROR)
+        end
+
+        sig { params(message: String).returns(String) }
+        def extract_url(message)
+          match = message.match(GENERIC_URL_REGEX)
+          match ? T.must(match[1]).chomp(":") : FALLBACK_SOURCE
+        end
+
+        sig { params(message: String).returns(String) }
+        def extract_network_error_host(message)
+          match = message.match(NETWORK_ERROR_HOST_REGEX)
+          return T.must(match[1]) if match
+
+          match = message.match(GENERIC_URL_REGEX)
+          match ? T.must(match[1]) : FALLBACK_SOURCE
         end
       end
     end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher/lockfile_generator_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
       end
 
       context "when lockfile generation fails" do
-        it "re-raises the error after logging" do
+        it "raises a classified error after logging" do
           allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
             .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                          message: "npm ERR! ERESOLVE could not resolve",
@@ -92,7 +92,7 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
 
           expect(Dependabot.logger).to receive(:error).at_least(:once)
 
-          expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+          expect { generator.generate }.to raise_error(Dependabot::DependencyFileNotResolvable)
         end
       end
     end
@@ -198,7 +198,7 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
     let(:dependency_files) { project_dependency_files("grapher/npm_no_lockfile") }
 
     context "with ERESOLVE error" do
-      it "logs a helpful error message about peer dependencies and re-raises" do
+      it "raises DependencyFileNotResolvable with a user-friendly message" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
           .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                        message: "npm ERR! ERESOLVE could not resolve peer dependencies",
@@ -208,14 +208,16 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
         expect(Dependabot.logger).to receive(:error)
           .with(/Failed to generate lockfile with npm/)
         expect(Dependabot.logger).to receive(:error)
-          .with(/conflicting peer dependencies/)
+          .with("Dependency resolution failed. This may be due to conflicting peer dependencies.")
 
-        expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+        expect { generator.generate }.to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
+          expect(error.message).to include("conflicting peer dependencies")
+        end
       end
     end
 
     context "with network error" do
-      it "logs a helpful error message about network issues and re-raises" do
+      it "raises PrivateSourceTimedOut with the registry hostname" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
           .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                        message: "npm ERR! ENOTFOUND registry.npmjs.org",
@@ -225,26 +227,111 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator do
         expect(Dependabot.logger).to receive(:error)
           .with(/Failed to generate lockfile with npm/)
         expect(Dependabot.logger).to receive(:error)
-          .with(/Network error/)
+          .with("Network error while generating lockfile. Registry may be unreachable.")
 
-        expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+        expect { generator.generate }.to raise_error(Dependabot::PrivateSourceTimedOut) do |error|
+          expect(error.message).to include("registry.npmjs.org")
+        end
       end
     end
 
-    context "with authentication error" do
-      it "logs a helpful error message about credentials and re-raises" do
+    context "with timeout error" do
+      it "raises PrivateSourceTimedOut with the registry hostname" do
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
           .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-                       message: "npm ERR! 401 Unauthorized",
+                       message: "npm ERR! ETIMEDOUT npm.pkg.github.com",
                        error_context: {}
                      ))
 
         expect(Dependabot.logger).to receive(:error)
           .with(/Failed to generate lockfile with npm/)
         expect(Dependabot.logger).to receive(:error)
-          .with(/Authentication error/)
+          .with("Network error while generating lockfile. Registry may be unreachable.")
 
-        expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+        expect { generator.generate }.to raise_error(Dependabot::PrivateSourceTimedOut) do |error|
+          expect(error.message).to include("npm.pkg.github.com")
+        end
+      end
+    end
+
+    context "with authentication error (401)" do
+      it "raises PrivateSourceAuthenticationFailure with the registry URL" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
+          .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                       message: "npm error code E401\n" \
+                                "npm error 401 Unauthorized - GET https://npm.pkg.github.com/@scope%2fpkg\n" \
+                                "npm error authentication token not provided",
+                       error_context: {}
+                     ))
+
+        expect(Dependabot.logger).to receive(:error)
+          .with(/Failed to generate lockfile with npm/)
+        expect(Dependabot.logger).to receive(:error)
+          .with("Authentication error. Check that credentials are configured correctly.")
+
+        expect { generator.generate }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
+          expect(error.message).to include("npm.pkg.github.com/@scope%2fpkg")
+        end
+      end
+    end
+
+    context "with authentication error (403)" do
+      it "raises PrivateSourceAuthenticationFailure with the registry URL" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
+          .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                       message: "npm error code E403\n" \
+                                "npm error 403 Forbidden - GET https://registry.npmjs.org/@private%2fpkg",
+                       error_context: {}
+                     ))
+
+        expect(Dependabot.logger).to receive(:error)
+          .with(/Failed to generate lockfile with npm/)
+        expect(Dependabot.logger).to receive(:error)
+          .with("Authentication error. Check that credentials are configured correctly.")
+
+        expect { generator.generate }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
+          expect(error.message).to include("registry.npmjs.org/@private%2fpkg")
+        end
+      end
+    end
+
+    context "with an unrecognized error" do
+      it "re-raises the original HelperSubprocessFailed error" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command)
+          .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                       message: "npm ERR! something completely unexpected happened",
+                       error_context: {}
+                     ))
+
+        expect(Dependabot.logger).to receive(:error)
+          .with(/Failed to generate lockfile with npm/)
+
+        expect { generator.generate }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed) do |error|
+          expect(error.message).to include("something completely unexpected happened")
+        end
+      end
+    end
+
+    context "with yarn authentication error" do
+      let(:package_manager) { "yarn" }
+      let(:dependency_files) { project_dependency_files("grapher/yarn_no_lockfile") }
+
+      it "raises PrivateSourceAuthenticationFailure with the registry URL" do
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                       message: "error An unexpected error occurred: " \
+                                "\"https://npm.pkg.github.com/@scope%2fpkg: authentication token not provided\"",
+                       error_context: {}
+                     ))
+
+        expect(Dependabot.logger).to receive(:error)
+          .with(/Failed to generate lockfile with yarn/)
+        expect(Dependabot.logger).to receive(:error)
+          .with("Authentication error. Check that credentials are configured correctly.")
+
+        expect { generator.generate }.to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
+          expect(error.message).to include("npm.pkg.github.com/@scope%2fpkg")
+        end
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
@@ -296,9 +296,8 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
             Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
           ).tap do |gen|
             allow(gen).to receive(:generate).and_raise(
-              Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-                message: "npm install failed: authentication required",
-                error_context: {}
+              Dependabot::DependencyFileNotResolvable.new(
+                "Could not resolve dependencies. This may be due to conflicting peer dependencies."
               )
             )
           end
@@ -322,11 +321,11 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
           expect(grapher.errored_fetching_subdependencies).to be(true)
         end
 
-        it "preserves the original error as the subdependency error" do
+        it "stores the classified error as the subdependency error" do
           grapher.resolved_dependencies
 
-          expect(grapher.subdependency_error).to be_a(Dependabot::SharedHelpers::HelperSubprocessFailed)
-          expect(grapher.subdependency_error.message).to include("npm install failed")
+          expect(grapher.subdependency_error).to be_a(Dependabot::DependencyFileNotResolvable)
+          expect(grapher.subdependency_error.message).to include("conflicting peer dependencies")
         end
 
         it "returns dependencies without relationship data" do
@@ -335,6 +334,117 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
           resolved_dependencies.each_value do |dep|
             expect(dep.dependencies).to eq([])
           end
+        end
+      end
+
+      context "when lockfile generation fails with a 401 authentication error" do
+        before do
+          lockfile_generator = instance_double(
+            Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+          ).tap do |gen|
+            allow(gen).to receive(:generate).and_raise(
+              Dependabot::PrivateSourceAuthenticationFailure.new(
+                "https://npm.pkg.github.com/@dsp-testing%2fbake-off-utils"
+              )
+            )
+          end
+          allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
+            .to receive(:new).and_return(lockfile_generator)
+        end
+
+        it "stores the PrivateSourceAuthenticationFailure as the subdependency error" do
+          grapher.resolved_dependencies
+
+          expect(grapher.subdependency_error).to be_a(Dependabot::PrivateSourceAuthenticationFailure)
+        end
+
+        it "includes the registry URL in the error message" do
+          grapher.resolved_dependencies
+
+          expect(grapher.subdependency_error.message).to include(
+            "npm.pkg.github.com/@dsp-testing%2fbake-off-utils"
+          )
+          expect(grapher.subdependency_error.message).not_to include("npm warn")
+          expect(grapher.subdependency_error.message).not_to include("complete log of this run")
+        end
+
+        it "sets the error flag for degraded status" do
+          grapher.resolved_dependencies
+
+          expect(grapher.errored_fetching_subdependencies).to be(true)
+        end
+      end
+
+      context "when lockfile generation fails with a 403 forbidden error" do
+        before do
+          lockfile_generator = instance_double(
+            Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+          ).tap do |gen|
+            allow(gen).to receive(:generate).and_raise(
+              Dependabot::PrivateSourceAuthenticationFailure.new(
+                "https://registry.npmjs.org/@private%2fpkg"
+              )
+            )
+          end
+          allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
+            .to receive(:new).and_return(lockfile_generator)
+        end
+
+        it "stores the PrivateSourceAuthenticationFailure as the subdependency error" do
+          grapher.resolved_dependencies
+
+          expect(grapher.subdependency_error).to be_a(Dependabot::PrivateSourceAuthenticationFailure)
+          expect(grapher.subdependency_error.message).to include(
+            "registry.npmjs.org/@private%2fpkg"
+          )
+        end
+      end
+
+      context "when lockfile generation fails with a yarn authentication error" do
+        before do
+          lockfile_generator = instance_double(
+            Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+          ).tap do |gen|
+            allow(gen).to receive(:generate).and_raise(
+              Dependabot::PrivateSourceAuthenticationFailure.new(
+                "https://npm.pkg.github.com/@scope%2fpkg"
+              )
+            )
+          end
+          allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
+            .to receive(:new).and_return(lockfile_generator)
+        end
+
+        it "stores the PrivateSourceAuthenticationFailure as the subdependency error" do
+          grapher.resolved_dependencies
+
+          expect(grapher.subdependency_error).to be_a(Dependabot::PrivateSourceAuthenticationFailure)
+          expect(grapher.subdependency_error.message).to include(
+            "npm.pkg.github.com/@scope%2fpkg"
+          )
+        end
+      end
+
+      context "when lockfile generation fails with a non-auth error" do
+        before do
+          lockfile_generator = instance_double(
+            Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator
+          ).tap do |gen|
+            allow(gen).to receive(:generate).and_raise(
+              Dependabot::DependencyFileNotResolvable.new(
+                "Could not resolve dependencies. This may be due to conflicting peer dependencies."
+              )
+            )
+          end
+          allow(Dependabot::NpmAndYarn::DependencyGrapher::LockfileGenerator)
+            .to receive(:new).and_return(lockfile_generator)
+        end
+
+        it "preserves the error as a DependabotError" do
+          grapher.resolved_dependencies
+
+          expect(grapher.subdependency_error).to be_a(Dependabot::DependencyFileNotResolvable)
+          expect(grapher.subdependency_error.message).to include("conflicting peer dependencies")
         end
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

At present, if we fail to generate an ephemeral lockfile from a `package.json` due to missing credentials the `HelperSubprocessFailed` error is returned to the service as a warning which results in a very hard-to-parse UI message:
<img width="905" height="196" alt="586567761-27c61958-19b3-4acf-bdd2-39f8ab8f8434" src="https://github.com/user-attachments/assets/b9dcdb38-5206-4b7a-9e3d-2ec2a1e951cd" />

The actual log messages are well-formed and explain what to do but this warning is currently used in a few places where we can't show or point to the full logs.

### Anything you want to highlight for special attention from reviewers?

In order to resolve this I've used a similar strategy to Go's `ResolvabilityErrors` module to extract and re-raise specific known problems using a more applicable Dependabot error type and a cleaned up detail message that focuses on the two most likely reasons for failure:

- 401/403 due to a lack of credential
- Network weather reaching the package registry

We already intercept and log these error categories, this change just extends the intercept to re-raising them as known error types.

### How will you know you've accomplished your goal?

My test repository will no longer expose a raw npm error when I don't provide credentials, instead it will look similar to Go:
<img width="910" height="159" alt="Screenshot 2026-05-20 at 13 59 34" src="https://github.com/user-attachments/assets/e318f750-d9e5-41f5-ba3d-e5f8a5b36042" />

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
