### PR TITLE
handle errant whitespace in global.json

### DIFF
--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -17,7 +17,7 @@ function Get-SdkVersionsToInstall([string] $repoRoot, [string[]] $updateDirector
     foreach ($globalJsonPath in $globalJsonPaths) {
         $resolvedGlobalJsonPath = Convert-Path "$repoRoot/$globalJsonPath"
         Write-LogMessage "  Processing $globalJsonPath (resolved to $resolvedGlobalJsonPath) for SDK version information"
-        $globalJson = Get-Content $resolvedGlobalJsonPath | ConvertFrom-Json
+        $globalJson = Get-Content $resolvedGlobalJsonPath -Raw | ConvertFrom-Json
         if (@($globalJson.PSobject.Properties).Count -eq 0) {
             Write-LogMessage "    No properties found in $globalJsonPath, skipping"
             continue

--- a/nuget/updater/test-data/global-json-whitespace/leading-comment/global.json
+++ b/nuget/updater/test-data/global-json-whitespace/leading-comment/global.json
@@ -1,0 +1,6 @@
+// this is a leading comment
+{
+    "sdk": {
+        "version": "1.2.3-leading-comment"
+    }
+}

--- a/nuget/updater/test-data/global-json-whitespace/leading-newline/global.json
+++ b/nuget/updater/test-data/global-json-whitespace/leading-newline/global.json
@@ -1,0 +1,6 @@
+
+{
+    "sdk": {
+        "version": "1.2.3-leading-newline"
+    }
+}

--- a/nuget/updater/test-data/global-json-whitespace/leading-whitespace/global.json
+++ b/nuget/updater/test-data/global-json-whitespace/leading-whitespace/global.json
@@ -1,0 +1,5 @@
+        {
+    "sdk": {
+        "version": "1.2.3-leading-whitespace"
+    }
+}

--- a/nuget/updater/test.ps1
+++ b/nuget/updater/test.ps1
@@ -3,6 +3,9 @@ $ErrorActionPreference = "Stop"
 
 . $PSScriptRoot\common.ps1
 
+# uncomment line to enable detailed test logging
+#$env:DEPENDABOT_LOG_MESSAGES = "true"
+
 function Assert-ArraysEqual([string[]]$expected, [string[]]$actual) {
     $expectedText = $expected -join ", "
     $actualText = $actual -join ", "
@@ -101,6 +104,12 @@ try {
         -directories @("/") `
         -installedSdks @("8.0.404") `
         -expectedSdksToInstall @("9.0")
+
+    Test-GlobalJsonVersions `
+        -testDirectory "global-json-whitespace" `
+        -directories @("/leading-comment", "/leading-newline", "/leading-whitespace") `
+        -installedSdks @("8.0.404") `
+        -expectedSdksToInstall @("1.2.3-leading-comment", "1.2.3-leading-newline", "1.2.3-leading-whitespace")
 
     Test-RequiredTargetingPacks `
         -testDirectory "targeting-packs" `


### PR DESCRIPTION
The JSON parser in PowerShell doesn't like leading newline characters which makes handling `global.json` files difficult.  This PR forces the file to be read as a single string with `-Raw` which enables `ConvertFrom-Json` to work.