### PR TITLE
raise generic error without path information

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -213,6 +213,11 @@ internal static class SdkProjectDiscovery
                     logger.Warn($"  Error determining dependencies from `{startingProjectPath}`:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}");
                 }
 
+                if (!File.Exists(binLogPath))
+                {
+                    throw new FileNotFoundException("Dependency discovery didn't produce a log file.");
+                }
+
                 var buildRoot = BinaryLog.ReadBuild(binLogPath);
                 buildRoot.VisitAllChildren<BaseNode>(node =>
                 {


### PR DESCRIPTION
When SDK dependency discovery fails to produce a log file we get a `FileNotFoundException` at runtime but that exception also contains the missing filename which is randomly generated in temp.  Because of this, our telemetry generates a new error event for every one which makes it difficult to analyze how prevalent this error actually is.  This PR raises a more generic exception so all like errors can be bucketed together.