### PR TITLE
Add HasNoWarnNU1701 merge logic in project discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1927,6 +1927,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             AdditionalFiles = ["a/packages.config"],
             PackageManagementKind = PackageManagementKind.Default,
             PackageManagementSpecialFileRelativePath = null,
+            HasNoWarnNU1701 = false,
         };
         var result2 = new ProjectDiscoveryResult()
         {
@@ -1943,6 +1944,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             AdditionalFiles = ["b/app.config"],
             PackageManagementKind = PackageManagementKind.CentralPackageManagement,
             PackageManagementSpecialFileRelativePath = "Directory.Packages.props",
+            HasNoWarnNU1701 = true,
         };
 
         // to make sure we're checking everything exactly, we'll explicitly check each item
@@ -1971,6 +1973,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
         AssertEx.Equal(["a/packages.config", "b/app.config"], merged.AdditionalFiles);
         Assert.Equal(PackageManagementKind.CentralPackageManagement, merged.PackageManagementKind);
         Assert.Equal("Directory.Packages.props", merged.PackageManagementSpecialFileRelativePath);
+        Assert.True(merged.HasNoWarnNU1701);
     }
 
     [Fact]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -472,6 +472,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             AdditionalFiles = mergedAdditionalFiles,
             PackageManagementKind = (PackageManagementKind)Math.Max((int)result1.PackageManagementKind, (int)result2.PackageManagementKind),
             PackageManagementSpecialFileRelativePath = result1.PackageManagementSpecialFileRelativePath ?? result2.PackageManagementSpecialFileRelativePath,
+            HasNoWarnNU1701 = result1.HasNoWarnNU1701 || result2.HasNoWarnNU1701,
         };
         return mergedResult;
     }


### PR DESCRIPTION
Merge the `HasNoWarnNU1701` property using a simple OR when combining `ProjectDiscoveryResult` instances in `DiscoveryWorker.MergeProjectDiscovery`. Updated the existing merge test to verify the behavior (one result has `false`, the other has `true`, merged result is `true`).