### PR TITLE
NuGet: Auto-patch NuGet.Config to allow insecure HTTP feeds

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.InsecureHttpFeed.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.InsecureHttpFeed.cs
@@ -1,0 +1,292 @@
+using NuGetUpdater.Core.Run.ApiModel;
+using NuGetUpdater.Core.Test.Update;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run;
+
+using TestFile = (string Path, string Content);
+
+public class EndToEndTests_InsecureHttpFeed
+{
+    [Fact]
+    public async Task UpdatesPackagesFromInsecureHttpFeed_WithSlnxAndMixedProjectTypes()
+    {
+        // Verifies that packages can be discovered and updated from insecure HTTP feeds without
+        // explicitly setting allowInsecureConnections in the NuGet.Config file. The RunWorker
+        // automatically patches NuGet.Config files to add this attribute for http:// sources.
+        // Uses a V3 feed for the SDK-style project and a V2 feed for the packages.config project.
+        using var httpV3 = TestHttpServer.CreateTestNuGetFeed(
+            MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net9.0"),
+            MockNuGetPackage.CreateSimplePackage("Package.A", "1.1.0", "net9.0")
+        );
+
+        using var httpV2 = TestHttpServer.CreateTestNuGetV2Feed(
+            MockNuGetPackage.CreateSimplePackage("Package.B", "2.0.0", "net45"),
+            MockNuGetPackage.CreateSimplePackage("Package.B", "2.1.0", "net45")
+        );
+
+        await EndToEndTests.RunAsync(
+            packages: [
+                MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net9.0"),
+                MockNuGetPackage.CreateSimplePackage("Package.A", "1.1.0", "net9.0"),
+                MockNuGetPackage.CreateSimplePackage("Package.B", "2.0.0", "net45"),
+                MockNuGetPackage.CreateSimplePackage("Package.B", "2.1.0", "net45"),
+            ],
+            job: new()
+            {
+                Source = new()
+                {
+                    Provider = "github",
+                    Repo = "test/repo",
+                    Directory = "/",
+                }
+            },
+            files: [
+                ("Directory.Build.props", "<Project />"),
+                ("Directory.Build.targets", "<Project />"),
+                ("Directory.Packages.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+                      </PropertyGroup>
+                    </Project>
+                    """),
+                ("repo.slnx", """
+                    <Solution>
+                      <Project Path="src\project-a\project-a.csproj" />
+                      <Project Path="src\project-b\project-b.csproj" />
+                    </Solution>
+                    """),
+                ("src/project-a/project-a.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net9.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Package.A" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("src/project-a/NuGet.Config", $"""
+                    <configuration>
+                      <packageSources>
+                        <add key="test_v3_feed" value="{httpV3.GetPackageFeedIndex()}" />
+                      </packageSources>
+                    </configuration>
+                    """),
+                ("src/project-b/project-b.csproj", """
+                    <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <Reference Include="Package.B">
+                          <HintPath>packages\Package.B.2.0.0\lib\net45\Package.B.dll</HintPath>
+                          <Private>True</Private>
+                        </Reference>
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """),
+                ("src/project-b/packages.config", """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                      <package id="Package.B" version="2.0.0" targetFramework="net45" />
+                    </packages>
+                    """),
+                ("src/project-b/NuGet.Config", $"""
+                    <configuration>
+                      <packageSources>
+                        <add key="test_v2_feed" value="{httpV2.GetV2FeedUrl()}" />
+                      </packageSources>
+                    </configuration>
+                    """),
+            ],
+            discoveryWorker: null,
+            analyzeWorker: null,
+            updaterWorker: null,
+            expectedApiMessages: [
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new()
+                    {
+                        ["operation"] = "group_update_all_versions"
+                    }
+                },
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Package.A",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/src/project-a/project-a.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                        new()
+                        {
+                            Name = "Package.B",
+                            Version = "2.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "2.0.0",
+                                    File = "/src/project-b/project-b.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ]
+                        },
+                    ],
+                    DependencyFiles = [
+                        "/Directory.Build.props",
+                        "/Directory.Build.targets",
+                        "/Directory.Packages.props",
+                        "/src/project-a/project-a.csproj",
+                        "/src/project-b/packages.config",
+                        "/src/project-b/project-b.csproj",
+                    ],
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Package.A",
+                            Version = "1.1.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.1.0",
+                                    File = "/src/project-a/project-a.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = null,
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/src/project-a/project-a.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src/project-a",
+                            Name = "project-a.csproj",
+                            Content = """
+                                <Project Sdk="Microsoft.NET.Sdk">
+                                  <PropertyGroup>
+                                    <TargetFramework>net9.0</TargetFramework>
+                                  </PropertyGroup>
+                                  <ItemGroup>
+                                    <PackageReference Include="Package.A" Version="1.1.0" />
+                                  </ItemGroup>
+                                </Project>
+                                """
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = EndToEndTests.TestPullRequestCommitMessage,
+                    PrTitle = EndToEndTests.TestPullRequestTitle,
+                    PrBody = EndToEndTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Package.B",
+                            Version = "2.1.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "2.1.0",
+                                    File = "/src/project-b/project-b.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new()
+                                    {
+                                        SourceUrl = null,
+                                        Type = "nuget_repo",
+                                    }
+                                }
+                            ],
+                            PreviousVersion = "2.0.0",
+                            PreviousRequirements = [
+                                new()
+                                {
+                                    Requirement = "2.0.0",
+                                    File = "/src/project-b/project-b.csproj",
+                                    Groups = ["dependencies"],
+                                }
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src/project-b",
+                            Name = "packages.config",
+                            Content = """
+                                <?xml version="1.0" encoding="utf-8"?>
+                                <packages>
+                                  <package id="Package.B" version="2.1.0" targetFramework="net45" />
+                                </packages>
+                                """
+                        },
+                        new()
+                        {
+                            Directory = "/src/project-b",
+                            Name = "project-b.csproj",
+                            Content = """
+                                <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                                  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                                  <PropertyGroup>
+                                    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+                                  </PropertyGroup>
+                                  <ItemGroup>
+                                    <None Include="packages.config" />
+                                  </ItemGroup>
+                                  <ItemGroup>
+                                    <Reference Include="Package.B">
+                                      <HintPath>packages\Package.B.2.1.0\lib\net45\Package.B.dll</HintPath>
+                                      <Private>True</Private>
+                                    </Reference>
+                                  </ItemGroup>
+                                  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                                </Project>
+                                """
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = EndToEndTests.TestPullRequestCommitMessage,
+                    PrTitle = EndToEndTests.TestPullRequestTitle,
+                    PrBody = EndToEndTests.TestPullRequestBody,
+                    DependencyGroup = null,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA")
+            ]
+        );
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/RunWorkerTests.cs
@@ -1,0 +1,305 @@
+using NuGetUpdater.Core.Run;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Run;
+
+public class RunWorkerTests
+{
+    public class AddInsecureConnectionsAttribute
+    {
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void CorrectlyPatchesNuGetConfig(string testName, string input, string expected)
+        {
+            _ = testName; // used for test display only
+
+            var result = RunWorker.AddInsecureConnectionsAttribute(input);
+
+            Assert.Equal(expected, result);
+        }
+
+        public static TheoryData<string, string, string> TestData => new()
+        {
+            {
+                // testName
+                "adds attribute to http source",
+                // input
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="http://localhost:8080/index.json" />
+                  </packageSources>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="http://localhost:8080/index.json" allowInsecureConnections="true" />
+                  </packageSources>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "does not add attribute to https source",
+                // input
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                  </packageSources>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                  </packageSources>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "does not add attribute to local path source",
+                // input
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="../local-feed" />
+                  </packageSources>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="../local-feed" />
+                  </packageSources>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "does not duplicate existing attribute on http source",
+                // input
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="http://internal-server/nuget" allowInsecureConnections="false" />
+                  </packageSources>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="http://internal-server/nuget" allowInsecureConnections="false" />
+                  </packageSources>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "handles multiple sources with mixed protocols",
+                // input
+                """
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                    <add key="private" value="https://pkgs.dev.azure.com/org/_packaging/feed/nuget/v3/index.json" />
+                    <add key="local" value="http://internal-server/nuget" />
+                    <add key="disk" value="C:\packages" />
+                  </packageSources>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                    <add key="private" value="https://pkgs.dev.azure.com/org/_packaging/feed/nuget/v3/index.json" />
+                    <add key="local" value="http://internal-server/nuget" allowInsecureConnections="true" />
+                    <add key="disk" value="C:\packages" />
+                  </packageSources>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "preserves package source mappings",
+                // input
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                    <add key="private" value="http://internal-server/nuget/v3/index.json" />
+                  </packageSources>
+                  <packageSourceMapping>
+                    <packageSource key="nuget.org">
+                      <package pattern="*" />
+                    </packageSource>
+                    <packageSource key="private">
+                      <package pattern="Contoso.*" />
+                    </packageSource>
+                  </packageSourceMapping>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                    <add key="private" value="http://internal-server/nuget/v3/index.json" allowInsecureConnections="true" />
+                  </packageSources>
+                  <packageSourceMapping>
+                    <packageSource key="nuget.org">
+                      <package pattern="*" />
+                    </packageSource>
+                    <packageSource key="private">
+                      <package pattern="Contoso.*" />
+                    </packageSource>
+                  </packageSourceMapping>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "preserves other config sections",
+                // input
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="http://internal-server/nuget" />
+                  </packageSources>
+                  <disabledPackageSources>
+                    <add key="private" value="true" />
+                  </disabledPackageSources>
+                  <config>
+                    <add key="globalPackagesFolder" value=".\packages" />
+                  </config>
+                  <packageRestore>
+                    <add key="enabled" value="True" />
+                  </packageRestore>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="http://internal-server/nuget" allowInsecureConnections="true" />
+                  </packageSources>
+                  <disabledPackageSources>
+                    <add key="private" value="true" />
+                  </disabledPackageSources>
+                  <config>
+                    <add key="globalPackagesFolder" value=".\packages" />
+                  </config>
+                  <packageRestore>
+                    <add key="enabled" value="True" />
+                  </packageRestore>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "handles no packageSources element",
+                // input
+                """
+                <configuration>
+                  <config>
+                    <add key="globalPackagesFolder" value=".\packages" />
+                  </config>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <config>
+                    <add key="globalPackagesFolder" value=".\packages" />
+                  </config>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "handles empty packageSources",
+                // input
+                """
+                <configuration>
+                  <packageSources>
+                    <clear />
+                  </packageSources>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <packageSources>
+                    <clear />
+                  </packageSources>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "preserves package source credentials",
+                // input
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="private" value="http://internal-server/nuget/v3/index.json" />
+                  </packageSources>
+                  <packageSourceCredentials>
+                    <private>
+                      <add key="Username" value="user" />
+                      <add key="ClearTextPassword" value="token" />
+                    </private>
+                  </packageSourceCredentials>
+                </configuration>
+                """,
+                // expected
+                """
+                <configuration>
+                  <packageSources>
+                    <add key="private" value="http://internal-server/nuget/v3/index.json" allowInsecureConnections="true" />
+                  </packageSources>
+                  <packageSourceCredentials>
+                    <private>
+                      <add key="Username" value="user" />
+                      <add key="ClearTextPassword" value="token" />
+                    </private>
+                  </packageSourceCredentials>
+                </configuration>
+                """
+            },
+            {
+                // testName
+                "handles config with XML declaration",
+                // input
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="http://internal-server/nuget" />
+                  </packageSources>
+                </configuration>
+                """,
+                // expected
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="local" value="http://internal-server/nuget" allowInsecureConnections="true" />
+                  </packageSources>
+                </configuration>
+                """
+            },
+        };
+    }
+}
+

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestHttpServer.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/TestHttpServer.cs
@@ -189,6 +189,88 @@ namespace NuGetUpdater.Core.Test
             return server;
         }
 
+        public static TestHttpServer CreateTestNuGetV2Feed(params MockNuGetPackage[] packages)
+        {
+            var packagesByNameVersion = packages.ToDictionary(
+                p => (p.Id.ToLowerInvariant(), p.Version.ToLowerInvariant()),
+                p => p);
+            var packagesByName = packages
+                .GroupBy(p => p.Id, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key.ToLowerInvariant(), g => g.ToArray());
+
+            (int, byte[]) HttpHandler(string uriString)
+            {
+                var uri = new Uri(uriString, UriKind.Absolute);
+                var baseUrl = $"{uri.Scheme}://{uri.Host}:{uri.Port}";
+
+                // FindPackagesById
+                if (uri.AbsolutePath.TrimEnd('/').Equals("/FindPackagesById()", StringComparison.OrdinalIgnoreCase) ||
+                    uri.AbsolutePath.TrimEnd('/').Equals("/FindPackagesById", StringComparison.OrdinalIgnoreCase))
+                {
+                    // parse "id" from query string like "?id='Package.Name'"
+                    var queryString = uri.Query.TrimStart('?');
+                    var id = "";
+                    foreach (var part in queryString.Split('&'))
+                    {
+                        var kvp = part.Split('=', 2);
+                        if (kvp.Length == 2 && kvp[0].Equals("id", StringComparison.OrdinalIgnoreCase))
+                        {
+                            id = Uri.UnescapeDataString(kvp[1]).Trim('\'');
+                            break;
+                        }
+                    }
+
+                    var key = id.ToLowerInvariant();
+                    var matchedPackages = packagesByName.GetValueOrDefault(key) ?? [];
+
+                    var entries = string.Join("\n", matchedPackages.Select(p => $$"""
+                        <entry>
+                          <id>{{baseUrl}}/Packages(Id='{{p.Id}}',Version='{{p.Version}}')</id>
+                          <title type="text">{{p.Id}}</title>
+                          <content type="application/zip" src="{{baseUrl}}/package/{{p.Id.ToLowerInvariant()}}/{{p.Version.ToLowerInvariant()}}" />
+                          <m:properties>
+                            <d:Id>{{p.Id}}</d:Id>
+                            <d:Version>{{p.Version}}</d:Version>
+                            <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+                            <d:Listed m:type="Edm.Boolean">true</d:Listed>
+                          </m:properties>
+                        </entry>
+                        """));
+
+                    var atomFeed = $$"""
+                        <?xml version="1.0" encoding="utf-8"?>
+                        <feed xml:base="{{baseUrl}}" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+                          <id>{{baseUrl}}/FindPackagesById</id>
+                          <title type="text">FindPackagesById</title>
+                          {{entries}}
+                        </feed>
+                        """;
+                    return (200, Encoding.UTF8.GetBytes(atomFeed));
+                }
+
+                // Package download
+                if (uri.AbsolutePath.StartsWith("/package/", StringComparison.OrdinalIgnoreCase))
+                {
+                    var parts = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 3)
+                    {
+                        var pkgKey = (parts[1].ToLowerInvariant(), parts[2].ToLowerInvariant());
+                        if (packagesByNameVersion.TryGetValue(pkgKey, out var package))
+                        {
+                            return (200, package.GetZipStream().ReadAllBytes());
+                        }
+                    }
+                }
+
+                return (404, Encoding.UTF8.GetBytes("Not Found"));
+            }
+
+            var server = CreateTestServer((method, url) => HttpHandler(url));
+            return server;
+        }
+
+        public string GetV2FeedUrl() => BaseUrl.TrimEnd('/');
+
         private static int FindFreePort()
         {
             var tcpListener = new TcpListener(IPAddress.Loopback, 0);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.IO.Enumeration;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Xml.Linq;
 
 using NuGet.Versioning;
 
@@ -95,6 +96,7 @@ public class RunWorker
 
         try
         {
+            await PatchNuGetConfigFilesAsync(repoContentsPath);
             var handler = GetUpdateHandler(job);
             _logger.Info($"Starting update job of type {handler.TagName}");
             await handler.HandleAsync(job, repoContentsPath, caseInsensitiveRepoContentsPath, baseCommitSha, _discoveryWorker, _analyzeWorker, _updaterWorker, _apiHandler, experimentsManager, _logger);
@@ -379,5 +381,77 @@ public class RunWorker
         }
 
         return jobFile;
+    }
+
+    internal static string AddInsecureConnectionsAttribute(string nugetConfigContents)
+    {
+        try
+        {
+            var doc = XDocument.Parse(nugetConfigContents, LoadOptions.PreserveWhitespace);
+            var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+            var packageSources = doc.Root?.Element(ns + "packageSources");
+            if (packageSources is null)
+            {
+                return nugetConfigContents;
+            }
+
+            foreach (var addElement in packageSources.Elements(ns + "add"))
+            {
+                if (addElement.Attribute("allowInsecureConnections") is not null)
+                {
+                    continue;
+                }
+
+                var valueAttr = addElement.Attribute("value");
+                if (valueAttr is null)
+                {
+                    continue;
+                }
+
+                if (valueAttr.Value.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+                {
+                    addElement.SetAttributeValue("allowInsecureConnections", "true");
+                }
+            }
+
+            var result = doc.ToString(SaveOptions.DisableFormatting);
+            if (doc.Declaration is not null)
+            {
+                result = doc.Declaration.ToString() + result;
+            }
+
+            return result;
+        }
+        catch
+        {
+            return nugetConfigContents;
+        }
+    }
+
+    /// <summary>
+    /// Scans the repo for all NuGet.Config files (case-insensitive) and adds
+    /// <c>allowInsecureConnections="true"</c> to any package source using an <c>http://</c> URL.
+    /// This allows NuGet to restore from insecure feeds without requiring the attribute to be
+    /// present in the original config file.
+    /// </summary>
+    private static async Task PatchNuGetConfigFilesAsync(DirectoryInfo repoContentsPath)
+    {
+        var options = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            MatchCasing = MatchCasing.CaseInsensitive,
+            IgnoreInaccessible = true,
+        };
+        var configFiles = Directory.EnumerateFiles(repoContentsPath.FullName, "nuget.config", options);
+
+        foreach (var configFile in configFiles)
+        {
+            var contents = await File.ReadAllTextAsync(configFile);
+            var patched = AddInsecureConnectionsAttribute(contents);
+            if (patched != contents)
+            {
+                await File.WriteAllTextAsync(configFile, patched);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Automatically adds `allowInsecureConnections="true"` to `http://` package sources in NuGet.Config files before running update scenarios. This allows Dependabot to restore packages from insecure HTTP feeds without requiring the attribute in the original config file.

## Reasoning

A repo owner might locally use an older version of NuGet.exe that doesn't complain on insecure package feeds along with a custom, you guessed it, insecure package feed.  In that instance dependabot should still generate a package update PR.

## Changes

- **RunWorker.cs**: Added `AddInsecureConnectionsAttribute` (static, public) to patch NuGet.Config XML content, and `PatchNuGetConfigFilesAsync` (private) to scan the repo and apply patches before running handlers
- **TestHttpServer.cs**: Added `CreateTestNuGetV2Feed` factory method for V2 OData-based NuGet feeds
- **EndToEndTests.InsecureHttpFeed.cs**: End-to-end test with .slnx, SDK-style project (V3 feed), and packages.config project (V2 feed)
- **RunWorkerTests.cs**: Unit tests for the XML patching logic covering various config scenarios

## Testing

- 11 unit tests for `AddInsecureConnectionsAttribute` covering https sources, http sources, local paths, existing attributes, multiple sources, package source mappings, credentials, XML declarations, and other config sections
- 1 end-to-end test verifying both SDK and packages.config projects can update from insecure HTTP feeds