### PR TITLE
NuGet: Filter out submodule paths during discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1995,4 +1995,72 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
         };
         Assert.Throws<InvalidOperationException>(() => DiscoveryWorker.MergeProjectDiscovery(result1, result2));
     }
+
+    [Fact]
+    public async Task ProjectsInSubmodulesAreFilteredOut()
+    {
+        await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"),
+            ],
+            workspacePath: "",
+            files:
+            [
+                (".gitmodules", """
+                    [submodule "vendor/external"]
+                        path = vendor/external
+                        url = https://github.com/example/external.git
+                    """),
+                ("myapp.slnx", """
+                    <Solution>
+                      <Folder Name="/src/">
+                        <Project Path="src\project.csproj" />
+                      </Folder>
+                      <Folder Name="/vendor/external/">
+                        <Project Path="vendor\external\project.csproj" />
+                      </Folder>
+                    </Solution>
+                    """),
+                ("src/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("vendor/external/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+            ],
+            expectedResult: new()
+            {
+                Path = "",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "src/project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies = [
+                            new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                    }
+                ],
+                ExpectedProjectCount = 1,
+            }
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -2063,4 +2063,48 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             }
         );
     }
+
+    [Fact]
+    public async Task GlobalJsonInSubmoduleIsFilteredOut()
+    {
+        await TestDiscoveryAsync(
+            packages: [],
+            workspacePath: "vendor/external",
+            files:
+            [
+                (".gitmodules", """
+                    [submodule "vendor/external"]
+                        path = vendor/external
+                        url = https://github.com/example/external.git
+                    """),
+                ("vendor/external/global.json", """
+                    {
+                      "sdk": {
+                        "version": "8.0.100"
+                      }
+                    }
+                    """),
+                ("vendor/external/.config/dotnet-tools.json", """
+                    {
+                      "version": 1,
+                      "isRoot": true,
+                      "tools": {
+                        "dotnetsay": {
+                          "version": "2.1.3",
+                          "commands": ["dotnetsay"]
+                        }
+                      }
+                    }
+                    """),
+            ],
+            expectedResult: new()
+            {
+                Path = "vendor/external",
+                GlobalJson = null,
+                DotNetToolsJson = null,
+                Projects = [],
+                ExpectedProjectCount = 0,
+            }
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1667,13 +1667,55 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                 </Project>
                 """)
         );
-        var actualEntryPoints = (await DiscoveryWorker.ExpandEntryPointsIntoProjectsAsync([Path.Combine(tempDir.DirectoryPath, "src/dirs.proj")], new ExperimentsManager(), new TestLogger()))
+        var actualEntryPoints = (await DiscoveryWorker.ExpandEntryPointsIntoProjectsAsync([Path.Combine(tempDir.DirectoryPath, "src/dirs.proj")], new ExperimentsManager(), new TestLogger(), repoRootPath: tempDir.DirectoryPath))
             .Select(p => p.NormalizePathToUnix())
             .ToArray();
         var expectedEntryPoints = new[]
         {
             Path.Combine(tempDir.DirectoryPath, "src/project1/project1.csproj").NormalizePathToUnix(),
             Path.Combine(tempDir.DirectoryPath, "src/project2/project2.csproj").NormalizePathToUnix(),
+        };
+        AssertEx.Equal(expectedEntryPoints, actualEntryPoints);
+    }
+
+    [Fact]
+    public async Task ExpandEntryPoints_FiltersProjectsInSubmodules()
+    {
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(
+            (".gitmodules", """
+                [submodule "vendor/external"]
+                    path = vendor/external
+                    url = https://github.com/example/external.git
+                """),
+            ("src/dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="project1\project1.csproj" />
+                    <ProjectFile Include="$(MSBuildThisFileDirectory)..\vendor\external\project2.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/project1/project1.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """),
+            ("vendor/external/project2.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """)
+        );
+        var actualEntryPoints = (await DiscoveryWorker.ExpandEntryPointsIntoProjectsAsync([Path.Combine(tempDir.DirectoryPath, "src/dirs.proj")], new ExperimentsManager(), new TestLogger(), repoRootPath: tempDir.DirectoryPath))
+            .Select(p => p.NormalizePathToUnix())
+            .ToArray();
+        var expectedEntryPoints = new[]
+        {
+            Path.Combine(tempDir.DirectoryPath, "src/project1/project1.csproj").NormalizePathToUnix(),
         };
         AssertEx.Equal(expectedEntryPoints, actualEntryPoints);
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/GitSubmoduleParserTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/GitSubmoduleParserTests.cs
@@ -108,6 +108,9 @@ public class GitSubmoduleParserTests
     [InlineData("vendor/other/project.csproj", false)]
     [InlineData("src/project.csproj", false)]
     [InlineData("vendorlib/project.csproj", false)]
+    [InlineData("src/../vendor/lib/project.csproj", true)]
+    [InlineData("vendor/lib/../lib/project.csproj", true)]
+    [InlineData("vendor/lib/../other/project.csproj", false)]
     public void IsPathInSubmodule_CorrectlyIdentifiesSubmodulePaths(string path, bool expected)
     {
         var submodulePaths = ImmutableArray.Create("vendor/lib", "third_party/tools");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/GitSubmoduleParserTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/GitSubmoduleParserTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Immutable;
+
+using NuGetUpdater.Core.Utilities;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Utilities;
+
+public class GitSubmoduleParserTests
+{
+    [Theory]
+    [MemberData(nameof(ParseSubmodulePathsData))]
+    public void ParseSubmodulePaths(string gitmodulesContent, string[] expectedPaths)
+    {
+        var result = GitSubmoduleParser.ParseSubmodulePaths(gitmodulesContent);
+        Assert.Equal(expectedPaths, result);
+    }
+
+    public static IEnumerable<object[]> ParseSubmodulePathsData()
+    {
+        // empty content returns no paths
+        yield return
+        [
+            // gitmodulesContent
+            "",
+            // expectedPaths
+            Array.Empty<string>(),
+        ];
+
+        // single submodule
+        yield return
+        [
+            // gitmodulesContent
+            """
+            [submodule "external/lib"]
+                path = external/lib
+                url = https://github.com/example/lib.git
+            """,
+            // expectedPaths
+            new[] { "external/lib" },
+        ];
+
+        // multiple submodules
+        yield return
+        [
+            // gitmodulesContent
+            """
+            [submodule "vendor/lib1"]
+                path = vendor/lib1
+                url = https://github.com/example/lib1.git
+            [submodule "vendor/lib2"]
+                path = vendor/lib2
+                url = https://github.com/example/lib2.git
+            [submodule "third_party/tools"]
+                path = third_party/tools
+                url = https://github.com/example/tools.git
+            """,
+            // expectedPaths
+            new[] { "vendor/lib1", "vendor/lib2", "third_party/tools" },
+        ];
+
+        // Windows path separators are normalized to forward slashes
+        yield return
+        [
+            // gitmodulesContent
+            """
+            [submodule "vendor\lib"]
+                path = vendor\lib
+                url = https://github.com/example/lib.git
+            """,
+            // expectedPaths
+            new[] { "vendor/lib" },
+        ];
+
+        // no spaces around equals sign
+        yield return
+        [
+            // gitmodulesContent
+            """
+            [submodule "external/lib"]
+                path=external/lib
+                url=https://github.com/example/lib.git
+            """,
+            // expectedPaths
+            new[] { "external/lib" },
+        ];
+
+        // non-path keys are ignored
+        yield return
+        [
+            // gitmodulesContent
+            """
+            [submodule "external/lib"]
+                url = https://github.com/example/lib.git
+                branch = main
+                path = external/lib
+                update = rebase
+            """,
+            // expectedPaths
+            new[] { "external/lib" },
+        ];
+    }
+
+    [Theory]
+    [InlineData("vendor/lib/project.csproj", true)]
+    [InlineData("vendor/lib", true)]
+    [InlineData("vendor/lib/sub/deep/file.cs", true)]
+    [InlineData("vendor/other/project.csproj", false)]
+    [InlineData("src/project.csproj", false)]
+    [InlineData("vendorlib/project.csproj", false)]
+    public void IsPathInSubmodule_CorrectlyIdentifiesSubmodulePaths(string path, bool expected)
+    {
+        var submodulePaths = ImmutableArray.Create("vendor/lib", "third_party/tools");
+        var result = GitSubmoduleParser.IsPathInSubmodule(path, submodulePaths);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void IsPathInSubmodule_ReturnsFalse_WhenNoSubmodules()
+    {
+        var result = GitSubmoduleParser.IsPathInSubmodule("src/project.csproj", []);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsPathInSubmodule_IsCaseInsensitive()
+    {
+        var submodulePaths = ImmutableArray.Create("Vendor/Lib");
+        var result = GitSubmoduleParser.IsPathInSubmodule("vendor/lib/project.csproj", submodulePaths);
+        Assert.True(result);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -16,6 +16,8 @@ using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Updater;
 using NuGetUpdater.Core.Utilities;
 
+using static NuGetUpdater.Core.Utilities.GitSubmoduleParser;
+
 namespace NuGetUpdater.Core.Discover;
 
 public partial class DiscoveryWorker : IDiscoveryWorker
@@ -109,6 +111,33 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         // filter to only projects in the repo that could possibly be updated
         var repoRoot = new DirectoryInfo(repoRootPath);
         projectResults = [.. projectResults.Where(p => PathHelper.IsFileUnderDirectory(repoRoot, new FileInfo(Path.Join(workspacePath, p.FilePath))))];
+
+        // filter out projects that are in submodules
+        var submodulePaths = GetSubmodulePaths(repoRootPath);
+        if (submodulePaths.Length > 0)
+        {
+            projectResults = FilterProjectsInSubmodules(projectResults, initialWorkspacePath, submodulePaths);
+
+            if (dotNetToolsJsonDiscovery is not null)
+            {
+                var fullRelativePath = PathHelper.JoinPath(initialWorkspacePath, dotNetToolsJsonDiscovery.FilePath).NormalizePathToUnix();
+                if (IsPathInSubmodule(fullRelativePath, submodulePaths))
+                {
+                    _logger.Info($"  Excluding file [{dotNetToolsJsonDiscovery.FilePath}] because it is in a submodule.");
+                    dotNetToolsJsonDiscovery = null;
+                }
+            }
+
+            if (globalJsonDiscovery is not null)
+            {
+                var fullRelativePath = PathHelper.JoinPath(initialWorkspacePath, globalJsonDiscovery.FilePath).NormalizePathToUnix();
+                if (IsPathInSubmodule(fullRelativePath, submodulePaths))
+                {
+                    _logger.Info($"  Excluding file [{globalJsonDiscovery.FilePath}] because it is in a submodule.");
+                    globalJsonDiscovery = null;
+                }
+            }
+        }
 
         // if any projectResults are not successful, return a failed result
         if (projectResults.Any(p => p.IsSuccess == false))
@@ -475,6 +504,28 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             HasNoWarnNU1701 = result1.HasNoWarnNU1701 || result2.HasNoWarnNU1701,
         };
         return mergedResult;
+    }
+
+    internal ImmutableArray<ProjectDiscoveryResult> FilterProjectsInSubmodules(
+        ImmutableArray<ProjectDiscoveryResult> projectResults,
+        string workspacePath,
+        ImmutableArray<string> submodulePaths)
+    {
+        var filtered = new List<ProjectDiscoveryResult>();
+        foreach (var project in projectResults)
+        {
+            var fullRelativePath = PathHelper.JoinPath(workspacePath, project.FilePath).NormalizePathToUnix();
+            if (IsPathInSubmodule(fullRelativePath, submodulePaths))
+            {
+                _logger.Info($"  Excluding project [{project.FilePath}] because it is in a submodule.");
+            }
+            else
+            {
+                filtered.Add(project);
+            }
+        }
+
+        return [.. filtered];
     }
 
     internal static async Task WriteResultsAsync(string repoRootPath, string outputPath, WorkspaceDiscoveryResult result)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -204,7 +204,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         ImmutableArray<string> projects;
         try
         {
-            projects = await ExpandEntryPointsIntoProjectsAsync(entryPoints, _experimentsManager, _logger);
+            projects = await ExpandEntryPointsIntoProjectsAsync(entryPoints, _experimentsManager, _logger, repoRootPath);
         }
         catch (InvalidProjectFileException e)
         {
@@ -252,7 +252,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             .ToImmutableArray();
     }
 
-    internal async static Task<ImmutableArray<string>> ExpandEntryPointsIntoProjectsAsync(IEnumerable<string> entryPoints, ExperimentsManager experimentsManager, ILogger logger)
+    internal async static Task<ImmutableArray<string>> ExpandEntryPointsIntoProjectsAsync(IEnumerable<string> entryPoints, ExperimentsManager experimentsManager, ILogger logger, string repoRootPath)
     {
         HashSet<string> expandedProjects = new(PathComparer.Instance);
         HashSet<string> seenProjects = new(PathComparer.Instance);
@@ -313,6 +313,24 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         }
 
         var result = expandedProjects.OrderBy(p => p).ToImmutableArray();
+
+        // pre-filter projects that are in submodules to avoid unnecessary restore operations
+        var submodulePaths = GetSubmodulePaths(repoRootPath);
+        if (submodulePaths.Length > 0)
+        {
+            result = [.. result.Where(p =>
+            {
+                var relativePath = Path.GetRelativePath(repoRootPath, p).NormalizePathToUnix();
+                if (IsPathInSubmodule(relativePath, submodulePaths))
+                {
+                    logger.Info($"    Excluding project [{relativePath}] because it is in a submodule.");
+                    return false;
+                }
+
+                return true;
+            })];
+        }
+
         return result;
     }
 
@@ -373,7 +391,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         try
         {
             // get all packages.config results first
-            var expandedProjects = await ExpandEntryPointsIntoProjectsAsync(normalizedProjectPaths, _experimentsManager, _logger);
+            var expandedProjects = await ExpandEntryPointsIntoProjectsAsync(normalizedProjectPaths, _experimentsManager, _logger, repoRootPath);
             foreach (var expandedProject in expandedProjects)
             {
                 var packagesConfigResult = await PackagesConfigDiscovery.Discover(repoRootPath, workspacePath, expandedProject, _logger);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/GitSubmoduleParser.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/GitSubmoduleParser.cs
@@ -34,7 +34,7 @@ internal static class GitSubmoduleParser
                 var pathValue = trimmed[(equalsIndex + 1)..].Trim();
                 if (!string.IsNullOrEmpty(pathValue))
                 {
-                    paths.Add(pathValue.NormalizePathToUnix());
+                    paths.Add(pathValue.NormalizePathToUnix().NormalizeUnixPathParts().TrimEnd('/'));
                 }
             }
         }
@@ -47,7 +47,7 @@ internal static class GitSubmoduleParser
     /// </summary>
     public static bool IsPathInSubmodule(string relativePath, ImmutableArray<string> submodulePaths)
     {
-        var normalizedPath = relativePath.NormalizePathToUnix();
+        var normalizedPath = relativePath.NormalizePathToUnix().NormalizeUnixPathParts().TrimEnd('/');
         foreach (var submodulePath in submodulePaths)
         {
             if (normalizedPath.Equals(submodulePath, StringComparison.OrdinalIgnoreCase) ||

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/GitSubmoduleParser.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/GitSubmoduleParser.cs
@@ -1,0 +1,62 @@
+using System.Collections.Immutable;
+
+namespace NuGetUpdater.Core.Utilities;
+
+internal static class GitSubmoduleParser
+{
+    /// <summary>
+    /// Parses a .gitmodules file and returns the set of submodule paths relative to the repo root.
+    /// </summary>
+    public static ImmutableArray<string> GetSubmodulePaths(string repoRootPath)
+    {
+        var gitmodulesPath = Path.Combine(repoRootPath, ".gitmodules");
+        if (!File.Exists(gitmodulesPath))
+        {
+            return [];
+        }
+
+        var content = File.ReadAllText(gitmodulesPath);
+        return ParseSubmodulePaths(content);
+    }
+
+    /// <summary>
+    /// Parses .gitmodules content and extracts the "path" values from each submodule section.
+    /// </summary>
+    internal static ImmutableArray<string> ParseSubmodulePaths(string content)
+    {
+        var paths = new List<string>();
+        foreach (var line in content.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith("path", StringComparison.OrdinalIgnoreCase) && trimmed.Contains('='))
+            {
+                var equalsIndex = trimmed.IndexOf('=');
+                var pathValue = trimmed[(equalsIndex + 1)..].Trim();
+                if (!string.IsNullOrEmpty(pathValue))
+                {
+                    paths.Add(pathValue.NormalizePathToUnix());
+                }
+            }
+        }
+
+        return [.. paths];
+    }
+
+    /// <summary>
+    /// Determines whether a given relative path (unix-style, relative to the repo root) falls under any submodule path.
+    /// </summary>
+    public static bool IsPathInSubmodule(string relativePath, ImmutableArray<string> submodulePaths)
+    {
+        var normalizedPath = relativePath.NormalizePathToUnix();
+        foreach (var submodulePath in submodulePaths)
+        {
+            if (normalizedPath.Equals(submodulePath, StringComparison.OrdinalIgnoreCase) ||
+                normalizedPath.StartsWith(submodulePath + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

During NuGet dependency discovery, the updater now parses `.gitmodules` in the repo root and excludes any projects, `global.json`, or `dotnet-tools.json` files that fall under submodule directories. This prevents the updater from attempting to update dependencies in submodules, which would produce corrupted PRs.

## Details

- Added `GitSubmoduleParser` utility that parses `.gitmodules` to extract submodule paths
- Modified `DiscoveryWorker.RunAsync` to filter discovered projects and files against submodule paths
- Logs when files/projects are excluded due to being in a submodule

Closes #9433