### PR TITLE
fix(go_modules): run strict go mod tidy and surface real errors

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -271,13 +271,7 @@ module Dependabot
 
           workspace_module_paths.each do |mod_path|
             Dir.chdir(mod_path) do
-              command = "go mod tidy -e"
-              _, stderr, status = Open3.capture3(command)
-              if status.success?
-                Dependabot.logger.info "`go mod tidy` succeeded in #{mod_path}"
-              else
-                Dependabot.logger.info "Failed to `go mod tidy` in #{mod_path}: #{stderr}"
-              end
+              run_go_mod_tidy(context: mod_path)
             end
           end
         end
@@ -332,21 +326,28 @@ module Dependabot
           results
         end
 
-        sig { void }
-        def run_go_mod_tidy
+        sig { params(context: T.nilable(String)).void }
+        def run_go_mod_tidy(context: nil)
           return unless tidy?
 
-          command = "go mod tidy -e"
+          label = context ? " in #{context}" : ""
 
-          # we explicitly don't raise an error for 'go mod tidy' and silently
-          # continue with an info log here. `go mod tidy` shouldn't block
-          # updating versions because there are some edge cases where it's OK to fail
-          # (such as generated files not available yet to us).
+          # Run a strict `go mod tidy` (without the `-e` flag). `-e` tells tidy
+          # to continue despite errors loading packages, which silently
+          # tolerates unreachable/private modules and can over-prune `/go.mod`
+          # checksum entries from go.sum for unrelated modules. We surface the
+          # real error instead so the underlying dependency problem is visible
+          # and can be fixed by giving Dependabot the same access to
+          # dependencies as the rest of the team.
+          command = "go mod tidy"
           _, stderr, status = Open3.capture3(command)
           if status.success?
-            Dependabot.logger.info "`go mod tidy` succeeded"
+            Dependabot.logger.info "`#{command}` succeeded#{label}"
           else
-            Dependabot.logger.info "Failed to `go mod tidy`: #{stderr}"
+            # Log the failing module before raising, as handle_subprocess_error
+            # scrubs the working directory from the message.
+            Dependabot.logger.info "Failed to `#{command}`#{label}: #{stderr}"
+            handle_subprocess_error(stderr)
           end
         end
 

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -276,6 +276,28 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
               .not_to include(%(rsc.io/quote v1.4.0/go.mod h1:))
           end
 
+          context "when `go mod tidy` fails" do
+            before do
+              allow(Open3).to receive(:capture3).and_wrap_original do |original, *args|
+                if args == ["go mod tidy"]
+                  ["", "missing go.sum entry for go.mod file", instance_double(Process::Status, success?: false)]
+                else
+                  original.call(*args)
+                end
+              end
+            end
+
+            it "surfaces the real error instead of silently continuing" do
+              expect { updated_go_mod_content }
+                .to raise_error(Dependabot::DependencyFileNotResolvable)
+            end
+
+            it "does not fall back to `go mod tidy -e`" do
+              expect { updated_go_mod_content }.to raise_error(Dependabot::DependabotError)
+              expect(Open3).not_to have_received(:capture3).with("go mod tidy -e")
+            end
+          end
+
           describe "a non-existent dependency with a pseudo-version" do
             let(:project_name) { "non_existent_dependency" }
 


### PR DESCRIPTION
### What are you trying to accomplish?

When updating Go dependencies, Dependabot ran `go mod tidy -e` and ignored any failure. The `-e` flag tells `go mod tidy` to keep going despite errors loading packages. In practice this caused two problems:

- On a cold module cache, Go silently over-pruned `/go.mod` checksum entries from `go.sum` for modules unrelated to the update, so Dependabot PRs removed hashes that downstream CI still needs (#14872).
- Genuine resolution failures (for example intermittent proxy 404s from `gonum.org`, #15050) were swallowed and never surfaced, so the update looked successful while quietly degrading `go.sum`.

This change runs a strict `go mod tidy` (without `-e`) and lets real failures surface as typed Dependabot errors instead of being hidden. This aligns with treating Dependabot like any other developer on the team: it needs the same access to dependencies as everyone else, and when it doesn't have it, we should say so clearly rather than produce a subtly broken PR.

Fixes #14872

### Anything you want to highlight for special attention from reviewers?

This supersedes the earlier strict-with-fallback and module-graph-diffing approaches; the fallback to `go mod tidy -e` is removed entirely. Failures are routed through the existing `handle_subprocess_error`, and for workspace updates the failing module path is logged before the error message has its working directory scrubbed, so context is preserved. The behavioural change worth noting: a tidy failure now fails the update rather than passing silently.

### How will you know you've accomplished your goal?

- The full `go_mod_updater` spec suite passes, confirming no existing fixture depended on `-e` swallowing failures (including the no-top-level-package case, which still resolves cleanly under strict tidy).
- New specs assert that a `go mod tidy` failure now surfaces as a `DependencyFileNotResolvable` error and that the `-e` fallback is never invoked.
- Users affected by #14872 should no longer see unexpected removal of `/go.mod` checksum lines from `go.sum`.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
