### PR TITLE
Suppress Docker digest-only updates when tag version is unchanged

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -213,6 +213,15 @@ module Dependabot
           expected_digest =
             if source_tag
               latest_tag = latest_tag_from(source_tag)
+
+              # When digest-only updates are suppressed and the tag hasn't changed,
+              # treat the digest as up-to-date to avoid proposing a PR that only
+              # bumps the digest without a corresponding version change.
+              if Dependabot::Experiments.enabled?(:docker_digest_only_update_suppression) &&
+                 latest_tag.name == source_tag
+                next true
+              end
+
               digest_of(latest_tag.name)
             else
               updated_digest

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -217,7 +217,10 @@ module Dependabot
               # When digest-only updates are suppressed and the tag hasn't changed,
               # treat the digest as up-to-date to avoid proposing a PR that only
               # bumps the digest without a corresponding version change.
+              # Only apply to comparable (versioned) tags — non-comparable tags like
+              # "latest" or distro codenames should still get digest updates.
               if Dependabot::Experiments.enabled?(:docker_digest_only_update_suppression) &&
+                 Tag.new(source_tag).comparable? &&
                  latest_tag.name == source_tag
                 next true
               end

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -3310,6 +3310,25 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           expect(digest_up_to_date?).to be false
         end
       end
+
+      context "when the tag is non-comparable (e.g., 'latest' or distro codename) with digest" do
+        let(:version) { "artful" }
+        let(:source) do
+          {
+            tag: "artful",
+            digest: "old_digest_that_differs_from_registry"
+          }
+        end
+
+        before do
+          stub_request(:head, repo_url + "manifests/artful")
+            .and_return(status: 200, headers: JSON.parse(headers_response))
+        end
+
+        it "still detects digest changes (suppression only applies to versioned tags)" do
+          expect(digest_up_to_date?).to be false
+        end
+      end
     end
 
     context "when experiment is disabled" do

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -85,6 +85,19 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       end
 
       it { is_expected.to be_falsy }
+
+      context "when docker_digest_only_update_suppression experiment is enabled" do
+        before do
+          allow(Dependabot::Experiments).to receive(:enabled?)
+            .with(:docker_digest_only_update_suppression).and_return(true)
+          allow(Dependabot::Experiments).to receive(:enabled?)
+            .with(:docker_created_timestamp_validation).and_return(false)
+          allow(Dependabot::Experiments).to receive(:enabled?)
+            .with(:docker_pin_digests).and_return(false)
+        end
+
+        it { is_expected.to be_truthy }
+      end
     end
   end
 
@@ -3221,6 +3234,111 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       it "returns true" do
         expect(digest_up_to_date?).to be true
+      end
+    end
+  end
+
+  describe "#digest_up_to_date? with docker_digest_only_update_suppression experiment" do
+    subject(:digest_up_to_date?) { checker.send(:digest_up_to_date?) }
+
+    let(:headers_response) do
+      fixture("docker", "registry_manifest_headers", "generic.json")
+    end
+
+    context "when experiment is enabled" do
+      before do
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:docker_digest_only_update_suppression).and_return(true)
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:docker_created_timestamp_validation).and_return(false)
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:docker_pin_digests).and_return(false)
+      end
+
+      context "when the tag has not changed but the digest has" do
+        let(:version) { "17.10" }
+        let(:source) do
+          {
+            tag: "17.10",
+            digest: "old_digest_that_differs_from_registry"
+          }
+        end
+
+        before do
+          stub_request(:head, repo_url + "manifests/17.10")
+            .and_return(status: 200, headers: JSON.parse(headers_response))
+        end
+
+        it "treats the digest as up-to-date (suppresses digest-only update)" do
+          expect(digest_up_to_date?).to be true
+        end
+      end
+
+      context "when the tag has changed and the digest differs" do
+        let(:version) { "17.04" }
+        let(:source) do
+          {
+            tag: "17.04",
+            digest: "old_digest"
+          }
+        end
+
+        before do
+          stub_request(:head, repo_url + "manifests/17.10")
+            .and_return(status: 200, headers: JSON.parse(headers_response))
+        end
+
+        it "reports the digest as out of date" do
+          expect(digest_up_to_date?).to be false
+        end
+      end
+
+      context "when only a digest is present (no tag)" do
+        let(:version) { "latest" }
+        let(:source) do
+          {
+            digest: "old_digest"
+          }
+        end
+
+        before do
+          stub_request(:head, repo_url + "manifests/latest")
+            .and_return(status: 200, headers: JSON.parse(headers_response))
+        end
+
+        it "still detects digest changes (suppression only applies to tagged images)" do
+          expect(digest_up_to_date?).to be false
+        end
+      end
+    end
+
+    context "when experiment is disabled" do
+      before do
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:docker_digest_only_update_suppression).and_return(false)
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:docker_created_timestamp_validation).and_return(false)
+        allow(Dependabot::Experiments).to receive(:enabled?)
+          .with(:docker_pin_digests).and_return(false)
+      end
+
+      context "when the tag has not changed but the digest has" do
+        let(:version) { "17.10" }
+        let(:source) do
+          {
+            tag: "17.10",
+            digest: "old_digest_that_differs_from_registry"
+          }
+        end
+
+        before do
+          stub_request(:head, repo_url + "manifests/17.10")
+            .and_return(status: 200, headers: JSON.parse(headers_response))
+        end
+
+        it "reports the digest as out of date (existing behavior)" do
+          expect(digest_up_to_date?).to be false
+        end
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #15081 — Dependabot is bumping Docker image digests when the tag value has not changed.

When a Dockerfile pins both a tag and a digest (e.g., `FROM golang:1.26.3-bookworm@sha256:...`), Dependabot proposes PRs that only update the digest when the same tag is re-pushed on the registry. This is noisy because the user's intent with a tag+digest pin is to track version changes while ensuring reproducibility for a given version — not to chase every tag re-push.

This adds a new experiment flag `docker_digest_only_update_suppression` that, when enabled, treats the digest as up-to-date if the latest resolved tag name matches the current pinned tag. Digest updates still occur whenever the tag version actually advances.

### Anything you want to highlight for special attention from reviewers?

The fix is scoped entirely to the `digest_up_to_date?` method in the Docker update checker. When the experiment is enabled and a source has both a tag and a digest:
- If `latest_tag_from(source_tag).name == source_tag` (tag hasn't changed), we short-circuit and treat the digest as current
- If the tag has changed, we proceed with the normal digest comparison

This means:
- Tag+digest pins: digest-only updates suppressed ✓
- Digest-only pins (no tag): unaffected, still updates ✓
- Tag-only pins (no digest): unaffected ✓
- Experiment off: existing behavior preserved ✓

### How will you know you've accomplished your goal?

After enabling the `docker_digest_only_update_suppression` experiment in production, we expect to observe:

- **Reduction in digest-only Docker PRs**: Repositories that pin both a tag and digest (e.g., `image:1.26.3@sha256:...`) should stop receiving PRs that only update the `@sha256:` portion when the tag itself hasn't changed.
- **Version-advancing PRs still include digest updates**: When a newer tag is available (e.g., `1.26.3` → `1.26.4`), the PR should update both the tag and the digest as before.
- **No regression for digest-only references**: Repositories using `FROM image@sha256:...` (no tag) should continue receiving digest update PRs normally.
- **Specifically for the reporter's case**: Repos like [atc0005/go-ci](https://github.com/atc0005/go-ci) should no longer see PRs like [#2510](https://github.com/atc0005/go-ci/pull/2510) that bump the digest for `amd64/golang:1.26.3-bookworm` without a version change.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.