### PR TITLE
npm_and_yarn: add --no-save to pnpm deep-update fallback

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/native_helpers.rb
@@ -72,14 +72,21 @@ module Dependabot
       sig { params(dependency_name: String, recursive: T::Boolean).returns(String) }
       def self.run_pnpm_deep_update_command(dependency_name, recursive: false)
         # `pnpm update --depth Infinity <dep>` traverses the full dependency
-        # graph, allowing transitive dependencies to be updated in the lockfile
-        # without modifying any package.json (unlike `pnpm audit --fix`).
-        # `-r --include-workspace-root` is required for workspace repos so the
-        # update is applied across all packages.
+        # graph so transitive dependencies can be updated in the lockfile.
+        # `--no-save` is required: without it, pnpm rewrites caret ranges in
+        # `package.json` and the matching `specifier:` lines in
+        # `pnpm-lock.yaml` to `^<currently-resolved-version>` for every
+        # direct dependency whose resolved version is newer than its
+        # declared range floor. Dependabot only returns the lockfile from
+        # this flow, so those package.json mutations are discarded while
+        # the lockfile keeps `specifier:` entries that no longer match the
+        # manifest, which a downstream frozen-lockfile install rejects.
+        # `-r --include-workspace-root` is required for workspace repos so
+        # the update is applied across all packages.
         flags = recursive ? "-r --include-workspace-root " : ""
         Helpers.run_pnpm_command(
-          "#{flags}update #{dependency_name} --depth Infinity --lockfile-only",
-          fingerprint: "#{flags}update <dependency_name> --depth Infinity --lockfile-only"
+          "#{flags}update #{dependency_name} --depth Infinity --lockfile-only --no-save",
+          fingerprint: "#{flags}update <dependency_name> --depth Infinity --lockfile-only --no-save"
         )
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -773,7 +773,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command)
             .with(
               "-r --include-workspace-root update prettier --depth Infinity --lockfile-only --no-save",
-              { fingerprint: "-r --include-workspace-root update <dependency_name> --depth Infinity --lockfile-only --no-save" }
+              { fingerprint: "-r --include-workspace-root update <dependency_name> " \
+                             "--depth Infinity --lockfile-only --no-save" }
             )
             .ordered
             .and_return("")

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -772,8 +772,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
             .ordered
           expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command)
             .with(
-              "-r --include-workspace-root update prettier --depth Infinity --lockfile-only",
-              { fingerprint: "-r --include-workspace-root update <dependency_name> --depth Infinity --lockfile-only" }
+              "-r --include-workspace-root update prettier --depth Infinity --lockfile-only --no-save",
+              { fingerprint: "-r --include-workspace-root update <dependency_name> --depth Infinity --lockfile-only --no-save" }
             )
             .ordered
             .and_return("")


### PR DESCRIPTION
### What are you trying to accomplish?

Fix a manifest/lockfile mismatch produced by the deep-update fallback during pnpm security updates. `pnpm update <dep> --depth Infinity --lockfile-only` rewrites caret ranges in `package.json` and the matching `specifier:` lines in `pnpm-lock.yaml` to `^<currently-resolved-version>` for every direct dep whose resolved version is newer than its declared floor. Dependabot only returns the lockfile from this flow, so the package.json mutations are dropped while the lockfile keeps `specifier:` entries that no longer match the manifest. CI's frozen-lockfile install rejects the PR.

The comment above `run_pnpm_deep_update_command` claims this command does not modify `package.json`. That has not been true on the pnpm versions Dependabot ships against (`9.0.5` via corepack, `10.16.0` global).

Fix: add `--no-save` to the deep-update command. `--no-save` tells pnpm to leave `package.json` ranges alone while still resolving and writing the lockfile graph for the target transitive.

Fixes: https://github.com/dependabot/dependabot-core/issues/15104

### Anything you want to highlight for special attention from reviewers?

- The companion bug report (with a reproducible public repo) is in issue #15104.
- Verified manually that `--no-save` does not block the legitimate transitive bump: against a manifest where `ws@8.18.3` was vulnerable and `ws@8.20.1` was the patched version, `pnpm update ws --depth Infinity --lockfile-only --no-save` still moved `ws` to `8.20.1` everywhere the parent ranges allowed.
- One existing spec (`pnpm_lockfile_updater_spec.rb:775-776`) asserts the exact command string, updated to match the new flag.
- Prior art: `--no-save` is already in use on three of dependabot-core's other pnpm command paths (`file_updater/pnpm_lockfile_updater.rb:192` in `run_pnpm_update_packages`, and `update_checker/subdependency_version_resolver.rb:256` in `pnpm_update_command`). This PR brings the deep-update fallback in line with the primary path, no new minimum-version requirement is introduced.
- Related, not duplicate: #15073 (different command, `pnpm audit --fix` writing overrides into version-update PRs) and #15051 (gates audit-fix fallback to security updates only). #15051 does not fix this bug because affected PRs are themselves security updates.

### How will you know you've accomplished your goal?

Reproducer: <https://github.com/ivnnv/dependabot-pnpm-deep-update-bug>

```
=== Without --no-save (current dependabot behavior) ===
  command : pnpm update ws --depth Infinity --lockfile-only
  lockfile specifier rewrites : 10
  package.json diff lines     : 18

=== With --no-save (this PR) ===
  command : pnpm update ws --depth Infinity --lockfile-only --no-save
  lockfile specifier rewrites : 0
  package.json diff lines     : 0
```

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
  <sub>Run via this PR's CI — the call-site spec at `pnpm_lockfile_updater_spec.rb:775-776` already asserts the exact `pnpm update --depth Infinity` command string and is updated in this PR to match the new flag. Lint is green; e2e/integration/updater suites are still in progress at the time of writing and will be monitored.</sub>
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
  <sub>Verified against the public reproducer at <https://github.com/ivnnv/dependabot-pnpm-deep-update-bug> (before/after `--no-save`: 10 → 0 `specifier:` rewrites, 18 → 0 lines of `package.json` mutations). Also verified against a real workspace with a vulnerable transitive `ws@8.18.3` that `--no-save` still bumps `ws` to `8.20.1` wherever parent ranges allow.</sub>
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
  <sub>The previous comment above `run_pnpm_deep_update_command` claimed the command did not modify `package.json`; that claim was wrong on the pnpm versions Dependabot ships against. The replacement comment spells out exactly when and why `--no-save` is required, so the next reader does not have to rediscover this.</sub>


