### PR TITLE
fix(go_modules): reconcile go.sum checksums using module graph diffing

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_graph.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_graph.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_graph.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_graph.rb
@@ -1,0 +1,109 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "open3"
+
+require "dependabot/go_modules/file_updater"
+
+module Dependabot
+  module GoModules
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      # Captures and parses the output of `go mod graph` to provide
+      # a structured view of the module dependency graph.
+      # Can be used to detect which modules changed between two states.
+      class GoModGraph
+        extend T::Sig
+
+        sig { returns(T::Set[String]) }
+        attr_reader :modules
+
+        sig { params(modules: T::Set[String]).void }
+        def initialize(modules: Set.new)
+          @modules = modules
+        end
+
+        # Captures the current module graph by running `go mod graph`.
+        # Returns a new GoModGraph instance, or an empty one if the
+        # command fails (non-fatal — callers can proceed without it).
+        sig { returns(GoModGraph) }
+        def self.capture
+          stdout, _, status = Open3.capture3("go mod graph")
+          return new unless status.success?
+
+          new(modules: parse_graph(stdout))
+        end
+
+        # Returns the set of module paths (without versions) that
+        # differ between this graph and another — modules that were
+        # added, removed, or changed version.
+        sig { params(other: GoModGraph).returns(T::Set[String]) }
+        def changed_modules(other)
+          changed = T.let(Set.new, T::Set[String])
+
+          # Group by module path, compare versions
+          before_by_path = group_by_path(modules)
+          after_by_path = group_by_path(other.modules)
+
+          all_paths = before_by_path.keys.to_set | after_by_path.keys.to_set
+          all_paths.each do |path|
+            before_versions = before_by_path.fetch(path, Set.new)
+            after_versions = after_by_path.fetch(path, Set.new)
+            changed.add(path) if before_versions != after_versions
+          end
+
+          changed
+        end
+
+        # Returns true if the graph has no modules (e.g. capture failed).
+        sig { returns(T::Boolean) }
+        def empty?
+          modules.empty?
+        end
+
+        class << self
+          extend T::Sig
+
+          private
+
+          # Parses `go mod graph` output into a set of "module@version" entries.
+          # Each line is "parent@version child@version".
+          sig { params(output: String).returns(T::Set[String]) }
+          def parse_graph(output)
+            result = T.let(Set.new, T::Set[String])
+
+            output.each_line do |line|
+              line.strip.split(/\s+/).each do |entry|
+                result.add(entry) unless entry.empty?
+              end
+            end
+
+            result
+          end
+        end
+
+        private
+
+        # Groups "module@version" entries by module path.
+        # Returns { "module/path" => Set["v1.0.0", "v2.0.0"] }
+        sig { params(entries: T::Set[String]).returns(T::Hash[String, T::Set[String]]) }
+        def group_by_path(entries)
+          result = T.let(Hash.new { |h, k| h[k] = Set.new }, T::Hash[String, T::Set[String]])
+
+          entries.each do |entry|
+            at_index = T.must(entry).rindex("@")
+            next unless at_index
+
+            path = T.must(entry)[0...at_index]
+            version = T.must(entry)[(at_index + 1)..]
+            next unless path && version && !path.empty?
+
+            result[path].add(version)
+          end
+
+          result
+        end
+      end
+    end
+  end
+end

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_graph.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_graph.rb
@@ -74,7 +74,9 @@ module Dependabot
 
             output.each_line do |line|
               line.strip.split(/\s+/).each do |entry|
-                result.add(entry) unless entry.empty?
+                # Only include versioned entries (module@version), skip
+                # the root module which has no @version suffix.
+                result.add(entry) if entry.include?("@")
               end
             end
 
@@ -91,14 +93,14 @@ module Dependabot
           result = T.let(Hash.new { |h, k| h[k] = Set.new }, T::Hash[String, T::Set[String]])
 
           entries.each do |entry|
-            at_index = T.must(entry).rindex("@")
+            at_index = entry.rindex("@")
             next unless at_index
 
-            path = T.must(entry)[0...at_index]
-            version = T.must(entry)[(at_index + 1)..]
+            path = entry[0...at_index]
+            version = entry[(at_index + 1)..]
             next unless path && version && !path.empty?
 
-            result[path].add(version)
+            T.must(result[path]).add(version)
           end
 
           result

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_graph.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_graph.rb
@@ -18,9 +18,9 @@ module Dependabot
         sig { returns(T::Set[String]) }
         attr_reader :modules
 
-        sig { params(modules: T::Set[String]).void }
-        def initialize(modules: Set.new)
-          @modules = modules
+        sig { params(modules: T.nilable(T::Set[String])).void }
+        def initialize(modules: nil)
+          @modules = T.let(modules || Set.new, T::Set[String])
         end
 
         # Captures the current module graph by running `go mod graph`.
@@ -90,7 +90,10 @@ module Dependabot
         # Returns { "module/path" => Set["v1.0.0", "v2.0.0"] }
         sig { params(entries: T::Set[String]).returns(T::Hash[String, T::Set[String]]) }
         def group_by_path(entries)
-          result = T.let(Hash.new { |h, k| h[k] = Set.new }, T::Hash[String, T::Set[String]])
+          result = T.let(
+            Hash.new { |h, k| h[k] = T.let(Set.new, T::Set[String]) },
+            T::Hash[String, T::Set[String]]
+          )
 
           entries.each do |entry|
             at_index = entry.rindex("@")

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -7,6 +7,7 @@ require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/logger"
 require "dependabot/go_modules/file_updater"
+require "dependabot/go_modules/file_updater/go_mod_graph"
 require "dependabot/go_modules/go_work_parser"
 require "dependabot/go_modules/replace_stubber"
 require "dependabot/go_modules/resolvability_errors"
@@ -197,6 +198,10 @@ module Dependabot
             original_manifest = parse_manifest
             original_go_sum = File.read("go.sum") if File.exist?("go.sum")
 
+            # Capture module graph before updating to detect which modules
+            # actually change, so we can scope go.sum modifications.
+            graph_before = GoModGraph.capture
+
             substitutions = replace_directive_substitutions(original_manifest)
             build_module_stubs(substitutions.values)
 
@@ -224,6 +229,17 @@ module Dependabot
 
             updated_go_sum = original_go_sum ? File.read("go.sum") : nil
             updated_go_mod = File.read("go.mod")
+
+            # Restore go.sum lines that were removed for modules unrelated
+            # to the update — Go tooling can over-prune /go.mod checksums.
+            if original_go_sum && updated_go_sum
+              graph_after = GoModGraph.capture
+              updated_go_sum = reconcile_go_sum(
+                original_go_sum,
+                updated_go_sum,
+                graph_before.changed_modules(graph_after)
+              )
+            end
 
             { go_mod: updated_go_mod, go_sum: updated_go_sum }
           end
@@ -403,6 +419,38 @@ module Dependabot
           SharedHelpers.in_a_temporary_repo_directory(directory, repo_contents_path) do
             SharedHelpers.with_git_configured(credentials: credentials, &block)
           end
+        end
+
+        # Restores /go.mod checksum lines in go.sum that were removed for
+        # modules unrelated to the dependency update. Go tooling can
+        # over-prune these entries, causing CI failures downstream.
+        sig do
+          params(
+            original: String,
+            updated: String,
+            changed_modules: T::Set[String]
+          ).returns(String)
+        end
+        def reconcile_go_sum(original, updated, changed_modules)
+          return updated if changed_modules.empty?
+
+          updated_lines = updated.lines(chomp: true).reject(&:empty?)
+          updated_set = updated_lines.to_set
+
+          restored = original.lines(chomp: true).reject(&:empty?).select do |line|
+            next false if updated_set.include?(line)
+            next false unless line.include?("/go.mod h1:")
+
+            module_path = line.split(/\s+/, 2).first
+            next false unless module_path
+
+            !changed_modules.include?(module_path)
+          end
+
+          return updated if restored.empty?
+
+          Dependabot.logger.info "Restoring #{restored.size} over-pruned go.sum checksum(s)"
+          (updated_lines + restored).sort.join("\n") + "\n"
         end
 
         sig { params(stub_paths: T::Array[String]).void }

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -234,11 +234,13 @@ module Dependabot
             # to the update — Go tooling can over-prune /go.mod checksums.
             if original_go_sum && updated_go_sum
               graph_after = GoModGraph.capture
-              updated_go_sum = reconcile_go_sum(
-                original_go_sum,
-                updated_go_sum,
-                graph_before.changed_modules(graph_after)
-              )
+              unless graph_before.empty? || graph_after.empty?
+                updated_go_sum = reconcile_go_sum(
+                  original_go_sum,
+                  updated_go_sum,
+                  graph_before.changed_modules(graph_after)
+                )
+              end
             end
 
             { go_mod: updated_go_mod, go_sum: updated_go_sum }
@@ -432,8 +434,6 @@ module Dependabot
           ).returns(String)
         end
         def reconcile_go_sum(original, updated, changed_modules)
-          return updated if changed_modules.empty?
-
           updated_lines = updated.lines(chomp: true).reject(&:empty?)
           updated_set = updated_lines.to_set
 

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -198,15 +198,17 @@ module Dependabot
             original_manifest = parse_manifest
             original_go_sum = File.read("go.sum") if File.exist?("go.sum")
 
-            # Capture module graph before updating to detect which modules
-            # actually change, so we can scope go.sum modifications.
-            graph_before = GoModGraph.capture
-
             substitutions = replace_directive_substitutions(original_manifest)
             build_module_stubs(substitutions.values)
 
             # Replace full paths with path hashes in the go.mod
             substitute_all(substitutions)
+
+            # Capture the module graph with stubs/substitutions in place, so
+            # `go mod graph` runs in the same "safe" state as the go commands
+            # below. Capturing before this point fails for repos with local
+            # replace directives, leaving the graph empty.
+            graph_before = GoModGraph.capture
 
             # Bump the deps we want to upgrade using `go get lib@version`
             run_go_get(dependencies)
@@ -223,15 +225,19 @@ module Dependabot
               # dependencies removed by go mod tidy are also removed from vendors.
               run_go_mod_tidy
               run_go_vendor
-            else
-              substitute_all(substitutions.invert)
             end
+
+            # Capture the post-update graph while stubs/substitutions are still
+            # active, before reverting them below, for the same reason.
+            graph_after = GoModGraph.capture
+
+            substitute_all(substitutions.invert) unless substitutions.empty?
 
             updated_go_sum = original_go_sum ? File.read("go.sum") : nil
             updated_go_mod = File.read("go.mod")
 
             if original_go_sum && updated_go_sum
-              updated_go_sum = reconcile_updated_go_sum(original_go_sum, updated_go_sum, graph_before)
+              updated_go_sum = reconcile_updated_go_sum(original_go_sum, updated_go_sum, graph_before, graph_after)
             end
 
             { go_mod: updated_go_mod, go_sum: updated_go_sum }
@@ -414,17 +420,19 @@ module Dependabot
           end
         end
 
-        # Captures the post-update module graph, diffs it against the
-        # pre-update graph, and restores over-pruned go.sum lines.
+        # Diffs the pre- and post-update module graphs and restores
+        # over-pruned go.sum lines. Both graphs are captured by the caller
+        # while stubs/substitutions are active so `go mod graph` succeeds
+        # even for repos with local replace directives.
         sig do
           params(
             original_go_sum: String,
             updated_go_sum: String,
-            graph_before: GoModGraph
+            graph_before: GoModGraph,
+            graph_after: GoModGraph
           ).returns(String)
         end
-        def reconcile_updated_go_sum(original_go_sum, updated_go_sum, graph_before)
-          graph_after = GoModGraph.capture
+        def reconcile_updated_go_sum(original_go_sum, updated_go_sum, graph_before, graph_after)
           return updated_go_sum if graph_before.empty? || graph_after.empty?
 
           reconcile_go_sum(original_go_sum, updated_go_sum, graph_before.changed_modules(graph_after))

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -207,8 +207,9 @@ module Dependabot
             # Capture the module graph with stubs/substitutions in place, so
             # `go mod graph` runs in the same "safe" state as the go commands
             # below. Capturing before this point fails for repos with local
-            # replace directives, leaving the graph empty.
-            graph_before = GoModGraph.capture
+            # replace directives, leaving the graph empty. Skip entirely when
+            # there is no go.sum, since reconciliation can never run.
+            graph_before = capture_module_graph(original_go_sum)
 
             # Bump the deps we want to upgrade using `go get lib@version`
             run_go_get(dependencies)
@@ -228,8 +229,9 @@ module Dependabot
             end
 
             # Capture the post-update graph while stubs/substitutions are still
-            # active, before reverting them below, for the same reason.
-            graph_after = GoModGraph.capture
+            # active, before reverting them below, for the same reason. Skip
+            # when there is no go.sum to reconcile.
+            graph_after = capture_module_graph(original_go_sum)
 
             substitute_all(substitutions.invert) unless substitutions.empty?
 
@@ -418,6 +420,14 @@ module Dependabot
           SharedHelpers.in_a_temporary_repo_directory(directory, repo_contents_path) do
             SharedHelpers.with_git_configured(credentials: credentials, &block)
           end
+        end
+
+        # Captures the current module graph, but only when the project has a
+        # go.sum to reconcile. Returns an empty graph otherwise, avoiding an
+        # unnecessary `go mod graph` subprocess call.
+        sig { params(original_go_sum: T.nilable(String)).returns(GoModGraph) }
+        def capture_module_graph(original_go_sum)
+          original_go_sum ? GoModGraph.capture : GoModGraph.new
         end
 
         # Diffs the pre- and post-update module graphs and restores

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -442,11 +442,17 @@ module Dependabot
         end
         def reconcile_go_sum(original, updated, changed_modules)
           updated_lines = updated.lines(chomp: true).reject(&:empty?)
-          updated_set = updated_lines.to_set
+
+          # Track existing "module version/go.mod" keys so we never restore a
+          # checksum for a module@version the updated go.sum already covers,
+          # even if Go recalculated the hash (avoids duplicate entries).
+          updated_gomod_keys = updated_lines.each_with_object(Set.new) do |line, set|
+            set.add(go_sum_module_key(line)) if line.include?("/go.mod h1:")
+          end
 
           restored = original.lines(chomp: true).reject(&:empty?).select do |line|
-            next false if updated_set.include?(line)
             next false unless line.include?("/go.mod h1:")
+            next false if updated_gomod_keys.include?(go_sum_module_key(line))
 
             module_path = line.split(/\s+/, 2).first
             next false unless module_path
@@ -458,6 +464,14 @@ module Dependabot
 
           Dependabot.logger.info "Restoring #{restored.size} over-pruned go.sum checksum(s)"
           (updated_lines + restored).sort.join("\n") + "\n"
+        end
+
+        # Builds a "module version/go.mod" identity key for a go.sum line,
+        # ignoring the trailing hash so the same module@version dedups
+        # regardless of the recorded checksum value.
+        sig { params(line: String).returns(String) }
+        def go_sum_module_key(line)
+          line.split(/\s+/, 3).first(2).join(" ")
         end
 
         sig { params(stub_paths: T::Array[String]).void }

--- a/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
+++ b/go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb
@@ -230,17 +230,8 @@ module Dependabot
             updated_go_sum = original_go_sum ? File.read("go.sum") : nil
             updated_go_mod = File.read("go.mod")
 
-            # Restore go.sum lines that were removed for modules unrelated
-            # to the update — Go tooling can over-prune /go.mod checksums.
             if original_go_sum && updated_go_sum
-              graph_after = GoModGraph.capture
-              unless graph_before.empty? || graph_after.empty?
-                updated_go_sum = reconcile_go_sum(
-                  original_go_sum,
-                  updated_go_sum,
-                  graph_before.changed_modules(graph_after)
-                )
-              end
+              updated_go_sum = reconcile_updated_go_sum(original_go_sum, updated_go_sum, graph_before)
             end
 
             { go_mod: updated_go_mod, go_sum: updated_go_sum }
@@ -421,6 +412,22 @@ module Dependabot
           SharedHelpers.in_a_temporary_repo_directory(directory, repo_contents_path) do
             SharedHelpers.with_git_configured(credentials: credentials, &block)
           end
+        end
+
+        # Captures the post-update module graph, diffs it against the
+        # pre-update graph, and restores over-pruned go.sum lines.
+        sig do
+          params(
+            original_go_sum: String,
+            updated_go_sum: String,
+            graph_before: GoModGraph
+          ).returns(String)
+        end
+        def reconcile_updated_go_sum(original_go_sum, updated_go_sum, graph_before)
+          graph_after = GoModGraph.capture
+          return updated_go_sum if graph_before.empty? || graph_after.empty?
+
+          reconcile_go_sum(original_go_sum, updated_go_sum, graph_before.changed_modules(graph_after))
         end
 
         # Restores /go.mod checksum lines in go.sum that were removed for

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_graph_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_graph_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModGraph do
         expect(graph.modules).to include("github.com/onsi/gomega@v1.39.0")
       end
 
+      it "excludes the unversioned root module from parsed entries" do
+        graph = described_class.capture
+        expect(graph.modules).not_to include("github.com/test/app")
+      end
+
       it "is not empty" do
         expect(described_class.capture).not_to be_empty
       end
@@ -112,6 +117,17 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModGraph do
       )
 
       expect(graph.changed_modules(graph)).to be_empty
+    end
+  end
+
+  describe "#empty?" do
+    it "returns true when initialized without modules" do
+      expect(described_class.new).to be_empty
+    end
+
+    it "returns false when initialized with modules" do
+      graph = described_class.new(modules: Set["github.com/foo/bar@v1.0.0"])
+      expect(graph).not_to be_empty
     end
   end
 end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_graph_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_graph_spec.rb
@@ -47,17 +47,21 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModGraph do
 
   describe "#changed_modules" do
     it "detects modules with changed versions" do
-      before_graph = described_class.new(modules: Set[
-        "github.com/onsi/gomega@v1.39.0",
-        "google.golang.org/grpc@v1.81.1",
-        "gonum.org/v1/gonum@v0.17.0"
-      ])
+      before_graph = described_class.new(
+        modules: Set[
+          "github.com/onsi/gomega@v1.39.0",
+          "google.golang.org/grpc@v1.81.1",
+          "gonum.org/v1/gonum@v0.17.0"
+        ]
+      )
 
-      after_graph = described_class.new(modules: Set[
-        "github.com/onsi/gomega@v1.40.0",
-        "google.golang.org/grpc@v1.81.1",
-        "gonum.org/v1/gonum@v0.17.0"
-      ])
+      after_graph = described_class.new(
+        modules: Set[
+          "github.com/onsi/gomega@v1.40.0",
+          "google.golang.org/grpc@v1.81.1",
+          "gonum.org/v1/gonum@v0.17.0"
+        ]
+      )
 
       changed = before_graph.changed_modules(after_graph)
       expect(changed).to include("github.com/onsi/gomega")
@@ -66,14 +70,16 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModGraph do
     end
 
     it "detects added modules" do
-      before_graph = described_class.new(modules: Set[
-        "github.com/onsi/gomega@v1.39.0"
-      ])
+      before_graph = described_class.new(
+        modules: Set["github.com/onsi/gomega@v1.39.0"]
+      )
 
-      after_graph = described_class.new(modules: Set[
-        "github.com/onsi/gomega@v1.39.0",
-        "github.com/kr/pretty@v0.3.1"
-      ])
+      after_graph = described_class.new(
+        modules: Set[
+          "github.com/onsi/gomega@v1.39.0",
+          "github.com/kr/pretty@v0.3.1"
+        ]
+      )
 
       changed = before_graph.changed_modules(after_graph)
       expect(changed).to include("github.com/kr/pretty")
@@ -81,14 +87,16 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModGraph do
     end
 
     it "detects removed modules" do
-      before_graph = described_class.new(modules: Set[
-        "github.com/onsi/gomega@v1.39.0",
-        "github.com/old/dep@v1.0.0"
-      ])
+      before_graph = described_class.new(
+        modules: Set[
+          "github.com/onsi/gomega@v1.39.0",
+          "github.com/old/dep@v1.0.0"
+        ]
+      )
 
-      after_graph = described_class.new(modules: Set[
-        "github.com/onsi/gomega@v1.39.0"
-      ])
+      after_graph = described_class.new(
+        modules: Set["github.com/onsi/gomega@v1.39.0"]
+      )
 
       changed = before_graph.changed_modules(after_graph)
       expect(changed).to include("github.com/old/dep")
@@ -96,10 +104,12 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModGraph do
     end
 
     it "returns empty set when graphs are identical" do
-      graph = described_class.new(modules: Set[
-        "github.com/onsi/gomega@v1.39.0",
-        "gonum.org/v1/gonum@v0.17.0"
-      ])
+      graph = described_class.new(
+        modules: Set[
+          "github.com/onsi/gomega@v1.39.0",
+          "gonum.org/v1/gonum@v0.17.0"
+        ]
+      )
 
       expect(graph.changed_modules(graph)).to be_empty
     end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_graph_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_graph_spec.rb
@@ -1,0 +1,107 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/go_modules/file_updater/go_mod_graph"
+
+RSpec.describe Dependabot::GoModules::FileUpdater::GoModGraph do
+  describe ".capture" do
+    context "when go mod graph succeeds" do
+      before do
+        graph_output = <<~GRAPH
+          github.com/test/app github.com/onsi/gomega@v1.39.0
+          github.com/test/app google.golang.org/grpc@v1.81.1
+          google.golang.org/grpc@v1.81.1 gonum.org/v1/gonum@v0.17.0
+          github.com/onsi/gomega@v1.39.0 golang.org/x/net@v0.43.0
+        GRAPH
+
+        allow(Open3).to receive(:capture3)
+          .with("go mod graph")
+          .and_return([graph_output, "", instance_double(Process::Status, success?: true)])
+      end
+
+      it "parses module entries from the graph output" do
+        graph = described_class.capture
+        expect(graph.modules).to include("google.golang.org/grpc@v1.81.1")
+        expect(graph.modules).to include("gonum.org/v1/gonum@v0.17.0")
+        expect(graph.modules).to include("github.com/onsi/gomega@v1.39.0")
+      end
+
+      it "is not empty" do
+        expect(described_class.capture).not_to be_empty
+      end
+    end
+
+    context "when go mod graph fails" do
+      before do
+        allow(Open3).to receive(:capture3)
+          .with("go mod graph")
+          .and_return(["", "error", instance_double(Process::Status, success?: false)])
+      end
+
+      it "returns an empty graph" do
+        expect(described_class.capture).to be_empty
+      end
+    end
+  end
+
+  describe "#changed_modules" do
+    it "detects modules with changed versions" do
+      before_graph = described_class.new(modules: Set[
+        "github.com/onsi/gomega@v1.39.0",
+        "google.golang.org/grpc@v1.81.1",
+        "gonum.org/v1/gonum@v0.17.0"
+      ])
+
+      after_graph = described_class.new(modules: Set[
+        "github.com/onsi/gomega@v1.40.0",
+        "google.golang.org/grpc@v1.81.1",
+        "gonum.org/v1/gonum@v0.17.0"
+      ])
+
+      changed = before_graph.changed_modules(after_graph)
+      expect(changed).to include("github.com/onsi/gomega")
+      expect(changed).not_to include("google.golang.org/grpc")
+      expect(changed).not_to include("gonum.org/v1/gonum")
+    end
+
+    it "detects added modules" do
+      before_graph = described_class.new(modules: Set[
+        "github.com/onsi/gomega@v1.39.0"
+      ])
+
+      after_graph = described_class.new(modules: Set[
+        "github.com/onsi/gomega@v1.39.0",
+        "github.com/kr/pretty@v0.3.1"
+      ])
+
+      changed = before_graph.changed_modules(after_graph)
+      expect(changed).to include("github.com/kr/pretty")
+      expect(changed).not_to include("github.com/onsi/gomega")
+    end
+
+    it "detects removed modules" do
+      before_graph = described_class.new(modules: Set[
+        "github.com/onsi/gomega@v1.39.0",
+        "github.com/old/dep@v1.0.0"
+      ])
+
+      after_graph = described_class.new(modules: Set[
+        "github.com/onsi/gomega@v1.39.0"
+      ])
+
+      changed = before_graph.changed_modules(after_graph)
+      expect(changed).to include("github.com/old/dep")
+      expect(changed).not_to include("github.com/onsi/gomega")
+    end
+
+    it "returns empty set when graphs are identical" do
+      graph = described_class.new(modules: Set[
+        "github.com/onsi/gomega@v1.39.0",
+        "gonum.org/v1/gonum@v0.17.0"
+      ])
+
+      expect(graph.changed_modules(graph)).to be_empty
+    end
+  end
+end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -276,6 +276,73 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
               .not_to include(%(rsc.io/quote v1.4.0/go.mod h1:))
           end
 
+          context "when go tooling over-prunes an unrelated go.mod checksum" do
+            let(:gonum_gomod_line) do
+              "gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E="
+            end
+            let(:gonum_zip_line) do
+              "gonum.org/v1/gonum v0.16.0 h1:JKbmSgVMFkFMDpGCixMRJCMEMmNhrsJuJqVDPMGPnQY="
+            end
+
+            before do
+              # Simulate: original go.sum has gonum lines, go tooling removes the /go.mod one
+              original_sum = fixture("projects", project_name, "go.sum") +
+                             "#{gonum_zip_line}\n#{gonum_gomod_line}\n"
+              pruned_sum = original_sum.lines.reject { |l| l.chomp == gonum_gomod_line }.join
+
+              allow(File).to receive(:read).and_call_original
+              allow(File).to receive(:read).with("go.sum").and_return(original_sum, pruned_sum)
+
+              # Graph shows gonum unchanged before and after
+              graph_with_gonum = Dependabot::GoModules::FileUpdater::GoModGraph.new(
+                modules: Set[
+                  "rsc.io/quote@v1.5.2",
+                  "gonum.org/v1/gonum@v0.16.0"
+                ]
+              )
+              graph_after = Dependabot::GoModules::FileUpdater::GoModGraph.new(
+                modules: Set[
+                  "rsc.io/quote@v1.5.2",
+                  "gonum.org/v1/gonum@v0.16.0"
+                ]
+              )
+
+              allow(Dependabot::GoModules::FileUpdater::GoModGraph)
+                .to receive(:capture)
+                .and_return(graph_with_gonum, graph_after)
+            end
+
+            it "restores the unrelated go.mod checksum line" do
+              expect(updated_go_mod_content).to include(gonum_gomod_line)
+            end
+          end
+
+          context "when a module version changes legitimately" do
+            before do
+              original_sum = fixture("projects", project_name, "go.sum")
+
+              allow(File).to receive(:read).and_call_original
+              allow(File).to receive(:read).with("go.sum").and_return(original_sum)
+
+              # Graph shows rsc.io/quote changed version (it's being updated)
+              graph_before = Dependabot::GoModules::FileUpdater::GoModGraph.new(
+                modules: Set["rsc.io/quote@v1.4.0"]
+              )
+              graph_after = Dependabot::GoModules::FileUpdater::GoModGraph.new(
+                modules: Set["rsc.io/quote@v1.5.2"]
+              )
+
+              allow(Dependabot::GoModules::FileUpdater::GoModGraph)
+                .to receive(:capture)
+                .and_return(graph_before, graph_after)
+            end
+
+            it "does not restore the old checksum for the updated dependency" do
+              expect(updated_go_mod_content)
+                .not_to include(%(rsc.io/quote v1.4.0/go.mod h1:))
+            end
+          end
+
           describe "a non-existent dependency with a pseudo-version" do
             let(:project_name) { "non_existent_dependency" }
 

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -389,6 +389,34 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             end
           end
 
+          context "when graph capture fails" do
+            let(:gonum_gomod_line) do
+              "gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E="
+            end
+
+            before do
+              original_sum = fixture("projects", project_name, "go.sum") +
+                             "#{gonum_gomod_line}\n"
+              pruned_sum = original_sum.lines.reject { |l| l.chomp == gonum_gomod_line }.join
+
+              read_count = 0
+              allow(File).to receive(:read).and_call_original
+              allow(File).to receive(:read).with("go.sum") do
+                read_count += 1
+                read_count == 1 ? original_sum : pruned_sum
+              end
+
+              # Simulate capture failure — returns empty graphs
+              allow(Dependabot::GoModules::FileUpdater::GoModGraph)
+                .to receive(:capture)
+                .and_return(Dependabot::GoModules::FileUpdater::GoModGraph.new)
+            end
+
+            it "skips reconciliation and returns go.sum unchanged" do
+              expect(updated_go_mod_content).not_to include(gonum_gomod_line)
+            end
+          end
+
           describe "a non-existent dependency with a pseudo-version" do
             let(:project_name) { "non_existent_dependency" }
 
@@ -487,6 +515,16 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
           it "doesn't return a go.sum" do
             expect(updater.updated_go_sum_content).to be_nil
+          end
+
+          it "does not invoke go mod graph" do
+            allow(Dependabot::GoModules::FileUpdater::GoModGraph)
+              .to receive(:capture)
+
+            updater.updated_go_sum_content
+
+            expect(Dependabot::GoModules::FileUpdater::GoModGraph)
+              .not_to have_received(:capture)
           end
         end
       end

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -321,6 +321,53 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
             end
           end
 
+          context "when the updated go.sum already has the module's go.mod hash" do
+            let(:gonum_old_gomod_line) do
+              "gonum.org/v1/gonum v0.16.0/go.mod h1:OLDoldOLDoldOLDoldOLDoldOLDoldOLDoldOLDold==="
+            end
+            let(:gonum_new_gomod_line) do
+              "gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E="
+            end
+
+            before do
+              # Original has the OLD hash; updated keeps the SAME module@version
+              # but with a recalculated hash. Reconciliation must not re-add the
+              # old line, which would duplicate the module@version/go.mod entry.
+              original_sum = fixture("projects", project_name, "go.sum") +
+                             "#{gonum_old_gomod_line}\n"
+              updated_sum = fixture("projects", project_name, "go.sum") +
+                            "#{gonum_new_gomod_line}\n"
+
+              read_count = 0
+              allow(File).to receive(:read).and_call_original
+              allow(File).to receive(:read).with("go.sum") do
+                read_count += 1
+                read_count == 1 ? original_sum : updated_sum
+              end
+
+              graph = Dependabot::GoModules::FileUpdater::GoModGraph.new(
+                modules: Set[
+                  "rsc.io/quote@v1.5.2",
+                  "gonum.org/v1/gonum@v0.16.0"
+                ]
+              )
+
+              allow(Dependabot::GoModules::FileUpdater::GoModGraph)
+                .to receive(:capture)
+                .and_return(graph, graph)
+            end
+
+            it "does not restore the stale hash" do
+              expect(updated_go_mod_content).not_to include(gonum_old_gomod_line)
+            end
+
+            it "keeps a single go.mod checksum for the module" do
+              matches = updated_go_mod_content.lines
+                                              .count { |l| l.start_with?("gonum.org/v1/gonum v0.16.0/go.mod ") }
+              expect(matches).to eq(1)
+            end
+          end
+
           context "when a module version changes legitimately" do
             before do
               # Graph shows rsc.io/quote changed version (it's being updated)

--- a/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_updater/go_mod_updater_spec.rb
@@ -290,13 +290,17 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
                              "#{gonum_zip_line}\n#{gonum_gomod_line}\n"
               pruned_sum = original_sum.lines.reject { |l| l.chomp == gonum_gomod_line }.join
 
+              read_count = 0
               allow(File).to receive(:read).and_call_original
-              allow(File).to receive(:read).with("go.sum").and_return(original_sum, pruned_sum)
+              allow(File).to receive(:read).with("go.sum") do
+                read_count += 1
+                read_count == 1 ? original_sum : pruned_sum
+              end
 
-              # Graph shows gonum unchanged before and after
-              graph_with_gonum = Dependabot::GoModules::FileUpdater::GoModGraph.new(
+              # Graph: rsc.io/quote updated, gonum unchanged
+              graph_before = Dependabot::GoModules::FileUpdater::GoModGraph.new(
                 modules: Set[
-                  "rsc.io/quote@v1.5.2",
+                  "rsc.io/quote@v1.4.0",
                   "gonum.org/v1/gonum@v0.16.0"
                 ]
               )
@@ -309,7 +313,7 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
               allow(Dependabot::GoModules::FileUpdater::GoModGraph)
                 .to receive(:capture)
-                .and_return(graph_with_gonum, graph_after)
+                .and_return(graph_before, graph_after)
             end
 
             it "restores the unrelated go.mod checksum line" do
@@ -319,11 +323,6 @@ RSpec.describe Dependabot::GoModules::FileUpdater::GoModUpdater do
 
           context "when a module version changes legitimately" do
             before do
-              original_sum = fixture("projects", project_name, "go.sum")
-
-              allow(File).to receive(:read).and_call_original
-              allow(File).to receive(:read).with("go.sum").and_return(original_sum)
-
               # Graph shows rsc.io/quote changed version (it's being updated)
               graph_before = Dependabot::GoModules::FileUpdater::GoModGraph.new(
                 modules: Set["rsc.io/quote@v1.4.0"]


### PR DESCRIPTION
### What are you trying to accomplish?

When Dependabot updates Go dependencies, Go tooling (`go get`, `go mod tidy -e`) can over-prune `/go.mod` checksum entries from `go.sum` for transitive dependencies unrelated to the update. This causes Dependabot PRs to unexpectedly remove hash entries, leading to CI failures when downstream pipelines run `go mod tidy` and detect a diff.

The fix captures the module dependency graph (via `go mod graph`) before and after the update to determine which modules actually changed. Any `/go.mod` checksum lines removed for unchanged modules are restored, while legitimate changes from the update are preserved.

Fixes https://github.com/dependabot/dependabot-core/issues/14872

### Anything you want to highlight for special attention from reviewers?

A reusable `GoModGraph` helper is introduced for capturing and diffing Go module graphs. This can be used beyond this fix for any future need to understand module graph changes. The reconciliation is scoped precisely — it only restores `/go.mod` checksum lines for modules whose version did not change in the graph, ensuring we never interfere with legitimate dependency updates including transitive ones.

### How will you know you have accomplished your goal?

- Existing go_modules specs continue to pass.
- New specs verify: unrelated checksums are restored when over-pruned, and checksums for updated dependencies are not restored.
- Users from issue #14872 should no longer see unexpected removal of `/go.mod` checksum lines from `go.sum`.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.