### PR TITLE
add common pattern for directory specification

### DIFF
--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -57,6 +57,10 @@ function Get-SdkVersionsToInstall([string] $repoRoot, [string[]] $updateDirector
 function Get-DirectoriesMatchingPattern([string] $repoRoot, [string] $pattern) {
     $repoRoot = $repoRoot.Replace("\", "/").TrimEnd("/")
     $pattern = $pattern.Replace("\", "/").Trim("/")
+    if ($pattern -eq ".") {
+        # this handles a common scenario where `$pattern` is initially "/."
+        $pattern = ""
+    }
     $normalizedDirectory = "$repoRoot/$pattern"
     $directoryRegex = "^"
     $includeAnchor = $true

--- a/nuget/updater/test.ps1
+++ b/nuget/updater/test.ps1
@@ -52,6 +52,12 @@ try {
         -expectedSdksToInstall @("1.2.3")
 
     Test-GlobalJsonVersions `
+        -testDirectory "global-json-discovery-root-with-file" `
+        -directories @("/.") `
+        -installedSdks @("8.0.404", "9.0.101") `
+        -expectedSdksToInstall @("1.2.3")
+
+    Test-GlobalJsonVersions `
         -testDirectory "global-json-discovery-none" `
         -directories @("src") `
         -installedSdks @("8.0.404", "9.0.101") `


### PR DESCRIPTION
Recently the discovery of `global.json` files was updated but I missed a common pattern of the job file listing `"/."`.  The fix is simply to account for this in the pattern builder.

Fixes #15083