### PR TITLE
change test for file path to account for empty string

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -722,12 +722,16 @@ internal static class SdkProjectDiscovery
                 _ => null,
             };
 
-            if (packageManagementFile is not null)
+            // If a repo has an incomplete setup of package management, it's possible we detect it but then get an
+            // empty string for the special file path.  The fix is to explicitly check for that and not just a null
+            // value.  A check below will then autocorrect to default package management since that's what's really
+            // being used.
+            if (!string.IsNullOrWhiteSpace(packageManagementFile))
             {
                 packageManagementFile = Path.GetRelativePath(projectFullDirectory, packageManagementFile).NormalizePathToUnix();
             }
 
-            if (packageManagementKind != PackageManagementKind.Default && packageManagementFile is null)
+            if (packageManagementKind != PackageManagementKind.Default && string.IsNullOrWhiteSpace(packageManagementFile))
             {
                 logger.Warn($"Project [{projectRelativePath}] detected package management kind of {packageManagementKind} but no package management file found; forcing management kind to {PackageManagementKind.Default}.");
                 packageManagementKind = PackageManagementKind.Default;


### PR DESCRIPTION
A review of telemetry found an error in the wild where a repo specifies that it uses Central Package Versions but then has no `Packages.props` file.  This is most likely a copy/paste error on the repo owner's part, but nevertheless a sentinel property `UsingMicrosoftCentralPackageVersionsSdk` is set to `true` which set off the process of finding the path to the expected `Packages.props` but when pulling out the next property `CentralPackagesFile` an empty string was returned.

The fix is to change the test `is not null` to `!string.IsNullOrWhiteSpace` since an empty file name isn't possible and a check a few lines down will then revert back to "Default" package management so normal updates can proceed.

This is such an edge case I don't even want to honor it with a test, so a detailed comment in the source will have to suffice.