### PR TITLE
julia: strip JLL build metadata from versions

### DIFF
--- a/julia/lib/dependabot/julia/version.rb
+++ b/julia/lib/dependabot/julia/version.rb
@@ -25,6 +25,12 @@ module Dependabot
         # Remove 'v' prefix if present (common in Julia)
         version_string = version_string.sub(/^v/, "") if version_string.match?(/^v\d/)
 
+        # Strip build metadata suffix (e.g. "0.0.43+1" -> "0.0.43"). Julia's JLL
+        # packages use the "+N" suffix to identify rebuilds of the same source
+        # version; per semver build metadata is ignored when ordering versions,
+        # and Julia's Pkg treats "0.0.43" and "0.0.43+1" as compatibility-equivalent.
+        version_string = version_string.sub(/\+.*\z/, "")
+
         @version_string = T.let(version_string, String)
         super(version_string)
       end

--- a/julia/spec/dependabot/julia/version_spec.rb
+++ b/julia/spec/dependabot/julia/version_spec.rb
@@ -1,0 +1,82 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/julia/version"
+
+RSpec.describe Dependabot::Julia::Version do
+  describe ".correct?" do
+    it "returns true for plain versions" do
+      expect(described_class.correct?("1.2.3")).to be true
+      expect(described_class.correct?("0.0.43")).to be true
+    end
+
+    it "returns true for versions with a 'v' prefix" do
+      expect(described_class.correct?("v1.2.3")).to be true
+    end
+
+    it "returns true for versions with build metadata" do
+      expect(described_class.correct?("0.0.43+0")).to be true
+      expect(described_class.correct?("0.0.43+1")).to be true
+    end
+
+    it "returns false for non-versions" do
+      expect(described_class.correct?("not-a-version")).to be false
+    end
+
+    it "returns false for nil" do
+      expect(described_class.correct?(nil)).to be false
+    end
+  end
+
+  describe "#initialize" do
+    it "accepts a plain version" do
+      expect(described_class.new("1.2.3").to_s).to eq("1.2.3")
+    end
+
+    it "strips a leading 'v' prefix" do
+      expect(described_class.new("v1.2.3").to_s).to eq("1.2.3")
+    end
+
+    it "strips JLL build metadata" do
+      # Julia's JLL packages use the "+N" suffix to identify rebuilds of the
+      # same source version. Per semver, build metadata is ignored when ordering,
+      # and Julia's Pkg treats e.g. "0.0.43" and "0.0.43+1" as equivalent for
+      # compatibility purposes.
+      expect(described_class.new("0.0.43+0").to_s).to eq("0.0.43")
+      expect(described_class.new("0.0.43+1").to_s).to eq("0.0.43")
+      expect(described_class.new("1.2.3+build.5").to_s).to eq("1.2.3")
+    end
+
+    it "strips both 'v' prefix and build metadata" do
+      expect(described_class.new("v0.0.43+1").to_s).to eq("0.0.43")
+    end
+  end
+
+  describe "ordering" do
+    it "treats build metadata as equivalent to the source version" do
+      # Versions differing only in build metadata must compare equal so that
+      # a JLL rebuild (e.g. 0.0.43+1) does not appear as a newer release than
+      # the source version (0.0.43) it was rebuilt from.
+      expect(described_class.new("0.0.43+1") <=> described_class.new("0.0.43")).to eq(0)
+      expect(described_class.new("0.0.43+1") <=> described_class.new("0.0.43+0")).to eq(0)
+      expect(described_class.new("0.0.43+1")).to eq(described_class.new("0.0.43"))
+    end
+
+    it "compares plain versions" do
+      expect(described_class.new("1.2.3") < described_class.new("1.2.4")).to be true
+      expect(described_class.new("2.0.0") > described_class.new("1.99.99")).to be true
+    end
+  end
+
+  describe "satisfying requirements" do
+    it "considers a build-metadata version satisfied by an exact pin on the source version" do
+      # Regression: previously "=0.0.43" would not be satisfied by "0.0.43+1",
+      # causing Dependabot to propose a redundant relaxation when JLL packages
+      # published a rebuild (e.g. 0.0.43+1) of an exactly-pinned version.
+      req = Gem::Requirement.new("=0.0.43")
+      expect(req.satisfied_by?(described_class.new("0.0.43+1"))).to be true
+      expect(req.satisfied_by?(described_class.new("0.0.43+0"))).to be true
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Julia's JLL packages use a `+N` suffix on the version (e.g. `0.0.43+1`) to identify rebuilds of the same source version. Per semver, build metadata is ignored when ordering versions, and Julia's `Pkg` treats e.g. `0.0.43` and `0.0.43+1` as compatibility-equivalent.

Previously, `Dependabot::Julia::Version.new("0.0.43+1")` parsed the build suffix as an additional segment, producing `[0, 0, 43, 1]`. That sorted strictly greater than `0.0.43`, so:

- `LatestVersionFinder` reported a JLL rebuild as a newer release available for update.
- `Gem::Requirement.new("=0.0.43").satisfied_by?` returned `false` for the rebuild, so `RequirementsUpdater` did not short-circuit and appended a redundant version spec.

The result was spurious PRs like [JuliaLLVM/LLVM.jl#562](https://github.com/JuliaLLVM/LLVM.jl/pull/562), which proposed changing `LLVMExtra_jll = "=0.0.43"` to `LLVMExtra_jll = "=0.0.43, 0.0.43"` after `LLVMExtra_jll` published a `0.0.43+1` rebuild.

This change strips the `+...` suffix in the `Version` constructor so JLL rebuilds compare equal to the underlying source version, matching Julia's resolution semantics.

### Anything you want to highlight for special attention from reviewers?

The strip happens before `super`, so all downstream comparisons (`<=>`, `satisfied_by?`, sorting) see the canonical 3-segment version. `to_s` returns the stripped form, which I think is the right tradeoff — the build counter is not semantically meaningful and surfacing it elsewhere just risks the same comparison bug recurring. Open to feedback if you'd rather preserve the original string for display.

### How will you know you've accomplished your goal?

Added `julia/spec/dependabot/julia/version_spec.rb` covering:
- Parsing versions with `+N` build metadata
- Equality of `0.0.43+1` and `0.0.43` for ordering
- Exact-pin requirement (`=0.0.43`) being satisfied by a rebuild

Running locally:

```
$ bundle exec rspec spec/dependabot/julia/version_spec.rb spec/dependabot/julia/requirement_spec.rb spec/dependabot/julia/requirements_updater_spec.rb
99 examples, 0 failures
```

### Checklist

- [x] I have run the relevant pure-Ruby tests (`version_spec`, `requirement_spec`, `requirements_updater_spec`) locally. I have not run the integration tests that require the Julia helper.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request.
- [x] I have ensured that the code is well-documented and easy to understand.