### PR TITLE
julia: bump exact pins to the new target instead of appending

### DIFF
--- a/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
+++ b/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
@@ -63,6 +63,8 @@ module Dependabot
         requirement.merge(requirement: new_requirement)
       end
 
+      EXACT_PIN_REGEX = /\A\s*=\s*\d+(?:\.\d+)*\s*\z/
+
       sig { params(requirement_string: String, target_version: Dependabot::Julia::Version).returns(String) }
       def updated_version_requirement(requirement_string, target_version)
         # Don't update range requirements (e.g., "0.34-0.35") - these are explicit manual constraints
@@ -74,6 +76,11 @@ module Dependabot
         # Check if any requirement is satisfied by the target version
         # Note: This uses the implicit caret semantics from the Requirement class
         return requirement_string if reqs.any? { |req| req.satisfied_by?(target_version) }
+
+        # An exact pin (e.g. "=1.2.3") expresses a hard constraint: only that one
+        # version is acceptable. Appending a looser spec would silently relax it.
+        # Bump the pin to the new target instead, so user intent is preserved.
+        return "=#{target_version}" if requirement_string.match?(EXACT_PIN_REGEX)
 
         # Otherwise, append a new requirement that includes the target version
         # Following CompatHelper.jl's approach: use major.minor for versions >= 1.0,

--- a/julia/spec/dependabot/julia/requirements_updater_spec.rb
+++ b/julia/spec/dependabot/julia/requirements_updater_spec.rb
@@ -63,6 +63,16 @@ RSpec.describe Dependabot::Julia::RequirementsUpdater do
         ["1", "1.0.0", "1"],
         # Caret spec covering the target
         ["^2.0", "2.6.0", "^2.0"]
+      ],
+      "bumps exact pins to the new target rather than appending a looser spec" => [
+        # An exact "=X" pin expresses a hard constraint; appending would silently
+        # relax it. Bump the pin to the new exact version instead.
+        ["=6.1.0", "6.1.1", "=6.1.1"],
+        ["=6.1.0", "7.0.0", "=7.0.0"],
+        ["=0.0.43", "0.0.44", "=0.0.44"],
+        ["=1.2.3", "2.0.0", "=2.0.0"],
+        # Tolerate spaces around the operator
+        ["= 1.2.3", "1.5.0", "=1.5.0"]
       ]
     }.each do |description, test_cases|
       context "when #{description}" do


### PR DESCRIPTION
### What are you trying to accomplish?

An exact `=X` compat pin in Julia expresses a hard constraint: only that one version is acceptable. The current `RequirementsUpdater` — inheriting [CompatHelper.jl's `KeepEntry` behavior](https://github.com/dependabot/dependabot-core/commit/26949dc358f634f64614ca4f3f8fb691d068cbcb) — appends a new spec when the current requirement doesn't already satisfy the target, regardless of whether the existing spec is an exact pin:

```diff
-CUDACore = \"=6.1.0\"
+CUDACore = \"=6.1.0, 6.1\"
```

That silently relaxes the constraint to `[6.1.0, 7.0.0)`, contradicting the user's explicit pin. This is what produced [JuliaGPU/CUDA.jl#3152](https://github.com/JuliaGPU/CUDA.jl/pull/3152), where the repo pins `CUDACore = \"=6.1.0\"` and a `6.1.1` release was published.

When the entire current requirement is a single exact pin (e.g. `=6.1.0`), replace it with an exact pin to the new target (`=6.1.1`) instead of appending. This preserves the user's intent — exact pinning — while still proposing the available update.

### Anything you want to highlight for special attention from reviewers?

The fix only triggers when the **entire** requirement string is a single exact pin (regex `\\A\\s*=\\s*\\d+(?:\\.\\d+)*\\s*\\z`). Compound requirements that happen to include an `=` (e.g. `>= 1.0, < 2.0`, `=1.2.3, =1.2.4` — uncommon but legal) still go through the existing append path, since the user's intent there is less obvious.

The behavior for non-pin requirements (caret, tilde, plain, ranges) is unchanged.

### How will you know you've accomplished your goal?

Extended `requirements_updater_spec.rb` with a new context covering exact-pin bumps:

```
\"=6.1.0\", target 6.1.1   ->   \"=6.1.1\"
\"=6.1.0\", target 7.0.0   ->   \"=7.0.0\"
\"=0.0.43\", target 0.0.44 ->   \"=0.0.44\"
\"=1.2.3\", target 2.0.0   ->   \"=2.0.0\"
\"= 1.2.3\", target 1.5.0  ->   \"=1.5.0\"   # tolerates spaces around =
```

Running locally:

```
$ bundle exec rspec spec/dependabot/julia/requirements_updater_spec.rb spec/dependabot/julia/requirement_spec.rb
92 examples, 0 failures
```

### Checklist

- [x] I have run the relevant pure-Ruby tests (`requirements_updater_spec`, `requirement_spec`) locally. I have not run the integration tests that require the Julia helper.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request.
- [x] I have ensured that the code is well-documented and easy to understand.