### PR TITLE
NuGet: Add circular dependency detection to MSBuildHelper.ThrowOnError

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -646,5 +646,13 @@ public class MSBuildHelperTests : TestBase
             // expectedError
             new DependencyFileNotParseable("/path/to/packages.config", "Unexpected XML declaration. The XML declaration must be the first node in the document, and no whitespace characters are allowed to appear before it. Line 1, position 5.")
         ];
+
+        yield return
+        [
+            // output
+            "Circular dependency detected 'ReactiveProperty 3.6.0 => System.Reactive 3.1.1 => System.Reactive.PlatformServices 6.1.0 => System.Reactive 3.1.1'.",
+            // expectedError
+            new UnknownError(new Exception("Circular dependency detected"), "TEST-JOB-ID"),
+        ];
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -646,6 +646,7 @@ internal static partial class MSBuildHelper
         ThrowOnBadResponse(output);
         ThrowOnUnparseableFile(output);
         ThrowOnMultipleProjectsForPackagesConfig(output);
+        ThrowOnCircularDependency(output);
     }
 
     private static void ThrowOnUnauthenticatedFeed(string stdout)
@@ -785,6 +786,15 @@ internal static partial class MSBuildHelper
         if (output.Contains("Found multiple project files for "))
         {
             throw new Exception("Multiple project files found for single packages.config");
+        }
+    }
+
+    private static void ThrowOnCircularDependency(string output)
+    {
+        var pattern = new Regex(@"Circular dependency detected '.*'");
+        if (pattern.IsMatch(output))
+        {
+            throw new Exception("Circular dependency detected");
         }
     }
 


### PR DESCRIPTION
Add a new ThrowOnCircularDependency helper that matches the pattern 'Circular dependency detected ...' in MSBuild output and throws a plain Exception with the message 'Circular dependency detected' to enable proper grouping in telemetry.

### Changes
- Added ThrowOnCircularDependency private method in MSBuildHelper.cs
- Wired it into the ThrowOnError dispatch method
- Added test case in MSBuildHelperTests.cs verifying the pattern match