### PR TITLE
Catch FatalProtocolException from source repository initialization

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/CompatabilityChecker.cs
@@ -172,15 +172,13 @@ internal static class CompatibilityChecker
 
         foreach (var source in sources)
         {
-            var sourceRepository = Repository.Factory.GetCoreV3(source);
-            var feed = await sourceRepository.GetResourceAsync<FindPackageByIdResource>();
-            if (feed is null)
-            {
-                throw new NotSupportedException($"Failed to get FindPackageByIdResource for {source.SourceUri}");
-            }
-
+            FindPackageByIdResource feed;
             try
             {
+                var sourceRepository = Repository.Factory.GetCoreV3(source);
+                feed = await sourceRepository.GetResourceAsync<FindPackageByIdResource>()
+                    ?? throw new NotSupportedException($"Failed to get FindPackageByIdResource for {source.SourceUri}");
+
                 // a non-compliant v2 API returning 404 can cause this to throw
                 var exists = await feed.DoesPackageExistAsync(
                     package.Id,


### PR DESCRIPTION
Move sourceRepository and GetResourceAsync calls inside the existing try/catch block in CompatabilityChecker.cs so that FatalProtocolException thrown during feed resolution is handled the same as failures during DoesPackageExistAsync.