### PR TITLE
Fix gomod tag resolution for monorepos with path-prefixed tags

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -85,7 +85,9 @@ module Dependabot
                  .select { |tag| tag_matches_version?(tag, new_version) }
                  .sort_by(&:length)
 
-          tags.find { |t| t.include?(dependency.name) } || tags.first
+          tags.find { |t| t.include?(dependency.name) } ||
+            preferred_tag_by_directory(tags) ||
+            tags.first
         end
 
         private
@@ -105,7 +107,9 @@ module Dependabot
                    .select { |tag| tag_matches_version?(tag, previous_version) }
                    .sort_by(&:length)
 
-            tags.find { |t| t.include?(dependency.name) } || tags.first
+            tags.find { |t| t.include?(dependency.name) } ||
+              preferred_tag_by_directory(tags) ||
+              tags.first
           elsif !git_source?(dependency.previous_requirements)
             lowest_tag_satisfying_previous_requirements
           end
@@ -120,7 +124,17 @@ module Dependabot
                  .select { |t| satisfies_previous_reqs?(version_from_tag(t)) }
                  .sort_by { |t| [version_from_tag(t), t.length] }
 
-          tags.find { |t| t.include?(dependency.name) } || tags.first
+          tags.find { |t| t.include?(dependency.name) } ||
+            preferred_tag_by_directory(tags) ||
+            tags.first
+        end
+
+        sig { params(tags: T::Array[String]).returns(T.nilable(String)) }
+        def preferred_tag_by_directory(tags)
+          return unless source&.directory
+          return if [".", "/"].include?(source.directory)
+
+          tags.find { |t| t.start_with?("#{T.must(source).directory}/") }
         end
 
         sig { params(tag: String).returns(T.nilable(Dependabot::Version)) }

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -85,9 +85,7 @@ module Dependabot
                  .select { |tag| tag_matches_version?(tag, new_version) }
                  .sort_by(&:length)
 
-          tags.find { |t| t.include?(dependency.name) } ||
-            preferred_tag_by_directory(tags) ||
-            tags.first
+          pick_preferred_tag(tags)
         end
 
         private
@@ -107,9 +105,7 @@ module Dependabot
                    .select { |tag| tag_matches_version?(tag, previous_version) }
                    .sort_by(&:length)
 
-            tags.find { |t| t.include?(dependency.name) } ||
-              preferred_tag_by_directory(tags) ||
-              tags.first
+            pick_preferred_tag(tags)
           elsif !git_source?(dependency.previous_requirements)
             lowest_tag_satisfying_previous_requirements
           end
@@ -124,17 +120,15 @@ module Dependabot
                  .select { |t| satisfies_previous_reqs?(version_from_tag(t)) }
                  .sort_by { |t| [version_from_tag(t), t.length] }
 
-          tags.find { |t| t.include?(dependency.name) } ||
-            preferred_tag_by_directory(tags) ||
-            tags.first
+          pick_preferred_tag(tags)
         end
 
         sig { params(tags: T::Array[String]).returns(T.nilable(String)) }
-        def preferred_tag_by_directory(tags)
-          return unless source&.directory
-          return if [".", "/"].include?(source.directory)
-
-          tags.find { |t| t.start_with?("#{T.must(source).directory}/") }
+        def pick_preferred_tag(tags)
+          dir = source&.directory
+          tags.find { |t| t.include?(dependency.name) } ||
+            (dir && ![".", "/"].include?(dir) && tags.find { |t| t.start_with?("#{dir}/") }) ||
+            tags.first
         end
 
         sig { params(tag: String).returns(T.nilable(Dependabot::Version)) }

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -90,7 +90,6 @@ module Dependabot
 
         private
 
-        # rubocop:disable Metrics/PerceivedComplexity
         sig { returns(T.nilable(String)) }
         def previous_tag
           previous_version = dependency.previous_version
@@ -110,8 +109,6 @@ module Dependabot
             lowest_tag_satisfying_previous_requirements
           end
         end
-
-        # rubocop:enable Metrics/PerceivedComplexity
 
         sig { returns(T.nilable(String)) }
         def lowest_tag_satisfying_previous_requirements

--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -110,7 +110,7 @@ module Dependabot
 
           return releases_with_dependency_name if releases_with_dependency_name.any?
 
-          if source&.directory && ![".", "/"].include?(source.directory)
+          if source&.directory && ![".", "/"].include?(T.must(source).directory)
             releases_with_dir_prefix =
               releases
               .reject { |r| r.tag_name.nil? }

--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -108,9 +108,18 @@ module Dependabot
             .reject { |r| r.tag_name.nil? }
             .select { |r| r.tag_name.start_with?(dep_prefix) }
 
-          return releases unless releases_with_dependency_name.any?
+          return releases_with_dependency_name if releases_with_dependency_name.any?
 
-          releases_with_dependency_name
+          if source&.directory && ![".", "/"].include?(source.directory)
+            releases_with_dir_prefix =
+              releases
+              .reject { |r| r.tag_name.nil? }
+              .select { |r| r.tag_name.start_with?("#{T.must(source).directory}/") }
+
+            return releases_with_dir_prefix if releases_with_dir_prefix.any?
+          end
+
+          releases
         end
 
         sig { returns(T::Array[T.untyped]) }

--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
       let(:dependency_name) { "github.com/opentdf/platform/protocol/go" }
       let(:dependency_version) { "0.31.0" }
       let(:dependency_previous_version) { "0.30.0" }
-      let(:package_manager) { "go_modules" }
+      let(:package_manager) { "dummy" }
       let(:source) do
         Dependabot::Source.new(
           provider: "github",

--- a/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/commits_finder_spec.rb
@@ -255,6 +255,42 @@ RSpec.describe Dependabot::MetadataFinders::Base::CommitsFinder do
       end
     end
 
+    context "with a Go module monorepo using path-prefixed tags" do
+      let(:dependency_name) { "github.com/opentdf/platform/protocol/go" }
+      let(:dependency_version) { "0.31.0" }
+      let(:dependency_previous_version) { "0.30.0" }
+      let(:package_manager) { "go_modules" }
+      let(:source) do
+        Dependabot::Source.new(
+          provider: "github",
+          repo: "opentdf/platform",
+          directory: "protocol/go"
+        )
+      end
+
+      before do
+        allow(builder)
+          .to receive(:fetch_dependency_tags)
+          .and_return(
+            %w(
+              otdfctl/v0.31.0
+              otdfctl/v0.30.0
+              protocol/go/v0.31.0
+              protocol/go/v0.30.0
+              sdk/v0.20.0
+              sdk/v0.19.0
+            )
+          )
+      end
+
+      it "uses the correct path-prefixed tags" do
+        expect(commits_url).to eq(
+          "https://github.com/opentdf/platform/" \
+          "compare/protocol/go/v0.30.0...protocol/go/v0.31.0"
+        )
+      end
+    end
+
     context "with a github repo and tags with no prefix" do
       before do
         allow(builder)

--- a/common/spec/dependabot/metadata_finders/base/release_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/release_finder_spec.rb
@@ -559,6 +559,38 @@ RSpec.describe Dependabot::MetadataFinders::Base::ReleaseFinder do
       end
     end
 
+    context "with a Go module monorepo using path-prefixed tags" do
+      let(:dependency_name) { "github.com/opentdf/platform/protocol/go" }
+      let(:dependency_version) { "0.31.0" }
+      let(:dependency_previous_version) { "0.30.0" }
+      let(:source) do
+        Dependabot::Source.new(
+          provider: "github",
+          repo: "opentdf/platform",
+          directory: "protocol/go"
+        )
+      end
+
+      let(:github_url) do
+        "https://api.github.com/repos/opentdf/platform/" \
+          "releases?per_page=100"
+      end
+
+      before do
+        stub_request(:get, github_url)
+          .to_return(
+            status: 200,
+            body: fixture("github", "go_monorepo_releases.json"),
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "only includes releases for the correct module" do
+        expect(releases_text).to include("remove deprecated grpc-gateway")
+        expect(releases_text).not_to include("migrate otdfctl")
+      end
+    end
+
     context "with a gitlab source" do
       let(:gitlab_url) do
         "https://gitlab.com/api/v4/projects/org%2Fbusiness/repository/tags"

--- a/common/spec/fixtures/github/go_monorepo_releases.json
+++ b/common/spec/fixtures/github/go_monorepo_releases.json
@@ -1,0 +1,42 @@
+[
+    {
+        "url": "https://api.github.com/repos/opentdf/platform/releases/1",
+        "html_url": "https://github.com/opentdf/platform/releases/tag/otdfctl/v0.31.0",
+        "id": 1,
+        "tag_name": "otdfctl/v0.31.0",
+        "name": "otdfctl: v0.31.0",
+        "draft": false,
+        "prerelease": false,
+        "body": "### Features\n- cli: migrate otdfctl into platform monorepo"
+    },
+    {
+        "url": "https://api.github.com/repos/opentdf/platform/releases/2",
+        "html_url": "https://github.com/opentdf/platform/releases/tag/protocol/go/v0.31.0",
+        "id": 2,
+        "tag_name": "protocol/go/v0.31.0",
+        "name": "protocol/go: v0.31.0",
+        "draft": false,
+        "prerelease": false,
+        "body": "### Bug Fixes\n- core: remove deprecated grpc-gateway"
+    },
+    {
+        "url": "https://api.github.com/repos/opentdf/platform/releases/3",
+        "html_url": "https://github.com/opentdf/platform/releases/tag/protocol/go/v0.30.0",
+        "id": 3,
+        "tag_name": "protocol/go/v0.30.0",
+        "name": "protocol/go: v0.30.0",
+        "draft": false,
+        "prerelease": false,
+        "body": "### Bug Fixes\n- core: previous release notes"
+    },
+    {
+        "url": "https://api.github.com/repos/opentdf/platform/releases/4",
+        "html_url": "https://github.com/opentdf/platform/releases/tag/otdfctl/v0.30.0",
+        "id": 4,
+        "tag_name": "otdfctl/v0.30.0",
+        "name": "otdfctl: v0.30.0",
+        "draft": false,
+        "prerelease": false,
+        "body": "### Features\n- cli: old release"
+    }
+]

--- a/go_modules/lib/dependabot/go_modules/metadata_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/metadata_finder.rb
@@ -17,7 +17,17 @@ module Dependabot
       sig { override.returns(T.nilable(Source)) }
       def look_up_source
         url = Dependabot::GoModules::PathConverter.git_url_for_path(dependency.name)
-        Source.from_url(url) if url
+        return unless url
+
+        source = Source.from_url(url)
+        return unless source
+
+        repo_import_path = url.gsub(%r{^https?://}, "").chomp("/").chomp(".git")
+        if dependency.name.start_with?("#{repo_import_path}/")
+          source.directory = dependency.name.delete_prefix("#{repo_import_path}/")
+        end
+
+        source
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/metadata_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/metadata_finder.rb
@@ -22,7 +22,7 @@ module Dependabot
         source = Source.from_url(url)
         return unless source
 
-        repo_import_path = url.gsub(%r{^https?://}, "").chomp("/").chomp(".git")
+        repo_import_path = source.url.gsub(%r{^https?://}, "").chomp("/").chomp(".git")
         if dependency.name.start_with?("#{repo_import_path}/")
           source.directory = dependency.name.delete_prefix("#{repo_import_path}/")
         end

--- a/go_modules/spec/dependabot/go_modules/metadata_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/metadata_finder_spec.rb
@@ -65,5 +65,29 @@ RSpec.describe Dependabot::GoModules::MetadataFinder do
 
       it { is_expected.to eq("https://github.com/satori/go.uuid") }
     end
+
+    context "with a subdirectory module in a monorepo" do
+      let(:dependency_name) { "github.com/opentdf/platform/protocol/go" }
+      let(:requirements) { [] }
+
+      it { is_expected.to eq("https://github.com/opentdf/platform") }
+
+      it "sets directory to the module subdirectory" do
+        finder.source_url
+        source = finder.send(:source)
+        expect(source.directory).to eq("protocol/go")
+      end
+    end
+
+    context "with a root module" do
+      let(:dependency_name) { "github.com/satori/go.uuid" }
+      let(:requirements) { [] }
+
+      it "does not set a directory" do
+        finder.source_url
+        source = finder.send(:source)
+        expect(source.directory).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

In Go monorepos with multiple independently versioned modules (like [opentdf/platform](https://github.com/opentdf/platform)), Dependabot generates wrong compare links and includes release notes from the wrong component in PR descriptions.

The root cause: when two modules share the same version number (e.g., `otdfctl/v0.31.0` and `protocol/go/v0.31.0`), `CommitsFinder` and `ReleaseFinder` can't disambiguate the tags and fall back to the shortest or first match. This produces compare links like `protocol/go/v0.30.0...otdfctl/v0.31.0` instead of the correct `protocol/go/v0.30.0...protocol/go/v0.31.0`.

This is the gomod equivalent of #11286 which fixed the same bug for the `github_actions` ecosystem.

Fixes #15119

### Anything you want to highlight for special attention from reviewers?

The fix is split across three layers, all additive:

1. **GoModules MetadataFinder** now derives the module's subdirectory path from the dependency name and sets `source.directory`. For `github.com/opentdf/platform/protocol/go`, this is `"protocol/go"`. Root-level modules get no directory set, so existing behavior is preserved.

2. **CommitsFinder** gets a new `preferred_tag_by_directory` helper that tries to match tags starting with the `source.directory` prefix. This sits between the existing `include?(dependency.name)` check and the `tags.first` fallback, so it only activates when the directory is set.

3. **ReleaseFinder** gets a similar fallback in `all_dep_releases` that filters releases by the directory prefix before falling through to returning all releases.

I considered putting all the logic in the gomod-specific MetadataFinder, but the tag selection happens in the common layer's `CommitsFinder` and `ReleaseFinder`. Overriding those at the ecosystem level would have required subclassing or monkey-patching, which felt heavier than adding a clean fallback path. The common layer changes only activate when `source.directory` is set, so other ecosystems are unaffected.

Note that `go_modules` is intentionally NOT added to `PACKAGE_MANAGERS_WITH_RELIABLE_DIRECTORIES`. This means `part_of_monorepo?` stays false and the compare URL format remains `compare/tag1...tag2` (not the directory-scoped commits view).

### How will you know you've accomplished your goal?

The PR that originally surfaced this issue ([opentdf/platform#3496](https://github.com/opentdf/platform/pull/3496)) shows `otdfctl: v0.31.0` release notes in a PR about `protocol/go`. With this fix, the tag resolution would correctly pick `protocol/go/v0.31.0` and only show the relevant release notes.

I've added tests for all three changes:
- **MetadataFinder spec**: verifies `source.directory` is set for subdirectory modules and nil for root modules
- **CommitsFinder spec**: verifies the compare URL uses the correct path-prefixed tags in a Go monorepo scenario
- **ReleaseFinder spec**: verifies only the correct module's releases are included when filtering by directory prefix

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.