### PR TITLE
NuGet: Remove redundant GetPackageGraphForDependencies and use discovery DependencyGraph

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -2266,4 +2266,63 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             }
         );
     }
+
+    [Theory]
+    [InlineData("net10.0", "net10.0")]
+    [InlineData("net10.0-android", "net10.0")]
+    [InlineData("net10.0-android", "net10.0-android")]
+    public async Task TestDependencyGraphWithDifferentTargetFrameworks(string projectTfm, string packageTfm)
+    {
+        await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Parent.Package", "1.0.0", packageTfm,
+                    dependencyGroups: [(null, [("Transitive.Package", "2.0.0")])]),
+                MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.0.0", packageTfm,
+                    dependencyGroups: [(null, [("Super.Transitive.Package", "3.0.0")])]),
+                MockNuGetPackage.CreateSimplePackage("Super.Transitive.Package", "3.0.0", "net8.0"),
+            ],
+            workspacePath: "src",
+            files:
+            [
+                ("src/project.csproj", $"""
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFrameworks>{projectTfm}</TargetFrameworks>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Parent.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects =
+                [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = [projectTfm],
+                        Dependencies =
+                        [
+                            new Dependency("Parent.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: [projectTfm]),
+                            new Dependency("Super.Transitive.Package", "3.0.0", DependencyType.Unknown, TargetFrameworks: [projectTfm], IsTopLevel: false),
+                            new Dependency("Transitive.Package", "2.0.0", DependencyType.Unknown, TargetFrameworks: [projectTfm], IsTopLevel: false),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                        ExpectedDependencyGraph = new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["Parent.Package/1.0.0"] = ["Transitive.Package/2.0.0"],
+                            ["Transitive.Package/2.0.0"] = ["Super.Transitive.Package/3.0.0"],
+                            ["Super.Transitive.Package/3.0.0"] = [],
+                        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
+                    }
+                ]
+            }
+        );
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackageReferenceUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackageReferenceUpdaterTests.cs
@@ -12,7 +12,7 @@ namespace NuGetUpdater.Core.Test.Update;
 public class PackageReferenceUpdaterTests
 {
     [Fact]
-    public void BuildReverseGraph_ReturnsCorrectParentsAndVersions()
+    public void BuildReverseGraph_ReturnsCorrectParents()
     {
         // arrange
         var dependencyGraph = new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
@@ -23,14 +23,30 @@ public class PackageReferenceUpdaterTests
         }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
         // act
-        var (packageParents, packageVersions) = PackageReferenceUpdater.BuildReverseGraph(dependencyGraph, new TestLogger());
+        var packageParents = PackageReferenceUpdater.BuildReverseGraph(dependencyGraph, new TestLogger());
 
         // assert
-        Assert.Equal("1.0.0", packageVersions["Parent.Package"].ToString());
-        Assert.Equal("2.0.0", packageVersions["Transitive.Package"].ToString());
-        Assert.Equal("3.0.0", packageVersions["Super.Transitive.Package"].ToString());
         Assert.Equal("Parent.Package", packageParents["Transitive.Package"].Single());
         Assert.Equal("Transitive.Package", packageParents["Super.Transitive.Package"].Single());
+    }
+
+    [Fact]
+    public void BuildReverseGraph_HandlesMultipleVersionsOfSamePackage()
+    {
+        // arrange - simulates a merged graph where the same package appears at different versions
+        var dependencyGraph = new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Parent.Package/1.0.0"] = ["Child.Package/1.0.0"],
+            ["Parent.Package/2.0.0"] = ["Child.Package/2.0.0"],
+            ["Child.Package/1.0.0"] = [],
+            ["Child.Package/2.0.0"] = [],
+        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+
+        // act
+        var packageParents = PackageReferenceUpdater.BuildReverseGraph(dependencyGraph, new TestLogger());
+
+        // assert - both version entries contribute the same parent name
+        Assert.Equal("Parent.Package", packageParents["Child.Package"].Single());
     }
 
     [Theory]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackageReferenceUpdaterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/PackageReferenceUpdaterTests.cs
@@ -11,72 +11,62 @@ namespace NuGetUpdater.Core.Test.Update;
 
 public class PackageReferenceUpdaterTests
 {
-    [Theory]
-    [InlineData("net9.0", "net9.0")]
-    [InlineData("net9.0-android", "net9.0")]
-    [InlineData("net9.0-android", "net9.0-android")]
-    public async Task GetPackageGraphForDependencies_DifferentTargetFrameworks(string projectTfm, string packageTfm)
+    [Fact]
+    public void BuildReverseGraph_ReturnsCorrectParentsAndVersions()
     {
         // arrange
-        using var repoRoot = await TemporaryDirectory.CreateWithContentsAsync(("project.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"));
-        var projectPath = Path.Combine(repoRoot.DirectoryPath, "project.csproj");
-        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory([
-            MockNuGetPackage.CreateSimplePackage("Parent.Package", "1.0.0", packageTfm, [(null, [("Transitive.Package", "2.0.0")])]),
-            MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.0.0", packageTfm, [(null, [("Super.Transitive.Package", "3.0.0")])]),
-            MockNuGetPackage.CreateSimplePackage("Super.Transitive.Package", "3.0.0", "net8.0"), // explicitly a different but compatible tfm
-        ], repoRoot.DirectoryPath);
-        var topLevelDependencies = new[]
+        var dependencyGraph = new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
         {
-            new Dependency("Parent.Package", "1.0.0", DependencyType.PackageReference),
-        };
+            ["Parent.Package/1.0.0"] = ["Transitive.Package/2.0.0"],
+            ["Transitive.Package/2.0.0"] = ["Super.Transitive.Package/3.0.0"],
+            ["Super.Transitive.Package/3.0.0"] = [],
+        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
         // act
-        var packageGraph = await PackageReferenceUpdater.GetPackageGraphForDependencies(repoRoot.DirectoryPath, projectPath, projectTfm, [.. topLevelDependencies], new TestLogger());
+        var (packageParents, packageVersions) = PackageReferenceUpdater.BuildReverseGraph(dependencyGraph, new TestLogger());
 
         // assert
-        Assert.Equal("1.0.0", packageGraph.PackageVersions["Parent.Package"].ToString());
-        Assert.Equal("2.0.0", packageGraph.PackageVersions["Transitive.Package"].ToString());
-        Assert.Equal("3.0.0", packageGraph.PackageVersions["Super.Transitive.Package"].ToString());
-        Assert.Equal("Parent.Package", packageGraph.PackageParents["Transitive.Package"].Single());
-        Assert.Equal("Transitive.Package", packageGraph.PackageParents["Super.Transitive.Package"].Single());
+        Assert.Equal("1.0.0", packageVersions["Parent.Package"].ToString());
+        Assert.Equal("2.0.0", packageVersions["Transitive.Package"].ToString());
+        Assert.Equal("3.0.0", packageVersions["Super.Transitive.Package"].ToString());
+        Assert.Equal("Parent.Package", packageParents["Transitive.Package"].Single());
+        Assert.Equal("Transitive.Package", packageParents["Super.Transitive.Package"].Single());
     }
 
     [Theory]
     [MemberData(nameof(ComputeUpdateOperationsTestData))]
-    public async Task ComputeUpdateOperations
+    public void ComputeUpdateOperations
     (
         ImmutableArray<Dependency> topLevelDependencies,
         ImmutableArray<Dependency> requestedUpdates,
         ImmutableArray<Dependency> resolvedDependencies,
+        ImmutableDictionary<string, ImmutableArray<string>> dependencyGraph,
         ImmutableArray<UpdateOperationBase> expectedUpdateOperations
     )
     {
-        // arrange
-        using var repoRoot = await TemporaryDirectory.CreateWithContentsAsync(("project.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\" />"));
-        var projectPath = Path.Combine(repoRoot.DirectoryPath, "project.csproj");
-        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory([
-            MockNuGetPackage.CreateSimplePackage("Parent.Package", "1.0.0", "net9.0", [(null, [("Transitive.Package", "1.0.0")])]),
-            MockNuGetPackage.CreateSimplePackage("Parent.Package", "2.0.0", "net9.0", [(null, [("Transitive.Package", "2.0.0")])]),
-            MockNuGetPackage.CreateSimplePackage("Transitive.Package", "1.0.0", "net9.0", [(null, [("Super.Transitive.Package", "1.0.0")])]),
-            MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.0.0", "net9.0", [(null, [("Super.Transitive.Package", "2.0.0")])]),
-            MockNuGetPackage.CreateSimplePackage("Super.Transitive.Package", "1.0.0", "net9.0"),
-            MockNuGetPackage.CreateSimplePackage("Super.Transitive.Package", "2.0.0", "net9.0"),
-            MockNuGetPackage.CreateSimplePackage("Unrelated.Package", "1.0.0", "net9.0"),
-        ], repoRoot.DirectoryPath);
-
         // act
-        var actualUpdateOperations = await PackageReferenceUpdater.ComputeUpdateOperations(
-            repoRoot.DirectoryPath,
-            projectPath,
-            "net9.0",
+        var actualUpdateOperations = PackageReferenceUpdater.ComputeUpdateOperations(
             topLevelDependencies,
             requestedUpdates,
             resolvedDependencies,
+            dependencyGraph,
             new TestLogger());
 
         // assert
         AssertEx.Equal(expectedUpdateOperations, actualUpdateOperations);
     }
+
+    /// <summary>
+    /// A dependency graph representing:
+    ///   Parent.Package/2.0.0 -> Transitive.Package/2.0.0 -> Super.Transitive.Package/2.0.0
+    /// </summary>
+    private static readonly ImmutableDictionary<string, ImmutableArray<string>> TestDependencyGraph =
+        new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Parent.Package/2.0.0"] = ["Transitive.Package/2.0.0"],
+            ["Transitive.Package/2.0.0"] = ["Super.Transitive.Package/2.0.0"],
+            ["Super.Transitive.Package/2.0.0"] = [],
+        }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
 
     public static IEnumerable<object[]> ComputeUpdateOperationsTestData()
     {
@@ -99,6 +89,13 @@ public class PackageReferenceUpdaterTests
                 new Dependency("Some.Package", "1.0.1", DependencyType.PackageReference),
                 new Dependency("Unrelated.Package", "2.0.0", DependencyType.PackageReference)
             ),
+
+            // dependencyGraph
+            new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Some.Package/1.0.1"] = [],
+                ["Unrelated.Package/2.0.0"] = [],
+            }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
 
             // expectedUpdateOperations
             ImmutableArray.Create<UpdateOperationBase>(
@@ -130,6 +127,13 @@ public class PackageReferenceUpdaterTests
                 new Dependency("Transitive.Package", "2.0.0", DependencyType.PackageReference)
             ),
 
+            // dependencyGraph
+            new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Top.Level.Package/1.0.0"] = ["Transitive.Package/2.0.0"],
+                ["Transitive.Package/2.0.0"] = [],
+            }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
+
             // expectedUpdateOperations
             ImmutableArray.Create<UpdateOperationBase>(
                 new PinnedUpdate()
@@ -158,6 +162,9 @@ public class PackageReferenceUpdaterTests
             ImmutableArray.Create(
                 new Dependency("Parent.Package", "2.0.0", DependencyType.PackageReference)
             ),
+
+            // dependencyGraph
+            TestDependencyGraph,
 
             // expectedUpdateOperations
             ImmutableArray.Create<UpdateOperationBase>(
@@ -190,6 +197,9 @@ public class PackageReferenceUpdaterTests
                 new Dependency("Parent.Package", "2.0.0", DependencyType.PackageReference)
             ),
 
+            // dependencyGraph
+            TestDependencyGraph,
+
             // expectedUpdateOperations
             ImmutableArray.Create<UpdateOperationBase>(
                 new ParentUpdate()
@@ -218,6 +228,12 @@ public class PackageReferenceUpdaterTests
             ImmutableArray.Create(
                 new Dependency("Parent.Package", "1.0.0", DependencyType.PackageReference)
             ),
+            // dependencyGraph
+            new Dictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Parent.Package/1.0.0"] = ["Transitive.Package/1.0.0"],
+                ["Transitive.Package/1.0.0"] = [],
+            }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
             // expectedUpdateOperations
             ImmutableArray<UpdateOperationBase>.Empty,
         ];
@@ -239,6 +255,8 @@ public class PackageReferenceUpdaterTests
                 new Dependency("Parent.Package", "2.0.0", DependencyType.PackageReference),
                 new Dependency("Unrelated.Package", "1.0.0", DependencyType.PackageReference)
             ),
+            // dependencyGraph
+            TestDependencyGraph,
             // expectedUpdateOperations
             ImmutableArray.Create<UpdateOperationBase>(
                 new ParentUpdate()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
@@ -302,13 +302,11 @@ public class FileWriterWorker
                 continue;
             }
 
-            var computedUpdateOperations = await PackageReferenceUpdater.ComputeUpdateOperations(
-                repoContentsPath.FullName,
-                projectPath.FullName,
-                targetFramework,
+            var computedUpdateOperations = PackageReferenceUpdater.ComputeUpdateOperations(
                 initialTopLevelDependencies,
                 desiredDependencies,
                 resolvedDependencies.Value,
+                finalProjectDiscovery.DependencyGraph,
                 _logger);
             var filteredUpdateOperations = computedUpdateOperations
                 .Where(op =>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
@@ -1,7 +1,5 @@
 using System.Collections.Immutable;
-using System.Text.Json;
 
-using NuGet.Frameworks;
 using NuGet.Versioning;
 
 using NuGetUpdater.Core.Updater;
@@ -22,13 +20,11 @@ namespace NuGetUpdater.Core;
 /// </remarks>
 internal static class PackageReferenceUpdater
 {
-    internal static async Task<IEnumerable<UpdateOperationBase>> ComputeUpdateOperations(
-        string repoRoot,
-        string projectPath,
-        string targetFramework,
+    internal static IEnumerable<UpdateOperationBase> ComputeUpdateOperations(
         ImmutableArray<Dependency> topLevelDependencies,
         ImmutableArray<Dependency> requestedUpdates,
         ImmutableArray<Dependency> resolvedDependencies,
+        ImmutableDictionary<string, ImmutableArray<string>> dependencyGraph,
         ILogger logger
     )
     {
@@ -40,7 +36,7 @@ internal static class PackageReferenceUpdater
             .Where(d => d.Item2)
             .ToDictionary(d => d.Item1, d => d.Item3!, StringComparer.OrdinalIgnoreCase);
 
-        var (packageParents, packageVersions) = await GetPackageGraphForDependencies(repoRoot, projectPath, targetFramework, resolvedDependencies, logger);
+        var (packageParents, packageVersions) = BuildReverseGraph(dependencyGraph, logger);
         var updateOperations = new List<UpdateOperationBase>();
         foreach (var (requestedDependencyName, requestedDependencyVersion) in requestedVersions)
         {
@@ -108,57 +104,46 @@ internal static class PackageReferenceUpdater
         return [.. updateOperations];
     }
 
-    internal static async Task<(Dictionary<string, HashSet<string>> PackageParents, Dictionary<string, NuGetVersion> PackageVersions)> GetPackageGraphForDependencies(string repoRoot, string projectPath, string targetFramework, ImmutableArray<Dependency> topLevelDependencies, ILogger logger)
+    /// <summary>
+    /// Converts a forward dependency graph (keyed as "Name/Version" -> children as "Name/Version") into a reverse
+    /// graph of package parents and a version lookup, suitable for walking transitive dependency chains upward.
+    /// </summary>
+    internal static (Dictionary<string, HashSet<string>> PackageParents, Dictionary<string, NuGetVersion> PackageVersions) BuildReverseGraph(
+        ImmutableDictionary<string, ImmutableArray<string>> dependencyGraph, ILogger logger)
     {
         var packageParents = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
         var packageVersions = new Dictionary<string, NuGetVersion>(StringComparer.OrdinalIgnoreCase);
-        var tempDir = Directory.CreateTempSubdirectory("_package_graph_for_dependencies_");
-        try
-        {
-            // generate project.assets.json
-            var parsedTargetFramework = NuGetFramework.Parse(targetFramework);
-            var tempProject = await MSBuildHelper.CreateTempProjectAsync(tempDir, repoRoot, projectPath, targetFramework, topLevelDependencies, logger, importDependencyTargets: true);
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync([tempProject, "/t:Restore,GenerateBuildDependencyFile"], tempDir.FullName);
-            var assetsJsonPath = Path.Join(tempDir.FullName, "obj", "project.assets.json");
-            var assetsJsonContent = await File.ReadAllTextAsync(assetsJsonPath);
 
-            // build reverse dependency graph
-            var assets = JsonDocument.Parse(assetsJsonContent).RootElement;
-            var tfmObjects = assets.GetProperty("targets").EnumerateObject().ToImmutableArray();
-            if (tfmObjects.Length != 1)
+        foreach (var (key, children) in dependencyGraph)
+        {
+            var parts = key.Split('/');
+            if (parts.Length != 2)
             {
-                logger.Error($"Expected exactly one target framework group compatible with {targetFramework} but found {tfmObjects.Length}.  Values: {tfmObjects.Select(t => t.Name)}");
-                return (packageParents, packageVersions);
+                logger.Error($"Expected dependency graph key in 'Name/Version' format but got '{key}'.");
+                continue;
             }
 
-            foreach (var parentObject in tfmObjects[0].Value.EnumerateObject())
+            var parentName = parts[0];
+            if (NuGetVersion.TryParse(parts[1], out var parentVersion))
             {
-                var parts = parentObject.Name.Split('/');
-                var parentName = parts[0];
-                var parentVersion = parts[1];
-                packageVersions[parentName] = NuGetVersion.Parse(parentVersion);
+                packageVersions[parentName] = parentVersion;
+            }
 
-                if (parentObject.Value.TryGetProperty("dependencies", out var dependencies))
+            foreach (var child in children)
+            {
+                var childParts = child.Split('/');
+                if (childParts.Length != 2)
                 {
-                    foreach (var childObject in dependencies.EnumerateObject())
-                    {
-                        var childName = childObject.Name;
-                        var parentSet = packageParents.GetOrAdd(childName, () => new(StringComparer.OrdinalIgnoreCase));
-                        parentSet.Add(parentName);
-                    }
+                    logger.Error($"Expected dependency graph entry in 'Name/Version' format but got '{child}'.");
+                    continue;
                 }
-            }
 
-            return (packageParents, packageVersions);
+                var childName = childParts[0];
+                var parentSet = packageParents.GetOrAdd(childName, () => new(StringComparer.OrdinalIgnoreCase));
+                parentSet.Add(parentName);
+            }
         }
-        catch (Exception ex)
-        {
-            logger.Error($"Error while generating package graph: {ex.Message}");
-            throw;
-        }
-        finally
-        {
-            tempDir.Delete(recursive: true);
-        }
+
+        return (packageParents, packageVersions);
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackageReferenceUpdater.cs
@@ -36,7 +36,7 @@ internal static class PackageReferenceUpdater
             .Where(d => d.Item2)
             .ToDictionary(d => d.Item1, d => d.Item3!, StringComparer.OrdinalIgnoreCase);
 
-        var (packageParents, packageVersions) = BuildReverseGraph(dependencyGraph, logger);
+        var packageParents = BuildReverseGraph(dependencyGraph, logger);
         var updateOperations = new List<UpdateOperationBase>();
         foreach (var (requestedDependencyName, requestedDependencyVersion) in requestedVersions)
         {
@@ -90,7 +90,7 @@ internal static class PackageReferenceUpdater
                                 NewVersion = requestedVersions[requestedDependencyName],
                                 UpdatedFiles = [],
                                 ParentDependencyName = rootPackageName,
-                                ParentNewVersion = packageVersions[rootPackageName],
+                                ParentNewVersion = rootPackageVersion,
                             });
                         }
                     }
@@ -106,13 +106,12 @@ internal static class PackageReferenceUpdater
 
     /// <summary>
     /// Converts a forward dependency graph (keyed as "Name/Version" -> children as "Name/Version") into a reverse
-    /// graph of package parents and a version lookup, suitable for walking transitive dependency chains upward.
+    /// graph of package parents, suitable for walking transitive dependency chains upward.
     /// </summary>
-    internal static (Dictionary<string, HashSet<string>> PackageParents, Dictionary<string, NuGetVersion> PackageVersions) BuildReverseGraph(
+    internal static Dictionary<string, HashSet<string>> BuildReverseGraph(
         ImmutableDictionary<string, ImmutableArray<string>> dependencyGraph, ILogger logger)
     {
         var packageParents = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-        var packageVersions = new Dictionary<string, NuGetVersion>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var (key, children) in dependencyGraph)
         {
@@ -124,10 +123,6 @@ internal static class PackageReferenceUpdater
             }
 
             var parentName = parts[0];
-            if (NuGetVersion.TryParse(parts[1], out var parentVersion))
-            {
-                packageVersions[parentName] = parentVersion;
-            }
 
             foreach (var child in children)
             {
@@ -144,6 +139,6 @@ internal static class PackageReferenceUpdater
             }
         }
 
-        return (packageParents, packageVersions);
+        return packageParents;
     }
 }


### PR DESCRIPTION
Now that project discovery generates a package graph, this PR removes duplicate code and instead uses the existing package graph to determine what update operations were performed.  One package parent test was moved to be a discovery test since that's where the bulk of the work now happens.

----

Replace the `GetPackageGraphForDependencies` method (which created a temp project, ran `dotnet restore`, and parsed `project.assets.json`) with `BuildReverseGraph`, a pure in-memory function that derives the same `(PackageParents, PackageVersions)` data from the discovery's existing `DependencyGraph` property.

## Changes

- **PackageReferenceUpdater.cs**: Removed `GetPackageGraphForDependencies` and replaced with `BuildReverseGraph` which converts the forward dependency graph (already available from project discovery) into the reverse parent/version lookup. `ComputeUpdateOperations` is now synchronous and no longer performs I/O.
- **FileWriterWorker.cs**: Updated the call site to pass `finalProjectDiscovery.DependencyGraph` directly.
- **PackageReferenceUpdaterTests.cs**: Replaced the integration test with a unit test for `BuildReverseGraph` and updated `ComputeUpdateOperations` tests to supply an explicit dependency graph.
- **DiscoveryWorkerTests.cs**: Added a new discovery test (`TestDependencyGraphWithDifferentTargetFrameworks`) that verifies the dependency graph is correctly populated when a project targets a different-but-compatible TFM (e.g., `net10.0-android`) from its packages.