### PR TITLE
Fix misleading Terraform registry error when TLS certificate verification fails

### DIFF
--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -21,6 +21,10 @@ module Dependabot
         T::Array[String]
       )
       PUBLIC_HOSTNAME = "registry.terraform.io"
+      CERTIFICATE_ERROR_KEYWORDS = T.let(
+        %w(certificate SSL x509 verify).freeze,
+        T::Array[String]
+      )
 
       sig { params(hostname: String, credentials: T::Array[Dependabot::Credential]).void }
       def initialize(hostname: PUBLIC_HOSTNAME, credentials: [])
@@ -176,10 +180,14 @@ module Dependabot
         @services ||= T.let(
           begin
             response = http_get(url_for("/.well-known/terraform.json"))
-            if response.status == 200 && !response.body.empty?
-              JSON.parse(response.body)
-            else
+            if response.status == 200
+              response.body.empty? ? {} : JSON.parse(response.body)
+            elsif response.status == 404
               {}
+            elsif response.status == 401
+              raise PrivateSourceAuthenticationFailure, hostname
+            else
+              raise PrivateSourceBadResponse, hostname
             end
           rescue JSON::ParserError => e
             Dependabot.logger.warn("Failed to parse Terraform registry services: #{e.message}")
@@ -207,7 +215,11 @@ module Dependabot
           url: url.to_s,
           headers: headers_for(hostname)
         )
-      rescue Excon::Error::Socket, Excon::Error::Timeout
+      rescue Excon::Error::Socket => e
+        raise PrivateSourceCertificateFailure, hostname if certificate_error?(e.message)
+
+        raise PrivateSourceBadResponse, hostname
+      rescue Excon::Error::Timeout
         raise PrivateSourceBadResponse, hostname
       end
 
@@ -239,6 +251,11 @@ module Dependabot
       sig { params(message: String).returns(Dependabot::DependabotError) }
       def error(message)
         Dependabot::DependabotError.new(message)
+      end
+
+      sig { params(message: String).returns(T::Boolean) }
+      def certificate_error?(message)
+        CERTIFICATE_ERROR_KEYWORDS.any? { |keyword| message.include?(keyword) }
       end
     end
   end

--- a/terraform/spec/dependabot/terraform/registry_client_spec.rb
+++ b/terraform/spec/dependabot/terraform/registry_client_spec.rb
@@ -299,6 +299,40 @@ RSpec.describe Dependabot::Terraform::RegistryClient do
       end
     end
 
+    context "when the metadata endpoint raises a certificate error" do
+      it "raises PrivateSourceCertificateFailure" do
+        stub_request(:get, metadata).to_raise(
+          Excon::Error::Socket.new(
+            StandardError.new("SSL_connect returned=1 errno=0 state=error: certificate verify failed")
+          )
+        )
+
+        expect do
+          client.service_url_for("modules.v1")
+        end.to raise_error(Dependabot::PrivateSourceCertificateFailure)
+      end
+    end
+
+    context "when the metadata endpoint returns a 5xx error" do
+      it "raises PrivateSourceBadResponse instead of the misleading service error" do
+        stub_request(:get, metadata).and_return(status: 502)
+
+        expect do
+          client.service_url_for("modules.v1")
+        end.to raise_error(Dependabot::PrivateSourceBadResponse)
+      end
+    end
+
+    context "when the metadata endpoint returns a 401 error" do
+      it "raises PrivateSourceAuthenticationFailure" do
+        stub_request(:get, metadata).and_return(status: 401)
+
+        expect do
+          client.service_url_for("modules.v1")
+        end.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+      end
+    end
+
     context "when the service url is not available" do
       it "raises an error" do
         stub_request(:get, metadata).and_return(body: { "modules.v1": "/v1/modules/" }.to_json)


### PR DESCRIPTION
### What are you trying to accomplish?

When a private Terraform registry uses a certificate signed by an unknown authority, the Dependabot proxy cannot establish the MITM TLS connection and returns a non-200 response. Previously, the services method silently treated any non-200 response as "no service discovery supported", causing the unrelated error "Host does not support required Terraform-native service".

Fix the services method to raise PrivateSourceBadResponse for unexpected status codes (5xx, etc.) and PrivateSourceAuthenticationFailure for 401, reserving the "does not support" message for genuine 404 responses.

Also detect TLS/certificate-related keywords in Excon::Error::Socket exceptions and raise PrivateSourceCertificateFailure to surface the actual certificate issue to the user.

Fixes #15089

### How will you know you've accomplished your goal?

We have better error handling and the propagated error is correct


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
