### PR TITLE
Read npm min-release-age from .npmrc and apply as cooldown

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -65,6 +65,7 @@ module Dependabot
         @package_json = T.let(nil, T.nilable(Dependabot::DependencyFile))
         @git_commit_checker = T.let(nil, T.nilable(Dependabot::GitCommitChecker))
         super
+        apply_npmrc_min_release_age
       end
 
       sig { returns(T::Boolean) }
@@ -570,6 +571,115 @@ module Dependabot
           end
 
         sources.first
+      end
+
+      # Reads `min-release-age` from .npmrc and applies it as a floor for every
+      # cooldown field. npm enforces this constraint at install time, so any version
+      # younger than the threshold will cause `npm install` to fail. When a
+      # dependabot.yml cooldown is also present, the npmrc value raises any field
+      # that is below it and leaves higher values unchanged. Include/exclude patterns
+      # are always dropped because npm applies min-release-age globally with no
+      # per-package filtering.
+      sig { void }
+      def apply_npmrc_min_release_age
+        npmrc_days = npmrc_min_release_age_days
+        return unless npmrc_days&.positive?
+
+        if @update_cooldown.nil?
+          @update_cooldown = Dependabot::Package::ReleaseCooldownOptions.new(default_days: npmrc_days)
+        else
+          existing = @update_cooldown
+          log_npmrc_cooldown_conflicts(existing, npmrc_days)
+          @update_cooldown = merge_cooldown_with_npmrc_floor(existing, npmrc_days)
+        end
+      end
+
+      sig do
+        params(
+          existing: Dependabot::Package::ReleaseCooldownOptions,
+          npmrc_days: Integer
+        ).void
+      end
+      def log_npmrc_cooldown_conflicts(existing, npmrc_days)
+        if existing.include.any? || existing.exclude.any?
+          Dependabot.logger.warn(
+            ".npmrc min-release-age does not support include/exclude patterns; " \
+            "dropping dependabot.yml update_cooldown include/exclude configuration."
+          )
+        end
+
+        all_days = [existing.default_days, existing.semver_major_days,
+                    existing.semver_minor_days, existing.semver_patch_days]
+        unless all_days.any? { |days| days < npmrc_days }
+          Dependabot.logger.debug(
+            ".npmrc min-release-age (#{npmrc_days} days) is already satisfied by all " \
+            "dependabot.yml update_cooldown values; no adjustment needed."
+          )
+          return
+        end
+
+        Dependabot.logger.warn(
+          ".npmrc min-release-age (#{npmrc_days} days) conflicts with dependabot.yml update_cooldown " \
+          "(default_days: #{existing.default_days}); it acts as a minimum floor for all cooldown values."
+        )
+        { semver_major_days: existing.semver_major_days,
+          semver_minor_days: existing.semver_minor_days,
+          semver_patch_days: existing.semver_patch_days }.each do |field, configured_days|
+          next unless configured_days < npmrc_days
+
+          Dependabot.logger.warn(
+            ".npmrc min-release-age (#{npmrc_days} days) overrides dependabot.yml #{field} " \
+            "(#{configured_days} days) because it would cause npm install to fail."
+          )
+        end
+      end
+
+      sig do
+        params(
+          existing: Dependabot::Package::ReleaseCooldownOptions,
+          npmrc_days: Integer
+        ).returns(Dependabot::Package::ReleaseCooldownOptions)
+      end
+      def merge_cooldown_with_npmrc_floor(existing, npmrc_days)
+        Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: [existing.default_days, npmrc_days].max,
+          semver_major_days: [existing.semver_major_days, npmrc_days].max,
+          semver_minor_days: [existing.semver_minor_days, npmrc_days].max,
+          semver_patch_days: [existing.semver_patch_days, npmrc_days].max,
+          include: [],
+          exclude: []
+        )
+      end
+
+      sig { returns(T.nilable(Integer)) }
+      def npmrc_min_release_age_days
+        npmrc_file = dependency_files.find { |f| File.basename(f.name) == ".npmrc" }
+        unless npmrc_file&.content
+          Dependabot.logger.debug("No .npmrc file found; skipping min-release-age check.")
+          return nil
+        end
+
+        T.must(npmrc_file.content).split("\n").each do |line|
+          days = parse_min_release_age_line(line, npmrc_file.name)
+          return days if days
+        end
+        Dependabot.logger.debug("No min-release-age key found in #{npmrc_file.name}.")
+        nil
+      end
+
+      sig { params(line: String, filename: String).returns(T.nilable(Integer)) }
+      def parse_min_release_age_line(line, filename)
+        key, value = line.strip.split("=", 2)
+        return nil unless key&.strip == "min-release-age" && value
+
+        parsed = T.let(Integer(value.strip, 10, exception: false), T.nilable(Integer))
+        if parsed&.positive?
+          Dependabot.logger.debug("Found min-release-age=#{parsed} days in #{filename}.")
+          parsed
+        else
+          Dependabot.logger.debug("Ignoring invalid min-release-age value '#{value.strip}' in #{filename}.")
+          nil
+        end
       end
 
       sig { returns(T.nilable(Dependabot::DependencyFile)) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -2395,4 +2395,110 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       expect(updated_deps[0].name).to eq("is-stream")
     end
   end
+
+  describe "npmrc min-release-age cooldown" do
+    let(:dependency_files) { project_dependency_files("npm6/npmrc_min_release_age") }
+
+    it "creates a cooldown from the npmrc min-release-age value" do
+      expect(checker.update_cooldown).to be_a(Dependabot::Package::ReleaseCooldownOptions)
+      expect(checker.update_cooldown.default_days).to eq(3)
+    end
+
+    context "when an explicit update_cooldown already exceeds the npmrc floor" do
+      let(:checker) do
+        described_class.new(
+          dependency: dependency,
+          dependency_files: dependency_files,
+          credentials: credentials,
+          update_cooldown: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 10),
+          options: options
+        )
+      end
+
+      it "keeps default_days unchanged and logs no warning" do
+        expect(Dependabot.logger).not_to receive(:warn)
+        expect(checker.update_cooldown.default_days).to eq(10)
+      end
+    end
+
+    context "when dependabot.yml default_days is below the npmrc floor" do
+      let(:checker) do
+        described_class.new(
+          dependency: dependency,
+          dependency_files: dependency_files,
+          credentials: credentials,
+          update_cooldown: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 1),
+          options: options
+        )
+      end
+
+      it "raises default_days to the npmrc floor and logs semver-field warnings only" do
+        expect(Dependabot.logger).to receive(:warn).with(
+          ".npmrc min-release-age (3 days) conflicts with dependabot.yml update_cooldown " \
+          "(default_days: 1); it acts as a minimum floor for all cooldown values."
+        ).once
+        # ReleaseCooldownOptions derives semver fields from default_days when not set
+        # explicitly, so all three are 1 and each gets an override warning.
+        %w(semver_major_days semver_minor_days semver_patch_days).each do |field|
+          expect(Dependabot.logger).to receive(:warn).with(
+            ".npmrc min-release-age (3 days) overrides dependabot.yml #{field} " \
+            "(1 days) because it would cause npm install to fail."
+          )
+        end
+        expect(checker.update_cooldown.default_days).to eq(3)
+      end
+    end
+
+    context "when a semver-specific day is below the npmrc floor" do
+      let(:checker) do
+        described_class.new(
+          dependency: dependency,
+          dependency_files: dependency_files,
+          credentials: credentials,
+          update_cooldown: Dependabot::Package::ReleaseCooldownOptions.new(
+            default_days: 10,
+            semver_patch_days: 1
+          ),
+          options: options
+        )
+      end
+
+      it "raises semver_patch_days to the npmrc floor and logs an override warning" do
+        expect(Dependabot.logger).to receive(:warn).with(
+          ".npmrc min-release-age (3 days) conflicts with dependabot.yml update_cooldown " \
+          "(default_days: 10); it acts as a minimum floor for all cooldown values."
+        )
+        expect(Dependabot.logger).to receive(:warn).with(
+          ".npmrc min-release-age (3 days) overrides dependabot.yml semver_patch_days " \
+          "(1 days) because it would cause npm install to fail."
+        )
+        expect(checker.update_cooldown.semver_patch_days).to eq(3)
+      end
+    end
+
+    context "when include/exclude patterns are configured alongside npmrc" do
+      let(:checker) do
+        described_class.new(
+          dependency: dependency,
+          dependency_files: dependency_files,
+          credentials: credentials,
+          update_cooldown: Dependabot::Package::ReleaseCooldownOptions.new(
+            default_days: 5,
+            include: %w(lodash react)
+          ),
+          options: options
+        )
+      end
+
+      it "drops include/exclude and logs a warning" do
+        expect(Dependabot.logger).to receive(:warn).with(
+          ".npmrc min-release-age does not support include/exclude patterns; " \
+          "dropping dependabot.yml update_cooldown include/exclude configuration."
+        )
+        expect(checker.update_cooldown.include).to be_empty
+        expect(checker.update_cooldown.exclude).to be_empty
+        expect(checker.update_cooldown.default_days).to eq(5)
+      end
+    end
+  end
 end

--- a/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_min_release_age/.npmrc
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_min_release_age/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_min_release_age/package-lock.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_min_release_age/package-lock.json
@@ -1,0 +1,75 @@
+{
+	"name": "{{ name }}",
+	"version": "1.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "0.4.19"
+			}
+		},
+		"es6-promise": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+			"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+			"dev": true
+		},
+		"fetch-factory": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz",
+			"integrity": "sha1-4AdgWb2zHjFHx1s7jAQTO6jH4HE=",
+			"requires": {
+				"es6-promise": "3.3.1",
+				"isomorphic-fetch": "2.2.1",
+				"lodash": "3.10.1"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
+			}
+		},
+		"lodash": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+			"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+			"requires": {
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
+			}
+		},
+		"whatwg-fetch": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+		}
+	}
+}

--- a/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_min_release_age/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/npm6/npmrc_min_release_age/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "{{ name }}",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no\\ test\\ specified\" && exit 1",
+        "prettify": "prettier --write \"{{packages/*/src,examples,cypress,scripts}/**/,}*.{js,jsx,ts,tsx,css,md}\""
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/waltfy/PROTO_TEST.git"
+    },
+    "author": "",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/waltfy/PROTO_TEST/issues"
+    },
+    "homepage": "https://github.com/waltfy/PROTO_TEST#readme",
+    "dependencies": {
+      "fetch-factory": "^0.0.1"
+    },
+    "devDependencies": {
+      "etag" : "^1.0.0"
+    }}


### PR DESCRIPTION
## Summary

`min-release-age` setting in `.npmrc` prevents installing any package version younger than N days. Dependabot was unaware of this setting, so it could try to open PRs for versions that would violate user's configuration 

This pull request reads `min-release-age` from `.npmrc` and uses its value as a **lower bound** on every `update_cooldown` field. If no `update_cooldown` is configured in `dependabot.yml`, one is created from the npmrc value. If one is already configured, the npmrc value only raises individual fields that are below it

Fixes #14151

## Merge semantics

| Scenario | Result |
|---|---|
| No `update_cooldown` in `dependabot.yml` | `default_days` = `.npmrc` value |
| `dependabot.yml` `default_days` >= npmrc value | all fields unchanged (debug log only) |
| `dependabot.yml` `default_days` < npmrc value | `default_days` raised to npmrc floor; warn logged |
| `semver_*_days` field < npmrc value | that field raised to npmrc floor; per-field warn logged |
| `include`/`exclude` patterns | always dropped; npm applies `min-release-age` globally with no per-package filtering |

The npmrc value acts as a **floor**: it can only raise cooldown values, never lower them.

### Anything you want to highlight for special attention from reviewers?

 `.npmrc` and `dependabot.yml` cooldown settings don't translate cleanly. This is, for the most part, because Dependabot support features that npm does not support yet

- npm's `min-release-age` is a global, unconditional install-time constraint with no per-package filtering

- `dependabot.yml` supports `include`/`exclude` patterns and per-semver thresholds that have no npm equivalent. When both are present, the choices are: honour `dependabot.yml` as-is and risk Dependabot proposing versions `npm install` immediately rejects; or use `min-release-age` as a floor and silently drop incompatible `dependabot.yml` features 

This PR takes the second path on the grounds that a broken install is worse than a dropped preference, with a log warning to surface the trade-off. A third option such as failing the pipeline on conflict seems more damaging.


### How will you know you've accomplished your goal?

- Both existing an new tests pass
- Tested via the Dependabot CLI

Reproducer: https://github.com/yeikel/dependabot-issue-14151

Without this change, dependabot happily suggests the latest version of my dependency at test(3.5.34) ignoring my `min-release-age` configuration : 

<img width="1226" height="228" alt="image" src="https://github.com/user-attachments/assets/d07e3e60-5af4-4c2d-8830-8b61cc3da09a" />


However, after this change, it suggests the version the configuration expects(3.4.27): 

https://github.com/yeikel/dependabot-issue-14151/blob/bfc9181bbe5b21e8c9f2a8b0853506164946cdab/.npmrc#L1

<img width="1754" height="458" alt="image" src="https://github.com/user-attachments/assets/4c941aff-f74e-49e2-ba63-0fe61b1dfc25" />


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.