### PR TITLE
Ignore org.eclipse.m2e:lifecycle-mapping in Maven dependency checks

### DIFF
--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -40,6 +40,9 @@ module Dependabot
       PLUGIN_ARTIFACT_ITEMS_SELECTOR = "plugins > plugin > executions > execution > " \
                                        "configuration > artifactItems > artifactItem"
 
+      # Packages that are virtual/IDE-only and do not exist in any Maven repository.
+      VIRTUAL_PACKAGES = T.let(["org.eclipse.m2e:lifecycle-mapping"].freeze, T::Array[String])
+
       # Regex to get the property name from a declaration that uses a property
       PROPERTY_REGEX = /\$\{(?<property>.*?)\}/
 
@@ -223,6 +226,7 @@ module Dependabot
       def dependency_from_plugin_node(pom, dependency_node)
         return unless (name = plugin_name(dependency_node, pom))
         return if internal_dependency_names.include?(name)
+        return if VIRTUAL_PACKAGES.include?(name)
 
         build_dependency(pom, dependency_node, name, is_plugin: true)
       end

--- a/maven/spec/dependabot/maven/file_parser_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser_spec.rb
@@ -393,6 +393,21 @@ RSpec.describe Dependabot::Maven::FileParser do
       end
     end
 
+    context "when the pom includes org.eclipse.m2e:lifecycle-mapping" do
+      let(:pom_body) { fixture("poms", "lifecycle_mapping_pom.xml") }
+
+      it "skips org.eclipse.m2e:lifecycle-mapping" do
+        expect(dependencies.map(&:name)).not_to include("org.eclipse.m2e:lifecycle-mapping")
+      end
+
+      it "still includes other plugins" do
+        expect(dependencies.map(&:name))
+          .to include("org.apache.maven.plugins:maven-compiler-plugin")
+      end
+
+      its(:length) { is_expected.to eq(1) }
+    end
+
     context "when dealing with versions defined by a property" do
       let(:pom_body) { fixture("poms", "property_pom.xml") }
 

--- a/maven/spec/fixtures/poms/lifecycle_mapping_pom.xml
+++ b/maven/spec/fixtures/poms/lifecycle_mapping_pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.dependabot</groupId>
+  <artifactId>lifecycle-mapping-test</artifactId>
+  <version>0.0.1</version>
+
+  <packaging>pom</packaging>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- Virtual Eclipse IDE plugin -- not in any Maven repository -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+        </plugin>
+        <!-- Real plugin that should still be updated -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>


### PR DESCRIPTION
### What are you trying to accomplish?

This package is a virtual Eclipse IDE plugin that does not exist in any Maven repository. Dependabot was spending ~25 seconds per job making HTTP requests that always returned 404. 

After this change, we filter it out at parse time via a `VIRTUAL_PACKAGES` constant so version checking is never attempted.

Fixes #14877


### How will you know you've accomplished your goal?

Both existing and new tests pass

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
