### PR TITLE
Pass `--min-release-age=0` for npm security updates to bypass `.npmrc`

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -469,7 +469,8 @@ module Dependabot
           lockfile: file,
           dependencies: dependencies,
           dependency_files: dependency_files,
-          credentials: credentials
+          credentials: credentials,
+          security_updates_only: options.fetch(:security_updates_only, false)
         )
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -29,15 +29,17 @@ module Dependabot
             lockfile: Dependabot::DependencyFile,
             dependencies: T::Array[Dependabot::Dependency],
             dependency_files: T::Array[Dependabot::DependencyFile],
-            credentials: T::Array[Credential]
+            credentials: T::Array[Credential],
+            security_updates_only: T::Boolean
           )
             .void
         end
-        def initialize(lockfile:, dependencies:, dependency_files:, credentials:)
+        def initialize(lockfile:, dependencies:, dependency_files:, credentials:, security_updates_only: false)
           @lockfile = lockfile
           @dependencies = dependencies
           @dependency_files = dependency_files
           @credentials = credentials
+          @security_updates_only = T.let(security_updates_only, T::Boolean)
         end
 
         sig { returns(Dependabot::DependencyFile) }
@@ -71,6 +73,11 @@ module Dependabot
 
         sig { returns(T::Array[Credential]) }
         attr_reader :credentials
+
+        sig { returns(T::Boolean) }
+        def security_updates_only?
+          @security_updates_only
+        end
 
         UNREACHABLE_GIT = /fatal: repository '(?<url>.*)' not found/
         FORBIDDEN_GIT = /fatal: Authentication failed for '(?<url>.*)'/
@@ -394,6 +401,9 @@ module Dependabot
           ]
 
           command_args << "--save-optional" if has_optional_dependencies
+          # Override any min-release-age set in .npmrc: security fixes must not be
+          # blocked by a release-age gate the user configured for regular updates.
+          command_args << "--min-release-age=0" if security_updates_only?
 
           command = command_args.join(" ")
 
@@ -406,6 +416,7 @@ module Dependabot
           ]
 
           fingerprint_args << "--save-optional" if has_optional_dependencies
+          fingerprint_args << "--min-release-age=0" if security_updates_only?
 
           fingerprint = fingerprint_args.join(" ")
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -1360,6 +1360,46 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
       end
     end
 
+    describe "#run_npm_install_lockfile_only" do
+      let(:files) { project_dependency_files("npm8/simple") }
+      let(:install_args) { ["lodash@4.18.1"] }
+
+      context "when security_updates_only is true" do
+        let(:updater) do
+          described_class.new(
+            lockfile: package_lock,
+            dependency_files: files,
+            dependencies: dependencies,
+            credentials: credentials,
+            security_updates_only: true
+          )
+        end
+
+        it "passes --min-release-age=0 to override the .npmrc setting" do
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command) do |command, _options|
+            expect(command).to include("--min-release-age=0")
+            expect(command).to include("--package-lock-only")
+            expect(command).to include("--force")
+            ""
+          end
+
+          updater.send(:run_npm_install_lockfile_only, install_args)
+        end
+      end
+
+      context "when security_updates_only is false (default)" do
+        it "does not pass --min-release-age=0" do
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command) do |command, _options|
+            expect(command).not_to include("--min-release-age=0")
+            expect(command).to include("--package-lock-only")
+            ""
+          end
+
+          updater.send(:run_npm_install_lockfile_only, install_args)
+        end
+      end
+    end
+
     describe "#optional_dependency?" do
       it "correctly identifies optional dependencies" do
         optional_dep = Dependabot::Dependency.new(

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -189,7 +189,7 @@ module Dependabot
         dependency_files: dependency_files,
         repo_contents_path: job.repo_contents_path,
         credentials: job.credentials,
-        options: job.experiments
+        options: job.experiments.merge(security_updates_only: job.security_updates_only?)
       )
     end
   end

--- a/updater/spec/dependabot/dependency_change_builder_spec.rb
+++ b/updater/spec/dependabot/dependency_change_builder_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Dependabot::DependencyChangeBuilder do
         }
       ],
       experiments: {},
+      security_updates_only?: false,
       source: source
     )
   end
@@ -123,6 +124,40 @@ RSpec.describe Dependabot::DependencyChangeBuilder do
 
     def dependency_group_source
       Dependabot::DependencyGroup.new(name: "dummy-pkg-*", rules: { patterns: ["dummy-pkg-*"] })
+    end
+
+    context "when the job is a security update" do
+      let(:change_source) { lead_dependency_change_source }
+
+      before do
+        allow(job).to receive(:security_updates_only?).and_return(true)
+        stub_file_updater(updated_dependency_files: dependency_files.reject(&:support_file?))
+      end
+
+      it "passes security_updates_only: true in options to the file updater" do
+        create_change
+
+        expect(file_updater_class).to have_received(:new).with(
+          hash_including(options: hash_including(security_updates_only: true))
+        )
+      end
+    end
+
+    context "when the job is not a security update" do
+      let(:change_source) { lead_dependency_change_source }
+
+      before do
+        allow(job).to receive(:security_updates_only?).and_return(false)
+        stub_file_updater(updated_dependency_files: dependency_files.reject(&:support_file?))
+      end
+
+      it "passes security_updates_only: false in options to the file updater" do
+        create_change
+
+        expect(file_updater_class).to have_received(:new).with(
+          hash_including(options: hash_including(security_updates_only: false))
+        )
+      end
     end
 
     context "when the source is a lead dependency" do

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -660,7 +660,7 @@ RSpec.describe Dependabot::Updater do
           dependency_files: default_dependency_files,
           repo_contents_path: nil,
           credentials: anything,
-          options: { cloning: true }
+          options: hash_including(cloning: true)
         ).and_call_original
 
         expect(service).to receive(:create_pull_request).once
@@ -2165,7 +2165,7 @@ RSpec.describe Dependabot::Updater do
           ],
           repo_contents_path: nil,
           credentials: anything,
-          options: { large_hadron_collider: true }
+          options: hash_including(large_hadron_collider: true)
         ).and_call_original
 
         updater.run


### PR DESCRIPTION
### What are you trying to accomplish?

When a project sets `min-release-age` in `.npmrc`, npm refuses to resolve versions newer than the configured age window. This blocks security updates when the fix version was released too recently, producing an `ETARGET` error. For security updates the age restriction should not apply, so `--min-release-age=0` is now appended to the `npm install`  command when security advisories are present.

Fixes #15112

### How will you know you've accomplished your goal?

I documented and tested with a reproducer : https://github.com/yeikel/dependabot-reproducer-issue-15112

Example failure: https://github.com/yeikel/dependabot-reproducer-issue-15112/actions/runs/26425464099

Example logs: 

> 2026/05/26 00:19:56 ERROR <job_1384035612> Error running package manager command: corepack npm install lodash@4.17.15 --force --ignore-scripts --package-lock-only, Error: npm warn using --force Recommended protections disabled.
> npm error code ETARGET
> npm error notarget No matching version found for lodash@4.17.15 with a date before 6/20/1926, 12:19:56 AM.
> npm error notarget In most cases you or one of your dependencies are requesting
> npm error notarget a package version that doesn't exist.
> npm error A complete log of this run can be found in: /home/dependabot/.npm/_logs/2026-05-26T00_19_56_232Z-debug-0.log

Validating the change involved running my updated version in the security context using the reproducer: 


<details>
  <summary>Job details</summary>
  
```json
{
  "job": {
    "command": "security",
    "allowed-updates": [
      {
        "dependency-type": "direct",
        "update-type": "all"
      }
    ],
    "commit-message-options": {
      "prefix": null,
      "prefix-development": null,
      "include-scope": null
    },
    "credentials-metadata": [
      {
        "type": "git_source",
        "host": "github.com"
      }
    ],
    "debug": null,
    "dependencies": [
      "lodash"
    ],
    "dependency-groups": [],
    "dependency-group-to-refresh": null,
    "existing-pull-requests": [],
    "existing-group-pull-requests": [],
    "experiments": {
      "record-ecosystem-versions": true,
      "record-update-job-unknown-error": true,
      "proxy-cached": true,
      "enable-corepack-for-npm-and-yarn": true,
      "enable-private-registry-for-corepack": true,
      "allow-refresh-for-existing-pr-dependencies": true,
      "allow-refresh-group-with-all-dependencies": true,
      "azure-registry-backup": true,
      "enable-enhanced-error-details-for-updater": true,
      "gradle-lockfile-updater": true,
      "enable-exclude-paths-subdirectory-manifest-files": true
    },
    "ignore-conditions": [],
    "lockfile-only": false,
    "max-updater-run-time": 2700,
    "package-manager": "npm_and_yarn",
    "requirements-update-strategy": null,
    "reject-external-code": false,
    "security-advisories": [
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          ">= 4.0.0 <= 4.17.23"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          "<= 4.17.23"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          ">= 4.0.0 <= 4.17.22"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          ">= 4.0.0 < 4.17.21"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          "<= 4.17.21"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          "< 4.17.21"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          ">= 3.7.0 < 4.17.19"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          ">= 4.7.0 < 4.17.11"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          "< 4.17.12"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          "< 4.17.11"
        ]
      },
      {
        "dependency-name": "lodash",
        "patched-versions": [],
        "unaffected-versions": [],
        "affected-versions": [
          "< 4.17.5"
        ]
      }
    ],
    "security-updates-only": true,
    "source": {
      "provider": "github",
      "repo": "yeikel/dependabot-reproducer-issue-15112",
      "branch": null,
      "api-endpoint": "https://api.github.com/",
      "hostname": "github.com",
      "directories": [
        "/."
      ]
    },
    "updating-a-pull-request": false,
    "update-subdependencies": false,
    "vendor-dependencies": false,
    "enable-beta-ecosystems": false,
    "repo-private": false,
    "multi-ecosystem-update": false,
    "exclude-paths": null
  }
}

```
  
</details>




<details>
  <summary>Before </summary>

```
    cli | 2026/05/26 00:55:41 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2026/05/26 00:55:42 image ghcr.io/dependabot/proxy:latest is already up to date
    cli | 2026/05/26 00:55:42 using image ghcr.io/dependabot/proxy:latest at sha256:f72e108e50c3f208936f4d287a69c31299874a558c19de779526b5bc90513e8b
    cli | 2026/05/26 00:55:42 pulling image: ghcr.io/dependabot/dependabot-updater-npm
    cli | 2026/05/26 00:56:32 using image ghcr.io/dependabot/dependabot-updater-npm at sha256:362324a2093c1449369eb591d02beb5e2a601181ca9cc291e0d9f30e4c5c5eb3
  proxy | 2026/05/26 00:56:35 proxy starting, commit: 824e4800ce477028cb36d81e3ff5c3e96ffb8c06
  proxy | 2026/05/26 00:56:35 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/05/26 00:56:39 INFO Starting job processing
updater | 2026/05/26 00:56:39 INFO Job definition: {"job":{"command":"security","package-manager":"npm_and_yarn","allowed-updates":[{"dependency-type":"direct","update-type":"all"}],"debug":false,"dependency-groups":[],"dependencies":["lodash"],"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":{"allow-refresh-for-existing-pr-dependencies":true,"allow-refresh-group-with-all-dependencies":true,"azure-registry-backup":true,"enable-corepack-for-npm-and-yarn":true,"enable-enhanced-error-details-for-updater":true,"enable-exclude-paths-subdirectory-manifest-files":true,"enable-private-registry-for-corepack":true,"gradle-lockfile-updater":true,"proxy-cached":true,"record-ecosystem-versions":true,"record-update-job-unknown-error":true},"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c= 4.17.23"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c= 4.17.23"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c= 4.17.22"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c= 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 3.7.0 \u003c 4.17.19"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.7.0 \u003c 4.17.11"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.12"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.11"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.5"],"patched-versions":[],"unaffected-versions":[]}],"security-updates-only":true,"source":{"provider":"github","repo":"yeikel/dependabot-reproducer-issue-15112","directories":["/."],"hostname":"github.com","api-endpoint":"https://api.github.com/"},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":{},"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":2700,"exclude-paths":null,"multi-ecosystem-update":false}}
  proxy | 2026/05/26 00:56:39 [002] GET https://github.com:443/yeikel/dependabot-reproducer-issue-15112.git/info/refs?service=git-upload-pack
  proxy | 2026/05/26 00:56:39 [002] * authenticating git server request (host: github.com)
  proxy | 2026/05/26 00:56:39 [002] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15112.git/info/refs?service=git-upload-pack
updater | 2026/05/26 00:56:39 INFO Started process PID: 1164 with command: {} git clone --no-tags --depth 1 --recurse-submodules --shallow-submodules https://github.com/yeikel/dependabot-reproducer-issue-15112 /home/dependabot/dependabot-updater/repo {}
  proxy | 2026/05/26 00:56:39 [004] GET https://github.com:443/yeikel/dependabot-reproducer-issue-15112/info/refs?service=git-upload-pack
  proxy | 2026/05/26 00:56:39 [004] * authenticating git server request (host: github.com)
  proxy | 2026/05/26 00:56:39 [004] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15112/info/refs?service=git-upload-pack
  proxy | 2026/05/26 00:56:39 [006] POST https://github.com:443/yeikel/dependabot-reproducer-issue-15112/git-upload-pack
  proxy | 2026/05/26 00:56:39 [006] * authenticating git server request (host: github.com)
  proxy | 2026/05/26 00:56:39 [006] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15112/git-upload-pack
  proxy | 2026/05/26 00:56:40 [008] POST https://github.com:443/yeikel/dependabot-reproducer-issue-15112/git-upload-pack
  proxy | 2026/05/26 00:56:40 [008] * authenticating git server request (host: github.com)
  proxy | 2026/05/26 00:56:40 [008] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15112/git-upload-pack
updater | 2026/05/26 00:56:40 INFO Process PID: 1164 completed with status: pid 1164 exit 0
updater | 2026/05/26 00:56:40 INFO Total execution time: 0.53 seconds
updater | 2026/05/26 00:56:40 INFO Started process PID: 1203 with command: {} git -C /home/dependabot/dependabot-updater/repo ls-files --stage {}
updater | 2026/05/26 00:56:40 INFO Process PID: 1203 completed with status: pid 1203 exit 0
updater | 2026/05/26 00:56:40 INFO Total execution time: 0.01 seconds
updater | 2026/05/26 00:56:40 INFO Started process PID: 1297 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/26 00:56:40 INFO Process PID: 1297 completed with status: pid 1297 exit 0
updater | 2026/05/26 00:56:40 INFO Total execution time: 0.05 seconds
updater | 2026/05/26 00:56:40 INFO Started process PID: 1419 with command: {} git rev-parse HEAD {}
updater | 2026/05/26 00:56:40 INFO Process PID: 1419 completed with status: pid 1419 exit 0
updater | 2026/05/26 00:56:40 INFO Total execution time: 0.01 seconds
updater | 2026/05/26 00:56:40 INFO Started process PID: 1601 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/26 00:56:40 INFO Process PID: 1601 completed with status: pid 1601 exit 0
updater | 2026/05/26 00:56:40 INFO Total execution time: 0.04 seconds
updater | 2026/05/26 00:56:40 INFO Detected package manager: npm
updater | 2026/05/26 00:56:40 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:40 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:40 INFO Fetching version for package manager: npm
updater | 2026/05/26 00:56:40 INFO Started process PID: 1634 with command: {} corepack npm -v {}
updater | 2026/05/26 00:56:40 INFO Process PID: 1634 completed with status: pid 1634 exit 0
updater | 2026/05/26 00:56:40 INFO Total execution time: 0.14 seconds
updater | 2026/05/26 00:56:40 INFO Installed version of npm: 11.8.0
updater | 2026/05/26 00:56:40 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:56:40 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:40 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:40 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:40 INFO No version requirement found for npm
updater | 2026/05/26 00:56:40 INFO Detected package manager: npm
updater | 2026/05/26 00:56:40 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:40 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:40 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:56:40 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:40 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:40 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:40 INFO No version requirement found for npm
updater | 2026/05/26 00:56:40 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:40 INFO Installing "npm@11.10.0"
updater | 2026/05/26 00:56:40 INFO Started process PID: 1646 with command: {} corepack prepare npm@11.10.0 --activate {}
  proxy | 2026/05/26 00:56:40 [010] GET https://registry.npmjs.org:443/npm/-/npm-11.10.0.tgz
  proxy | 2026/05/26 00:56:40 [010] 200 https://registry.npmjs.org:443/npm/-/npm-11.10.0.tgz
  proxy | 2026/05/26 00:56:42 [012] GET https://registry.npmjs.org:443/npm/11.10.0
  proxy | 2026/05/26 00:56:42 [012] 200 https://registry.npmjs.org:443/npm/11.10.0
updater | 2026/05/26 00:56:42 INFO Process PID: 1646 completed with status: pid 1646 exit 0
updater | 2026/05/26 00:56:42 INFO Total execution time: 2.13 seconds
updater | 2026/05/26 00:56:42 INFO npm@11.10.0 successfully installed.
updater | 2026/05/26 00:56:42 INFO Activating currently installed version of npm: 11.10.0
updater | 2026/05/26 00:56:42 INFO Fetching version for package manager: npm
updater | 2026/05/26 00:56:42 INFO Started process PID: 1659 with command: {} corepack npm -v {}
updater | 2026/05/26 00:56:42 INFO Process PID: 1659 completed with status: pid 1659 exit 0
updater | 2026/05/26 00:56:42 INFO Total execution time: 0.13 seconds
updater | 2026/05/26 00:56:42 INFO Installed version of npm: 11.10.0
updater | 2026/05/26 00:56:42 INFO Detected package manager: npm
updater | 2026/05/26 00:56:42 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:42 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:42 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:56:42 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:42 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:42 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:42 INFO No version requirement found for npm
updater | 2026/05/26 00:56:42 INFO Detected package manager: npm
updater | 2026/05/26 00:56:42 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:42 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:42 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:56:42 INFO Processing engine constraints for npm
  proxy | 2026/05/26 00:56:42 [013] POST http://host.docker.internal:62774/update_jobs/cli/record_ecosystem_versions
updater | 2026/05/26 00:56:42 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:42 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
{"data":{"ecosystem_versions":{"package_managers":{"npm":"11.10.0"}}},"type":"record_ecosystem_versions"}
updater | 2026/05/26 00:56:42 INFO No version requirement found for npm
updater | 2026/05/26 00:56:42 INFO Detected package manager: npm
updater | 2026/05/26 00:56:42 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:42 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:42 INFO Installed version for npm: 11.8.0
  proxy | 2026/05/26 00:56:42 [013] 200 http://host.docker.internal:62774/update_jobs/cli/record_ecosystem_versions
updater | 2026/05/26 00:56:42 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:42 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:42 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:42 INFO No version requirement found for npm
updater | 2026/05/26 00:56:42 INFO Detected package manager: npm
updater | 2026/05/26 00:56:42 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:42 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:42 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:56:42 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:42 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:42 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:42 INFO No version requirement found for npm
updater | 2026/05/26 00:56:42 INFO Detected package manager: npm
updater | 2026/05/26 00:56:42 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:42 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:42 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:56:42 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:42 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:42 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:42 INFO No version requirement found for npm
updater | 2026/05/26 00:56:42 INFO Detected package manager: npm
updater | 2026/05/26 00:56:42 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:42 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:42 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:56:42 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:42 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:42 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:42 INFO No version requirement found for npm
updater | 2026/05/26 00:56:42 INFO Detected package manager: npm
updater | 2026/05/26 00:56:42 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:42 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:42 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:56:42 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:42 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:42 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:42 INFO No version requirement found for npm
updater | 2026/05/26 00:56:42 INFO Detected package manager: npm
updater | 2026/05/26 00:56:42 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:42 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:42 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:56:42 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:42 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:42 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:42 INFO No version requirement found for npm
updater | 2026/05/26 00:56:42 INFO Base commit SHA: 97e5f6da7f8013c430e44c964cb173ee58131fcb
updater | 2026/05/26 00:56:42 INFO Finished job processing
updater | 2026/05/26 00:56:42 INFO Starting job processing
updater | 2026/05/26 00:56:42 INFO Detected package manager: npm
updater | 2026/05/26 00:56:42 INFO Resolving package manager for: npm
updater | 2026/05/26 00:56:42 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:56:42 INFO Fetching version for package manager: npm
updater | 2026/05/26 00:56:42 INFO Started process PID: 1671 with command: {} corepack npm -v {}
updater | 2026/05/26 00:56:43 INFO Process PID: 1671 completed with status: pid 1671 exit 0
updater | 2026/05/26 00:56:43 INFO Total execution time: 0.15 seconds
updater | 2026/05/26 00:56:43 INFO Installed version of npm: 11.10.0
updater | 2026/05/26 00:56:43 INFO Installed version for npm: 11.10.0
updater | 2026/05/26 00:56:43 INFO Processing engine constraints for npm
updater | 2026/05/26 00:56:43 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:56:43 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:56:43 INFO No version requirement found for npm
updater | 2026/05/26 00:56:43 INFO Running node command: node -v
updater | 2026/05/26 00:56:43 INFO Started process PID: 1683 with command: {} node -v {}
updater | 2026/05/26 00:56:43 INFO Process PID: 1683 completed with status: pid 1683 exit 0
updater | 2026/05/26 00:56:43 INFO Total execution time: 0.01 seconds
updater | 2026/05/26 00:56:43 INFO Command executed successfully: node -v
updater | 2026/05/26 00:56:43 INFO Processing engine constraints for node
  proxy | 2026/05/26 00:56:43 [014] POST http://host.docker.internal:62774/update_jobs/cli/update_dependency_list
{"data":{"dependencies":[{"name":"lodash","requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"4.17.15","source":{"type":"registry","url":"https://registry.npmjs.org"}}],"version":"4.17.15"}],"dependency_files":["/package.json","/package-lock.json"]},"type":"update_dependency_list"}
  proxy | 2026/05/26 00:56:43 [014] 200 http://host.docker.internal:62774/update_jobs/cli/update_dependency_list
{"data":{"metric":"updater.started","tags":{"operation":"create_security_pr"}},"type":"increment_metric"}
  proxy | 2026/05/26 00:56:43 [015] POST http://host.docker.internal:62774/update_jobs/cli/increment_metric
  proxy | 2026/05/26 00:56:43 [015] 200 http://host.docker.internal:62774/update_jobs/cli/increment_metric
updater | 2026/05/26 00:56:43 INFO Starting security update job for yeikel/dependabot-reproducer-issue-15112
updater | 2026/05/26 00:56:43 INFO Checking if lodash 4.17.15 needs updating
  proxy | 2026/05/26 00:56:43 [017] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:56:43 [017] 200 https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:56:43 [019] HEAD https://registry.npmjs.org:443/lodash/-/lodash-4.18.1.tgz
  proxy | 2026/05/26 00:56:43 [019] 200 https://registry.npmjs.org:443/lodash/-/lodash-4.18.1.tgz
updater | 2026/05/26 00:56:43 INFO Latest version is 4.18.1
  proxy | 2026/05/26 00:56:43 [021] GET https://registry.npmjs.org:443/dependabot-reproducer-issue-15112
  proxy | 2026/05/26 00:56:43 [021] 404 https://registry.npmjs.org:443/dependabot-reproducer-issue-15112
updater | 2026/05/26 00:56:43 INFO VulnerabilityAuditor: starting audit
updater | 2026/05/26 00:56:43 INFO Started process PID: 1685 with command: node /opt/npm_and_yarn/dist/run.js
  proxy | 2026/05/26 00:56:44 [023] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:56:44 [023] 200 https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:56:44 [025] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:56:44 [025] 200 https://registry.npmjs.org:443/lodash
updater | 2026/05/26 00:56:44 INFO Process PID: 1685 completed with status: pid 1685 exit 0
updater | 2026/05/26 00:56:44 INFO Total execution time: 1.13 seconds
updater | 2026/05/26 00:56:44 INFO VulnerabilityAuditor: audit result viable
  proxy | 2026/05/26 00:56:44 [027] GET https://registry.npmjs.org:443/dependabot-reproducer-issue-15112
  proxy | 2026/05/26 00:56:44 [027] 404 https://registry.npmjs.org:443/dependabot-reproducer-issue-15112 (cached)
updater | 2026/05/26 00:56:44 INFO Requirements to unlock own
  proxy | 2026/05/26 00:56:44 [027] * auth'd git request previously retried, won't retry again. (cached)
  proxy | 2026/05/26 00:56:45 [029] GET https://registry.npmjs.org:443/dependabot-reproducer-issue-15112
  proxy | 2026/05/26 00:56:45 [029] 404 https://registry.npmjs.org:443/dependabot-reproducer-issue-15112 (cached)
updater | 2026/05/26 00:56:45 INFO Requirements update strategy bump_versions
  proxy | 2026/05/26 00:56:45 [029] * auth'd git request previously retried, won't retry again. (cached)
updater | 2026/05/26 00:56:45 INFO Updating lodash from 4.17.15 to 4.18.1
updater | 2026/05/26 00:56:45 INFO Started process PID: 1797 with command: {} corepack npm install lodash@4.18.1 --force --ignore-scripts --package-lock-only {}
updater | 2026/05/26 00:56:45 INFO Process PID: 1797 completed with status: pid 1797 exit 1
updater | 2026/05/26 00:56:45 INFO Total execution time: 0.45 seconds
updater | 2026/05/26 00:56:45 ERROR Error running package manager command: corepack npm install lodash@4.18.1 --force --ignore-scripts --package-lock-only, Error: npm warn using --force Recommended protections disabled.
updater | npm error code ETARGET
updater | npm error notarget No matching version found for lodash@4.18.1 with a date before 6/20/1926, 12:56:45 AM.
updater | npm error notarget In most cases you or one of your dependencies are requesting
updater | npm error notarget a package version that doesn't exist.
updater | npm error A complete log of this run can be found in: /home/dependabot/.npm/_logs/2026-05-26T00_56_45_291Z-debug-0.log
updater | 2026/05/26 00:56:45 WARN NPM : npm warn using --force Recommended protections disabled.
updater | npm error code ETARGET
updater | npm error notarget No matching version found for lodash@4.18.1 with a date before 6/20/1926, 12:56:45 AM.
updater | npm error notarget In most cases you or one of your dependencies are requesting
updater | npm error notarget a package version that doesn't exist.
updater | npm error A complete log of this run can be found in: /home/dependabot/.npm/_logs/2026-05-26T00_56_45_291Z-debug-0.log
updater | 2026/05/26 00:56:45 INFO Started process PID: 1897 with command: {} corepack npm install lodash@4.17.15 --force --ignore-scripts --package-lock-only {}
updater | 2026/05/26 00:56:46 INFO Process PID: 1897 completed with status: pid 1897 exit 1
updater | 2026/05/26 00:56:46 INFO Total execution time: 0.46 seconds
updater | 2026/05/26 00:56:46 ERROR Error running package manager command: corepack npm install lodash@4.17.15 --force --ignore-scripts --package-lock-only, Error: npm warn using --force Recommended protections disabled.
updater | npm error code ETARGET
updater | npm error notarget No matching version found for lodash@4.17.15 with a date before 6/20/1926, 12:56:45 AM.
updater | npm error notarget In most cases you or one of your dependencies are requesting
updater | npm error notarget a package version that doesn't exist.
updater | npm error A complete log of this run can be found in: /home/dependabot/.npm/_logs/2026-05-26T00_56_45_814Z-debug-0.log
updater | 2026/05/26 00:56:46 INFO Started process PID: 1998 with command: {} corepack npm install lodash@4.17.15 --force --ignore-scripts --package-lock-only {}
updater | 2026/05/26 00:56:46 INFO Process PID: 1998 completed with status: pid 1998 exit 1
updater | 2026/05/26 00:56:46 INFO Total execution time: 0.41 seconds
{"data":{"error-type":"dependency_file_not_resolvable","error-details":{"message":"Error whilst updating lodash in /package-lock.json:\nnpm warn using --force Recommended protections disabled.\nnpm error code ETARGET\nnpm error notarget No matching version found for lodash@4.18.1 with a date before 6/20/1926, 12:56:45 AM.\nnpm error notarget In most cases you or one of your dependencies are requesting\nnpm error notarget a package version that doesn't exist.\nnpm error A complete log of this run can be found in: /home/dependabot/.npm/_logs/2026-05-26T00_56_45_291Z-debug-0.log"}},"type":"record_update_job_error"}
  proxy | 2026/05/26 00:56:46 [030] POST http://host.docker.internal:62774/update_jobs/cli/record_update_job_error
updater | 2026/05/26 00:56:46 ERROR Error running package manager command: corepack npm install lodash@4.17.15 --force --ignore-scripts --package-lock-only, Error: npm warn using --force Recommended protections disabled.
updater | npm error code ETARGET
updater | npm error notarget No matching version found for lodash@4.17.15 with a date before 6/20/1926, 12:56:46 AM.
updater | npm error notarget In most cases you or one of your dependencies are requesting
updater | npm error notarget a package version that doesn't exist.
updater | npm error A complete log of this run can be found in: /home/dependabot/.npm/_logs/2026-05-26T00_56_46_327Z-debug-0.log
{"data":[{"ecosystem":{"name":"npm_and_yarn","package_manager":{"name":"npm","version":"11.10.0","raw_version":"11.10.0"},"language":{"name":"node","version":"24.15.0","raw_version":"24.15.0"}}}],"type":"record_ecosystem_meta"}
  proxy | 2026/05/26 00:56:46 [030] 200 http://host.docker.internal:62774/update_jobs/cli/record_update_job_error
updater | 2026/05/26 00:56:46 INFO Handled error whilst updating lodash: dependency_file_not_resolvable {message: "Error whilst updating lodash in /package-lock.json:\nnpm warn using --force Recommended protections disabled.\nnpm error code ETARGET\nnpm error notarget No matching version found for lodash@4.18.1 with a date before 6/20/1926, 12:56:45 AM.\nnpm error notarget In most cases you or one of your dependencies are requesting\nnpm error notarget a package version that doesn't exist.\nnpm error A complete log of this run can be found in: /home/dependabot/.npm/_logs/2026-05-26T00_56_45_291Z-debug-0.log"}
  proxy | 2026/05/26 00:56:46 [031] POST http://host.docker.internal:62774/update_jobs/cli/record_ecosystem_meta
  proxy | 2026/05/26 00:56:46 [031] 200 http://host.docker.internal:62774/update_jobs/cli/record_ecosystem_meta
{"data":{"base-commit-sha":"97e5f6da7f8013c430e44c964cb173ee58131fcb"},"type":"mark_as_processed"}
  proxy | 2026/05/26 00:56:46 [032] PATCH http://host.docker.internal:62774/update_jobs/cli/mark_as_processed
  proxy | 2026/05/26 00:56:46 [032] 200 http://host.docker.internal:62774/update_jobs/cli/mark_as_processed
updater | 2026/05/26 00:56:46 INFO Finished job processing
updater | 2026/05/26 00:56:46 INFO Results:
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
updater | |                                                                                                                                                                                                                                                                          Dependencies failed to update                                                                                                                                                                                                                                                                           |
updater | +------------+--------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
updater | | Dependency | Error Type                     | Error Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
updater | +------------+--------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
updater | | lodash     | dependency_file_not_resolvable | {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
updater | |            |                                |   "message": "Error whilst updating lodash in /package-lock.json:\nnpm warn using --force Recommended protections disabled.\nnpm error code ETARGET\nnpm error notarget No matching version found for lodash@4.18.1 with a date before 6/20/1926, 12:56:45 AM.\nnpm error notarget In most cases you or one of your dependencies are requesting\nnpm error notarget a package version that doesn't exist.\nnpm error A complete log of this run can be found in: /home/dependabot/.npm/_logs/2026-05-26T00_56_45_291Z-debug-0.log" |
updater | |            |                                | }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
updater | +------------+--------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
  proxy | 2026/05/26 00:56:47 Skipping sending metrics because api endpoint is empty
  proxy | 2026/05/26 00:56:47 2/13 calls cached (15%)
    cli | 2026/05/26 00:56:48 updater failure: updater exited with code 1

```  

</details>

<details>
  <summary>After</summary>
  
```
    cli | 2026/05/26 00:53:18 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2026/05/26 00:53:19 image ghcr.io/dependabot/proxy:latest is already up to date
    cli | 2026/05/26 00:53:19 using image ghcr.io/dependabot/proxy:latest at sha256:f72e108e50c3f208936f4d287a69c31299874a558c19de779526b5bc90513e8b
    cli | 2026/05/26 00:53:19 digest sha256:cc34955e078d4119051487c0124ff75102a8cab7df34aabd859608c48c20163b for image ghcr.io/dependabot/dependabot-updater-npm does not exist remotely
  proxy | 2026/05/26 00:53:20 proxy starting, commit: 824e4800ce477028cb36d81e3ff5c3e96ffb8c06
  proxy | 2026/05/26 00:53:20 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/05/26 00:53:23 INFO Starting job processing
updater | 2026/05/26 00:53:23 INFO Job definition: {"job":{"command":"security","package-manager":"npm_and_yarn","allowed-updates":[{"dependency-type":"direct","update-type":"all"}],"debug":false,"dependency-groups":[],"dependencies":["lodash"],"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":{"allow-refresh-for-existing-pr-dependencies":true,"allow-refresh-group-with-all-dependencies":true,"azure-registry-backup":true,"enable-corepack-for-npm-and-yarn":true,"enable-enhanced-error-details-for-updater":true,"enable-exclude-paths-subdirectory-manifest-files":true,"enable-private-registry-for-corepack":true,"gradle-lockfile-updater":true,"proxy-cached":true,"record-ecosystem-versions":true,"record-update-job-unknown-error":true},"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c= 4.17.23"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c= 4.17.23"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c= 4.17.22"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c= 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 3.7.0 \u003c 4.17.19"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.7.0 \u003c 4.17.11"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.12"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.11"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.5"],"patched-versions":[],"unaffected-versions":[]}],"security-updates-only":true,"source":{"provider":"github","repo":"yeikel/dependabot-reproducer-issue-15112","directories":["/."],"hostname":"github.com","api-endpoint":"https://api.github.com/"},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":false,"commit-message-options":{},"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":2700,"exclude-paths":null,"multi-ecosystem-update":false}}
  proxy | 2026/05/26 00:53:23 [002] GET https://github.com:443/yeikel/dependabot-reproducer-issue-15112.git/info/refs?service=git-upload-pack
  proxy | 2026/05/26 00:53:23 [002] * authenticating git server request (host: github.com)
  proxy | 2026/05/26 00:53:24 [002] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15112.git/info/refs?service=git-upload-pack
updater | 2026/05/26 00:53:24 INFO Started process PID: 1162 with command: {} git clone --no-tags --depth 1 --recurse-submodules --shallow-submodules https://github.com/yeikel/dependabot-reproducer-issue-15112 /home/dependabot/dependabot-updater/repo {}
  proxy | 2026/05/26 00:53:24 [004] GET https://github.com:443/yeikel/dependabot-reproducer-issue-15112/info/refs?service=git-upload-pack
  proxy | 2026/05/26 00:53:24 [004] * authenticating git server request (host: github.com)
  proxy | 2026/05/26 00:53:24 [004] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15112/info/refs?service=git-upload-pack
  proxy | 2026/05/26 00:53:24 [006] POST https://github.com:443/yeikel/dependabot-reproducer-issue-15112/git-upload-pack
  proxy | 2026/05/26 00:53:24 [006] * authenticating git server request (host: github.com)
  proxy | 2026/05/26 00:53:24 [006] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15112/git-upload-pack
  proxy | 2026/05/26 00:53:24 [008] POST https://github.com:443/yeikel/dependabot-reproducer-issue-15112/git-upload-pack
  proxy | 2026/05/26 00:53:24 [008] * authenticating git server request (host: github.com)
  proxy | 2026/05/26 00:53:24 [008] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15112/git-upload-pack
updater | 2026/05/26 00:53:24 INFO Process PID: 1162 completed with status: pid 1162 exit 0
updater | 2026/05/26 00:53:24 INFO Total execution time: 0.44 seconds
updater | 2026/05/26 00:53:24 INFO Started process PID: 1201 with command: {} git -C /home/dependabot/dependabot-updater/repo ls-files --stage {}
updater | 2026/05/26 00:53:24 INFO Process PID: 1201 completed with status: pid 1201 exit 0
updater | 2026/05/26 00:53:24 INFO Total execution time: 0.01 seconds
updater | 2026/05/26 00:53:24 INFO Started process PID: 1294 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/26 00:53:24 INFO Process PID: 1294 completed with status: pid 1294 exit 0
updater | 2026/05/26 00:53:24 INFO Total execution time: 0.04 seconds
updater | 2026/05/26 00:53:24 INFO Started process PID: 1415 with command: {} git rev-parse HEAD {}
updater | 2026/05/26 00:53:24 INFO Process PID: 1415 completed with status: pid 1415 exit 0
updater | 2026/05/26 00:53:24 INFO Total execution time: 0.0 seconds
updater | 2026/05/26 00:53:24 INFO Started process PID: 1596 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/26 00:53:24 INFO Process PID: 1596 completed with status: pid 1596 exit 0
updater | 2026/05/26 00:53:24 INFO Total execution time: 0.04 seconds
updater | 2026/05/26 00:53:24 INFO Detected package manager: npm
updater | 2026/05/26 00:53:24 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:24 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:24 INFO Fetching version for package manager: npm
updater | 2026/05/26 00:53:24 INFO Started process PID: 1628 with command: {} corepack npm -v {}
updater | 2026/05/26 00:53:25 INFO Process PID: 1628 completed with status: pid 1628 exit 0
updater | 2026/05/26 00:53:25 INFO Total execution time: 0.12 seconds
updater | 2026/05/26 00:53:25 INFO Installed version of npm: 11.8.0
updater | 2026/05/26 00:53:25 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:25 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:25 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:25 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:25 INFO No version requirement found for npm
updater | 2026/05/26 00:53:25 INFO Detected package manager: npm
updater | 2026/05/26 00:53:25 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:25 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:25 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:25 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:25 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:25 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:25 INFO No version requirement found for npm
updater | 2026/05/26 00:53:25 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:25 INFO Installing "npm@11.10.0"
updater | 2026/05/26 00:53:25 INFO Started process PID: 1640 with command: {} corepack prepare npm@11.10.0 --activate {}
  proxy | 2026/05/26 00:53:25 [010] GET https://registry.npmjs.org:443/npm/-/npm-11.10.0.tgz
  proxy | 2026/05/26 00:53:25 [010] 200 https://registry.npmjs.org:443/npm/-/npm-11.10.0.tgz
  proxy | 2026/05/26 00:53:27 [012] GET https://registry.npmjs.org:443/npm/11.10.0
  proxy | 2026/05/26 00:53:27 [012] 200 https://registry.npmjs.org:443/npm/11.10.0
updater | 2026/05/26 00:53:27 INFO Process PID: 1640 completed with status: pid 1640 exit 0
updater | 2026/05/26 00:53:27 INFO Total execution time: 2.7 seconds
updater | 2026/05/26 00:53:27 INFO npm@11.10.0 successfully installed.
updater | 2026/05/26 00:53:27 INFO Activating currently installed version of npm: 11.10.0
updater | 2026/05/26 00:53:27 INFO Fetching version for package manager: npm
updater | 2026/05/26 00:53:27 INFO Started process PID: 1653 with command: {} corepack npm -v {}
updater | 2026/05/26 00:53:27 INFO Process PID: 1653 completed with status: pid 1653 exit 0
updater | 2026/05/26 00:53:27 INFO Total execution time: 0.13 seconds
updater | 2026/05/26 00:53:27 INFO Installed version of npm: 11.10.0
updater | 2026/05/26 00:53:27 INFO Detected package manager: npm
updater | 2026/05/26 00:53:27 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:27 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:27 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:27 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:27 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:27 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:27 INFO No version requirement found for npm
updater | 2026/05/26 00:53:27 INFO Detected package manager: npm
updater | 2026/05/26 00:53:27 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:27 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:27 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:27 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:27 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:27 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:27 INFO No version requirement found for npm
updater | 2026/05/26 00:53:27 INFO Detected package manager: npm
updater | 2026/05/26 00:53:27 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:27 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:27 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:27 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:27 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:27 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:27 INFO No version requirement found for npm
updater | 2026/05/26 00:53:27 INFO Detected package manager: npm
updater | 2026/05/26 00:53:27 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:27 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:27 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:27 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:27 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:27 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:27 INFO No version requirement found for npm
updater | 2026/05/26 00:53:27 INFO Detected package manager: npm
updater | 2026/05/26 00:53:27 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:27 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:27 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:27 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:27 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:27 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:27 INFO No version requirement found for npm
{"data":{"ecosystem_versions":{"package_managers":{"npm":"11.10.0"}}},"type":"record_ecosystem_versions"}
  proxy | 2026/05/26 00:53:27 [013] POST http://host.docker.internal:62684/update_jobs/cli/record_ecosystem_versions
updater | 2026/05/26 00:53:27 INFO Detected package manager: npm
updater | 2026/05/26 00:53:27 INFO Resolving package manager for: npm
  proxy | 2026/05/26 00:53:27 [013] 200 http://host.docker.internal:62684/update_jobs/cli/record_ecosystem_versions
updater | 2026/05/26 00:53:27 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:27 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:27 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:27 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:27 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:27 INFO No version requirement found for npm
updater | 2026/05/26 00:53:27 INFO Detected package manager: npm
updater | 2026/05/26 00:53:27 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:27 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:27 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:27 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:27 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:27 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:27 INFO No version requirement found for npm
updater | 2026/05/26 00:53:27 INFO Detected package manager: npm
updater | 2026/05/26 00:53:27 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:27 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:27 INFO Installed version for npm: 11.8.0
updater | 2026/05/26 00:53:27 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:27 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:27 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:27 INFO No version requirement found for npm
updater | 2026/05/26 00:53:27 INFO Base commit SHA: 97e5f6da7f8013c430e44c964cb173ee58131fcb
updater | 2026/05/26 00:53:27 INFO Finished job processing
updater | 2026/05/26 00:53:27 INFO Starting job processing
updater | 2026/05/26 00:53:27 INFO Detected package manager: npm
updater | 2026/05/26 00:53:27 INFO Resolving package manager for: npm
updater | 2026/05/26 00:53:27 INFO Returned (engines) info "npm" : "11.10.0"
updater | 2026/05/26 00:53:27 INFO Fetching version for package manager: npm
updater | 2026/05/26 00:53:27 INFO Started process PID: 1665 with command: {} corepack npm -v {}
updater | 2026/05/26 00:53:28 INFO Process PID: 1665 completed with status: pid 1665 exit 0
updater | 2026/05/26 00:53:28 INFO Total execution time: 0.13 seconds
updater | 2026/05/26 00:53:28 INFO Installed version of npm: 11.10.0
updater | 2026/05/26 00:53:28 INFO Installed version for npm: 11.10.0
updater | 2026/05/26 00:53:28 INFO Processing engine constraints for npm
updater | 2026/05/26 00:53:28 INFO Parsed constraints for npm: >=11.10.0 <12.0.0
updater | 2026/05/26 00:53:28 ERROR Error processing constraints for npm: Illformed requirement [">=11.10.0 <12.0.0"]
updater | 2026/05/26 00:53:28 INFO No version requirement found for npm
updater | 2026/05/26 00:53:28 INFO Running node command: node -v
updater | 2026/05/26 00:53:28 INFO Started process PID: 1677 with command: {} node -v {}
updater | 2026/05/26 00:53:28 INFO Process PID: 1677 completed with status: pid 1677 exit 0
updater | 2026/05/26 00:53:28 INFO Total execution time: 0.01 seconds
updater | 2026/05/26 00:53:28 INFO Command executed successfully: node -v
updater | 2026/05/26 00:53:28 INFO Processing engine constraints for node
  proxy | 2026/05/26 00:53:28 [014] POST http://host.docker.internal:62684/update_jobs/cli/update_dependency_list
{"data":{"dependencies":[{"name":"lodash","requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"4.17.15","source":{"type":"registry","url":"https://registry.npmjs.org"}}],"version":"4.17.15"}],"dependency_files":["/package.json","/package-lock.json"]},"type":"update_dependency_list"}
  proxy | 2026/05/26 00:53:28 [014] 200 http://host.docker.internal:62684/update_jobs/cli/update_dependency_list
{"data":{"metric":"updater.started","tags":{"operation":"create_security_pr"}},"type":"increment_metric"}
  proxy | 2026/05/26 00:53:28 [015] POST http://host.docker.internal:62684/update_jobs/cli/increment_metric
  proxy | 2026/05/26 00:53:28 [015] 200 http://host.docker.internal:62684/update_jobs/cli/increment_metric
updater | 2026/05/26 00:53:28 INFO Starting security update job for yeikel/dependabot-reproducer-issue-15112
updater | 2026/05/26 00:53:28 INFO Checking if lodash 4.17.15 needs updating
  proxy | 2026/05/26 00:53:28 [017] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:53:28 [017] 200 https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:53:28 [019] HEAD https://registry.npmjs.org:443/lodash/-/lodash-4.18.1.tgz
  proxy | 2026/05/26 00:53:28 [019] 200 https://registry.npmjs.org:443/lodash/-/lodash-4.18.1.tgz
updater | 2026/05/26 00:53:28 INFO Latest version is 4.18.1
  proxy | 2026/05/26 00:53:28 [021] GET https://registry.npmjs.org:443/dependabot-reproducer-issue-15112
  proxy | 2026/05/26 00:53:28 [021] 404 https://registry.npmjs.org:443/dependabot-reproducer-issue-15112
updater | 2026/05/26 00:53:28 INFO VulnerabilityAuditor: starting audit
updater | 2026/05/26 00:53:28 INFO Started process PID: 1679 with command: node /opt/npm_and_yarn/dist/run.js
  proxy | 2026/05/26 00:53:29 [023] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:53:29 [023] 200 https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:53:29 [025] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:53:29 [025] 200 https://registry.npmjs.org:443/lodash
updater | 2026/05/26 00:53:29 INFO Process PID: 1679 completed with status: pid 1679 exit 0
updater | 2026/05/26 00:53:29 INFO Total execution time: 1.03 seconds
updater | 2026/05/26 00:53:29 INFO VulnerabilityAuditor: audit result viable
  proxy | 2026/05/26 00:53:29 [027] GET https://registry.npmjs.org:443/dependabot-reproducer-issue-15112
  proxy | 2026/05/26 00:53:29 [027] 404 https://registry.npmjs.org:443/dependabot-reproducer-issue-15112 (cached)
  proxy | 2026/05/26 00:53:29 [027] * auth'd git request previously retried, won't retry again. (cached)
updater | 2026/05/26 00:53:29 INFO Requirements to unlock own
  proxy | 2026/05/26 00:53:29 [029] GET https://registry.npmjs.org:443/dependabot-reproducer-issue-15112
  proxy | 2026/05/26 00:53:29 [029] 404 https://registry.npmjs.org:443/dependabot-reproducer-issue-15112 (cached)
  proxy | 2026/05/26 00:53:29 [029] * auth'd git request previously retried, won't retry again. (cached)
updater | 2026/05/26 00:53:29 INFO Requirements update strategy bump_versions
updater | 2026/05/26 00:53:29 INFO Updating lodash from 4.17.15 to 4.18.1
updater | 2026/05/26 00:53:30 INFO Started process PID: 1791 with command: {} corepack npm install lodash@4.18.1 --force --ignore-scripts --package-lock-only --min-release-age\=0 {}
updater | 2026/05/26 00:53:30 INFO Process PID: 1791 completed with status: pid 1791 exit 0
updater | 2026/05/26 00:53:30 INFO Total execution time: 0.4 seconds
updater | 2026/05/26 00:53:30 INFO Started process PID: 1805 with command: {} git status --untracked-files all --porcelain v1 . {}
updater | 2026/05/26 00:53:30 INFO Process PID: 1805 completed with status: pid 1805 exit 0
updater | 2026/05/26 00:53:30 INFO Total execution time: 0.01 seconds
updater | 2026/05/26 00:53:30 INFO Started process PID: 1812 with command: {} git status --untracked-files all --porcelain v1 .yarn/cache {}
updater | 2026/05/26 00:53:30 INFO Process PID: 1812 completed with status: pid 1812 exit 0
updater | 2026/05/26 00:53:30 INFO Total execution time: 0.01 seconds
updater | 2026/05/26 00:53:30 INFO Started process PID: 1819 with command: {} git status --untracked-files all --porcelain v1 .yarn/install-state.gz {}
updater | 2026/05/26 00:53:30 INFO Process PID: 1819 completed with status: pid 1819 exit 0
updater | 2026/05/26 00:53:30 INFO Total execution time: 0.01 seconds
updater | 2026/05/26 00:53:30 INFO Submitting lodash pull request for creation
  proxy | 2026/05/26 00:53:30 [031] GET https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-15112/commits?per_page=100
  proxy | 2026/05/26 00:53:30 [031] * authenticating github api request with token for api.github.com
  proxy | 2026/05/26 00:53:31 [031] 200 https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-15112/commits?per_page=100
  proxy | 2026/05/26 00:53:31 [033] GET https://registry.npmjs.org:443/lodash/latest
  proxy | 2026/05/26 00:53:31 [033] 200 https://registry.npmjs.org:443/lodash/latest
  proxy | 2026/05/26 00:53:31 [035] GET https://api.github.com:443/repos/lodash/lodash/releases?per_page=100
  proxy | 2026/05/26 00:53:31 [035] * authenticating github api request with token for api.github.com
  proxy | 2026/05/26 00:53:31 [035] 200 https://api.github.com:443/repos/lodash/lodash/releases?per_page=100
  proxy | 2026/05/26 00:53:31 [037] GET https://api.github.com:443/repos/lodash/lodash/contents/
  proxy | 2026/05/26 00:53:31 [037] * authenticating github api request with token for api.github.com
  proxy | 2026/05/26 00:53:32 [037] 200 https://api.github.com:443/repos/lodash/lodash/contents/
  proxy | 2026/05/26 00:53:32 [039] GET https://api.github.com:443/repos/lodash/lodash/contents/doc
  proxy | 2026/05/26 00:53:32 [039] * authenticating github api request with token for api.github.com
  proxy | 2026/05/26 00:53:32 [039] 200 https://api.github.com:443/repos/lodash/lodash/contents/doc
  proxy | 2026/05/26 00:53:32 [041] GET https://github.com:443/lodash/lodash.git/info/refs?service=git-upload-pack
  proxy | 2026/05/26 00:53:32 [041] * authenticating git server request (host: github.com)
  proxy | 2026/05/26 00:53:32 [041] 200 https://github.com:443/lodash/lodash.git/info/refs?service=git-upload-pack
  proxy | 2026/05/26 00:53:32 [043] GET https://api.github.com:443/repos/lodash/lodash/contents/?ref=4.18.1
  proxy | 2026/05/26 00:53:32 [043] * authenticating github api request with token for api.github.com
  proxy | 2026/05/26 00:53:32 [043] 200 https://api.github.com:443/repos/lodash/lodash/contents/?ref=4.18.1
  proxy | 2026/05/26 00:53:32 [045] GET https://api.github.com:443/repos/lodash/lodash/contents/doc?ref=4.18.1
  proxy | 2026/05/26 00:53:32 [045] * authenticating github api request with token for api.github.com
  proxy | 2026/05/26 00:53:33 [045] 200 https://api.github.com:443/repos/lodash/lodash/contents/doc?ref=4.18.1
  proxy | 2026/05/26 00:53:33 [047] GET https://github.com:443/lodash/lodash.git/info/refs?service=git-upload-pack
  proxy | 2026/05/26 00:53:33 [047] 200 https://github.com:443/lodash/lodash.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/05/26 00:53:33 [049] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15
  proxy | 2026/05/26 00:53:33 [049] * authenticating github api request with token for api.github.com
  proxy | 2026/05/26 00:53:33 [049] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15
  proxy | 2026/05/26 00:53:33 [051] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1
  proxy | 2026/05/26 00:53:33 [051] * authenticating github api request with token for api.github.com
  proxy | 2026/05/26 00:53:34 [051] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1
  proxy | 2026/05/26 00:53:34 [053] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15
  proxy | 2026/05/26 00:53:34 [053] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15 (cached)
  proxy | 2026/05/26 00:53:34 [055] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1
  proxy | 2026/05/26 00:53:34 [055] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1 (cached)
  proxy | 2026/05/26 00:53:34 [057] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15
  proxy | 2026/05/26 00:53:34 [057] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15 (cached)
  proxy | 2026/05/26 00:53:34 [059] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1
  proxy | 2026/05/26 00:53:34 [059] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1 (cached)
  proxy | 2026/05/26 00:53:34 [061] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/26 00:53:34 [061] 200 https://registry.npmjs.org:443/lodash (cached)
  proxy | 2026/05/26 00:53:34 [062] POST http://host.docker.internal:62684/update_jobs/cli/create_pull_request
{"data":{"base-commit-sha":"97e5f6da7f8013c430e44c964cb173ee58131fcb","dependencies":[{"name":"lodash","previous-requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"4.17.15","source":{"type":"registry","url":"https://registry.npmjs.org"}}],"previous-version":"4.17.15","requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"4.18.1","source":{"type":"registry","url":"https://registry.npmjs.org"}}],"version":"4.18.1","directory":"/"}],"updated-dependency-files":[{"content":"{\n  \"name\": \"dependabot-reproducer-issue-15112\",\n  \"version\": \"1.0.0\",\n  \"description\": \"Reproducer for dependabot-core issue #15112\",\n  \"engines\": {\n    \"npm\": \"^11.10.0\"\n  },\n  \"dependencies\": {\n    \"lodash\": \"4.18.1\"\n  }\n}\n","content_encoding":"utf-8","deleted":false,"directory":"/","name":"package.json","operation":"update","support_file":false,"type":"file","mode":""},{"content":"{\n  \"name\": \"dependabot-reproducer-issue-15112\",\n  \"version\": \"1.0.0\",\n  \"lockfileVersion\": 3,\n  \"requires\": true,\n  \"packages\": {\n    \"\": {\n      \"name\": \"dependabot-reproducer-issue-15112\",\n      \"version\": \"1.0.0\",\n      \"dependencies\": {\n        \"lodash\": \"4.18.1\"\n      },\n      \"engines\": {\n        \"npm\": \"^11.10.0\"\n      }\n    },\n    \"node_modules/lodash\": {\n      \"version\": \"4.18.1\",\n      \"resolved\": \"https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz\",\n      \"integrity\": \"sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==\",\n      \"license\": \"MIT\"\n    }\n  }\n}\n","content_encoding":"utf-8","deleted":false,"directory":"/","name":"package-lock.json","operation":"update","support_file":false,"type":"file","mode":""}],"pr-title":"Bump lodash from 4.17.15 to 4.18.1","pr-body":"Bumps [lodash](https://github.com/lodash/lodash) from 4.17.15 to 4.18.1.\n\u003cdetails\u003e\n\u003csummary\u003eRelease notes\u003c/summary\u003e\n\u003cp\u003e\u003cem\u003eSourced from \u003ca href=\"https://github.com/lodash/lodash/releases\"\u003elodash's releases\u003c/a\u003e.\u003c/em\u003e\u003c/p\u003e\n\u003cblockquote\u003e\n\u003ch2\u003e4.18.1\u003c/h2\u003e\n\u003ch2\u003eBugs\u003c/h2\u003e\n\u003cp\u003eFixes a \u003ccode\u003eReferenceError\u003c/code\u003e issue in \u003ccode\u003elodash\u003c/code\u003e \u003ccode\u003elodash-es\u003c/code\u003e \u003ccode\u003elodash-amd\u003c/code\u003e and \u003ccode\u003elodash.template\u003c/code\u003e when using the \u003ccode\u003etemplate\u003c/code\u003e and \u003ccode\u003efromPairs\u003c/code\u003e functions from the modular builds. See \u003ca href=\"https://redirect.github.com/lodash/lodash/issues/6167#issuecomment-4165269769\"\u003elodash/lodash#6167\u003c/a\u003e\u003c/p\u003e\n\u003cp\u003eThese defects were related to how lodash distributions are built from the main branch using \u003ca href=\"https://github.com/lodash-archive/lodash-cli\"\u003ehttps://github.com/lodash-archive/lodash-cli\u003c/a\u003e. When internal dependencies change inside lodash functions, equivalent updates need to be made to a mapping in the lodash-cli. (hey, it was ahead of its time once upon a time!). We know this, but we missed it in the last release. It's the kind of thing that passes in CI, but fails bc the build is not the same thing you tested.\u003c/p\u003e\n\u003cp\u003eThere is no diff on main for this, but you can see the diffs for each of the npm packages on their respective branches:\u003c/p\u003e\n\u003cul\u003e\n\u003cli\u003e\u003ccode\u003elodash\u003c/code\u003e: \u003ca href=\"https://github.com/lodash/lodash/compare/4.18.0-npm...4.18.1-npm\"\u003ehttps://github.com/lodash/lodash/compare/4.18.0-npm...4.18.1-npm\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ccode\u003elodash-es\u003c/code\u003e: \u003ca href=\"https://github.com/lodash/lodash/compare/4.18.0-es...4.18.1-es\"\u003ehttps://github.com/lodash/lodash/compare/4.18.0-es...4.18.1-es\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ccode\u003elodash-amd\u003c/code\u003e: \u003ca href=\"https://github.com/lodash/lodash/compare/4.18.0-amd...4.18.1-amd\"\u003ehttps://github.com/lodash/lodash/compare/4.18.0-amd...4.18.1-amd\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ccode\u003elodash.template\u003c/code\u003e\u003ca href=\"https://github.com/lodash/lodash/compare/4.18.0-npm-packages...4.18.1-npm-packages\"\u003ehttps://github.com/lodash/lodash/compare/4.18.0-npm-packages...4.18.1-npm-packages\u003c/a\u003e\u003c/li\u003e\n\u003c/ul\u003e\n\u003ch2\u003e4.18.0\u003c/h2\u003e\n\u003ch2\u003ev4.18.0\u003c/h2\u003e\n\u003cp\u003e\u003cstrong\u003eFull Changelog\u003c/strong\u003e: \u003ca href=\"https://github.com/lodash/lodash/compare/4.17.23...4.18.0\"\u003ehttps://github.com/lodash/lodash/compare/4.17.23...4.18.0\u003c/a\u003e\u003c/p\u003e\n\u003ch3\u003eSecurity\u003c/h3\u003e\n\u003cp\u003e\u003cstrong\u003e\u003ccode\u003e_.unset\u003c/code\u003e / \u003ccode\u003e_.omit\u003c/code\u003e\u003c/strong\u003e: Fixed prototype pollution via \u003ccode\u003econstructor\u003c/code\u003e/\u003ccode\u003eprototype\u003c/code\u003e path traversal (\u003ca href=\"https://github.com/lodash/lodash/security/advisories/GHSA-f23m-r3pf-42rh\"\u003eGHSA-f23m-r3pf-42rh\u003c/a\u003e, \u003ca href=\"https://github.com/lodash/lodash/commit/fe8d32eda854377349a4f922ab7655c8e5df9a0b\"\u003efe8d32e\u003c/a\u003e). Previously, array-wrapped path segments and primitive roots could bypass the existing guards, allowing deletion of properties from built-in prototypes. Now \u003ccode\u003econstructor\u003c/code\u003e and \u003ccode\u003eprototype\u003c/code\u003e are blocked unconditionally as non-terminal path keys, matching \u003ccode\u003ebaseSet\u003c/code\u003e. Calls that previously returned \u003ccode\u003etrue\u003c/code\u003e and deleted the property now return \u003ccode\u003efalse\u003c/code\u003e and leave the target untouched.\u003c/p\u003e\n\u003cp\u003e\u003cstrong\u003e\u003ccode\u003e_.template\u003c/code\u003e\u003c/strong\u003e: Fixed code injection via \u003ccode\u003eimports\u003c/code\u003e keys (\u003ca href=\"https://github.com/lodash/lodash/security/advisories/GHSA-r5fr-rjxr-66jc\"\u003eGHSA-r5fr-rjxr-66jc\u003c/a\u003e, CVE-2026-4800, \u003ca href=\"https://github.com/lodash/lodash/commit/879aaa93132d78c2f8d20c60279da9f8b21576d6\"\u003e879aaa9\u003c/a\u003e). Fixes an incomplete patch for CVE-2021-23337. The \u003ccode\u003evariable\u003c/code\u003e option was validated against \u003ccode\u003ereForbiddenIdentifierChars\u003c/code\u003e but \u003ccode\u003eimportsKeys\u003c/code\u003e was left unguarded, allowing code injection via the same \u003ccode\u003eFunction()\u003c/code\u003e constructor sink. \u003ccode\u003eimports\u003c/code\u003e keys containing forbidden identifier characters now throw \u003ccode\u003e\u0026quot;Invalid imports option passed into _.template\u0026quot;\u003c/code\u003e.\u003c/p\u003e\n\u003ch3\u003eDocs\u003c/h3\u003e\n\u003cul\u003e\n\u003cli\u003eAdd security notice for \u003ccode\u003e_.template\u003c/code\u003e in threat model and API docs (\u003ca href=\"https://redirect.github.com/lodash/lodash/pull/6099\"\u003e#6099\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003eDocument \u003ccode\u003elower \u0026gt; upper\u003c/code\u003e behavior in \u003ccode\u003e_.random\u003c/code\u003e (\u003ca href=\"https://redirect.github.com/lodash/lodash/pull/6115\"\u003e#6115\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003eFix quotes in \u003ccode\u003e_.compact\u003c/code\u003e jsdoc (\u003ca href=\"https://redirect.github.com/lodash/lodash/pull/6090\"\u003e#6090\u003c/a\u003e)\u003c/li\u003e\n\u003c/ul\u003e\n\u003ch3\u003e\u003ccode\u003elodash.*\u003c/code\u003e modular packages\u003c/h3\u003e\n\u003cp\u003e\u003ca href=\"https://redirect.github.com/lodash/lodash/pull/6157\"\u003eDiff\u003c/a\u003e\u003c/p\u003e\n\u003cp\u003eWe have also regenerated and published a select number of the \u003ccode\u003elodash.*\u003c/code\u003e modular packages.\u003c/p\u003e\n\u003cp\u003eThese modular packages had fallen out of sync significantly from the minor/patch updates to lodash. Specifically, we have brought the following packages up to parity w/ the latest lodash release because they have had CVEs on them in the past:\u003c/p\u003e\n\u003cul\u003e\n\u003cli\u003e\u003ca href=\"https://www.npmjs.com/package/lodash.orderby\"\u003elodash.orderby\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://www.npmjs.com/package/lodash.tonumber\"\u003elodash.tonumber\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://www.npmjs.com/package/lodash.trim\"\u003elodash.trim\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://www.npmjs.com/package/lodash.trimend\"\u003elodash.trimend\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://www.npmjs.com/package/lodash.sortedindexby\"\u003elodash.sortedindexby\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://www.npmjs.com/package/lodash.zipobjectdeep\"\u003elodash.zipobjectdeep\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://www.npmjs.com/package/lodash.unset\"\u003elodash.unset\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://www.npmjs.com/package/lodash.omit\"\u003elodash.omit\u003c/a\u003e\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://www.npmjs.com/package/lodash.template\"\u003elodash.template\u003c/a\u003e\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/blockquote\u003e\n\u003c/details\u003e\n\u003cdetails\u003e\n\u003csummary\u003eCommits\u003c/summary\u003e\n\u003cul\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/cb0b9b9212521c08e3eafe7c8cb0af1b42b6649e\"\u003e\u003ccode\u003ecb0b9b9\u003c/code\u003e\u003c/a\u003e release(patch): bump main to 4.18.1 (\u003ca href=\"https://redirect.github.com/lodash/lodash/issues/6177\"\u003e#6177\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/75535f57883b7225adb96de1cfc1cd4169cfcb51\"\u003e\u003ccode\u003e75535f5\u003c/code\u003e\u003c/a\u003e chore: prune stale advisory refs (\u003ca href=\"https://redirect.github.com/lodash/lodash/issues/6170\"\u003e#6170\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/62e91bc6a39c98d85b9ada8c44d40593deaf82a4\"\u003e\u003ccode\u003e62e91bc\u003c/code\u003e\u003c/a\u003e docs: remove n_ Node.js \u0026lt; 6 REPL note from README (\u003ca href=\"https://redirect.github.com/lodash/lodash/issues/6165\"\u003e#6165\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/59be2de61f8aa9461c7856533b51d31b7d8babc4\"\u003e\u003ccode\u003e59be2de\u003c/code\u003e\u003c/a\u003e release(minor): bump to 4.18.0 (\u003ca href=\"https://redirect.github.com/lodash/lodash/issues/6161\"\u003e#6161\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/af634573030f979194871da7c68f79420992f53d\"\u003e\u003ccode\u003eaf63457\u003c/code\u003e\u003c/a\u003e fix: broken tests for _.template 879aaa9\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/1073a7693e1727e0cf3641e5f71f75ddcf8de7c0\"\u003e\u003ccode\u003e1073a76\u003c/code\u003e\u003c/a\u003e fix: linting issues\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/879aaa93132d78c2f8d20c60279da9f8b21576d6\"\u003e\u003ccode\u003e879aaa9\u003c/code\u003e\u003c/a\u003e fix: validate imports keys in _.template\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/fe8d32eda854377349a4f922ab7655c8e5df9a0b\"\u003e\u003ccode\u003efe8d32e\u003c/code\u003e\u003c/a\u003e fix: block prototype pollution in baseUnset via constructor/prototype traversal\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/18ba0a32f42fd02117f096b032f89c984173462d\"\u003e\u003ccode\u003e18ba0a3\u003c/code\u003e\u003c/a\u003e refactor(fromPairs): use baseAssignValue for consistent assignment (\u003ca href=\"https://redirect.github.com/lodash/lodash/issues/6153\"\u003e#6153\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/lodash/lodash/commit/b8190803d48d60b8c80ad45d39125f32fa618cb2\"\u003e\u003ccode\u003eb819080\u003c/code\u003e\u003c/a\u003e ci: add dist sync validation workflow (\u003ca href=\"https://redirect.github.com/lodash/lodash/issues/6137\"\u003e#6137\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003eAdditional commits viewable in \u003ca href=\"https://github.com/lodash/lodash/compare/4.17.15...4.18.1\"\u003ecompare view\u003c/a\u003e\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/details\u003e\n\u003cbr /\u003e\n","commit-message":"Bump lodash from 4.17.15 to 4.18.1\n\nBumps [lodash](https://github.com/lodash/lodash) from 4.17.15 to 4.18.1.\n- [Release notes](https://github.com/lodash/lodash/releases)\n- [Commits](https://github.com/lodash/lodash/compare/4.17.15...4.18.1)","dependency-group":null},"type":"create_pull_request"}
  proxy | 2026/05/26 00:53:34 [062] 200 http://host.docker.internal:62684/update_jobs/cli/create_pull_request
  proxy | 2026/05/26 00:53:34 [063] POST http://host.docker.internal:62684/update_jobs/cli/record_ecosystem_meta
{"data":[{"ecosystem":{"name":"npm_and_yarn","package_manager":{"name":"npm","version":"11.10.0","raw_version":"11.10.0"},"language":{"name":"node","version":"24.15.0","raw_version":"24.15.0"}}}],"type":"record_ecosystem_meta"}
  proxy | 2026/05/26 00:53:34 [063] 200 http://host.docker.internal:62684/update_jobs/cli/record_ecosystem_meta
{"data":{"base-commit-sha":"97e5f6da7f8013c430e44c964cb173ee58131fcb"},"type":"mark_as_processed"}
  proxy | 2026/05/26 00:53:34 [064] PATCH http://host.docker.internal:62684/update_jobs/cli/mark_as_processed
  proxy | 2026/05/26 00:53:34 [064] 200 http://host.docker.internal:62684/update_jobs/cli/mark_as_processed
updater | 2026/05/26 00:53:34 INFO Finished job processing
updater | 2026/05/26 00:53:34 INFO Results:
updater | +---------------------------------------------+
updater | |     Changes to Dependabot Pull Requests     |
updater | +---------+-----------------------------------+
updater | | created | lodash ( from 4.17.15 to 4.18.1 ) |
updater | +---------+-----------------------------------+
  proxy | 2026/05/26 00:53:35 Skipping sending metrics because api endpoint is empty
  proxy | 2026/05/26 00:53:35 8/29 calls cached (27%)
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
