### PR TITLE
fix(npm_and_yarn): handle engines OR constraints and split caret-expanded bounds

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -334,7 +334,9 @@ module Dependabot
 
         # Validate the output format (e.g., "v20.18.1" or "20.18.1")
         if version.match?(/^v?\d+(\.\d+){2}$/)
-          version.strip.delete_prefix("v") # Remove the "v" prefix if present
+          parsed_version = version.strip.delete_prefix("v") # Remove the "v" prefix if present
+          Dependabot.logger.info("Using node version: #{parsed_version}")
+          parsed_version
         end
       rescue StandardError => e
         Dependabot.logger.error("Error retrieving Node.js version: #{e.message}")

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -223,9 +223,9 @@ module Dependabot
 
       sig { params(raw_constraint: String).returns(T::Array[T::Array[String]]) }
       def parse_constraint_groups(raw_constraint)
-        raw_constraint.split("||").map(&:strip).reject(&:empty?).filter_map do |constraint_group|
+        raw_constraint.split("||").map(&:strip).reject(&:empty?).map do |constraint_group|
           constraints = ConstraintHelper.extract_ruby_constraints(constraint_group)
-          next if constraints.nil?
+          return [] if constraints.nil?
 
           expanded_constraints(constraints)
         end.reject(&:empty?)
@@ -273,6 +273,12 @@ module Dependabot
       rescue StandardError
         nil
       end
+
+      private :raw_engine_constraint,
+              :parse_constraint_groups,
+              :expanded_constraints,
+              :requirement_for_group,
+              :current_engine_version
 
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/AbcSize

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -251,12 +251,13 @@ module Dependabot
       end
       def requirement_for_group(constraint_groups, name)
         requirements = constraint_groups.map { |constraints| Requirement.new(constraints) }
+        fallback_requirement = T.must(requirements.first)
 
         current_version = current_engine_version(name)
-        return requirements.first unless current_version
+        return fallback_requirement unless current_version
 
         matching_requirement = requirements.find { |requirement| requirement.satisfied_by?(current_version) }
-        matching_requirement || requirements.first
+        matching_requirement || fallback_requirement
       end
 
       sig { params(name: String).returns(T.nilable(Dependabot::Version)) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -197,11 +197,20 @@ module Dependabot
         return nil if raw_constraint.empty?
 
         constraint_groups = parse_constraint_groups(raw_constraint)
-
-        if constraint_groups.empty?
+        if constraint_groups.nil?
           Dependabot.logger.warn(
             "Unrecognized constraint format for #{name}: #{raw_constraint}"
           )
+          return nil
+        end
+
+        # A wildcard/latest branch translates to no constraints, which means
+        # there is effectively no engine requirement.
+        return nil if constraint_groups.any?(&:empty?)
+
+        constraint_groups = constraint_groups.reject(&:empty?)
+
+        if constraint_groups.empty?
           return nil
         end
 
@@ -221,14 +230,14 @@ module Dependabot
         @engines[name].to_s.strip
       end
 
-      sig { params(raw_constraint: String).returns(T::Array[T::Array[String]]) }
+      sig { params(raw_constraint: String).returns(T.nilable(T::Array[T::Array[String]])) }
       def parse_constraint_groups(raw_constraint)
         raw_constraint.split("||").map(&:strip).reject(&:empty?).map do |constraint_group|
           constraints = ConstraintHelper.extract_ruby_constraints(constraint_group)
-          return [] if constraints.nil?
+          return nil if constraints.nil?
 
           expanded_constraints(constraints)
-        end.reject(&:empty?)
+        end
       end
 
       sig { params(constraints: T::Array[String]).returns(T::Array[String]) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -193,25 +193,84 @@ module Dependabot
       def find_engine_constraints_as_requirement(name)
         Dependabot.logger.info("Processing engine constraints for #{name}")
 
-        return nil unless @engines.is_a?(Hash) && @engines[name]
-
-        raw_constraint = @engines[name].to_s.strip
+        raw_constraint = raw_engine_constraint(name)
         return nil if raw_constraint.empty?
 
-        constraints = ConstraintHelper.extract_ruby_constraints(raw_constraint)
-        # When constraints are invalid we return constraints array nil
-        if constraints.nil?
+        constraint_groups = parse_constraint_groups(raw_constraint)
+
+        if constraint_groups.empty?
           Dependabot.logger.warn(
             "Unrecognized constraint format for #{name}: #{raw_constraint}"
           )
+          return nil
         end
 
-        if constraints && !constraints.empty?
-          Dependabot.logger.info("Parsed constraints for #{name}: #{constraints.join(', ')}")
-          Requirement.new(constraints)
-        end
+        parsed_constraints = constraint_groups.map { |group| group.join(" ") }.join(" || ")
+        Dependabot.logger.info("Parsed constraints for #{name}: #{parsed_constraints}")
+
+        requirement_for_group(constraint_groups, name)
       rescue StandardError => e
         Dependabot.logger.error("Error processing constraints for #{name}: #{e.message}")
+        nil
+      end
+
+      sig { params(name: String).returns(String) }
+      def raw_engine_constraint(name)
+        return "" unless @engines.is_a?(Hash) && @engines[name]
+
+        @engines[name].to_s.strip
+      end
+
+      sig { params(raw_constraint: String).returns(T::Array[T::Array[String]]) }
+      def parse_constraint_groups(raw_constraint)
+        raw_constraint.split("||").map(&:strip).reject(&:empty?).filter_map do |constraint_group|
+          constraints = ConstraintHelper.extract_ruby_constraints(constraint_group)
+          next if constraints.nil?
+
+          expanded_constraints(constraints)
+        end.reject(&:empty?)
+      end
+
+      sig { params(constraints: T::Array[String]).returns(T::Array[String]) }
+      def expanded_constraints(constraints)
+        constraints.flat_map do |constraint|
+          parts = constraint.strip.split(/\s+/)
+          if parts.length > 1 && parts.all? { |part| part.match?(ConstraintHelper::VALID_CONSTRAINT_REGEX) }
+            parts
+          else
+            [constraint]
+          end
+        end
+      end
+
+      sig do
+        params(
+          constraint_groups: T::Array[T::Array[String]],
+          name: String
+        ).returns(Requirement)
+      end
+      def requirement_for_group(constraint_groups, name)
+        requirements = constraint_groups.map { |constraints| Requirement.new(constraints) }
+
+        current_version = current_engine_version(name)
+        return requirements.first unless current_version
+
+        matching_requirement = requirements.find { |requirement| requirement.satisfied_by?(current_version) }
+        matching_requirement || requirements.first
+      end
+
+      sig { params(name: String).returns(T.nilable(Dependabot::Version)) }
+      def current_engine_version(name)
+        raw_version = if name == Language::NAME
+                        Helpers.node_version
+                      else
+                        @installed_versions[name]
+                      end
+
+        return nil if raw_version.to_s.strip.empty?
+
+        Version.new(raw_version)
+      rescue StandardError
         nil
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -210,9 +210,7 @@ module Dependabot
 
         constraint_groups = constraint_groups.reject(&:empty?)
 
-        if constraint_groups.empty?
-          return nil
-        end
+        return nil if constraint_groups.empty?
 
         parsed_constraints = constraint_groups.map { |group| group.join(" ") }.join(" || ")
         Dependabot.logger.info("Parsed constraints for #{name}: #{parsed_constraints}")

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -610,8 +610,10 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
         "node -v",
         fingerprint: "node -v"
       ).and_return("v16.13.1")
+      allow(Dependabot.logger).to receive(:info)
 
       expect(described_class.node_version).to eq("16.13.1")
+      expect(Dependabot.logger).to have_received(:info).with("Using node version: 16.13.1")
     end
 
     it "raises an error if the Node.js version command fails" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
@@ -579,6 +579,28 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerHelper do
           expect(requirement).to be_nil
         end
       end
+
+      context "when one OR branch is a wildcard" do
+        let(:package_json) do
+          {
+            "name" => "example",
+            "version" => "1.0.0",
+            "engines" => {
+              "node" => "* || >=24"
+            }
+          }
+        end
+
+        it "returns nil without logging an unrecognized warning" do
+          allow(Dependabot.logger).to receive(:warn)
+
+          requirement = helper.find_engine_constraints_as_requirement("node")
+
+          expect(requirement).to be_nil
+          expect(Dependabot.logger).not_to have_received(:warn)
+            .with(/Unrecognized constraint format for node/)
+        end
+      end
     end
 
     context "when the engines field does not contain the specified package manager" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
@@ -161,6 +161,16 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerHelper do
       end
     end
 
+    context "with OR constraints where the lower branch is on the right" do
+      let(:lockfiles) { {} }
+      let(:package_json) { { "engines" => { "pnpm" => ">=10 || >=7 <9" } } }
+
+      it "selects the highest matching supported pnpm version" do
+        expect(helper.package_manager).to be_a(Dependabot::NpmAndYarn::PNPMPackageManager)
+        expect(helper.package_manager.detected_version).to eq("10")
+      end
+    end
+
     context "when neither lockfile, packageManager, nor engines field exists" do
       let(:lockfiles) { {} }
       let(:package_json) { {} }
@@ -621,6 +631,27 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerHelper do
 
         expect(requirement).to be_a(Dependabot::NpmAndYarn::Requirement)
         expect(requirement.constraints).to eq([">= 22.0.0", "< 23.0.0"])
+      end
+
+      context "when the lower branch appears on the right" do
+        let(:package_json) do
+          {
+            "name" => "example",
+            "version" => "1.0.0",
+            "engines" => {
+              "node" => ">=24 || >=22.0.0 <23.0.0"
+            }
+          }
+        end
+
+        it "selects the higher matching branch" do
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:node_version).and_return("24.2.0")
+
+          requirement = helper.find_engine_constraints_as_requirement("node")
+
+          expect(requirement).to be_a(Dependabot::NpmAndYarn::Requirement)
+          expect(requirement.constraints).to eq([">= 24"])
+        end
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
@@ -559,6 +559,26 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerHelper do
         expect(requirement).to be_a(Dependabot::NpmAndYarn::Requirement)
         expect(requirement.constraints).to eq([">= 22.0.0", "< 23.0.0"])
       end
+
+      context "when one OR branch is invalid" do
+        let(:package_json) do
+          {
+            "name" => "example",
+            "version" => "1.0.0",
+            "engines" => {
+              "node" => "^22 || invalid"
+            }
+          }
+        end
+
+        it "logs a warning and returns nil" do
+          expect(Dependabot.logger).to receive(:warn).with(/Unrecognized constraint format for node: \^22 \|\| invalid/)
+
+          requirement = helper.find_engine_constraints_as_requirement("node")
+
+          expect(requirement).to be_nil
+        end
+      end
     end
 
     context "when the engines field does not contain the specified package manager" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
@@ -522,6 +522,45 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerHelper do
       end
     end
 
+    context "when the engines field contains a caret OR constraint" do
+      let(:package_json) do
+        {
+          "name" => "example",
+          "version" => "1.0.0",
+          "engines" => {
+            "node" => "^22 || >=24"
+          }
+        }
+      end
+
+      it "expands caret constraints into separate comparators" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:node_version).and_return("22.6.0")
+
+        requirement = helper.find_engine_constraints_as_requirement("node")
+
+        expect(requirement).to be_a(Dependabot::NpmAndYarn::Requirement)
+        expect(requirement.constraints).to eq([">= 22.0.0", "< 23.0.0"])
+      end
+
+      it "selects the matching OR branch for current node version" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:node_version).and_return("24.2.0")
+
+        requirement = helper.find_engine_constraints_as_requirement("node")
+
+        expect(requirement).to be_a(Dependabot::NpmAndYarn::Requirement)
+        expect(requirement.constraints).to eq([">= 24"])
+      end
+
+      it "falls back to the first OR branch when current node version is unavailable" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:node_version).and_return(nil)
+
+        requirement = helper.find_engine_constraints_as_requirement("node")
+
+        expect(requirement).to be_a(Dependabot::NpmAndYarn::Requirement)
+        expect(requirement.constraints).to eq([">= 22.0.0", "< 23.0.0"])
+      end
+    end
+
     context "when the engines field does not contain the specified package manager" do
       it "returns nil" do
         requirement = helper.find_engine_constraints_as_requirement("nonexistent")

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
@@ -603,6 +603,27 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerHelper do
       end
     end
 
+    context "when the engines field contains an explicit comparator OR constraint" do
+      let(:package_json) do
+        {
+          "name" => "example",
+          "version" => "1.0.0",
+          "engines" => {
+            "node" => ">=22.0.0 <23.0.0 || >=24"
+          }
+        }
+      end
+
+      it "splits the first OR branch into separate comparators" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:node_version).and_return("22.6.0")
+
+        requirement = helper.find_engine_constraints_as_requirement("node")
+
+        expect(requirement).to be_a(Dependabot::NpmAndYarn::Requirement)
+        expect(requirement.constraints).to eq([">= 22.0.0", "< 23.0.0"])
+      end
+    end
+
     context "when the engines field does not contain the specified package manager" do
       it "returns nil" do
         requirement = helper.find_engine_constraints_as_requirement("nonexistent")


### PR DESCRIPTION
### What are you trying to accomplish?

fix(npm_and_yarn): handle engines OR constraints and split caret-expanded bounds
- parse engines constraints by OR groups instead of flattening into one AND list
- split compound comparator strings (for example ">=22.0.0 <23.0.0") into separate requirements before `Requirement.new`
- select the OR branch that matches current runtime version when available, with fallback to first branch
- add regression tests for "^22 || >=24", including fallback behavior when node version is unavailable

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Testing against the workflow: https://github.com/thavaahariharangit/dependabot-caret-engines-repro-FR-13667/actions/runs/26219192273/job/77149420577

before:
```
updater | 2026/05/21 10:01:42 INFO <job_1377883513> Command executed successfully: node -v
updater | 2026/05/21 10:01:42 INFO <job_1377883513> Processing engine constraints for node
updater | 2026/05/21 10:01:42 INFO <job_1377883513> Parsed constraints for node: >=22.0.0 <23.0.0, >=24
updater | 2026/05/21 10:01:42 ERROR <job_1377883513> Error processing constraints for node: Illformed requirement [">=22.0.0 <23.0.0"]
  proxy | 2026/05/21 10:01:42 [012] POST /update_jobs/1377883513/update_dependency_list
  proxy | 2026/05/21 10:01:42 [012] 204 /update_jobs/1377883513/update_dependency_list
  proxy | 2026/05/21 10:01:42 [014] POST /update_jobs/1377883513/increment_metric
  proxy | 2026/05/21 10:01:42 [014] 204 /update_jobs/1377883513/increment_metric
updater | 2026/05/21 10:01:42 INFO <job_1377883513> Starting update job for thavaahariharangit/dependabot-caret-engines-repro-FR-13667
2026/05/21 10:01:42 INFO <job_1377883513> Checking all dependencies for version updates...
updater | 2026/05/21 10:01:42 INFO <job_1377883513> Checking if lodash 4.17.21 needs updating
```

After:
```
updater | 2026/05/26 11:47:40 INFO Command executed successfully: node -v
updater | 2026/05/26 11:47:40 INFO Processing engine constraints for node
updater | 2026/05/26 11:47:40 INFO Parsed constraints for node: >=22.0.0 <23.0.0 || >=24
updater | 2026/05/26 11:47:40 INFO Running node command: node -v
updater | 2026/05/26 11:47:40 INFO Started process PID: 4784 with command: {} node -v {}
updater | 2026/05/26 11:47:40 INFO Process PID: 4784 completed with status: pid 4784 exit 0
updater | 2026/05/26 11:47:40 INFO Total execution time: 0.01 seconds
updater | 2026/05/26 11:47:40 INFO Command executed successfully: node -v
  proxy | 2026/05/26 11:47:40 [010] POST http://host.docker.internal:41121/update_jobs/cli/update_dependency_list
{"data":{"dependencies":[{"name":"lodash","requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"^4.17.21","source":{"type":"registry","url":"https://registry.npmjs.org"}}],"version":"4.17.21"}],"dependency_files":["/package.json","/package-lock.json"]},"type":"update_dependency_list"}
  proxy | 2026/05/26 11:47:40 [010] 200 http://host.docker.internal:41121/update_jobs/cli/update_dependency_list
  proxy | 2026/05/26 11:47:40 [011] POST http://host.docker.internal:41121/update_jobs/cli/increment_metric
{"data":{"metric":"updater.started","tags":{"operation":"group_update_all_versions"}},"type":"increment_metric"}
  proxy | 2026/05/26 11:47:40 [011] 200 http://host.docker.internal:41121/update_jobs/cli/increment_metric
updater | 2026/05/26 11:47:40 INFO Starting update job for thavaahariharangit/dependabot-caret-engines-repro-FR-13667
updater | 2026/05/26 11:47:40 INFO Checking all dependencies for version updates...
updater | 2026/05/26 11:47:40 INFO Checking if lodash 4.17.21 needs updating
```

confirmation of things working as expected: `updater | 2026/05/26 11:47:40 INFO Command executed successfully: node -v`

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
