### PR TITLE
NuGet: Fix binding redirect XML parse error to report unparseable file

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/BindingRedirectsTests.cs
@@ -205,6 +205,58 @@ public class BindingRedirectsTests : TestBase
         );
     }
 
+    [Fact]
+    public async Task MalformedConfigFileThrowsUnparseableFileException()
+    {
+        var projectContents = """
+            <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+              <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+              <PropertyGroup>
+                <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+              </PropertyGroup>
+              <ItemGroup>
+                <None Include="app.config" />
+              </ItemGroup>
+              <ItemGroup>
+                <Reference Include="Some.Package, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
+                  <HintPath>packages\Some.Package.2.0.0\lib\net45\Some.Package.dll</HintPath>
+                  <Private>True</Private>
+                </Reference>
+              </ItemGroup>
+              <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+            </Project>
+            """;
+        var configContents = """
+            <configuration>
+              <appSettings>
+                <add key="SomeKey" value="SomeValue" />
+              </appSettings
+              <runtime>
+                <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+                  <dependentAssembly>
+                    <assemblyIdentity name="Some.Package" publicKeyToken="null" culture="neutral" />
+                    <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+                  </dependentAssembly>
+                </assemblyBinding>
+              </runtime>
+            </configuration>
+            """;
+
+        using var tempDir = new TemporaryDirectory();
+        var projectFileName = "project.csproj";
+        var projectFilePath = Path.Combine(tempDir.DirectoryPath, projectFileName);
+        var configFilePath = Path.Combine(tempDir.DirectoryPath, "app.config");
+
+        File.WriteAllText(projectFilePath, projectContents);
+        File.WriteAllText(configFilePath, configContents);
+
+        var projectBuildFile = ProjectBuildFile.Open(tempDir.DirectoryPath, projectFilePath);
+        var exception = await Assert.ThrowsAsync<UnparseableFileException>(
+            () => BindingRedirectManager.UpdateBindingRedirectsAsync(tempDir.DirectoryPath, projectBuildFile, "Some.Package", "2.0.0").AsTask());
+        Assert.Equal(configFilePath.NormalizePathToUnix(), exception.FilePath);
+        Assert.Contains("Error loading binding redirect configuration", exception.Message);
+    }
+
     private static async Task VerifyBindingRedirectsAsync(string projectContents, string configContents, string expectedConfigContents, string updatedPackageName, string updatedPackageVersion, string configFileName = "app.config")
     {
         using var tempDir = new TemporaryDirectory();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/BindingRedirectManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Xml;
 using System.Xml.Linq;
 
 using Microsoft.Language.Xml;
@@ -154,7 +155,7 @@ internal static class BindingRedirectManager
         }
 
         // Get the configuration file
-        var document = GetConfiguration(configFile.Content);
+        var document = GetConfiguration(configFile.Content, configFile.Path);
 
         // Get the runtime element
         var runtime = document.Root?.Element("runtime");
@@ -211,15 +212,19 @@ internal static class BindingRedirectManager
             document.ToString()
         );
 
-        static XDocument GetConfiguration(string configFileContent)
+        static XDocument GetConfiguration(string configFileContent, string configFilePath)
         {
             try
             {
                 return XDocument.Parse(configFileContent, LoadOptions.PreserveWhitespace);
             }
+            catch (XmlException ex)
+            {
+                throw new UnparseableFileException($"Error loading binding redirect configuration: {ex.Message}", configFilePath);
+            }
             catch (Exception ex)
             {
-                throw new InvalidOperationException("Error loading binging redirect configuration", ex);
+                throw new InvalidOperationException("Error loading binding redirect configuration", ex);
             }
         }
 


### PR DESCRIPTION
When updating binding redirects, a failure to parse the XML config file was throwing an `InvalidOperationException` which resulted in an unknown error being reported to the API (`record_update_job_unknown_error`).

This change:
- Catches `XmlException` specifically and throws `UnparseableFileException` instead, which is properly mapped to the `dependency_file_not_parseable` error type
- Fixes the typo 'binging' → 'binding' in the error message

**Testing:** Added a test verifying that malformed XML in a config file produces `UnparseableFileException` with the correct file path and message.