### PR TITLE
Honor exclude_paths in graph jobs

### DIFF
--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -53,8 +53,6 @@ module Dependabot
       branch = job.source.branch || default_branch
 
       T.must(job.source.directories).each do |directory|
-        next if Dependabot::FileFiltering.should_exclude_path?(directory, "graph job directory", job.exclude_paths)
-
         # Each directory is processed with its own error handling so one failure will not
         # block the overall job.
         process_directory(branch:, directory:)
@@ -81,18 +79,8 @@ module Dependabot
     sig { params(branch: String, directory: String).void }
     def process_directory(branch:, directory:) # rubocop:disable Metrics/MethodLength
       directory_source = create_source_for(directory)
-      directory_dependency_files = dependency_files_for(directory)
 
-      submission = if directory_dependency_files.empty?
-                     empty_submission(
-                       branch,
-                       directory_source,
-                       GithubApi::DependencySubmission::SnapshotStatus::SKIPPED,
-                       GithubApi::DependencySubmission::EMPTY_REASON_NO_MANIFESTS
-                     )
-                   else
-                     create_submission(branch, directory_source, directory_dependency_files)
-                   end
+      submission = build_submission(branch, directory, directory_source)
 
       Dependabot.logger.info("Dependency submission payload:\n#{JSON.pretty_generate(submission.payload)}")
       service.create_dependency_submission(dependency_submission: submission)
@@ -157,9 +145,56 @@ module Dependabot
       end
     end
 
-    sig { params(directory: String).returns(T::Array[Dependabot::DependencyFile]) }
-    def dependency_files_for(directory)
-      files = dependency_files.select { |f| f.directory == directory }
+    sig do
+      params(
+        branch: String,
+        directory: String,
+        directory_source: Dependabot::Source
+      ).returns(GithubApi::DependencySubmission)
+    end
+    def build_submission(branch, directory, directory_source)
+      if directory_excluded?(directory)
+        return skipped_submission(branch, directory_source, GithubApi::DependencySubmission::EMPTY_REASON_EXCLUDED_PATHS)
+      end
+
+      all_directory_files = dependency_files.select { |f| f.directory == directory }
+      directory_dependency_files = filter_excluded_files(all_directory_files)
+
+      if directory_dependency_files.empty?
+        reason = if all_directory_files.any?
+                   GithubApi::DependencySubmission::EMPTY_REASON_EXCLUDED_PATHS
+                 else
+                   GithubApi::DependencySubmission::EMPTY_REASON_NO_MANIFESTS
+                 end
+        return skipped_submission(branch, directory_source, reason)
+      end
+
+      create_submission(branch, directory_source, directory_dependency_files)
+    end
+
+    sig do
+      params(
+        branch: String,
+        source: Dependabot::Source,
+        reason: String
+      ).returns(GithubApi::DependencySubmission)
+    end
+    def skipped_submission(branch, source, reason)
+      empty_submission(
+        branch,
+        source,
+        GithubApi::DependencySubmission::SnapshotStatus::SKIPPED,
+        reason
+      )
+    end
+
+    sig { params(directory: String).returns(T::Boolean) }
+    def directory_excluded?(directory)
+      Dependabot::FileFiltering.should_exclude_path?(directory, "graph job directory", job.exclude_paths)
+    end
+
+    sig { params(files: T::Array[Dependabot::DependencyFile]).returns(T::Array[Dependabot::DependencyFile]) }
+    def filter_excluded_files(files)
       exclude_paths = job.exclude_paths
       return files if exclude_paths.nil? || exclude_paths.empty?
 

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -7,6 +7,7 @@ require "sorbet-runtime"
 require "dependabot/environment"
 require "dependabot/experiments"
 require "dependabot/dependency_graphers"
+require "dependabot/file_filtering"
 require "dependabot/logger"
 
 # Updater components
@@ -52,6 +53,8 @@ module Dependabot
       branch = job.source.branch || default_branch
 
       T.must(job.source.directories).each do |directory|
+        next if Dependabot::FileFiltering.should_exclude_path?(directory, "graph job directory", job.exclude_paths)
+
         # Each directory is processed with its own error handling so one failure will not
         # block the overall job.
         process_directory(branch:, directory:)
@@ -156,7 +159,14 @@ module Dependabot
 
     sig { params(directory: String).returns(T::Array[Dependabot::DependencyFile]) }
     def dependency_files_for(directory)
-      dependency_files.select { |f| f.directory == directory }
+      files = dependency_files.select { |f| f.directory == directory }
+      exclude_paths = job.exclude_paths
+      return files if exclude_paths.nil? || exclude_paths.empty?
+
+      files.reject do |file|
+        path = File.join(file.directory, file.name).sub(%r{^/+}, "/")
+        Dependabot::FileFiltering.should_exclude_path?(path, "graph job dependency file", exclude_paths)
+      end
     end
 
     sig do

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -164,8 +164,7 @@ module Dependabot
       return files if exclude_paths.nil? || exclude_paths.empty?
 
       files.reject do |file|
-        path = File.join(file.directory, file.name).sub(%r{^/+}, "/")
-        Dependabot::FileFiltering.should_exclude_path?(path, "graph job dependency file", exclude_paths)
+        Dependabot::FileFiltering.should_exclude_path?(file.path, "graph job dependency file", exclude_paths)
       end
     end
 

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -21,6 +21,7 @@ module GithubApi
     # Expected reasons for empty or degraded snapshots
     DEGRADED_REASON_SUBDEPENDENCY_ERR = "error fetching sub-dependencies"
     EMPTY_REASON_NO_MANIFESTS = "missing manifest files"
+    EMPTY_REASON_EXCLUDED_PATHS = "all manifest files excluded by exclude_paths configuration"
 
     class SnapshotStatus < T::Enum
       enums do

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -61,9 +61,12 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       credentials: credentials,
       source: source,
       reject_external_code?: false,
-      experiments: { large_hadron_collider: true }
+      experiments: { large_hadron_collider: true },
+      exclude_paths: exclude_paths
     )
   end
+
+  let(:exclude_paths) { [] }
 
   let(:base_commit_sha) { "fake-sha" }
   let(:repo_contents_path) { nil }
@@ -881,6 +884,93 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
 
       it "records an error for each directory" do
         expect(service).to receive(:record_update_job_error).twice
+
+        update_graph_processor.run
+      end
+    end
+  end
+
+  context "when exclude_paths is configured" do
+    let(:directories) { [dir1, dir2] }
+
+    let(:dir1) { "/" }
+    let(:dir2) { "/subproject/" }
+    let(:repo_contents_path) { build_tmp_repo("bundler_sinatra_app/original", path: "") }
+    let(:experiment_enabled) { true }
+
+    let(:dependency_files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "Gemfile",
+          content: fixture("bundler_sinatra_app/original/Gemfile"),
+          directory: dir1
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: fixture("bundler_sinatra_app/original/Gemfile.lock"),
+          directory: dir1
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile",
+          content: fixture("bundler/original/Gemfile"),
+          directory: dir2
+        ),
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: fixture("bundler/original/Gemfile.lock"),
+          directory: dir2
+        )
+      ]
+    end
+
+    around do |example|
+      Dependabot::Experiments.register(:enable_exclude_paths_subdirectory_manifest_files, experiment_enabled)
+      example.run
+    ensure
+      Dependabot::Experiments.reset!
+    end
+
+    context "when an excluded path matches a configured directory" do
+      let(:exclude_paths) { ["subproject"] }
+
+      it "skips the excluded directory and processes the rest" do
+        payload = nil
+        expect(service).to receive(:create_dependency_submission).once do |args|
+          payload = args[:dependency_submission].payload
+        end
+
+        update_graph_processor.run
+
+        expect(payload).not_to be_nil
+        expect(payload[:job][:correlator]).to eq("dependabot-bundler")
+        expect(payload[:manifests].keys).to eq(["/Gemfile.lock"])
+      end
+    end
+
+    context "when an excluded path matches a dependency file inside an included directory" do
+      let(:exclude_paths) { ["subproject/Gemfile.lock"] }
+
+      it "filters the excluded file from the submission for that directory" do
+        payloads = []
+        allow(service).to receive(:create_dependency_submission) do |args|
+          payloads << args[:dependency_submission].payload
+        end
+
+        update_graph_processor.run
+
+        subproject_payload = payloads.find { |p| p[:job][:correlator] == "dependabot-bundler-subproject" }
+        expect(subproject_payload).not_to be_nil
+        # Gemfile.lock was excluded, leaving only the Gemfile manifest for /subproject.
+        expect(subproject_payload[:manifests].keys).to eq(["/subproject/Gemfile"])
+      end
+    end
+
+    context "when the experiment is disabled" do
+      let(:experiment_enabled) { false }
+      let(:exclude_paths) { ["subproject"] }
+
+      it "ignores exclude_paths and processes every directory" do
+        expect(service).to receive(:create_dependency_submission).twice
 
         update_graph_processor.run
       end

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -933,17 +933,37 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
     context "when an excluded path matches a configured directory" do
       let(:exclude_paths) { ["subproject"] }
 
-      it "skips the excluded directory and processes the rest" do
-        payload = nil
-        expect(service).to receive(:create_dependency_submission).once do |args|
-          payload = args[:dependency_submission].payload
+      it "emits a SKIPPED submission for the excluded directory so the previous snapshot is replaced" do
+        payloads = []
+        allow(service).to receive(:create_dependency_submission) do |args|
+          payloads << args[:dependency_submission].payload
         end
 
         update_graph_processor.run
 
-        expect(payload).not_to be_nil
-        expect(payload[:job][:correlator]).to eq("dependabot-bundler")
-        expect(payload[:manifests].keys).to eq(["/Gemfile.lock"])
+        expect(payloads.length).to eq(2)
+        included = payloads.find { |p| p[:job][:correlator] == "dependabot-bundler" }
+        excluded = payloads.find { |p| p[:job][:correlator] == "dependabot-bundler-subproject" }
+
+        expect(included[:manifests].keys).to eq(["/Gemfile.lock"])
+
+        expect(excluded[:detector][:name]).to eq("dependabot")
+        expect(excluded[:manifests]).to be_empty
+        expect(excluded[:job][:html_url]).to be_nil if excluded[:job].key?(:html_url)
+        expect(excluded[:scanned]).to be_nil if excluded.key?(:scanned)
+      end
+
+      it "marks the excluded-directory submission as SKIPPED with the exclude_paths reason" do
+        submissions = []
+        allow(service).to receive(:create_dependency_submission) do |args|
+          submissions << args[:dependency_submission]
+        end
+
+        update_graph_processor.run
+
+        excluded = submissions.find { |s| s.payload[:job][:correlator] == "dependabot-bundler-subproject" }
+        expect(excluded.status).to eq(GithubApi::DependencySubmission::SnapshotStatus::SKIPPED)
+        expect(excluded.reason).to eq(GithubApi::DependencySubmission::EMPTY_REASON_EXCLUDED_PATHS)
       end
     end
 
@@ -962,6 +982,24 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
         expect(subproject_payload).not_to be_nil
         # Gemfile.lock was excluded, leaving only the Gemfile manifest for /subproject.
         expect(subproject_payload[:manifests].keys).to eq(["/subproject/Gemfile"])
+      end
+    end
+
+    context "when every dependency file in a directory is excluded" do
+      let(:exclude_paths) { ["subproject/Gemfile", "subproject/Gemfile.lock"] }
+
+      it "emits a SKIPPED submission tagged with the exclude_paths reason" do
+        submissions = []
+        allow(service).to receive(:create_dependency_submission) do |args|
+          submissions << args[:dependency_submission]
+        end
+
+        update_graph_processor.run
+
+        excluded = submissions.find { |s| s.payload[:job][:correlator] == "dependabot-bundler-subproject" }
+        expect(excluded.status).to eq(GithubApi::DependencySubmission::SnapshotStatus::SKIPPED)
+        expect(excluded.reason).to eq(GithubApi::DependencySubmission::EMPTY_REASON_EXCLUDED_PATHS)
+        expect(excluded.payload[:manifests]).to be_empty
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/dependabot/dependabot-core/issues/15102

Filter out excluded paths

### Anything you want to highlight for special attention from reviewers?

enable_exclude_paths_subdirectory_manifest_files is fully rolled out already and should probably be removed

### How will you know you've accomplished your goal?

Excluded paths are skipped

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
