### PR TITLE
Gate uv .in/.txt parsing behind uv_excludes_pip experiment

### DIFF
--- a/uv/lib/dependabot/uv/file_fetcher.rb
+++ b/uv/lib/dependabot/uv/file_fetcher.rb
@@ -4,6 +4,7 @@
 require "toml-rb"
 require "sorbet-runtime"
 
+require "dependabot/experiments"
 require "dependabot/file_fetchers"
 require "dependabot/python/file_fetcher"
 require "dependabot/uv"
@@ -43,6 +44,19 @@ module Dependabot
         "Repo must contain a requirements.txt, uv.lock, requirements.in, or pyproject.toml"
       end
 
+      sig { override.returns(T::Array[DependencyFile]) }
+      def fetch_files
+        fetched_files = super
+        return fetched_files unless exclude_pip_files?
+
+        pip_files, kept_files = fetched_files.partition { |f| pip_compile_only_file?(f) }
+
+        log_pip_file_deprecation(pip_files) if pip_files.any?
+        ensure_uv_native_files_present!(kept_files)
+
+        kept_files
+      end
+
       private
 
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
@@ -63,6 +77,8 @@ module Dependabot
 
       sig { override.returns(T::Array[T::Hash[Symbol, String]]) }
       def path_dependencies
+        return uv_sources_path_dependencies if exclude_pip_files?
+
         [
           *requirement_txt_path_dependencies,
           *requirement_in_path_dependencies,
@@ -355,6 +371,41 @@ module Dependabot
       def fetch_file_with_path(filename, base_path)
         path = base_path ? File.join(base_path, filename) : filename
         fetch_file_from_host(path)
+      end
+
+      sig { returns(T::Boolean) }
+      def exclude_pip_files?
+        Dependabot::Experiments.enabled?(:uv_excludes_pip)
+      end
+
+      sig { params(file: Dependabot::DependencyFile).returns(T::Boolean) }
+      def pip_compile_only_file?(file)
+        return false if file.name.end_with?("uv.lock")
+
+        file.name.end_with?(".txt", ".in")
+      end
+
+      sig { params(pip_files: T::Array[Dependabot::DependencyFile]).void }
+      def log_pip_file_deprecation(pip_files)
+        Dependabot.logger.warn(
+          "[uv] Skipping #{pip_files.size} requirements.in/.txt file(s): " \
+          "#{pip_files.map(&:name).join(', ')}. " \
+          "The uv ecosystem no longer parses pip-compile files. " \
+          "Move dependencies to pyproject.toml + uv.lock, or switch your " \
+          "Dependabot config to package-ecosystem: \"pip\"."
+        )
+      end
+
+      sig { params(files: T::Array[Dependabot::DependencyFile]).void }
+      def ensure_uv_native_files_present!(files)
+        return if files.any? { |f| f.name == "pyproject.toml" || f.name.end_with?("uv.lock") }
+
+        raise Dependabot::DependencyFileNotFound.new(
+          File.join(directory, "pyproject.toml"),
+          "No pyproject.toml or uv.lock found. The uv ecosystem requires " \
+          "pyproject.toml and/or uv.lock. For repos using requirements.in/.txt " \
+          "only, switch your Dependabot config to package-ecosystem: \"pip\"."
+        )
       end
     end
   end

--- a/uv/lib/dependabot/uv/file_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser.rb
@@ -21,6 +21,7 @@ require "toml-rb"
 
 module Dependabot
   module Uv
+    # rubocop:disable Metrics/ClassLength
     class FileParser < Dependabot::FileParsers::Base
       extend T::Sig
 
@@ -56,7 +57,8 @@ module Dependabot
 
         dependency_set += pyproject_file_dependencies if pyproject
         dependency_set += uv_lock_file_dependencies
-        dependency_set += requirement_dependencies if requirement_files.any? && !exclude_pip_files?
+        dependency_set += requirement_dependencies if requirement_files.any? &&
+                                                      !Dependabot::Experiments.enabled?(:uv_excludes_pip)
 
         dependency_set.dependencies
       end
@@ -187,11 +189,6 @@ module Dependabot
       sig { returns(T::Array[DependencyFile]) }
       def requirement_files
         dependency_files.select { |f| f.name.end_with?(".txt", ".in") }
-      end
-
-      sig { returns(T::Boolean) }
-      def exclude_pip_files?
-        Dependabot::Experiments.enabled?(:uv_excludes_pip)
       end
 
       sig { returns(T::Array[DependencyFile]) }
@@ -461,6 +458,7 @@ module Dependabot
         )
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end
 

--- a/uv/lib/dependabot/uv/file_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser.rb
@@ -3,6 +3,7 @@
 
 require "dependabot/dependency"
 require "dependabot/dependency_file"
+require "dependabot/experiments"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/file_parsers/base/dependency_set"
@@ -55,7 +56,7 @@ module Dependabot
 
         dependency_set += pyproject_file_dependencies if pyproject
         dependency_set += uv_lock_file_dependencies
-        dependency_set += requirement_dependencies if requirement_files.any?
+        dependency_set += requirement_dependencies if requirement_files.any? && !exclude_pip_files?
 
         dependency_set.dependencies
       end
@@ -186,6 +187,11 @@ module Dependabot
       sig { returns(T::Array[DependencyFile]) }
       def requirement_files
         dependency_files.select { |f| f.name.end_with?(".txt", ".in") }
+      end
+
+      sig { returns(T::Boolean) }
+      def exclude_pip_files?
+        Dependabot::Experiments.enabled?(:uv_excludes_pip)
       end
 
       sig { returns(T::Array[DependencyFile]) }

--- a/uv/spec/dependabot/uv/file_fetcher_spec.rb
+++ b/uv/spec/dependabot/uv/file_fetcher_spec.rb
@@ -162,6 +162,20 @@ RSpec.describe Dependabot::Uv::FileFetcher do
           .to eq(["requirements.txt"])
       end
 
+      context "when uv_excludes_pip experiment is enabled" do
+        before { Dependabot::Experiments.register(:uv_excludes_pip, true) }
+
+        it "raises DependencyFileNotFound pointing at pyproject.toml" do
+          expect { file_fetcher_instance.files }
+            .to raise_error(Dependabot::DependencyFileNotFound, /pyproject\.toml or uv\.lock/)
+        end
+
+        it "mentions the package-ecosystem: pip migration in the error" do
+          expect { file_fetcher_instance.files }
+            .to raise_error(Dependabot::DependencyFileNotFound, /package-ecosystem.*pip/)
+        end
+      end
+
       context "when including comments" do
         let(:requirements_fixture_name) { "requirements_with_comments.json" }
 
@@ -921,6 +935,15 @@ RSpec.describe Dependabot::Uv::FileFetcher do
       it "doesn't raise a path dependency error" do
         primary_files = file_fetcher_instance.files.reject(&:support_file?)
         expect(primary_files.map(&:name)).to contain_exactly("requirements-test.txt", "pyproject.toml")
+      end
+
+      context "when uv_excludes_pip experiment is enabled" do
+        before { Dependabot::Experiments.register(:uv_excludes_pip, true) }
+
+        it "filters out the requirements file and keeps pyproject.toml" do
+          primary_files = file_fetcher_instance.files.reject(&:support_file?)
+          expect(primary_files.map(&:name)).to contain_exactly("pyproject.toml")
+        end
       end
     end
 

--- a/uv/spec/dependabot/uv/file_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser_spec.rb
@@ -947,6 +947,55 @@ RSpec.describe Dependabot::Uv::FileParser do
       end
     end
 
+    context "when uv_excludes_pip experiment is enabled" do
+      before { Dependabot::Experiments.register(:uv_excludes_pip, true) }
+
+      context "with only requirements.txt files" do
+        let(:files) { [requirements] }
+
+        it "returns no dependencies" do
+          expect(parser.parse).to be_empty
+        end
+      end
+
+      context "with pyproject.toml and requirements.txt" do
+        let(:pyproject) do
+          Dependabot::DependencyFile.new(
+            name: "pyproject.toml",
+            content: fixture("pyproject_files", "uv_simple.toml")
+          )
+        end
+        let(:files) { [pyproject, requirements] }
+
+        it "parses pyproject.toml dependencies and ignores requirements.txt" do
+          names = parser.parse.map(&:name)
+          expect(names).to include("requests")
+          expect(names).not_to include("psycopg2")
+        end
+      end
+
+      context "with uv.lock, pyproject.toml, and requirements.txt" do
+        let(:pyproject) do
+          Dependabot::DependencyFile.new(
+            name: "pyproject.toml",
+            content: fixture("pyproject_files", "uv_simple.toml")
+          )
+        end
+        let(:uv_lock) do
+          Dependabot::DependencyFile.new(
+            name: "uv.lock",
+            content: fixture("uv_locks", "simple.lock")
+          )
+        end
+        let(:files) { [pyproject, uv_lock, requirements] }
+
+        it "parses pyproject.toml + uv.lock dependencies and ignores requirements.txt" do
+          names = parser.parse.map(&:name)
+          expect(names).not_to include("psycopg2")
+        end
+      end
+    end
+
     context "with uv workspace member pyprojects" do
       let(:files) { [pyproject, workspace_member_pyproject] }
       let(:parsed_files) { [] }


### PR DESCRIPTION
### What are you trying to accomplish?

Step 1 of moving the uv ecosystem to only parse `pyproject.toml` + `uv.lock`. Gates `.in` / `.txt` handling behind a new experiment, `uv_excludes_pip`, so we can roll it out via the monolith `dependabot_uv_excludes_pip` ff before deleting any code.

When the experiment is on:

- `Uv::FileFetcher#fetch_files` filters `requirements.in` / `requirements.txt` out of the fetched set and skips parsing them for path dependencies. If nothing but `.in` / `.txt` is left, it raises `DependencyFileNotFound` with a message pointing the user at `package-ecosystem: "pip"`.
- `Uv::FileParser#parse` skips `requirement_dependencies`, so only `pyproject.toml` + `uv.lock` deps are returned.

`uv.lock` is fetched through the same `req_txt_and_in_files` path as `.in` / `.txt` but is preserved by the filter.

### Anything you want to highlight for special attention from reviewers?

- Ships behind an experiment that defaults to off. No behavior change in prod until the monolith ff is registered and `dependabot-api` wires it through.
- The `dependabot-api` one-liner needed to actually flip the behavior:
  ```ruby
  uv_excludes_pip: repo.monolith_feature_enabled?(:dependabot_uv_excludes_pip),
  ```
  In `app/models/update_job.rb#experiments`. Tracked as a separate PR.
- Monolith ff `dependabot_uv_excludes_pip` to be registered in devportal separately.
- PR 2 will remove the now-dead `.in` / `.txt` code (and the `requirements_file_matcher`, child `.in` / `.txt` fetch, etc.) once the ff is at 100% for ~2 weeks.
- Filter happens after `super` returns rather than overriding upstream `requirements_in_files` / `req_txt_and_in_files` to keep the diff minimal. Trade-off is we still do the network fetch for files we discard. Acceptable for the gate PR. PR 2 can clean it up.

### How will you know you've accomplished your goal?

- New spec contexts in `uv/spec/dependabot/uv/file_parser_spec.rb` cover the parser FF-on behavior (no requirement deps, pyproject + uv.lock still parsed).
- New spec contexts in `uv/spec/dependabot/uv/file_fetcher_spec.rb` cover the fetcher FF-on behavior (`.in` / `.txt` filtered, raises with migration message when nothing else is left).
- Full uv suite runs in CI.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
