### PR TITLE
NuGet: Fix version range double-wrapping in temp project creation

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
@@ -636,6 +636,62 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
         Assert.False(File.Exists(errorSentinelPath), "Build targets should not have executed during discovery");
     }
 
+    [Fact]
+    public async Task LegacyProjectWithPackagesConfigAndVersionRangePackageReference_DoesNotThrow()
+    {
+        // A legacy project with packages.config and a <PackageReference> using a version range
+        // correctly resolves both direct and transitive dependencies.
+        await TestDiscoverAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("SdkStyle.Package", "1.5.0", "net48", [(null, [("Transitive.Dependency", "3.0.0")])]),
+                MockNuGetPackage.CreateSimplePackage("Transitive.Dependency", "3.0.0", "net48"),
+            ],
+            startingDirectory: "",
+            projectPath: "project.csproj",
+            files:
+            [
+                ("project.csproj", """
+                    <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+                      <PropertyGroup>
+                        <OutputType>Library</OutputType>
+                        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <None Include="packages.config" />
+                      </ItemGroup>
+                      <ItemGroup>
+                        <PackageReference Include="SdkStyle.Package" Version="[1.0.0,2.0.0)" />
+                      </ItemGroup>
+                      <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+                    </Project>
+                    """),
+                ("packages.config", """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <packages>
+                    </packages>
+                    """)
+            ],
+            expectedProjects:
+            [
+                new()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies =
+                    [
+                        new("SdkStyle.Package", "1.5.0", DependencyType.PackageReference, TargetFrameworks: ["net48"]),
+                        new("Transitive.Dependency", "3.0.0", DependencyType.Unknown, TargetFrameworks: ["net48"], IsTopLevel: false),
+                    ],
+                    ImportedFiles = [],
+                    TargetFrameworks = ["net48"],
+                    ReferencedProjectPaths = [],
+                    AdditionalFiles = ["packages.config"],
+                }
+            ]
+        );
+    }
+
     private static async Task TestDiscoverAsync(
         string startingDirectory,
         string projectPath,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -346,7 +346,7 @@ internal static partial class MSBuildHelper
                 // empty `Version` attributes will cause the temporary project to not build
                 .Where(p => (p.EvaluationResult is null || p.EvaluationResult.ResultType == EvaluationResultType.Success) && !string.IsNullOrWhiteSpace(p.Version))
                 // If all PackageReferences for a package are update-only mark it as such, otherwise it can cause package incoherence errors which do not exist in the repo.
-                .Select(p => $"<{(usePackageDownload ? "PackageDownload" : "PackageReference")} {(p.IsUpdate ? "Update" : "Include")}=\"{p.Name}\" Version=\"{(p.Version!.Contains("*") ? p.Version : $"[{p.Version}]")}\" />"));
+                .Select(p => $"<{(usePackageDownload ? "PackageDownload" : "PackageReference")} {(p.IsUpdate ? "Update" : "Include")}=\"{p.Name}\" Version=\"{GetExactVersionConstraint(p.Version!)}\" />"));
 
         var dependencyTargetsImport = importDependencyTargets
             ? $"""<Import Project="{GetFileFromRuntimeDirectory("DependencyDiscovery.targets")}" />"""
@@ -398,6 +398,29 @@ internal static partial class MSBuildHelper
         await File.WriteAllTextAsync(Path.Combine(tempDir.FullName, "Directory.Build.targets"), "<Project />");
 
         return tempProjectPath;
+    }
+
+    /// <summary>
+    /// Returns a NuGet version constraint string suitable for use in a temporary project file.
+    /// If the version is a single version (e.g., "1.0.0"), it is wrapped in square brackets to
+    /// pin to that exact version (e.g., "[1.0.0]").
+    /// If the version is already a valid version range (e.g., "[1.0.0,2.0.0)" or "1.*"), it is
+    /// returned as-is.
+    /// Throws if the string is neither a valid version nor a valid version range.
+    /// </summary>
+    internal static string GetExactVersionConstraint(string version)
+    {
+        if (NuGetVersion.TryParse(version, out _))
+        {
+            return $"[{version}]";
+        }
+
+        if (VersionRange.TryParse(version, out _))
+        {
+            return version;
+        }
+
+        throw new ArgumentException($"Invalid NuGet version or version range: '{version}'", nameof(version));
     }
 
     internal static async Task<ImmutableArray<string>> GetTargetFrameworkValuesFromProject(string repoRoot, string projectPath, ILogger logger)


### PR DESCRIPTION
## Summary
When creating temporary projects for legacy package resolution, version ranges like `[1.0.0,2.0.0)` were incorrectly wrapped in additional square brackets (e.g., `[[1.0.0,2.0.0)]`), producing an invalid NuGet version constraint. This caused the restore to fail silently, resulting in an empty discovery set and a `Sequence contains no elements` exception from `.Single()` which was showing up in telemetry.

## Fix
Extract `MSBuildHelper.GetExactVersionConstraint()` which:
- Uses `NuGetVersion.TryParse` to detect plain versions and pins them with brackets (e.g., `1.0.0` → `[1.0.0]`)
- Uses `VersionRange.TryParse` to detect existing range expressions and passes them through as-is
- Throws on invalid input (note, we should never get this far with an invalid version string because MSBuild should have failed already earlier in the discovery process but it's included for completeness.)

## Test
Adds a test for a legacy project with `packages.config` and a `<PackageReference>` using a version range `[1.0.0,2.0.0)`, verifying that both direct and transitive dependencies are resolved.