### PR TITLE
Add deno lockfile support

### DIFF
--- a/deno/README.md
+++ b/deno/README.md
@@ -19,20 +19,36 @@ Deno support for [`dependabot-core`][core-repo].
 
 ### Implementation Status
 
-This ecosystem is currently under development. See [NEW_ECOSYSTEMS.md](../NEW_ECOSYSTEMS.md) for implementation guidelines.
-
 #### Required Classes
-- [ ] FileFetcher
-- [ ] FileParser
-- [ ] UpdateChecker
-- [ ] FileUpdater
+- [x] FileFetcher
+- [x] FileParser
+- [x] UpdateChecker
+- [x] FileUpdater (manifest + `deno.lock` regeneration)
 
 #### Optional Classes
-- [ ] MetadataFinder
-- [ ] Version
-- [ ] Requirement
+- [x] MetadataFinder (npm sources; jsr returns nil)
+- [x] Version
+- [x] Requirement
 
 #### Supporting Infrastructure
-- [ ] Comprehensive unit tests
-- [ ] CI/CD integration
-- [ ] Documentation
+- [x] Comprehensive unit tests
+- [x] CI/CD integration
+- [x] Documentation
+
+### Supported
+
+- `deno.json` and `deno.jsonc` import maps
+- `jsr:` and `npm:` specifiers (scoped, unscoped, versionless, sub-path)
+- `deno.lock` regeneration when the manifest changes
+- Cooldown for direct dependencies
+
+### Not yet supported (planned)
+
+- HTTPS imports (`https://deno.land/x/...`)
+- `scopes` field overrides
+- `vendor/` directory regeneration
+- Workspaces (nested `deno.json`)
+- `links` field (local package overrides)
+- `DENO_AUTH_TOKENS` / private registries
+- Frozen-lockfile UX (we pass `--frozen=false` and may overwrite a frozen lockfile)
+- Custom lockfile path (`"lock": { "path": "..." }`)

--- a/deno/README.md
+++ b/deno/README.md
@@ -15,6 +15,11 @@ Deno support for [`dependabot-core`][core-repo].
   [dependabot-core-dev] ~ $ cd deno && rspec
   ```
 
+  The lockfile-regeneration specs (`spec/dependabot/deno/file_updater/lockfile_updater_spec.rb`) shell out
+  to a real `deno install` and hit the JSR/npm registries. They expect the `deno` binary on `PATH` and
+  network access — both are provided by the `bin/docker-dev-shell deno` image, but local runs outside
+  the container need them too.
+
 [core-repo]: https://github.com/dependabot/dependabot-core
 
 ### Implementation Status

--- a/deno/lib/dependabot/deno.rb
+++ b/deno/lib/dependabot/deno.rb
@@ -9,6 +9,7 @@ require "dependabot/deno/update_checker"
 require "dependabot/deno/file_updater"
 require "dependabot/deno/metadata_finder"
 require "dependabot/deno/package/package_details_fetcher"
+require "dependabot/deno/helpers"
 require "dependabot/deno/version"
 require "dependabot/deno/requirement"
 

--- a/deno/lib/dependabot/deno/file_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/file_updaters"

--- a/deno/lib/dependabot/deno/file_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater.rb
@@ -9,6 +9,8 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
+      require_relative "file_updater/lockfile_updater"
+
       MANIFEST_FILENAMES = T.let(%w(deno.json deno.jsonc).freeze, T::Array[String])
 
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
@@ -24,6 +26,13 @@ module Dependabot
           updated_files << updated_file(file: file, content: new_content)
         end
 
+        if lockfile
+          updated_files << updated_file(
+            file: T.must(lockfile),
+            content: lockfile_updater.updated_lockfile_content
+          )
+        end
+
         updated_files
       end
 
@@ -34,6 +43,26 @@ module Dependabot
         return if dependency_files.any? { |f| MANIFEST_FILENAMES.include?(f.name) }
 
         raise "No deno.json or deno.jsonc found!"
+      end
+
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
+      def lockfile
+        @lockfile ||= T.let(
+          dependency_files.find { |f| f.name == "deno.lock" },
+          T.nilable(Dependabot::DependencyFile)
+        )
+      end
+
+      sig { returns(LockfileUpdater) }
+      def lockfile_updater
+        @lockfile_updater ||= T.let(
+          LockfileUpdater.new(
+            dependencies: dependencies,
+            dependency_files: dependency_files,
+            credentials: credentials
+          ),
+          T.nilable(LockfileUpdater)
+        )
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(String) }

--- a/deno/lib/dependabot/deno/file_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater.rb
@@ -9,6 +9,7 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
 
+      require_relative "file_updater/manifest_updater"
       require_relative "file_updater/lockfile_updater"
 
       MANIFEST_FILENAMES = T.let(%w(deno.json deno.jsonc).freeze, T::Array[String])
@@ -67,26 +68,7 @@ module Dependabot
 
       sig { params(file: Dependabot::DependencyFile).returns(String) }
       def update_manifest_content(file)
-        content = T.must(file.content)
-
-        dependencies.each do |dep|
-          prev_reqs = dep.previous_requirements&.select { |r| r[:file] == file.name } || []
-          new_reqs = dep.requirements.select { |r| r[:file] == file.name }
-
-          prev_reqs.zip(new_reqs).each do |prev_req, new_req|
-            source_type = prev_req[:source][:type]
-            prev_req_str = prev_req[:requirement]
-            new_req_str = T.must(new_req)[:requirement]
-
-            base = "#{source_type}:#{dep.name}"
-            old_specifier = prev_req_str ? "#{base}@#{prev_req_str}" : base
-            new_specifier = "#{base}@#{new_req_str}"
-
-            content = content.gsub(%r{#{Regexp.escape(old_specifier)}(?=["/])}, new_specifier)
-          end
-        end
-
-        content
+        ManifestUpdater.new(dependencies: dependencies, manifest: file).updated_manifest_content
       end
     end
   end

--- a/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
@@ -1,0 +1,139 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "json"
+require "sorbet-runtime"
+
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/errors"
+require "dependabot/shared_helpers"
+require "dependabot/deno/file_updater"
+require "dependabot/deno/helpers"
+
+module Dependabot
+  module Deno
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class LockfileUpdater
+        extend T::Sig
+
+        MANIFEST_FILENAMES = T.let(%w(deno.json deno.jsonc).freeze, T::Array[String])
+        LOCKFILE_FILENAME = "deno.lock"
+
+        sig do
+          params(
+            dependencies: T::Array[Dependabot::Dependency],
+            dependency_files: T::Array[Dependabot::DependencyFile],
+            credentials: T::Array[Dependabot::Credential]
+          ).void
+        end
+        def initialize(dependencies:, dependency_files:, credentials:)
+          @dependencies = dependencies
+          @dependency_files = dependency_files
+          @credentials = credentials
+        end
+
+        sig { returns(String) }
+        def updated_lockfile_content
+          @updated_lockfile_content ||= T.let(
+            regenerate_lockfile,
+            T.nilable(String)
+          )
+        end
+
+        private
+
+        sig { returns(T::Array[Dependabot::Dependency]) }
+        attr_reader :dependencies
+
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        attr_reader :dependency_files
+
+        sig { returns(T::Array[Dependabot::Credential]) }
+        attr_reader :credentials
+
+        sig { returns(String) }
+        def regenerate_lockfile
+          # Deno rewrites `deno.lock` holistically (not surgically) when its
+          # input manifest references newer constraints. Don't try to
+          # preserve unrelated entries here — that's deno install's job.
+          #
+          # Note on error detection: `deno install` exits 0 even when a
+          # specifier can't be resolved (missing package, unsatisfiable
+          # constraint) — it just silently leaves the lockfile unchanged.
+          # The byte-equal check below is the primary defense; the rescue
+          # wraps the rare-but-real cases where deno does exit non-zero
+          # (malformed config, binary missing, filesystem errors).
+          original_lockfile_content = T.must(lockfile.content)
+
+          new_content =
+            begin
+              SharedHelpers.in_a_temporary_directory do |dir|
+                write_temporary_files(dir.to_s)
+                Helpers.run_deno_command("install", "--frozen=false", dir: dir.to_s)
+                File.read(File.join(dir.to_s, LOCKFILE_FILENAME))
+              end
+            rescue Helpers::DenoCommandError => e
+              raise Dependabot::DependencyFileNotResolvable, e.message
+            end
+
+          if new_content == original_lockfile_content
+            raise Dependabot::DependencyFileNotResolvable,
+                  "deno install did not change #{LOCKFILE_FILENAME}; manifest bump did not take effect"
+          end
+
+          new_content
+        end
+
+        sig { params(dir: String).void }
+        def write_temporary_files(dir)
+          File.write(File.join(dir, manifest.name), updated_manifest_content)
+          File.write(File.join(dir, LOCKFILE_FILENAME), T.must(lockfile.content))
+        end
+
+        sig { returns(String) }
+        def updated_manifest_content
+          # Re-apply the same gsub FileUpdater uses. Duplicates ~20 lines but
+          # avoids exposing FileUpdater's private method; if the manifest
+          # update logic grows, extract a shared ManifestUpdater class.
+          content = T.must(manifest.content).dup
+          dependencies.each do |dep|
+            prev_reqs = dep.previous_requirements || []
+            new_reqs = dep.requirements
+            prev_reqs.zip(new_reqs).each do |prev_req, new_req|
+              next unless prev_req && new_req
+              next unless prev_req[:file] == manifest.name
+
+              source_type = prev_req[:source][:type]
+              prev_req_str = prev_req[:requirement]
+              new_req_str = new_req[:requirement]
+
+              base = "#{source_type}:#{dep.name}"
+              old_specifier = prev_req_str ? "#{base}@#{prev_req_str}" : base
+              new_specifier = "#{base}@#{new_req_str}"
+
+              content = content.gsub(%r{#{Regexp.escape(old_specifier)}(?=["/])}, new_specifier)
+            end
+          end
+          content
+        end
+
+        sig { returns(Dependabot::DependencyFile) }
+        def manifest
+          @manifest ||= T.let(
+            T.must(dependency_files.find { |f| MANIFEST_FILENAMES.include?(f.name) }),
+            T.nilable(Dependabot::DependencyFile)
+          )
+        end
+
+        sig { returns(Dependabot::DependencyFile) }
+        def lockfile
+          @lockfile ||= T.let(
+            T.must(dependency_files.find { |f| f.name == LOCKFILE_FILENAME }),
+            T.nilable(Dependabot::DependencyFile)
+          )
+        end
+      end
+    end
+  end
+end

--- a/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "json"
@@ -75,7 +75,7 @@ module Dependabot
                 Helpers.run_deno_command("install", "--frozen=false", dir: dir.to_s)
                 File.read(File.join(dir.to_s, LOCKFILE_FILENAME))
               end
-            rescue Helpers::DenoCommandError, Errno::ENOENT => e
+            rescue SharedHelpers::HelperSubprocessFailed, Errno::ENOENT => e
               raise Dependabot::DependencyFileNotResolvable, e.message
             end
 

--- a/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
@@ -9,6 +9,7 @@ require "dependabot/dependency_file"
 require "dependabot/errors"
 require "dependabot/shared_helpers"
 require "dependabot/deno/file_updater"
+require "dependabot/deno/file_updater/manifest_updater"
 require "dependabot/deno/helpers"
 
 module Dependabot
@@ -17,8 +18,7 @@ module Dependabot
       class LockfileUpdater
         extend T::Sig
 
-        MANIFEST_FILENAMES = T.let(%w(deno.json deno.jsonc).freeze, T::Array[String])
-        LOCKFILE_FILENAME = "deno.lock"
+        LOCKFILE_FILENAME = T.let("deno.lock", String)
 
         sig do
           params(
@@ -30,6 +30,8 @@ module Dependabot
         def initialize(dependencies:, dependency_files:, credentials:)
           @dependencies = dependencies
           @dependency_files = dependency_files
+          # Reserved for DENO_AUTH_TOKENS / private registry support — accepted now
+          # so callers don't need a signature change when that lands.
           @credentials = credentials
         end
 
@@ -73,7 +75,7 @@ module Dependabot
                 Helpers.run_deno_command("install", "--frozen=false", dir: dir.to_s)
                 File.read(File.join(dir.to_s, LOCKFILE_FILENAME))
               end
-            rescue Helpers::DenoCommandError => e
+            rescue Helpers::DenoCommandError, Errno::ENOENT => e
               raise Dependabot::DependencyFileNotResolvable, e.message
             end
 
@@ -93,35 +95,13 @@ module Dependabot
 
         sig { returns(String) }
         def updated_manifest_content
-          # Re-apply the same gsub FileUpdater uses. Duplicates ~20 lines but
-          # avoids exposing FileUpdater's private method; if the manifest
-          # update logic grows, extract a shared ManifestUpdater class.
-          content = T.must(manifest.content).dup
-          dependencies.each do |dep|
-            prev_reqs = dep.previous_requirements || []
-            new_reqs = dep.requirements
-            prev_reqs.zip(new_reqs).each do |prev_req, new_req|
-              next unless prev_req && new_req
-              next unless prev_req[:file] == manifest.name
-
-              source_type = prev_req[:source][:type]
-              prev_req_str = prev_req[:requirement]
-              new_req_str = new_req[:requirement]
-
-              base = "#{source_type}:#{dep.name}"
-              old_specifier = prev_req_str ? "#{base}@#{prev_req_str}" : base
-              new_specifier = "#{base}@#{new_req_str}"
-
-              content = content.gsub(%r{#{Regexp.escape(old_specifier)}(?=["/])}, new_specifier)
-            end
-          end
-          content
+          ManifestUpdater.new(dependencies: dependencies, manifest: manifest).updated_manifest_content
         end
 
         sig { returns(Dependabot::DependencyFile) }
         def manifest
           @manifest ||= T.let(
-            T.must(dependency_files.find { |f| MANIFEST_FILENAMES.include?(f.name) }),
+            T.must(dependency_files.find { |f| FileUpdater::MANIFEST_FILENAMES.include?(f.name) }),
             T.nilable(Dependabot::DependencyFile)
           )
         end

--- a/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
@@ -33,9 +33,7 @@ module Dependabot
             new_reqs = dep.requirements.select { |r| r[:file] == manifest.name }
 
             prev_reqs.zip(new_reqs).each do |prev_req, new_req|
-              next unless prev_req && new_req
-
-              content = apply_substitution(content, dep, prev_req, new_req)
+              content = apply_substitution(content, dep, prev_req, T.must(new_req))
             end
           end
 

--- a/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
@@ -1,0 +1,75 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/deno/file_updater"
+
+module Dependabot
+  module Deno
+    class FileUpdater
+      class ManifestUpdater
+        extend T::Sig
+
+        sig do
+          params(
+            dependencies: T::Array[Dependabot::Dependency],
+            manifest: Dependabot::DependencyFile
+          ).void
+        end
+        def initialize(dependencies:, manifest:)
+          @dependencies = dependencies
+          @manifest = manifest
+        end
+
+        sig { returns(String) }
+        def updated_manifest_content
+          content = T.must(manifest.content).dup
+
+          dependencies.each do |dep|
+            prev_reqs = (dep.previous_requirements || []).select { |r| r[:file] == manifest.name }
+            new_reqs = dep.requirements.select { |r| r[:file] == manifest.name }
+
+            prev_reqs.zip(new_reqs).each do |prev_req, new_req|
+              next unless prev_req && new_req
+
+              content = apply_substitution(content, dep, prev_req, new_req)
+            end
+          end
+
+          content
+        end
+
+        private
+
+        sig { returns(T::Array[Dependabot::Dependency]) }
+        attr_reader :dependencies
+
+        sig { returns(Dependabot::DependencyFile) }
+        attr_reader :manifest
+
+        sig do
+          params(
+            content: String,
+            dep: Dependabot::Dependency,
+            prev_req: T::Hash[Symbol, T.untyped],
+            new_req: T::Hash[Symbol, T.untyped]
+          ).returns(String)
+        end
+        def apply_substitution(content, dep, prev_req, new_req)
+          source_type = prev_req[:source][:type]
+          prev_req_str = prev_req[:requirement]
+          new_req_str = new_req[:requirement]
+
+          base = "#{source_type}:#{dep.name}"
+          old_specifier = prev_req_str ? "#{base}@#{prev_req_str}" : base
+          new_specifier = "#{base}@#{new_req_str}"
+
+          content.gsub(%r{#{Regexp.escape(old_specifier)}(?=["/])}, new_specifier)
+        end
+      end
+    end
+  end
+end

--- a/deno/lib/dependabot/deno/helpers.rb
+++ b/deno/lib/dependabot/deno/helpers.rb
@@ -1,0 +1,32 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "open3"
+require "sorbet-runtime"
+
+module Dependabot
+  module Deno
+    module Helpers
+      extend T::Sig
+
+      class DenoCommandError < StandardError; end
+
+      sig do
+        params(
+          args: String,
+          dir: String
+        ).returns(String)
+      end
+      def self.run_deno_command(*args, dir:)
+        env = { "DENO_DIR" => File.join(dir, ".deno_cache") }
+        output, status = Open3.capture2e(env, "deno", *args, chdir: dir)
+
+        unless status.success?
+          raise DenoCommandError, "deno #{args.join(' ')} failed (exit #{status.exitstatus}): #{output}"
+        end
+
+        output
+      end
+    end
+  end
+end

--- a/deno/lib/dependabot/deno/helpers.rb
+++ b/deno/lib/dependabot/deno/helpers.rb
@@ -1,21 +1,20 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
-require "open3"
 require "sorbet-runtime"
+
+require "dependabot/shared_helpers"
 
 module Dependabot
   module Deno
     module Helpers
       extend T::Sig
 
-      class DenoCommandError < StandardError; end
-
-      # Cap subprocess output bubbled into error messages so they stay readable
-      # in dependabot-core's error reporting (and any user-visible PR comments
-      # downstream).
-      MAX_ERROR_OUTPUT_BYTES = T.let(2_000, Integer)
-
+      # Wraps `deno <args>` via Dependabot's standard subprocess helper, so
+      # failures surface as Dependabot::SharedHelpers::HelperSubprocessFailed
+      # (consistent with cargo / bun / npm_and_yarn). DENO_DIR is scoped to
+      # the working directory so concurrent jobs don't trample each other's
+      # module cache.
       sig do
         params(
           args: String,
@@ -23,30 +22,12 @@ module Dependabot
         ).returns(String)
       end
       def self.run_deno_command(*args, dir:)
-        env = { "DENO_DIR" => File.join(dir, ".deno_cache") }
-        # T.unsafe escape hatch: Sorbet's strict mode rejects unbounded splats
-        # into variadic methods, but Open3.capture2e expects the splat form.
-        output, status = T.unsafe(Open3).capture2e(env, "deno", *args, chdir: dir)
-
-        unless status.success?
-          raise DenoCommandError,
-                "deno #{args.join(' ')} failed (exit #{status.exitstatus}): #{truncate(output)}"
-        end
-
-        output
+        Dependabot::SharedHelpers.run_shell_command(
+          "deno #{args.join(' ')}",
+          cwd: dir,
+          env: { "DENO_DIR" => File.join(dir, ".deno_cache") }
+        )
       end
-
-      sig { params(output: String).returns(String) }
-      def self.truncate(output)
-        return output if output.bytesize <= MAX_ERROR_OUTPUT_BYTES
-
-        head_bytes = MAX_ERROR_OUTPUT_BYTES / 2
-        head = output.byteslice(0, head_bytes)
-        tail = output.byteslice(-head_bytes, head_bytes)
-        omitted = output.bytesize - (2 * head_bytes)
-        "#{head}\n... [#{omitted} bytes omitted] ...\n#{tail}"
-      end
-      private_class_method :truncate
     end
   end
 end

--- a/deno/lib/dependabot/deno/helpers.rb
+++ b/deno/lib/dependabot/deno/helpers.rb
@@ -11,6 +11,11 @@ module Dependabot
 
       class DenoCommandError < StandardError; end
 
+      # Cap subprocess output bubbled into error messages so they stay readable
+      # in dependabot-core's error reporting (and any user-visible PR comments
+      # downstream).
+      MAX_ERROR_OUTPUT_BYTES = T.let(2_000, Integer)
+
       sig do
         params(
           args: String,
@@ -22,11 +27,24 @@ module Dependabot
         output, status = Open3.capture2e(env, "deno", *args, chdir: dir)
 
         unless status.success?
-          raise DenoCommandError, "deno #{args.join(' ')} failed (exit #{status.exitstatus}): #{output}"
+          raise DenoCommandError,
+                "deno #{args.join(' ')} failed (exit #{status.exitstatus}): #{truncate(output)}"
         end
 
         output
       end
+
+      sig { params(output: String).returns(String) }
+      def self.truncate(output)
+        return output if output.bytesize <= MAX_ERROR_OUTPUT_BYTES
+
+        head_bytes = MAX_ERROR_OUTPUT_BYTES / 2
+        head = output.byteslice(0, head_bytes)
+        tail = output.byteslice(-head_bytes, head_bytes)
+        omitted = output.bytesize - (2 * head_bytes)
+        "#{head}\n... [#{omitted} bytes omitted] ...\n#{tail}"
+      end
+      private_class_method :truncate
     end
   end
 end

--- a/deno/lib/dependabot/deno/helpers.rb
+++ b/deno/lib/dependabot/deno/helpers.rb
@@ -24,7 +24,9 @@ module Dependabot
       end
       def self.run_deno_command(*args, dir:)
         env = { "DENO_DIR" => File.join(dir, ".deno_cache") }
-        output, status = Open3.capture2e(env, "deno", *args, chdir: dir)
+        # T.unsafe escape hatch: Sorbet's strict mode rejects unbounded splats
+        # into variadic methods, but Open3.capture2e expects the splat form.
+        output, status = T.unsafe(Open3).capture2e(env, "deno", *args, chdir: dir)
 
         unless status.success?
           raise DenoCommandError,

--- a/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
+++ b/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
@@ -177,8 +177,10 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
     before do
       allow(Dependabot::Deno::Helpers).to receive(:run_deno_command)
         .and_raise(
-          Dependabot::Deno::Helpers::DenoCommandError,
-          "deno install failed (exit 1): error: Unable to parse config file"
+          Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+            message: "error: Unable to parse config file",
+            error_context: { command: "deno install" }
+          )
         )
     end
 

--- a/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
+++ b/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
@@ -42,9 +42,10 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
       content = updater.updated_lockfile_content
       lock = JSON.parse(content)
 
-      # Specifier key reflects the bumped constraint; resolved value is any 1.1.x.
-      resolved = lock.fetch("specifiers").fetch("jsr:@std/path@^1.1.4")
-      expect(resolved).to match(/\A1\.1\.\d+\z/)
+      # Specifier key reflects the bumped constraint; resolved value must satisfy ^1.1.4.
+      resolved = Gem::Version.new(lock.fetch("specifiers").fetch("jsr:@std/path@^1.1.4"))
+      expect(resolved).to be >= Gem::Version.new("1.1.4")
+      expect(resolved).to be < Gem::Version.new("2.0.0")
 
       # Old pinned 1.0.0 entry is gone.
       expect(lock.fetch("jsr")).not_to have_key("@std/path@1.0.0")
@@ -83,8 +84,9 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
     it "updates the npm block in the lockfile" do
       content = updater.updated_lockfile_content
       lock = JSON.parse(content)
-      resolved = lock.fetch("specifiers").fetch("npm:chalk@^5.4.0")
-      expect(resolved).to match(/\A5\.[4-9]\.\d+\z/)
+      resolved = Gem::Version.new(lock.fetch("specifiers").fetch("npm:chalk@^5.4.0"))
+      expect(resolved).to be >= Gem::Version.new("5.4.0")
+      expect(resolved).to be < Gem::Version.new("6.0.0")
       expect(lock.fetch("npm")).not_to have_key("chalk@5.3.0")
     end
   end
@@ -115,7 +117,9 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
     it "regenerates the lockfile from a JSONC manifest" do
       content = updater.updated_lockfile_content
       lock = JSON.parse(content)
-      expect(lock.dig("specifiers", "jsr:@std/path@^1.1.4")).to match(/\A1\.1\.\d+\z/)
+      resolved = Gem::Version.new(lock.dig("specifiers", "jsr:@std/path@^1.1.4"))
+      expect(resolved).to be >= Gem::Version.new("1.1.4")
+      expect(resolved).to be < Gem::Version.new("2.0.0")
     end
   end
 
@@ -145,7 +149,13 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
     it "bumps the targeted dep while keeping untouched deps resolvable" do
       content = updater.updated_lockfile_content
       lock = JSON.parse(content)
-      expect(lock["jsr"].keys).to include(match(%r{^@std/path@1\.1\.\d+$}))
+
+      path_keys = lock["jsr"].keys.grep(%r{^@std/path@})
+      expect(path_keys.length).to eq(1)
+      path_version = Gem::Version.new(path_keys.first.split("@").last)
+      expect(path_version).to be >= Gem::Version.new("1.1.4")
+      expect(path_version).to be < Gem::Version.new("2.0.0")
+
       expect(lock["jsr"].keys).to include(match(%r{^@std/assert@}))
     end
   end

--- a/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
+++ b/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
@@ -1,0 +1,181 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/deno/file_updater/lockfile_updater"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+
+RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
+  let(:updater) do
+    described_class.new(
+      dependencies: [dependency],
+      dependency_files: files,
+      credentials: credentials
+    )
+  end
+  let(:credentials) { [] }
+  let(:files) { project_dependency_files("deno/with_lockfile") }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "@std/path",
+      version: "1.1.4",
+      previous_version: "1.0.0",
+      requirements: [{
+        requirement: "^1.1.4",
+        file: "deno.json",
+        groups: ["imports"],
+        source: { type: "jsr" }
+      }],
+      previous_requirements: [{
+        requirement: "^1.0.0",
+        file: "deno.json",
+        groups: ["imports"],
+        source: { type: "jsr" }
+      }],
+      package_manager: "deno"
+    )
+  end
+
+  describe "#updated_lockfile_content" do
+    it "returns lockfile content with a version satisfying the new constraint" do
+      content = updater.updated_lockfile_content
+      lock = JSON.parse(content)
+
+      # Specifier key reflects the bumped constraint; resolved value is any 1.1.x.
+      resolved = lock.fetch("specifiers").fetch("jsr:@std/path@^1.1.4")
+      expect(resolved).to match(/\A1\.1\.\d+\z/)
+
+      # Old pinned 1.0.0 entry is gone.
+      expect(lock.fetch("jsr")).not_to have_key("@std/path@1.0.0")
+    end
+
+    it "preserves the v4 lockfile format" do
+      content = updater.updated_lockfile_content
+      lock = JSON.parse(content)
+      expect(lock["version"]).to eq("4")
+    end
+  end
+
+  context "with an npm dependency" do
+    let(:files) { project_dependency_files("deno/with_lockfile_npm") }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "chalk",
+        version: "5.4.0",
+        previous_version: "5.3.0",
+        requirements: [{
+          requirement: "^5.4.0",
+          file: "deno.json",
+          groups: ["imports"],
+          source: { type: "npm" }
+        }],
+        previous_requirements: [{
+          requirement: "^5.3.0",
+          file: "deno.json",
+          groups: ["imports"],
+          source: { type: "npm" }
+        }],
+        package_manager: "deno"
+      )
+    end
+
+    it "updates the npm block in the lockfile" do
+      content = updater.updated_lockfile_content
+      lock = JSON.parse(content)
+      resolved = lock.fetch("specifiers").fetch("npm:chalk@^5.4.0")
+      expect(resolved).to match(/\A5\.[4-9]\.\d+\z/)
+      expect(lock.fetch("npm")).not_to have_key("chalk@5.3.0")
+    end
+  end
+
+  context "with a deno.jsonc manifest" do
+    let(:files) { project_dependency_files("deno/with_lockfile_jsonc") }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "@std/path",
+        version: "1.1.4",
+        previous_version: "1.0.0",
+        requirements: [{
+          requirement: "^1.1.4",
+          file: "deno.jsonc",
+          groups: ["imports"],
+          source: { type: "jsr" }
+        }],
+        previous_requirements: [{
+          requirement: "^1.0.0",
+          file: "deno.jsonc",
+          groups: ["imports"],
+          source: { type: "jsr" }
+        }],
+        package_manager: "deno"
+      )
+    end
+
+    it "regenerates the lockfile from a JSONC manifest" do
+      content = updater.updated_lockfile_content
+      lock = JSON.parse(content)
+      expect(lock.dig("specifiers", "jsr:@std/path@^1.1.4")).to match(/\A1\.1\.\d+\z/)
+    end
+  end
+
+  context "with multiple dependencies in the lockfile" do
+    let(:files) { project_dependency_files("deno/with_lockfile_multi") }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "@std/path",
+        version: "1.1.4",
+        previous_version: "1.0.0",
+        requirements: [{
+          requirement: "^1.1.4",
+          file: "deno.json",
+          groups: ["imports"],
+          source: { type: "jsr" }
+        }],
+        previous_requirements: [{
+          requirement: "^1.0.0",
+          file: "deno.json",
+          groups: ["imports"],
+          source: { type: "jsr" }
+        }],
+        package_manager: "deno"
+      )
+    end
+
+    it "bumps the targeted dep while keeping untouched deps resolvable" do
+      content = updater.updated_lockfile_content
+      lock = JSON.parse(content)
+      expect(lock["jsr"].keys).to include(match(%r{^@std/path@1\.1\.\d+$}))
+      expect(lock["jsr"].keys).to include(match(%r{^@std/assert@}))
+    end
+  end
+
+  context "when deno install does not change the lockfile" do
+    before do
+      # Stub run_deno_command to leave the lockfile untouched in the tmpdir.
+      allow(Dependabot::Deno::Helpers).to receive(:run_deno_command).and_return("")
+    end
+
+    it "raises DependencyFileNotResolvable with a diagnostic message" do
+      expect do
+        updater.updated_lockfile_content
+      end.to raise_error(Dependabot::DependencyFileNotResolvable, /did not change/)
+    end
+  end
+
+  context "when deno install exits non-zero" do
+    before do
+      allow(Dependabot::Deno::Helpers).to receive(:run_deno_command)
+        .and_raise(
+          Dependabot::Deno::Helpers::DenoCommandError,
+          "deno install failed (exit 1): error: Unable to parse config file"
+        )
+    end
+
+    it "wraps the helper error as DependencyFileNotResolvable" do
+      expect do
+        updater.updated_lockfile_content
+      end.to raise_error(Dependabot::DependencyFileNotResolvable, /Unable to parse config file/)
+    end
+  end
+end

--- a/deno/spec/dependabot/deno/file_updater_spec.rb
+++ b/deno/spec/dependabot/deno/file_updater_spec.rb
@@ -237,7 +237,9 @@ RSpec.describe Dependabot::Deno::FileUpdater do
       it "updates the lockfile to a version satisfying the new constraint" do
         lockfile = updater.updated_dependency_files.find { |f| f.name == "deno.lock" }
         lock = JSON.parse(lockfile.content)
-        expect(lock.dig("specifiers", "jsr:@std/path@^1.1.4")).to match(/\A1\.1\.\d+\z/)
+        resolved = Gem::Version.new(lock.dig("specifiers", "jsr:@std/path@^1.1.4"))
+        expect(resolved).to be >= Gem::Version.new("1.1.4")
+        expect(resolved).to be < Gem::Version.new("2.0.0")
       end
     end
 

--- a/deno/spec/dependabot/deno/file_updater_spec.rb
+++ b/deno/spec/dependabot/deno/file_updater_spec.rb
@@ -223,5 +223,30 @@ RSpec.describe Dependabot::Deno::FileUpdater do
         expect(updated_content).to include('"jsr:@std/path@^1.1.4" // trailing comment')
       end
     end
+
+    context "when a deno.lock is present" do
+      let(:files) do
+        project_dependency_files("deno/with_lockfile")
+      end
+
+      it "emits both the manifest and the lockfile" do
+        updated_files = updater.updated_dependency_files
+        expect(updated_files.map(&:name)).to contain_exactly("deno.json", "deno.lock")
+      end
+
+      it "updates the lockfile to a version satisfying the new constraint" do
+        lockfile = updater.updated_dependency_files.find { |f| f.name == "deno.lock" }
+        lock = JSON.parse(lockfile.content)
+        expect(lock.dig("specifiers", "jsr:@std/path@^1.1.4")).to match(/\A1\.1\.\d+\z/)
+      end
+    end
+
+    context "when no deno.lock is present" do
+      # files defaults to the top-level inline manifest only (no lockfile)
+      it "emits only the manifest" do
+        updated_files = updater.updated_dependency_files
+        expect(updated_files.map(&:name)).to eq(["deno.json"])
+      end
+    end
   end
 end

--- a/deno/spec/dependabot/deno/helpers_spec.rb
+++ b/deno/spec/dependabot/deno/helpers_spec.rb
@@ -3,27 +3,37 @@
 
 require "spec_helper"
 require "dependabot/deno/helpers"
+require "dependabot/shared_helpers"
 
 RSpec.describe Dependabot::Deno::Helpers do
   describe ".run_deno_command" do
     let(:dir) { "/tmp/some-dir" }
 
-    it "invokes deno with the given args in the given dir and returns combined output" do
-      allow(Open3).to receive(:capture2e)
-        .with({ "DENO_DIR" => anything }, "deno", "install", "--frozen=false", chdir: dir)
-        .and_return(["ok\n", instance_double(Process::Status, success?: true, exitstatus: 0)])
+    it "delegates to SharedHelpers.run_shell_command with scoped DENO_DIR" do
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+        .with(
+          "deno install --frozen=false",
+          cwd: dir,
+          env: hash_including("DENO_DIR" => "#{dir}/.deno_cache")
+        )
+        .and_return("ok\n")
 
       result = described_class.run_deno_command("install", "--frozen=false", dir: dir)
       expect(result).to eq("ok\n")
     end
 
-    it "raises with combined output on non-zero exit" do
-      status = instance_double(Process::Status, success?: false, exitstatus: 1)
-      allow(Open3).to receive(:capture2e).and_return(["error: boom\n", status])
+    it "propagates HelperSubprocessFailed on non-zero exit" do
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+        .and_raise(
+          Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+            message: "boom",
+            error_context: { command: "deno install" }
+          )
+        )
 
       expect do
         described_class.run_deno_command("install", dir: dir)
-      end.to raise_error(Dependabot::Deno::Helpers::DenoCommandError, /error: boom/)
+      end.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed, /boom/)
     end
   end
 end

--- a/deno/spec/dependabot/deno/helpers_spec.rb
+++ b/deno/spec/dependabot/deno/helpers_spec.rb
@@ -1,0 +1,29 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/deno/helpers"
+
+RSpec.describe Dependabot::Deno::Helpers do
+  describe ".run_deno_command" do
+    let(:dir) { "/tmp/some-dir" }
+
+    it "invokes deno with the given args in the given dir and returns combined output" do
+      allow(Open3).to receive(:capture2e)
+        .with({ "DENO_DIR" => anything }, "deno", "install", "--frozen=false", chdir: dir)
+        .and_return(["ok\n", instance_double(Process::Status, success?: true, exitstatus: 0)])
+
+      result = described_class.run_deno_command("install", "--frozen=false", dir: dir)
+      expect(result).to eq("ok\n")
+    end
+
+    it "raises with combined output on non-zero exit" do
+      status = instance_double(Process::Status, success?: false, exitstatus: 1)
+      allow(Open3).to receive(:capture2e).and_return(["error: boom\n", status])
+
+      expect do
+        described_class.run_deno_command("install", dir: dir)
+      end.to raise_error(Dependabot::Deno::Helpers::DenoCommandError, /error: boom/)
+    end
+  end
+end

--- a/deno/spec/fixtures/projects/deno/with_lockfile/deno.json
+++ b/deno/spec/fixtures/projects/deno/with_lockfile/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@std/path": "jsr:@std/path@^1.0.0"
+  }
+}

--- a/deno/spec/fixtures/projects/deno/with_lockfile/deno.lock
+++ b/deno/spec/fixtures/projects/deno/with_lockfile/deno.lock
@@ -1,0 +1,23 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/path@^1.0.0": "1.0.0"
+  },
+  "jsr": {
+    "@std/internal@1.0.5": {
+      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/path@1.0.0": {
+      "integrity": "deadbeefcafedeadbeefcafedeadbeefcafedeadbeefcafedeadbeefcafe1234",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/path@^1.0.0"
+    ]
+  }
+}

--- a/deno/spec/fixtures/projects/deno/with_lockfile_jsonc/deno.jsonc
+++ b/deno/spec/fixtures/projects/deno/with_lockfile_jsonc/deno.jsonc
@@ -1,0 +1,6 @@
+{
+  // Top-level comment
+  "imports": {
+    "@std/path": "jsr:@std/path@^1.0.0" // trailing comment
+  }
+}

--- a/deno/spec/fixtures/projects/deno/with_lockfile_jsonc/deno.lock
+++ b/deno/spec/fixtures/projects/deno/with_lockfile_jsonc/deno.lock
@@ -1,0 +1,23 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/internal@^1.0.5": "1.0.5",
+    "jsr:@std/path@^1.0.0": "1.0.0"
+  },
+  "jsr": {
+    "@std/internal@1.0.5": {
+      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    },
+    "@std/path@1.0.0": {
+      "integrity": "deadbeefcafedeadbeefcafedeadbeefcafedeadbeefcafedeadbeefcafe1234",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/path@^1.0.0"
+    ]
+  }
+}

--- a/deno/spec/fixtures/projects/deno/with_lockfile_multi/deno.json
+++ b/deno/spec/fixtures/projects/deno/with_lockfile_multi/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@std/path": "jsr:@std/path@^1.0.0",
+    "@std/assert": "jsr:@std/assert@1.0.0"
+  }
+}

--- a/deno/spec/fixtures/projects/deno/with_lockfile_multi/deno.lock
+++ b/deno/spec/fixtures/projects/deno/with_lockfile_multi/deno.lock
@@ -1,0 +1,28 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/assert@1.0.0": "1.0.0",
+    "jsr:@std/internal@^1.0.1": "1.0.12",
+    "jsr:@std/path@^1.0.0": "1.0.0"
+  },
+  "jsr": {
+    "@std/assert@1.0.0": {
+      "integrity": "0e4f6d873f7f35e2a1e6194ceee39686c996b9e5d134948e644d35d4c4df2008",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.1"
+      ]
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/path@1.0.0": {
+      "integrity": "77fcb858b6e38777d1154df0f02245ba0b07e2c40ca3c0eec57c9233188c2d21"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@1.0.0",
+      "jsr:@std/path@^1.0.0"
+    ]
+  }
+}

--- a/deno/spec/fixtures/projects/deno/with_lockfile_npm/deno.json
+++ b/deno/spec/fixtures/projects/deno/with_lockfile_npm/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "chalk": "npm:chalk@^5.3.0"
+  }
+}

--- a/deno/spec/fixtures/projects/deno/with_lockfile_npm/deno.lock
+++ b/deno/spec/fixtures/projects/deno/with_lockfile_npm/deno.lock
@@ -1,0 +1,16 @@
+{
+  "version": "4",
+  "specifiers": {
+    "npm:chalk@^5.3.0": "5.3.0"
+  },
+  "npm": {
+    "chalk@5.3.0": {
+      "integrity": "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:chalk@^5.3.0"
+    ]
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Adds `deno.lock` regeneration to the Deno ecosystem's `FileUpdater`. When a `jsr:` or `npm:` specifier in `deno.json`/`deno.jsonc` is bumped, the updater now also emits an updated `deno.lock` so the user's PR carries both files in sync.

This closes the follow-up gap explicitly deferred in #14364.

Refs: #2417

### Anything you want to highlight for special attention from reviewers?

- I went with cargo's pattern: one `file_updater/lockfile_updater.rb` that shells out to a single CLI command (`deno install --frozen=false`) inside `SharedHelpers.in_a_temporary_directory`, no `helpers/` JS tree. The `deno` binary is already installed in `deno/Dockerfile` (added by #14364), so no native helper required.
- `deno install` exits 0 even on registry failures: an unsatisfiable constraint or missing package doesn't surface via exit code... deno just silently leaves the lockfile unchanged. The byte-equal check in `regenerate_lockfile` is the primary defense... the rescue wraps the rare cases where deno does exit non-zero (malformed config, binary missing, `Errno::ENOENT` on the read-back). This is all commented in the code.
- Manifest substitution is shared between `FileUpdater` and `LockfileUpdater`: both paths need to write a bumped manifest (FileUpdater for the user-facing diff, LockfileUpdater for the tmpdir input to `deno install`). Extracted the substitution into `Dependabot::Deno::FileUpdater::ManifestUpdater` (cargo pattern) so the two callers can't drift.
- Tests hit real registries: the 5 real-CLI specs in `lockfile_updater_spec.rb` invoke `deno install` against `jsr.io` and `registry.npmjs.org` (same as cargo's `lockfile_updater_spec.rb` hits `crates.io`). Version assertions use `Gem::Version` comparisons against the constraint's range, not literal regex matches... so they don't break when upstream ships a new patch/minor. Error paths use stubbed `Helpers.run_deno_command`.
- Out of scope for this PR: see `deno/README.md`

### How will you know you've accomplished your goal?

- Real-CLI integration coverage: bumping a JSR specifier, bumping an `npm:` specifier, bumping in a `deno.jsonc` manifest, and bumping one of several deps in a multi-dep lockfile each verify the resulting `deno.lock` resolves to a version satisfying the new constraint.
- Opt-out preserved: if `dependency_files` doesn't include `deno.lock`, `FileUpdater#updated_dependency_files` returns only the manifest... projects without a lockfile aren't forced into one.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
