### PR TITLE
fix(git): avoid github.com release lookups on GHES overrides and handle SSL failures

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -683,13 +683,14 @@ module Dependabot
 
           source = Source.from_url(listing_source_url)
           return [] unless source&.provider == "github"
+          source = T.must(source)
           return [] if source.hostname == "github.com" && github_dot_com_api_endpoint_overridden?
 
           client = Dependabot::Clients::GithubWithRetries.for_source(
-            source: T.must(source),
+            source: source,
             credentials: credentials
           )
-          T.unsafe(client).releases(T.must(source).repo, per_page: 100)
+          T.unsafe(client).releases(source.repo, per_page: 100)
         rescue Octokit::Error, Faraday::SSLError
           []
         end,

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -680,6 +680,7 @@ module Dependabot
       @github_releases ||= T.let(
         begin
           return [] unless listing_source_url
+          return [] if github_dot_com_api_endpoint_overridden?
 
           source = Source.from_url(listing_source_url)
           return [] unless source&.provider == "github"
@@ -689,11 +690,26 @@ module Dependabot
             credentials: credentials
           )
           T.unsafe(client).releases(T.must(source).repo, per_page: 100)
-        rescue Octokit::Error
+        rescue Octokit::Error, Faraday::SSLError
           []
         end,
         T.nilable(T::Array[T.untyped])
       )
+    end
+
+    sig { returns(T::Boolean) }
+    def github_dot_com_api_endpoint_overridden?
+      github_dot_com_credentials = credentials.select do |credential|
+        credential["type"] == "git_source" && credential["host"] == "github.com"
+      end
+      return false if github_dot_com_credentials.empty?
+
+      github_dot_com_credentials.any? do |credential|
+        api_endpoint = credential["api-endpoint"] || credential["api_endpoint"]
+        next false if api_endpoint.nil?
+
+        api_endpoint.delete_suffix("/") != "https://api.github.com"
+      end
     end
 
     sig { params(tag: Dependabot::GitRef).returns(Gem::Version) }

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -680,10 +680,10 @@ module Dependabot
       @github_releases ||= T.let(
         begin
           return [] unless listing_source_url
-          return [] if github_dot_com_api_endpoint_overridden?
 
           source = Source.from_url(listing_source_url)
           return [] unless source&.provider == "github"
+          return [] if source.hostname == "github.com" && github_dot_com_api_endpoint_overridden?
 
           client = Dependabot::Clients::GithubWithRetries.for_source(
             source: T.must(source),

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -683,6 +683,7 @@ module Dependabot
 
           source = Source.from_url(listing_source_url)
           return [] unless source&.provider == "github"
+
           source = T.must(source)
           return [] if source.hostname == "github.com" && github_dot_com_api_endpoint_overridden?
 

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -2130,6 +2130,41 @@ RSpec.describe Dependabot::GitCommitChecker do
           expect(checker.send(:github_releases)).to eq([])
         end
       end
+
+      context "when Faraday raises an SSL error" do
+        before do
+          mock_client = double("GithubWithRetries")
+          allow(Dependabot::Clients::GithubWithRetries)
+            .to receive(:for_source)
+            .and_return(mock_client)
+          allow(mock_client)
+            .to receive(:releases)
+            .and_raise(Faraday::SSLError.new("x509: certificate signed by unknown authority"))
+        end
+
+        it "returns an empty array" do
+          expect(checker.send(:github_releases)).to eq([])
+        end
+      end
+
+      context "when github.com credentials use a custom API endpoint" do
+        let(:credentials) do
+          [{
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => "token",
+            "api-endpoint" => "https://ghe.example.com/api/v3/"
+          }]
+        end
+
+        it "returns an empty array without calling releases API" do
+          expect(Dependabot::Clients::GithubWithRetries)
+            .not_to receive(:for_source)
+
+          expect(checker.send(:github_releases)).to eq([])
+        end
+      end
     end
 
     context "when dependency is not from GitHub" do

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -2165,6 +2165,43 @@ RSpec.describe Dependabot::GitCommitChecker do
           expect(checker.send(:github_releases)).to eq([])
         end
       end
+
+      context "when github.com credentials use a custom API endpoint but source is GHES" do
+        let(:credentials) do
+          [{
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => "token",
+            "api-endpoint" => "https://ghe.example.com/api/v3/"
+          }]
+        end
+
+        before do
+          allow(checker).to receive(:listing_source_url).and_return("https://ghe.example.com/org/repo")
+          allow(Dependabot::Source).to receive(:from_url)
+            .and_return(
+              Dependabot::Source.new(
+                provider: "github",
+                repo: "org/repo",
+                hostname: "ghe.example.com",
+                api_endpoint: "https://ghe.example.com/api/v3"
+              )
+            )
+
+          mock_client = double("GithubWithRetries")
+          allow(Dependabot::Clients::GithubWithRetries)
+            .to receive(:for_source)
+            .and_return(mock_client)
+          allow(mock_client).to receive(:releases).and_return([])
+        end
+
+        it "still attempts release lookup" do
+          checker.send(:github_releases)
+
+          expect(Dependabot::Clients::GithubWithRetries).to have_received(:for_source)
+        end
+      end
     end
 
     context "when dependency is not from GitHub" do


### PR DESCRIPTION
### What are you trying to accomplish?

Issue:
The github_actions ecosystem updater introduced a new outbound call to `https://api.github.com/repos/{owner}/{repo}/releases?per_page=100` for every candidate tag it evaluates. This call is made unconditionally whenever a tag's `listing_source_url` resolves to a github.com source (which is every public Action), regardless of whether the appliance is configured with api-endpoint: `https://<ghes-host>/api/v3/`.

This PR:
1. Prevent unnecessary calls to `api.github.com` for GitHub Actions tags when the environment is configured for GHES with a custom api-endpoint.
2. Make the code fail gracefully on **SSL/proxy certificate errors** by handling `Faraday::SSLError` instead of hanging on retries.
3. Add regression tests so this behavior stays fixed.

### Anything you want to highlight for special attention from reviewers?

Related to this PR: https://github.com/dependabot/dependabot-core/pull/13731

### How will you know you've accomplished your goal?

1. The updater no longer makes the `GitHub.com` releases call in `GHES-override` scenarios.
2. **SSL cert/proxy failures** on that path degrade quickly instead of hanging retries.
3. Regression tests cover both behaviors and pass.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
