### PR TITLE
Add GONOPROXY/GONOSUMDB env vars to go_modules FileParser

### DIFF
--- a/go_modules/lib/dependabot/go_modules/file_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/file_parser.rb
@@ -107,6 +107,8 @@ module Dependabot
         set_goenv_variable
         set_goproxy_variable
         set_goprivate_variable
+        set_gonoproxy_variable
+        set_gonosumdb_variable
       end
 
       sig { void }
@@ -146,6 +148,39 @@ module Dependabot
 
         goprivate = options.fetch(:goprivate, "*")
         ENV["GOPRIVATE"] = goprivate if goprivate
+      end
+
+      # GONOPROXY explicitly controls which module paths skip the proxy.
+      # Setting this overrides GOPRIVATE's default for proxy decisions, letting
+      # us keep GOPRIVATE=* (to skip sumdb for unknown enterprise orgs) while
+      # still routing public modules through proxy.golang.org. The literal
+      # value "none" matches no module paths — see Go's mod_gonoproxy.txt test.
+      sig { void }
+      def set_gonoproxy_variable
+        return if go_env_includes_any?(%w(GONOPROXY GOPRIVATE GOPROXY))
+        return if goproxy_credentials.any?
+
+        gonoproxy = options.fetch(:gonoproxy, nil)
+        ENV["GONOPROXY"] = gonoproxy if gonoproxy
+      end
+
+      # GONOSUMDB explicitly controls which module paths skip checksum DB
+      # verification. Setting this overrides GOPRIVATE's default for sumdb,
+      # letting us narrow the scope independently of proxy routing.
+      sig { void }
+      def set_gonosumdb_variable
+        return if go_env_includes_any?(%w(GONOSUMDB GOPRIVATE))
+
+        gonosumdb = options.fetch(:gonosumdb, nil)
+        ENV["GONOSUMDB"] = gonosumdb if gonosumdb
+      end
+
+      sig { params(keys: T::Array[String]).returns(T::Boolean) }
+      def go_env_includes_any?(keys)
+        content = go_env&.content
+        return false unless content
+
+        keys.any? { |key| content.include?(key) }
       end
 
       sig { void }

--- a/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/file_parser_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Dependabot::GoModules::FileParser do
     ENV.delete("GOENV")
     ENV.delete("GOPROXY")
     ENV.delete("GOPRIVATE")
+    ENV.delete("GONOPROXY")
+    ENV.delete("GONOSUMDB")
   end
 
   it_behaves_like "a dependency file parser"
@@ -138,6 +140,132 @@ RSpec.describe Dependabot::GoModules::FileParser do
         options: { goprivate: "*" }
       )
       expect(`go env GOPRIVATE`.strip).to be_empty
+    end
+
+    it "sets GONOPROXY from the gonoproxy option" do
+      described_class.new(
+        dependency_files: [go_mod],
+        source: source,
+        repo_contents_path: repo_contents_path,
+        options: { goprivate: "*", gonoproxy: "none" }
+      )
+      expect(`go env GOPRIVATE`.strip).to eq("*")
+      expect(`go env GONOPROXY`.strip).to eq("none")
+    end
+
+    it "sets GONOSUMDB from the gonosumdb option" do
+      described_class.new(
+        dependency_files: [go_mod],
+        source: source,
+        repo_contents_path: repo_contents_path,
+        options: { goprivate: "*", gonosumdb: "*" }
+      )
+      expect(`go env GOPRIVATE`.strip).to eq("*")
+      expect(`go env GONOSUMDB`.strip).to eq("*")
+    end
+
+    it "does not set GONOPROXY when the option is omitted" do
+      ENV.delete("GONOPROXY")
+      described_class.new(
+        dependency_files: [go_mod],
+        source: source,
+        repo_contents_path: repo_contents_path,
+        options: { goprivate: "*" }
+      )
+      expect(ENV.fetch("GONOPROXY", nil)).to be_nil
+    end
+
+    it "does not set GONOSUMDB when the option is omitted" do
+      ENV.delete("GONOSUMDB")
+      described_class.new(
+        dependency_files: [go_mod],
+        source: source,
+        repo_contents_path: repo_contents_path,
+        options: { goprivate: "*" }
+      )
+      expect(ENV.fetch("GONOSUMDB", nil)).to be_nil
+    end
+
+    it "does not override GONOPROXY if it is already set in the go.env file" do
+      go_env = Dependabot::DependencyFile.new(
+        name: "go.env",
+        content: "GONOPROXY=*.company.com",
+        directory: directory
+      )
+      described_class.new(
+        dependency_files: [go_mod, go_env],
+        source: source,
+        repo_contents_path: repo_contents_path,
+        options: { gonoproxy: "none" }
+      )
+      expect(`go env GONOPROXY`.strip).to eq("*.company.com")
+    end
+
+    it "does not override GONOSUMDB if it is already set in the go.env file" do
+      go_env = Dependabot::DependencyFile.new(
+        name: "go.env",
+        content: "GONOSUMDB=*.company.com",
+        directory: directory
+      )
+      described_class.new(
+        dependency_files: [go_mod, go_env],
+        source: source,
+        repo_contents_path: repo_contents_path,
+        options: { gonosumdb: "*" }
+      )
+      expect(`go env GONOSUMDB`.strip).to eq("*.company.com")
+    end
+
+    it "does not set GONOPROXY if GOPRIVATE is set in the go.env file" do
+      ENV.delete("GONOPROXY")
+      go_env = Dependabot::DependencyFile.new(
+        name: "go.env",
+        content: "GOPRIVATE=github.com/dependabot-fixtures",
+        directory: directory
+      )
+      described_class.new(
+        dependency_files: [go_mod, go_env],
+        source: source,
+        repo_contents_path: repo_contents_path,
+        options: { gonoproxy: "none" }
+      )
+      expect(ENV.fetch("GONOPROXY", nil)).to be_nil
+    end
+
+    it "does not set GONOSUMDB if GOPRIVATE is set in the go.env file" do
+      ENV.delete("GONOSUMDB")
+      go_env = Dependabot::DependencyFile.new(
+        name: "go.env",
+        content: "GOPRIVATE=github.com/dependabot-fixtures",
+        directory: directory
+      )
+      described_class.new(
+        dependency_files: [go_mod, go_env],
+        source: source,
+        repo_contents_path: repo_contents_path,
+        options: { gonosumdb: "*" }
+      )
+      expect(ENV.fetch("GONOSUMDB", nil)).to be_nil
+    end
+
+    it "does not set GONOPROXY if a goproxy_server credential is passed" do
+      ENV.delete("GONOPROXY")
+      credentials = [
+        Dependabot::Credential.new(
+          {
+            "type" => "goproxy_server",
+            "url" => "https://proxy.example.com"
+          }
+        )
+      ]
+      described_class.new(
+        dependency_files: [go_mod],
+        source: source,
+        credentials: credentials,
+        repo_contents_path: repo_contents_path,
+        options: { gonoproxy: "none" }
+      )
+      expect(ENV.fetch("GONOPROXY", nil)).to be_nil
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Adds support for two new options in `FileParser`:

- `:gonoproxy` sets `ENV["GONOPROXY"]`
- `:gonosumdb` sets `ENV["GONOSUMDB"]`

We currently set `GOPRIVATE=*` to make cross-org private modules work, but `GOPRIVATE` doubles as the default for `GONOPROXY` and `GONOSUMDB`, so every public module also bypasses proxy.golang.org and triggers a full git clone causing disk exhaustion on the updater.

Go treats `GONOPROXY` and `GONOSUMDB` as independent overrides, so let's use that feature and set them separately.

We end up with `goproxy=<proxies>,direct` and `gonoproxy=none` when a private registry is set up, which means all requests hit the proxies list, and if it's a public module it falls through to direct
This is fine since registries often have a transparent public proxy setting, so public module requests are handled by the private registry instead of actually hitting the direct vcs url

And for customers without a private registry set up, we use the Go default of `goproxy=proxy.golang.org,direct` so their requests are using the public proxy

### Anything you want to highlight for special attention from reviewers?

The values are set to `GOPRIVATE=*, GONOPROXY=none, GONOSUMDB=*` in the api.

The [direct](https://github.com/dependabot/dependabot-core/blob/21ec69a2cf6b9d7acbdd83d6c2fa6d5a366df22c/go_modules/lib/dependabot/go_modules/file_parser.rb#L157) fallback in GOPROXY is what makes this safe: public modules cache via proxy.golang.org and private modules fall through to a direct git via the Dependabot HTTP proxy which injects cross-org creds based on the URL.

Both follow the same bail-out pattern as `:goprivate` (skip if user supplied their own `go.env` with the same key). `:gonoproxy` additionally bails when `goproxy_credentials` is set, since a custom proxy server overrides proxy routing decisions.

### How will you know you've accomplished your goal?

- Public modules cache through the proxy
- Private and cross-org modules fall back to direct git auth as intended
- Updater disk usage issue is fixed
- Cross-org private module fetches continue to succeed

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.