### PR TITLE
bundler: avoid adding Bundler checksum for lockfiles using 4.0.0-4.0.10

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -26,6 +26,10 @@ module Dependabot
         LOCKFILE_ENDING = /(?<ending>\s*(?:RUBY VERSION|BUNDLED WITH).*)/m
         GIT_DEPENDENCIES_SECTION = /GIT\n.*?\n\n(?!GIT)/m
         GIT_DEPENDENCY_DETAILS = /GIT\n.*?\n\n/m
+        CHECKSUMS_SECTION = /(^CHECKSUMS\n)(?<entries>(?:^  .*\n)+)/m
+        BUNDLED_WITH_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+\.\d+\.\d+)/m
+        BUNDLER_CHECKSUM_ENTRY_REGEX = /^  bundler \([^)]+\).*\n?$/
+        MIN_BUNDLER_CHECKSUM_VERSION = Gem::Version.new("4.0.11")
 
         sig do
           params(
@@ -221,7 +225,34 @@ module Dependabot
         sig { params(lockfile_body: String).returns(String) }
         def post_process_lockfile(lockfile_body)
           lockfile_body = reorder_git_dependencies(lockfile_body)
+          lockfile_body = strip_new_bundler_checksum(lockfile_body)
           replace_lockfile_ending(lockfile_body)
+        end
+
+        sig { params(lockfile_body: String).returns(String) }
+        def strip_new_bundler_checksum(lockfile_body)
+          return lockfile_body unless should_strip_bundler_checksum?
+
+          checksums_section = lockfile_body.match(CHECKSUMS_SECTION)
+          return lockfile_body unless checksums_section
+
+          entries = checksums_section[:entries]
+          stripped_entries = entries.lines.reject { |line| line.match?(BUNDLER_CHECKSUM_ENTRY_REGEX) }.join
+
+          lockfile_body.sub(CHECKSUMS_SECTION, "\\1#{stripped_entries}")
+        end
+
+        sig { returns(T::Boolean) }
+        def should_strip_bundler_checksum?
+          lockfile_content = T.must(lockfile).content
+          return false unless lockfile_content&.include?("CHECKSUMS\n")
+          return false if lockfile_content.match?(BUNDLER_CHECKSUM_ENTRY_REGEX)
+
+          bundled_with = lockfile_content.match(BUNDLED_WITH_VERSION_REGEX)&.[](:version)
+          return false unless bundled_with
+
+          bundled_with_version = Gem::Version.new(bundled_with)
+          bundled_with_version >= Gem::Version.new("4.0.0") && bundled_with_version < MIN_BUNDLER_CHECKSUM_VERSION
         end
 
         sig { params(lockfile_body: String).returns(String) }

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -236,7 +236,7 @@ module Dependabot
           checksums_section = lockfile_body.match(CHECKSUMS_SECTION)
           return lockfile_body unless checksums_section
 
-          entries = checksums_section[:entries]
+          entries = T.must(checksums_section[:entries])
           stripped_entries = entries.lines.reject { |line| line.match?(BUNDLER_CHECKSUM_ENTRY_REGEX) }.join
 
           lockfile_body.sub(CHECKSUMS_SECTION, "\\1#{stripped_entries}")

--- a/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
@@ -9,6 +9,88 @@ require "dependabot/bundler/file_updater/lockfile_updater"
 RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
   include_context "when stubbing rubygems compact index"
 
+  describe "#post_process_lockfile" do
+    subject(:post_processed_lockfile) { updater.send(:post_process_lockfile, generated_lockfile) }
+
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "business",
+        version: "1.5.0",
+        previous_version: "1.4.0",
+        requirements: [],
+        previous_requirements: [],
+        package_manager: "bundler"
+      )
+    end
+    let(:files) { [gemfile, lockfile] }
+    let(:gemfile) do
+      Dependabot::DependencyFile.new(
+        name: "Gemfile",
+        content: "source 'https://rubygems.org'\n"
+      )
+    end
+    let(:generated_lockfile) do
+      <<~LOCKFILE
+        GEM
+          specs:
+            business (1.5.0)
+
+        CHECKSUMS
+          business (1.5.0) sha256=123
+          bundler (4.0.11) sha256=abc
+
+        BUNDLED WITH
+           4.0.11
+      LOCKFILE
+    end
+
+    context "when original lockfile uses Bundler 4.0.10" do
+      let(:lockfile) do
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: <<~LOCKFILE
+            GEM
+              specs:
+                business (1.4.0)
+
+            CHECKSUMS
+              business (1.4.0) sha256=456
+
+            BUNDLED WITH
+               4.0.10
+          LOCKFILE
+        )
+      end
+
+      it "removes newly added bundler checksums" do
+        expect(post_processed_lockfile).not_to include("bundler (4.0.11)")
+      end
+    end
+
+    context "when original lockfile uses Bundler 4.0.11" do
+      let(:lockfile) do
+        Dependabot::DependencyFile.new(
+          name: "Gemfile.lock",
+          content: <<~LOCKFILE
+            GEM
+              specs:
+                business (1.4.0)
+
+            CHECKSUMS
+              business (1.4.0) sha256=456
+
+            BUNDLED WITH
+               4.0.11
+          LOCKFILE
+        )
+      end
+
+      it "keeps bundler checksums" do
+        expect(post_processed_lockfile).to include("bundler (4.0.11)")
+      end
+    end
+  end
+
   let(:updater) do
     described_class.new(
       dependencies: [dependency],

--- a/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
@@ -9,88 +9,6 @@ require "dependabot/bundler/file_updater/lockfile_updater"
 RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
   include_context "when stubbing rubygems compact index"
 
-  describe "#post_process_lockfile" do
-    subject(:post_processed_lockfile) { updater.send(:post_process_lockfile, generated_lockfile) }
-
-    let(:dependency) do
-      Dependabot::Dependency.new(
-        name: "business",
-        version: "1.5.0",
-        previous_version: "1.4.0",
-        requirements: [],
-        previous_requirements: [],
-        package_manager: "bundler"
-      )
-    end
-    let(:files) { [gemfile, lockfile] }
-    let(:gemfile) do
-      Dependabot::DependencyFile.new(
-        name: "Gemfile",
-        content: "source 'https://rubygems.org'\n"
-      )
-    end
-    let(:generated_lockfile) do
-      <<~LOCKFILE
-        GEM
-          specs:
-            business (1.5.0)
-
-        CHECKSUMS
-          business (1.5.0) sha256=123
-          bundler (4.0.11) sha256=abc
-
-        BUNDLED WITH
-           4.0.11
-      LOCKFILE
-    end
-
-    context "when original lockfile uses Bundler 4.0.10" do
-      let(:lockfile) do
-        Dependabot::DependencyFile.new(
-          name: "Gemfile.lock",
-          content: <<~LOCKFILE
-            GEM
-              specs:
-                business (1.4.0)
-
-            CHECKSUMS
-              business (1.4.0) sha256=456
-
-            BUNDLED WITH
-               4.0.10
-          LOCKFILE
-        )
-      end
-
-      it "removes newly added bundler checksums" do
-        expect(post_processed_lockfile).not_to include("bundler (4.0.11)")
-      end
-    end
-
-    context "when original lockfile uses Bundler 4.0.11" do
-      let(:lockfile) do
-        Dependabot::DependencyFile.new(
-          name: "Gemfile.lock",
-          content: <<~LOCKFILE
-            GEM
-              specs:
-                business (1.4.0)
-
-            CHECKSUMS
-              business (1.4.0) sha256=456
-
-            BUNDLED WITH
-               4.0.11
-          LOCKFILE
-        )
-      end
-
-      it "keeps bundler checksums" do
-        expect(post_processed_lockfile).to include("bundler (4.0.11)")
-      end
-    end
-  end
-
   let(:updater) do
     described_class.new(
       dependencies: [dependency],
@@ -101,6 +19,63 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
   end
 
   let(:updated_lockfile_content) { updater.updated_lockfile_content }
+
+  describe "with lockfiles that include checksums" do
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "business",
+        version: "1.5.0",
+        previous_version: "1.4.0",
+        requirements: [],
+        previous_requirements: [],
+        package_manager: "bundler"
+      )
+    end
+    let(:files) { bundler_project_dependency_files(project_name) }
+    let(:generated_lockfile) do
+      <<~LOCKFILE
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            business (1.5.0)
+
+        PLATFORMS
+          ruby
+
+        DEPENDENCIES
+          business (~> 1.5)
+
+        CHECKSUMS
+          business (1.5.0) sha256=123
+          bundler (4.0.11) sha256=abc
+
+        BUNDLED WITH
+           4.0.11
+      LOCKFILE
+    end
+
+    before do
+      allow(Dependabot::Bundler::NativeHelpers)
+        .to receive(:run_bundler_subprocess)
+        .and_return(generated_lockfile)
+    end
+
+    context "when original lockfile uses Bundler 4.0.10" do
+      let(:project_name) { "checksums_bundler_4_0_10" }
+
+      it "removes newly added bundler checksums" do
+        expect(updated_lockfile_content).not_to include("bundler (4.0.11)")
+      end
+    end
+
+    context "when original lockfile uses Bundler 4.0.11" do
+      let(:project_name) { "checksums_bundler_4_0_11" }
+
+      it "keeps bundler checksums" do
+        expect(updated_lockfile_content).to include("bundler (4.0.11)")
+      end
+    end
+  end
 
   describe "with multiple path gems" do
     let(:dependency) do

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_10/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_10/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4"

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_10/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_10/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4)
+
+CHECKSUMS
+  business (1.4.0) sha256=456
+
+BUNDLED WITH
+   4.0.10

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_11/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_11/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4"

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_11/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_11/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4)
+
+CHECKSUMS
+  business (1.4.0) sha256=456
+
+BUNDLED WITH
+   4.0.11


### PR DESCRIPTION
### What are you trying to accomplish?

This PR prevents recurring lockfile churn in Dependabot PRs for Bundler 4 projects that are still on early 4.x patch versions.

At a high level, Dependabot updates lockfiles using a newer Bundler 4 runtime, which can add a Bundler entry in the CHECKSUMS section. For repositories still using Bundler 4.0.0 through 4.0.10 locally, that entry is not retained and gets removed on the next local bundle install. This creates noisy follow-up diffs even when dependencies did not meaningfully change.

The **fix introduces a compatibility guard** during lockfile post-processing:
- Detect the Bundler version recorded in the existing lockfile.
- If the project is on 4.0.0 through 4.0.10 and the lockfile did not originally contain a Bundler checksum entry, remove any newly injected
- Bundler checksum line before returning the updated lockfile.
- Keep current behavior unchanged for lockfiles on 4.0.11 and newer.

This keeps Dependabot output aligned with what the project local tooling can actually preserve, eliminating repetitive diff noise while preserving expected behavior for newer Bundler versions.

### Anything you want to highlight for special attention from reviewers?

Resolves: https://github.com/dependabot/dependabot-core/issues/15045

This change preserves current behavior for Bundler 4.0.11+, but adds a compatibility guard for lockfiles using Bundler 4.0.0–4.0.10 so Dependabot does not leave behind a checksum line those versions cannot retain.

### How will you know you've accomplished your goal?

Dependabot PRs for lockfiles with BUNDLED WITH 4.0.0–4.0.10 no longer introduce a Bundler checksum line that is removed by local bundle install, while lockfiles on 4.0.11+ continue to keep Bundler checksum behavior unchanged.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
