### PR TITLE
Throw UnparseableFileException when slnx parsing fails

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -276,7 +276,16 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                 else if (extension == ".slnx")
                 {
                     logger.Info($"    Expanding solution: {candidateEntryPoint}:");
-                    SolutionModel solution = await SolutionSerializers.SlnXml.OpenAsync(candidateEntryPoint, CancellationToken.None);
+                    SolutionModel solution;
+                    try
+                    {
+                        solution = await SolutionSerializers.SlnXml.OpenAsync(candidateEntryPoint, CancellationToken.None);
+                    }
+                    catch (SolutionException ex)
+                    {
+                        throw new UnparseableFileException(ex.Message, candidateEntryPoint);
+                    }
+
                     string solutionPath = Path.GetDirectoryName(candidateEntryPoint) ?? string.Empty;
 
                     foreach (SolutionProjectModel project in solution.SolutionProjects)


### PR DESCRIPTION
When expanding `.slnx` files in `ExpandEntryPointsIntoProjectsAsync`, any `SolutionException` is now caught and rethrown as an `UnparseableFileException` with the original exception message and the `.slnx` file path. This provides a more specific error for downstream handling.