### PR TITLE
Add specific error for missing .NET SDK in discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -215,6 +215,11 @@ internal static class SdkProjectDiscovery
 
                 if (!File.Exists(binLogPath))
                 {
+                    if (stdErr.Contains("A compatible .NET SDK was not found."))
+                    {
+                        throw new Exception("Missing SDK, check global.json locations vs. job directories.");
+                    }
+
                     throw new FileNotFoundException("Dependency discovery didn't produce a log file.");
                 }
 


### PR DESCRIPTION
When the binary log file is not produced during dependency discovery, check stderr for a missing SDK message and throw a more descriptive exception to help diagnose global.json vs. job directory mismatches.

I found an instance in the wild where this happened and the issue was that a dependabot job was started in the root directory `/` which had a solution file which was fine.  However there was no root `global.json` file, it was instead at `src/global.json` which meant the initial SDK installer didn't install the correct SDK but when we invoked MSBuild on a particular project it processed `src/global.json` and broke because the expected SDK wasn't present.

I'm not yet sure if I want to scan the entire repo for `global.json` and install them all, but this at least causes all of these errors to get grouped together in our telemetry so we can see how common it really is.