### PR TITLE
Pass `--config.minimumReleaseAge=0` for `pnpm` security updates to bypass pnpm-workspace.yaml

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -453,7 +453,8 @@ module Dependabot
             dependencies: dependencies,
             dependency_files: dependency_files,
             repo_contents_path: repo_contents_path,
-            credentials: credentials
+            credentials: credentials,
+            security_updates_only: options.fetch(:security_updates_only, false)
           ),
           T.nilable(Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater)
         )

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -21,14 +21,22 @@ module Dependabot
             dependencies: T::Array[Dependabot::Dependency],
             dependency_files: T::Array[Dependabot::DependencyFile],
             repo_contents_path: T.nilable(String),
-            credentials: T::Array[Dependabot::Credential]
+            credentials: T::Array[Dependabot::Credential],
+            security_updates_only: T::Boolean
           ).void
         end
-        def initialize(dependencies:, dependency_files:, repo_contents_path:, credentials:)
+        def initialize(
+          dependencies:,
+          dependency_files:,
+          repo_contents_path:,
+          credentials:,
+          security_updates_only: false
+        )
           @dependencies = dependencies
           @dependency_files = dependency_files
           @repo_contents_path = repo_contents_path
           @credentials = credentials
+          @security_updates_only = T.let(security_updates_only, T::Boolean)
           @error_handler = T.let(
             PnpmErrorHandler.new(
               dependencies: dependencies,
@@ -73,6 +81,11 @@ module Dependabot
 
         sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
+
+        sig { returns(T::Boolean) }
+        def security_updates_only?
+          @security_updates_only
+        end
 
         sig { returns(PnpmErrorHandler) }
         attr_reader :error_handler
@@ -192,17 +205,26 @@ module Dependabot
             "#{d.name}@#{d.version}"
           end.join(" ")
 
-          Helpers.run_pnpm_command(
-            "update #{dependency_updates}  --lockfile-only --no-save -r",
-            fingerprint: "update <dependency_updates>  --lockfile-only --no-save -r"
-          )
+          cmd = "update #{dependency_updates}  --lockfile-only --no-save -r"
+          fingerprint = "update <dependency_updates>  --lockfile-only --no-save -r"
+          if security_updates_only?
+            # Override any minimumReleaseAge set in pnpm-workspace.yaml: security fixes must not be
+            # blocked by a release-age gate the user configured for regular updates.
+            cmd += " --config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false"
+            fingerprint += " --config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false"
+          end
+          Helpers.run_pnpm_command(cmd, fingerprint: fingerprint)
         end
 
         sig { returns(T.nilable(String)) }
         def run_pnpm_install
-          Helpers.run_pnpm_command(
-            "install --lockfile-only"
-          )
+          cmd = "install --lockfile-only"
+          if security_updates_only?
+            # Override any minimumReleaseAge set in pnpm-workspace.yaml: security fixes must not be
+            # blocked by a release-age gate the user configured for regular updates.
+            cmd += " --config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false"
+          end
+          Helpers.run_pnpm_command(cmd)
         end
 
         # Tries `pnpm update --depth Infinity <dep>` for each dependency as a

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -814,4 +814,63 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
       end
     end
   end
+
+  describe "security_updates_only flag" do
+    let(:project_name) { "pnpm/simple" }
+    let(:files) { project_dependency_files(project_name) }
+
+    context "when security_updates_only is true" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: files,
+          dependencies: dependencies,
+          credentials: credentials,
+          repo_contents_path: repo_contents_path,
+          security_updates_only: true
+        )
+      end
+
+      it "passes --config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false to pnpm update" do
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          # Override any minimumReleaseAge set in pnpm-workspace.yaml: security fixes must not be
+          # blocked by a release-age gate the user configured for regular updates.
+          expect(cmd).to include("--config.minimumReleaseAge=0")
+          expect(cmd).to include("--config.minimumReleaseAgeStrict=false")
+          ""
+        end.at_least(:once)
+
+        updater.send(:run_pnpm_update_packages)
+      end
+
+      it "passes --config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false to pnpm install" do
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          expect(cmd).to include("--config.minimumReleaseAge=0")
+          expect(cmd).to include("--config.minimumReleaseAgeStrict=false")
+          ""
+        end
+
+        updater.send(:run_pnpm_install)
+      end
+    end
+
+    context "when security_updates_only is false (default)" do
+      it "does not pass --config.minimumReleaseAge=0 to pnpm update" do
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          expect(cmd).not_to include("--config.minimumReleaseAge=0")
+          ""
+        end
+
+        updater.send(:run_pnpm_update_packages)
+      end
+
+      it "does not pass --config.minimumReleaseAge=0 to pnpm install" do
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          expect(cmd).not_to include("--config.minimumReleaseAge=0")
+          ""
+        end
+
+        updater.send(:run_pnpm_install)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

When a pnpm project sets `minimumReleaseAge` in `pnpm-workspace.yaml`, pnpm rejects package versions published within that window with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`. This blocks security updates when the patched version was released too recently

The fix involves passing `--config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false` to both `pnpm update` and `pnpm install` when `security_updates_only` is true, overriding the project's release-age gate
for security updates only.

Fixes #15161.

### Anything you want to highlight for special attention from reviewers?

The design mirrors what we did for npm in #15139

Unlike npm's `--min-release-age`, pnpm uses ad-hoc config overrides via `--config.<key>=<value>`.
Both `minimumReleaseAge` and `minimumReleaseAgeStrict` are overridden so that setting one does not
implicitly re-enable the other.

From what I tested, these settings are no-op on older versions that don't have these features so it seems safe to enable them globally

### How will you know you've accomplished your goal?

- New unit specs assert the flags are present on both commands when `security_updates_only: true` and
absent when false.

**Tested against my reproducer:** 

Logs: https://github.com/yeikel/dependabot-reproducer-issue-15161/actions/runs/26613986300

<details>
  <summary>Current logs</summary>

```
🤖 ~ starting update ~
Fetching job details
🤖 ~ Failed to parse GITHUB_REGISTRIES_PROXY environment variable ~
Pulling updater images
Starting update process
Created proxy container: 010ce0259e22c0686caeaf675935a25d980d0edb1583b54591c7dd000b66a7d6
Created container: c02bd35dc7f837b50d5990f8a4ef30a9cf105aab3f9c3a72dac5f5da6d8b260a
Started container c02bd35dc7f837b50d5990f8a4ef30a9cf105aab3f9c3a72dac5f5da6d8b260a
updater | Updating certificates in /etc/ssl/certs...
  proxy | 2026/05/29 02:17:40 proxy starting, commit: 824e4800ce477028cb36d81e3ff5c3e96ffb8c06
  proxy | 2026/05/29 02:17:40 Listening (:1080)
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/05/29 02:17:43 INFO <job_1389208015> Starting job processing
updater | 2026/05/29 02:17:43 INFO <job_1389208015> Job definition: {"job":{"command":"security","allowed-updates":[{"dependency-type":"direct","update-type":"all"}],"commit-message-options":{"prefix":null,"prefix-development":null,"include-scope":null},"credentials-metadata":[{"type":"git_source","host":"github.com"}],"debug":null,"dependencies":["cookie"],"dependency-groups":[],"dependency-group-to-refresh":null,"existing-pull-requests":[{"pr-number":1,"dependencies":[{"dependency-name":"ws","dependency-version":"8.21.0","directory":"/"}]},{"pr-number":2,"dependencies":[{"dependency-name":"braces","dependency-version":"3.0.3","directory":"/"}]}],"existing-group-pull-requests":[],"experiments":{"record-ecosystem-versions":true,"record-update-job-unknown-error":true,"proxy-cached":true,"enable-corepack-for-npm-and-yarn":true,"enable-private-registry-for-corepack":true,"allow-refresh-for-existing-pr-dependencies":true,"allow-refresh-group-with-all-dependencies":true,"azure-registry-backup":true,"enable-enhanced-error-details-for-updater":true,"gradle-lockfile-updater":true,"enable-exclude-paths-subdirectory-manifest-files":true},"ignore-conditions":[],"lockfile-only":false,"max-updater-run-time":2700,"package-manager":"npm_and_yarn","requirements-update-strategy":null,"reject-external-code":false,"security-advisories":[{"dependency-name":"cookie","patched-versions":[],"unaffected-versions":[],"affected-versions":["< 0.7.0"]}],"security-updates-only":true,"source":{"provider":"github","repo":"yeikel/dependabot-reproducer-issue-15161","branch":null,"api-endpoint":"https://api.github.com/","hostname":"github.com","directories":["/."]},"updating-a-pull-request":false,"update-subdependencies":false,"vendor-dependencies":false,"enable-beta-ecosystems":false,"repo-private":true,"multi-ecosystem-update":false,"exclude-paths":null}}
  proxy | 2026/05/29 02:17:43 [002] GET [https://github.com:443/yeikel/dependabot-reproducer-issue-15161.git/info/refs?service=git-upload-pack](https://github.com/yeikel/dependabot-reproducer-issue-15161.git/info/refs?service=git-upload-pack)
2026/05/29 02:17:43 [002] * authenticating git server request (host: github.com)
  proxy | 2026/05/29 02:17:44 [002] 200 [https://github.com:443/yeikel/dependabot-reproducer-issue-15161.git/info/refs?service=git-upload-pack](https://github.com/yeikel/dependabot-reproducer-issue-15161.git/info/refs?service=git-upload-pack)
updater | 2026/05/29 02:17:44 INFO <job_1389208015> Started process PID: 1166 with command: {} git clone --no-tags --depth 1 --recurse-submodules --shallow-submodules https://github.com/yeikel/dependabot-reproducer-issue-15161 /home/dependabot/dependabot-updater/repo {}
  proxy | 2026/05/29 02:17:44 [004] GET [https://github.com:443/yeikel/dependabot-reproducer-issue-15161/info/refs?service=git-upload-pack](https://github.com/yeikel/dependabot-reproducer-issue-15161/info/refs?service=git-upload-pack)
  proxy | 2026/05/29 02:17:44 [004] * authenticating git server request (host: github.com)
  proxy | 2026/05/29 02:17:44 [004] 200 [https://github.com:443/yeikel/dependabot-reproducer-issue-15161/info/refs?service=git-upload-pack](https://github.com/yeikel/dependabot-reproducer-issue-15161/info/refs?service=git-upload-pack)
  proxy | 2026/05/29 02:17:44 [006] POST [https://github.com:443/yeikel/dependabot-reproducer-issue-15161/git-upload-pack](https://github.com/yeikel/dependabot-reproducer-issue-15161/git-upload-pack)
2026/05/29 02:17:44 [006] * authenticating git server request (host: github.com)
  proxy | 2026/05/29 02:17:44 [006] 200 [https://github.com:443/yeikel/dependabot-reproducer-issue-15161/git-upload-pack](https://github.com/yeikel/dependabot-reproducer-issue-15161/git-upload-pack)
  proxy | 2026/05/29 02:17:44 [008] POST [https://github.com:443/yeikel/dependabot-reproducer-issue-15161/git-upload-pack](https://github.com/yeikel/dependabot-reproducer-issue-15161/git-upload-pack)
2026/05/29 02:17:44 [008] * authenticating git server request (host: github.com)
  proxy | 2026/05/29 02:17:44 [008] 200 [https://github.com:443/yeikel/dependabot-reproducer-issue-15161/git-upload-pack](https://github.com/yeikel/dependabot-reproducer-issue-15161/git-upload-pack)
updater | 2026/05/29 02:17:44 INFO <job_1389208015> Process PID: 1166 completed with status: pid 1166 exit 0
updater | 2026/05/29 02:17:44 INFO <job_1389208015> Total execution time: 0.57 seconds
updater | 2026/05/29 02:17:44 INFO <job_1389208015> Started process PID: 1204 with command: {} git -C /home/dependabot/dependabot-updater/repo ls-files --stage {}
updater | 2026/05/29 02:17:44 INFO <job_1389208015> Process PID: 1204 completed with status: pid 1204 exit 0
updater | 2026/05/29 02:17:44 INFO <job_1389208015> Total execution time: 0.01 seconds
updater | 2026/05/29 02:17:44 INFO <job_1389208015> Started process PID: 1285 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/29 02:17:44 INFO <job_1389208015> Process PID: 1285 completed with status: pid 1285 exit 0
updater | 2026/05/29 02:17:44 INFO <job_1389208015> Total execution time: 0.05 seconds
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Started process PID: 1392 with command: {} git rev-parse HEAD {}
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Process PID: 1392 completed with status: pid 1392 exit 0
2026/05/29 02:17:45 INFO <job_1389208015> Total execution time: 0.01 seconds
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Started process PID: 1549 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Process PID: 1549 completed with status: pid 1549 exit 0
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Total execution time: 0.04 seconds
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Detected package manager: pnpm
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Resolving package manager for: pnpm
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Fetching version for package manager: pnpm
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Started process PID: 1579 with command: {} corepack pnpm -v {}
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Process PID: 1579 completed with status: pid 1579 exit 0
2026/05/29 02:17:45 INFO <job_1389208015> Total execution time: 0.7 seconds
2026/05/29 02:17:45 INFO <job_1389208015> Installed version of pnpm: 10.16.0
2026/05/29 02:17:45 INFO <job_1389208015> Installed version for pnpm: 10.16.0
2026/05/29 02:17:45 INFO <job_1389208015> Processing engine constraints for pnpm
2026/05/29 02:17:45 INFO <job_1389208015> No version requirement found for pnpm
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Detected package manager: pnpm
2026/05/29 02:17:45 INFO <job_1389208015> Resolving package manager for: pnpm
2026/05/29 02:17:45 INFO <job_1389208015> Installed version for pnpm: 10.16.0
2026/05/29 02:17:45 INFO <job_1389208015> Processing engine constraints for pnpm
2026/05/29 02:17:45 INFO <job_1389208015> No version requirement found for pnpm
2026/05/29 02:17:45 INFO <job_1389208015> Found "packageManager" : "pnpm@11.4.0". Skipped checking "engines".
2026/05/29 02:17:45 INFO <job_1389208015> Requested version 11.4.0
2026/05/29 02:17:45 INFO <job_1389208015> Installing "pnpm@11.4.0"
updater | 2026/05/29 02:17:45 INFO <job_1389208015> Started process PID: 1592 with command: {} corepack prepare pnpm@11.4.0 --activate {}
  proxy | 2026/05/29 02:17:46 [010] GET [https://registry.npmjs.org:443/pnpm/-/pnpm-11.4.0.tgz](https://registry.npmjs.org/pnpm/-/pnpm-11.4.0.tgz)
  proxy | 2026/05/29 02:17:46 [010] 200 [https://registry.npmjs.org:443/pnpm/-/pnpm-11.4.0.tgz](https://registry.npmjs.org/pnpm/-/pnpm-11.4.0.tgz)
  proxy | 2026/05/29 02:17:47 [012] GET [https://registry.npmjs.org:443/pnpm/11.4.0](https://registry.npmjs.org/pnpm/11.4.0)
  proxy | 2026/05/29 02:17:47 [012] 200 [https://registry.npmjs.org:443/pnpm/11.4.0](https://registry.npmjs.org/pnpm/11.4.0)
updater | 2026/05/29 02:17:47 INFO <job_1389208015> Process PID: 1592 completed with status: pid 1592 exit 0
updater | 2026/05/29 02:17:47 INFO <job_1389208015> Total execution time: 1.24 seconds
2026/05/29 02:17:47 INFO <job_1389208015> pnpm@11.4.0 successfully installed.
2026/05/29 02:17:47 INFO <job_1389208015> Activating currently installed version of pnpm: 11.4.0
updater | 2026/05/29 02:17:47 INFO <job_1389208015> Fetching version for package manager: pnpm
updater | 2026/05/29 02:17:47 INFO <job_1389208015> Started process PID: 1605 with command: {} corepack pnpm -v {}
updater | 2026/05/29 02:17:48 INFO <job_1389208015> Process PID: 1605 completed with status: pid 1605 exit 0
updater | 2026/05/29 02:17:48 INFO <job_1389208015> Total execution time: 0.9 seconds
2026/05/29 02:17:48 INFO <job_1389208015> Installed version of pnpm: 11.4.0
  proxy | 2026/05/29 02:17:48 [014] POST /update_jobs/1389208015/record_ecosystem_versions
  proxy | 2026/05/29 02:17:48 [014] 204 /update_jobs/1389208015/record_ecosystem_versions
updater | 2026/05/29 02:17:48 INFO <job_1389208015> Base commit SHA: b076fc0b61fd58e0e19fa47bd3fb2721d9a499a7
2026/05/29 02:17:48 INFO <job_1389208015> Finished job processing
updater | 2026/05/29 02:17:48 INFO <job_1389208015> Starting job processing
updater | 2026/05/29 02:17:48 INFO <job_1389208015> Detected package manager: pnpm
updater | 2026/05/29 02:17:48 INFO <job_1389208015> Resolving package manager for: pnpm
2026/05/29 02:17:48 INFO <job_1389208015> Fetching version for package manager: pnpm
updater | 2026/05/29 02:17:48 INFO <job_1389208015> Started process PID: 1618 with command: {} corepack pnpm -v {}
updater | 2026/05/29 02:17:49 INFO <job_1389208015> Process PID: 1618 completed with status: pid 1618 exit 0
updater | 2026/05/29 02:17:49 INFO <job_1389208015> Total execution time: 0.91 seconds
updater | 2026/05/29 02:17:49 INFO <job_1389208015> Installed version of pnpm: 11.4.0
2026/05/29 02:17:49 INFO <job_1389208015> Installed version for pnpm: 11.4.0
2026/05/29 02:17:49 INFO <job_1389208015> Processing engine constraints for pnpm
2026/05/29 02:17:49 INFO <job_1389208015> No version requirement found for pnpm
2026/05/29 02:17:49 INFO <job_1389208015> Running node command: node -v
updater | 2026/05/29 02:17:49 INFO <job_1389208015> Started process PID: 1631 with command: {} node -v {}
updater | 2026/05/29 02:17:49 INFO <job_1389208015> Process PID: 1631 completed with status: pid 1631 exit 0
updater | 2026/05/29 02:17:49 INFO <job_1389208015> Total execution time: 0.01 seconds
updater | 2026/05/29 02:17:49 INFO <job_1389208015> Command executed successfully: node -v
updater | 2026/05/29 02:17:49 INFO <job_1389208015> Using node version: 24.15.0
2026/05/29 02:17:49 INFO <job_1389208015> Processing engine constraints for node
updater | 2026/05/29 02:17:49 INFO <job_1389208015> Started process PID: 1633 with command: node /opt/npm_and_yarn/dist/run.js
updater | 2026/05/29 02:17:50 INFO <job_1389208015> Process PID: 1633 completed with status: pid 1633 exit 0
updater | 2026/05/29 02:17:50 INFO <job_1389208015> Total execution time: 1.01 seconds
  proxy | 2026/05/29 02:17:50 [016] POST /update_jobs/1389208015/update_dependency_list
  proxy | 2026/05/29 02:17:50 [016] 204 /update_jobs/1389208015/update_dependency_list
  proxy | 2026/05/29 02:17:50 [018] POST /update_jobs/1389208015/increment_metric
  proxy | 2026/05/29 02:17:50 [018] 204 /update_jobs/1389208015/increment_metric
updater | 2026/05/29 02:17:50 INFO <job_1389208015> Starting security update job for yeikel/dependabot-reproducer-issue-15161
updater | 2026/05/29 02:17:50 INFO <job_1389208015> Checking if cookie 0.6.0 needs updating
  proxy | 2026/05/29 02:17:50 [020] GET [https://registry.npmjs.org:443/cookie](https://registry.npmjs.org/cookie)
  proxy | 2026/05/29 02:17:50 [020] 200 [https://registry.npmjs.org:443/cookie](https://registry.npmjs.org/cookie)
  proxy | 2026/05/29 02:17:50 [022] HEAD [https://registry.npmjs.org:443/cookie/-/cookie-1.1.1.tgz](https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz)
  proxy | 2026/05/29 02:17:50 [022] 200 [https://registry.npmjs.org:443/cookie/-/cookie-1.1.1.tgz](https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz)
updater | 2026/05/29 02:17:50 INFO <job_1389208015> Latest version is 1.1.1
  proxy | 2026/05/29 02:17:50 [024] GET [https://registry.npmjs.org:443/dependabot-reproducer-issue-15161](https://registry.npmjs.org/dependabot-reproducer-issue-15161)
  proxy | 2026/05/29 02:17:51 [024] 404 [https://registry.npmjs.org:443/dependabot-reproducer-issue-15161](https://registry.npmjs.org/dependabot-reproducer-issue-15161)
updater | 2026/05/29 02:17:51 INFO <job_1389208015> VulnerabilityAuditor: starting audit
updater | 2026/05/29 02:17:51 INFO <job_1389208015> VulnerabilityAuditor: missing lockfile
  proxy | 2026/05/29 02:17:51 [026] HEAD [https://registry.npmjs.org:443/cookie/-/cookie-0.7.0.tgz](https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz)
  proxy | 2026/05/29 02:17:51 [026] 200 [https://registry.npmjs.org:443/cookie/-/cookie-0.7.0.tgz](https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz)
  proxy | 2026/05/29 02:17:51 [028] GET [https://registry.npmjs.org:443/dependabot-reproducer-issue-15161](https://registry.npmjs.org/dependabot-reproducer-issue-15161)
  proxy | 2026/05/29 02:17:51 [028] 404 [https://registry.npmjs.org:443/dependabot-reproducer-issue-15161](https://registry.npmjs.org/dependabot-reproducer-issue-15161) (cached)
2026/05/29 02:17:51 [028] * auth'd git request previously retried, won't retry again. (cached)
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Requirements to unlock own
  proxy | 2026/05/29 02:17:51 [030] GET [https://registry.npmjs.org:443/dependabot-reproducer-issue-15161](https://registry.npmjs.org/dependabot-reproducer-issue-15161)
  proxy | 2026/05/29 02:17:51 [030] 404 [https://registry.npmjs.org:443/dependabot-reproducer-issue-15161](https://registry.npmjs.org/dependabot-reproducer-issue-15161) (cached)
  proxy | 2026/05/29 02:17:51 [030] * auth'd git request previously retried, won't retry again. (cached)
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Requirements update strategy bump_versions
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Updating cookie from 0.6.0 to 0.7.0
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Started process PID: 1646 with command: {} git reset HEAD --hard {}
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Process PID: 1646 completed with status: pid 1646 exit 0
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Total execution time: 0.01 seconds
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Started process PID: 1652 with command: {} git clean -fx {}
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Process PID: 1652 completed with status: pid 1652 exit 0
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Total execution time: 0.01 seconds
updater | 2026/05/29 02:17:51 INFO <job_1389208015> Started process PID: 1658 with command: node /opt/npm_and_yarn/dist/run.js
updater | 2026/05/29 02:17:52 INFO <job_1389208015> Process PID: 1658 completed with status: pid 1658 exit 0
updater | 2026/05/29 02:17:52 INFO <job_1389208015> Total execution time: 1.01 seconds
updater | 2026/05/29 02:17:52 INFO <job_1389208015> Started process PID: 1746 with command: {} corepack pnpm update cookie@0.7.0 --lockfile-only --no-save -r {}
  proxy | 2026/05/29 02:17:53 [032] GET [https://registry.npmjs.org:443/cookie](https://registry.npmjs.org/cookie)
  proxy | 2026/05/29 02:17:53 [032] 200 [https://registry.npmjs.org:443/cookie](https://registry.npmjs.org/cookie)
  proxy | 2026/05/29 02:17:53 [034] GET [https://registry.npmjs.org:443/-/npm/v1/attestations/cookie@0.6.0](https://registry.npmjs.org/-/npm/v1/attestations/cookie@0.6.0)
  proxy | 2026/05/29 02:17:53 [034] 404 [https://registry.npmjs.org:443/-/npm/v1/attestations/cookie@0.6.0](https://registry.npmjs.org/-/npm/v1/attestations/cookie@0.6.0)
  proxy | 2026/05/29 02:17:53 [036] GET [https://registry.npmjs.org:443/cookie](https://registry.npmjs.org/cookie)
  proxy | 2026/05/29 02:17:53 [036] 200 [https://registry.npmjs.org:443/cookie](https://registry.npmjs.org/cookie)
updater | 2026/05/29 02:17:53 INFO <job_1389208015> Process PID: 1746 completed with status: pid 1746 exit 1
updater | 2026/05/29 02:17:53 INFO <job_1389208015> Total execution time: 1.33 seconds
updater | 2026/05/29 02:17:53 ERROR <job_1389208015> Error running package manager command: corepack pnpm update cookie@0.7.0  --lockfile-only --no-save -r, Error: ? Verifying lockfile against supply-chain policies (1 entry)...
✗ Lockfile failed supply-chain policy check (1 entry in 251ms)
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  cookie@0.6.0 was published at 2023-11-07T05:01:09.857Z, within the minimumReleaseAge cutoff (2007-05-24T15:38:53.531Z)

The lockfile contains entries that the active policies reject. This can mean the lockfile is stale, or that someone committed a lockfile that bypassed the policy locally — inspect recent changes to pnpm-lock.yaml before trusting it. If the changes look expected, run "pnpm clean --lockfile" and then "pnpm install" to rebuild from a fresh resolution. Alternatively, relax the policy that flagged them.
  proxy | 2026/05/29 02:17:53 [038] POST /update_jobs/1389208015/record_update_job_unknown_error
  proxy | 2026/05/29 02:17:54 [038] 204 /update_jobs/1389208015/record_update_job_unknown_error
  proxy | 2026/05/29 02:17:54 [040] POST /update_jobs/1389208015/record_update_job_error
  proxy | 2026/05/29 02:17:54 [040] 204 /update_jobs/1389208015/record_update_job_error
  proxy | 2026/05/29 02:17:54 [042] POST /update_jobs/1389208015/increment_metric
  proxy | 2026/05/29 02:17:54 [042] 204 /update_jobs/1389208015/increment_metric
  proxy | 2026/05/29 02:17:54 [044] POST /update_jobs/1389208015/record_update_job_unknown_error
  proxy | 2026/05/29 02:17:54 [044] 204 /update_jobs/1389208015/record_update_job_unknown_error
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> Error processing cookie (Dependabot::SharedHelpers::HelperSubprocessFailed)
2026/05/29 02:17:54 ERROR <job_1389208015> ? Verifying lockfile against supply-chain policies (1 entry)...
✗ Lockfile failed supply-chain policy check (1 entry in 251ms)
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  cookie@0.6.0 was published at 2023-11-07T05:01:09.857Z, within the minimumReleaseAge cutoff (2007-05-24T15:38:53.531Z)

The lockfile contains entries that the active policies reject. This can mean the lockfile is stale, or that someone committed a lockfile that bypassed the policy locally — inspect recent changes to pnpm-lock.yaml before trusting it. If the changes look expected, run "pnpm clean --lockfile" and then "pnpm install" to rebuild from a fresh resolution. Alternatively, relax the policy that flagged them.
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/common/lib/dependabot/shared_helpers.rb:521:in 'Dependabot::SharedHelpers.run_shell_command'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:191:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:191:in 'T::Private::Methods::CallValidation.validate_call_skip_block_type'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:133:in 'block in Dependabot::SharedHelpers.create_validator_slow_skip_block_type'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb:532:in 'Dependabot::NpmAndYarn::Helpers.package_manager_run_command'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:191:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:191:in 'T::Private::Methods::CallValidation.validate_call_skip_block_type'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:133:in 'block in Dependabot::NpmAndYarn::Helpers.create_validator_slow_skip_block_type'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb:375:in 'Dependabot::NpmAndYarn::Helpers.run_pnpm_command'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::Helpers._on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb:195:in 'Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater#run_pnpm_update_packages'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb:167:in 'block (2 levels) in Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater#run_pnpm_update'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/common/lib/dependabot/shared_helpers.rb:320:in 'Dependabot::SharedHelpers.with_git_configured'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:215:in 'block in Dependabot::SharedHelpers.create_validator_slow'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb:161:in 'block in Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater#run_pnpm_update'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/common/lib/dependabot/shared_helpers.rb:58:in 'block in Dependabot::SharedHelpers.in_a_temporary_repo_directory'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/common/lib/dependabot/shared_helpers.rb:58:in 'Dir.chdir'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/common/lib/dependabot/shared_helpers.rb:58:in 'Dependabot::SharedHelpers.in_a_temporary_repo_directory'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::SharedHelpers._on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb:158:in 'Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater#run_pnpm_update'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb:54:in 'Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater#updated_pnpm_lock_content'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:430:in 'Dependabot::NpmAndYarn::FileUpdater#updated_pnpm_lock_content'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:332:in 'Dependabot::NpmAndYarn::FileUpdater#pnpm_lock_changed?'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater#_on_method_added'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:122:in 'block in Dependabot::NpmAndYarn::FileUpdater#update_pnpm_locks'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:121:in 'Array#each'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:121:in 'Dependabot::NpmAndYarn::FileUpdater#update_pnpm_locks'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:378:in 'Dependabot::NpmAndYarn::FileUpdater#updated_lockfiles'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb:46:in 'Dependabot::NpmAndYarn::FileUpdater#updated_dependency_files'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::NpmAndYarn::FileUpdater#_on_method_added'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:155:in 'Dependabot::DependencyChangeBuilder#generate_dependency_files'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::DependencyChangeBuilder#_on_method_added'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:74:in 'Dependabot::DependencyChangeBuilder#run'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::DependencyChangeBuilder#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:44:in 'Dependabot::DependencyChangeBuilder.create_from'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::DependencyChangeBuilder._on_method_added'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:175:in 'Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#check_and_create_pull_request'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#_on_method_added'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:98:in 'Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#check_and_create_pr_with_error_handling'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:71:in 'block in Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#perform'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:71:in 'Array#each'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb:71:in 'Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#perform'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:56:in 'Dependabot::Updater#run'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::Updater#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:53:in 'block in Dependabot::UpdateFilesCommand#perform_job'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace/tracer.rb:37:in 'block in OpenTelemetry::Trace::Tracer#in_span'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace.rb:70:in 'block in OpenTelemetry::Trace#with_span'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/context.rb:88:in 'OpenTelemetry::Context.with_value'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace.rb:70:in 'OpenTelemetry::Trace#with_span'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/opentelemetry-api-1.9.0/lib/opentelemetry/trace/tracer.rb:37:in 'OpenTelemetry::Trace::Tracer#in_span'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/update_files_command.rb:30:in 'Dependabot::UpdateFilesCommand#perform_job'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:294:in 'T::Private::Methods::CallValidation.validate_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/_methods.rb:257:in 'block in Dependabot::UpdateFilesCommand#_on_method_added'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/lib/dependabot/base_command.rb:42:in 'Dependabot::BaseCommand#run'
updater | 2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:652:in 'UnboundMethod#bind_call'
2026/05/29 02:17:54 ERROR <job_1389208015> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:652:in 'block in Dependabot::BaseCommand#create_validator_procedure_fast0'
2026/05/29 02:17:54 ERROR <job_1389208015> bin/update_files.rb:48:in '<main>'
  proxy | 2026/05/29 02:17:54 [046] POST /update_jobs/1389208015/record_ecosystem_meta
  proxy | 2026/05/29 02:17:54 [046] 204 /update_jobs/1389208015/record_ecosystem_meta
  proxy | 2026/05/29 02:17:54 [048] PATCH /update_jobs/1389208015/mark_as_processed
  proxy | 2026/05/29 02:17:54 [048] 204 /update_jobs/1389208015/mark_as_processed
updater | 2026/05/29 02:17:54 INFO <job_1389208015> Finished job processing
updater | 2026/05/29 02:17:54 INFO Results:
Dependabot encountered '1' error(s) during execution, please check the logs for more details.
+--------------------------------------------+
|       Dependencies failed to update        |
+------------+---------------+---------------+
| Dependency | Error Type    | Error Details |
+------------+---------------+---------------+
| cookie     | unknown_error | null          |
+------------+---------------+---------------+
Failure running container c02bd35dc7f837b50d5990f8a4ef30a9cf105aab3f9c3a72dac5f5da6d8b260a: Error: Command failed with exit code 1: /bin/sh -c $DEPENDABOT_HOME/dependabot-updater/bin/run update_files
Cleaned up container c02bd35dc7f837b50d5990f8a4ef30a9cf105aab3f9c3a72dac5f5da6d8b260a
  proxy | 2026/05/29 02:17:55 2/24 calls cached (8%)
2026/05/29 02:17:55 Posting metrics to remote API endpoint
```
  
</details>

<details>
  <summary>After</summary>

```
    cli | 2026/05/29 02:48:49 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2026/05/29 02:48:50 image ghcr.io/dependabot/proxy:latest is already up to date
    cli | 2026/05/29 02:48:50 using image ghcr.io/dependabot/proxy:latest at sha256:f72e108e50c3f208936f4d287a69c31299874a558c19de779526b5bc90513e8b
    cli | 2026/05/29 02:48:50 digest sha256:dc59066bb283217d8a3a29d42cde10bdf435a866b7a18ff4c750de4dd9395b49 for image ghcr.io/dependabot/dependabot-updater-npm does not exist remotely
  proxy | 2026/05/29 02:48:52 proxy starting, commit: 824e4800ce477028cb36d81e3ff5c3e96ffb8c06
  proxy | 2026/05/29 02:48:52 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/05/29 02:48:56 INFO Starting job processing
updater | 2026/05/29 02:48:56 INFO Job definition: {"job":{"command":"security","package-manager":"npm_and_yarn","allowed-updates":[{"dependency-type":"direct","update-type":"all"}],"debug":false,"dependency-groups":[],"dependencies":["cookie"],"dependency-group-to-refresh":null,"existing-pull-requests":[{"pr-number":1,"dependencies":[{"dependency-name":"ws","dependency-version":"8.21.0","directory":"/"}]},{"pr-number":2,"dependencies":[{"dependency-name":"braces","dependency-version":"3.0.3","directory":"/"}]}],"existing-group-pull-requests":[],"experiments":{"allow-refresh-for-existing-pr-dependencies":true,"allow-refresh-group-with-all-dependencies":true,"azure-registry-backup":true,"enable-corepack-for-npm-and-yarn":true,"enable-enhanced-error-details-for-updater":true,"enable-exclude-paths-subdirectory-manifest-files":true,"enable-private-registry-for-corepack":true,"gradle-lockfile-updater":true,"proxy-cached":true,"record-ecosystem-versions":true,"record-update-job-unknown-error":true},"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[{"dependency-name":"cookie","affected-versions":["\u003c 0.7.0"],"patched-versions":[],"unaffected-versions":[]}],"security-updates-only":true,"source":{"provider":"github","repo":"yeikel/dependabot-reproducer-issue-15161","directories":["/."],"hostname":"github.com","api-endpoint":"https://api.github.com/"},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":true,"commit-message-options":{},"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":2700,"exclude-paths":null,"multi-ecosystem-update":false}}
  proxy | 2026/05/29 02:48:56 [002] GET https://github.com:443/yeikel/dependabot-reproducer-issue-15161.git/info/refs?service=git-upload-pack
  proxy | 2026/05/29 02:48:56 [002] * authenticating git server request (host: github.com)
  proxy | 2026/05/29 02:48:56 [002] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15161.git/info/refs?service=git-upload-pack
updater | 2026/05/29 02:48:56 INFO Started process PID: 1164 with command: {} git clone --no-tags --depth 1 --recurse-submodules --shallow-submodules https://github.com/yeikel/dependabot-reproducer-issue-15161 /home/dependabot/dependabot-updater/repo {}
  proxy | 2026/05/29 02:48:56 [004] GET https://github.com:443/yeikel/dependabot-reproducer-issue-15161/info/refs?service=git-upload-pack
  proxy | 2026/05/29 02:48:56 [004] * authenticating git server request (host: github.com)
  proxy | 2026/05/29 02:48:56 [004] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15161/info/refs?service=git-upload-pack
  proxy | 2026/05/29 02:48:56 [006] POST https://github.com:443/yeikel/dependabot-reproducer-issue-15161/git-upload-pack
  proxy | 2026/05/29 02:48:56 [006] * authenticating git server request (host: github.com)
  proxy | 2026/05/29 02:48:56 [006] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15161/git-upload-pack
  proxy | 2026/05/29 02:48:56 [008] POST https://github.com:443/yeikel/dependabot-reproducer-issue-15161/git-upload-pack
  proxy | 2026/05/29 02:48:56 [008] * authenticating git server request (host: github.com)
  proxy | 2026/05/29 02:48:57 [008] 200 https://github.com:443/yeikel/dependabot-reproducer-issue-15161/git-upload-pack
updater | 2026/05/29 02:48:57 INFO Process PID: 1164 completed with status: pid 1164 exit 0
updater | 2026/05/29 02:48:57 INFO Total execution time: 0.43 seconds
updater | 2026/05/29 02:48:57 INFO Started process PID: 1203 with command: {} git -C /home/dependabot/dependabot-updater/repo ls-files --stage {}
updater | 2026/05/29 02:48:57 INFO Process PID: 1203 completed with status: pid 1203 exit 0
updater | 2026/05/29 02:48:57 INFO Total execution time: 0.01 seconds
updater | 2026/05/29 02:48:57 INFO Started process PID: 1296 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/29 02:48:57 INFO Process PID: 1296 completed with status: pid 1296 exit 0
updater | 2026/05/29 02:48:57 INFO Total execution time: 0.05 seconds
updater | 2026/05/29 02:48:57 INFO Started process PID: 1416 with command: {} git rev-parse HEAD {}
updater | 2026/05/29 02:48:57 INFO Process PID: 1416 completed with status: pid 1416 exit 0
updater | 2026/05/29 02:48:57 INFO Total execution time: 0.01 seconds
updater | 2026/05/29 02:48:57 INFO Started process PID: 1597 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/29 02:48:57 INFO Process PID: 1597 completed with status: pid 1597 exit 0
updater | 2026/05/29 02:48:57 INFO Total execution time: 0.04 seconds
updater | 2026/05/29 02:48:57 INFO Detected package manager: pnpm
updater | 2026/05/29 02:48:57 INFO Resolving package manager for: pnpm
updater | 2026/05/29 02:48:57 INFO Fetching version for package manager: pnpm
updater | 2026/05/29 02:48:57 INFO Started process PID: 1631 with command: {} corepack pnpm -v {}
updater | 2026/05/29 02:48:57 INFO Process PID: 1631 completed with status: pid 1631 exit 0
updater | 2026/05/29 02:48:57 INFO Total execution time: 0.47 seconds
updater | 2026/05/29 02:48:57 INFO Installed version of pnpm: 10.16.0
updater | 2026/05/29 02:48:57 INFO Installed version for pnpm: 10.16.0
updater | 2026/05/29 02:48:57 INFO Processing engine constraints for pnpm
updater | 2026/05/29 02:48:57 INFO No version requirement found for pnpm
updater | 2026/05/29 02:48:57 INFO Detected package manager: pnpm
updater | 2026/05/29 02:48:57 INFO Resolving package manager for: pnpm
updater | 2026/05/29 02:48:57 INFO Installed version for pnpm: 10.16.0
updater | 2026/05/29 02:48:57 INFO Processing engine constraints for pnpm
updater | 2026/05/29 02:48:57 INFO No version requirement found for pnpm
updater | 2026/05/29 02:48:57 INFO Found "packageManager" : "pnpm@11.4.0". Skipped checking "engines".
updater | 2026/05/29 02:48:57 INFO Requested version 11.4.0
updater | 2026/05/29 02:48:57 INFO Installing "pnpm@11.4.0"
updater | 2026/05/29 02:48:57 INFO Started process PID: 1644 with command: {} corepack prepare pnpm@11.4.0 --activate {}
  proxy | 2026/05/29 02:48:58 [010] GET https://registry.npmjs.org:443/pnpm/-/pnpm-11.4.0.tgz
  proxy | 2026/05/29 02:48:58 [010] 200 https://registry.npmjs.org:443/pnpm/-/pnpm-11.4.0.tgz
  proxy | 2026/05/29 02:48:59 [012] GET https://registry.npmjs.org:443/pnpm/11.4.0
  proxy | 2026/05/29 02:48:59 [012] 200 https://registry.npmjs.org:443/pnpm/11.4.0
updater | 2026/05/29 02:48:59 INFO Process PID: 1644 completed with status: pid 1644 exit 0
updater | 2026/05/29 02:48:59 INFO Total execution time: 1.35 seconds
updater | 2026/05/29 02:48:59 INFO pnpm@11.4.0 successfully installed.
updater | 2026/05/29 02:48:59 INFO Activating currently installed version of pnpm: 11.4.0
updater | 2026/05/29 02:48:59 INFO Fetching version for package manager: pnpm
updater | 2026/05/29 02:48:59 INFO Started process PID: 1657 with command: {} corepack pnpm -v {}
updater | 2026/05/29 02:48:59 INFO Process PID: 1657 completed with status: pid 1657 exit 0
updater | 2026/05/29 02:48:59 INFO Total execution time: 0.63 seconds
updater | 2026/05/29 02:48:59 INFO Installed version of pnpm: 11.4.0
  proxy | 2026/05/29 02:48:59 [013] POST http://host.docker.internal:52117/update_jobs/cli/record_ecosystem_versions
{"data":{"ecosystem_versions":{"package_managers":{"pnpm":"11.4.0"}}},"type":"record_ecosystem_versions"}
  proxy | 2026/05/29 02:48:59 [013] 200 http://host.docker.internal:52117/update_jobs/cli/record_ecosystem_versions
updater | 2026/05/29 02:48:59 INFO Base commit SHA: b076fc0b61fd58e0e19fa47bd3fb2721d9a499a7
updater | 2026/05/29 02:48:59 INFO Finished job processing
updater | 2026/05/29 02:48:59 INFO Starting job processing
updater | 2026/05/29 02:48:59 INFO Detected package manager: pnpm
updater | 2026/05/29 02:48:59 INFO Resolving package manager for: pnpm
updater | 2026/05/29 02:48:59 INFO Fetching version for package manager: pnpm
updater | 2026/05/29 02:48:59 INFO Started process PID: 1670 with command: {} corepack pnpm -v {}
updater | 2026/05/29 02:49:00 INFO Process PID: 1670 completed with status: pid 1670 exit 0
updater | 2026/05/29 02:49:00 INFO Total execution time: 0.63 seconds
updater | 2026/05/29 02:49:00 INFO Installed version of pnpm: 11.4.0
updater | 2026/05/29 02:49:00 INFO Installed version for pnpm: 11.4.0
updater | 2026/05/29 02:49:00 INFO Processing engine constraints for pnpm
updater | 2026/05/29 02:49:00 INFO No version requirement found for pnpm
updater | 2026/05/29 02:49:00 INFO Running node command: node -v
updater | 2026/05/29 02:49:00 INFO Started process PID: 1683 with command: {} node -v {}
updater | 2026/05/29 02:49:00 INFO Process PID: 1683 completed with status: pid 1683 exit 0
updater | 2026/05/29 02:49:00 INFO Total execution time: 0.01 seconds
updater | 2026/05/29 02:49:00 INFO Command executed successfully: node -v
updater | 2026/05/29 02:49:00 INFO Using node version: 24.15.0
updater | 2026/05/29 02:49:00 INFO Processing engine constraints for node
updater | 2026/05/29 02:49:00 INFO Started process PID: 1685 with command: node /opt/npm_and_yarn/dist/run.js
updater | 2026/05/29 02:49:01 INFO Process PID: 1685 completed with status: pid 1685 exit 0
updater | 2026/05/29 02:49:01 INFO Total execution time: 0.94 seconds
  proxy | 2026/05/29 02:49:01 [014] POST http://host.docker.internal:52117/update_jobs/cli/update_dependency_list
{"data":{"dependencies":[{"name":"cookie","requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"0.6.0","source":null}],"version":"0.6.0"}],"dependency_files":["/package.json","/pnpm-lock.yaml","/pnpm-workspace.yaml"]},"type":"update_dependency_list"}
  proxy | 2026/05/29 02:49:01 [014] 200 http://host.docker.internal:52117/update_jobs/cli/update_dependency_list
  proxy | 2026/05/29 02:49:01 [015] POST http://host.docker.internal:52117/update_jobs/cli/increment_metric
{"data":{"metric":"updater.started","tags":{"operation":"create_security_pr"}},"type":"increment_metric"}
  proxy | 2026/05/29 02:49:01 [015] 200 http://host.docker.internal:52117/update_jobs/cli/increment_metric
updater | 2026/05/29 02:49:01 INFO Starting security update job for yeikel/dependabot-reproducer-issue-15161
updater | 2026/05/29 02:49:01 INFO Checking if cookie 0.6.0 needs updating
  proxy | 2026/05/29 02:49:01 [017] GET https://registry.npmjs.org:443/cookie
  proxy | 2026/05/29 02:49:01 [017] 200 https://registry.npmjs.org:443/cookie
  proxy | 2026/05/29 02:49:01 [019] HEAD https://registry.npmjs.org:443/cookie/-/cookie-1.1.1.tgz
  proxy | 2026/05/29 02:49:01 [019] 200 https://registry.npmjs.org:443/cookie/-/cookie-1.1.1.tgz
updater | 2026/05/29 02:49:01 INFO Latest version is 1.1.1
  proxy | 2026/05/29 02:49:01 [021] GET https://registry.npmjs.org:443/dependabot-reproducer-issue-15161
  proxy | 2026/05/29 02:49:02 [021] 404 https://registry.npmjs.org:443/dependabot-reproducer-issue-15161
updater | 2026/05/29 02:49:02 INFO VulnerabilityAuditor: starting audit
updater | 2026/05/29 02:49:02 INFO VulnerabilityAuditor: missing lockfile
  proxy | 2026/05/29 02:49:02 [023] HEAD https://registry.npmjs.org:443/cookie/-/cookie-0.7.0.tgz
  proxy | 2026/05/29 02:49:02 [023] 200 https://registry.npmjs.org:443/cookie/-/cookie-0.7.0.tgz
  proxy | 2026/05/29 02:49:02 [025] GET https://registry.npmjs.org:443/dependabot-reproducer-issue-15161
  proxy | 2026/05/29 02:49:02 [025] 404 https://registry.npmjs.org:443/dependabot-reproducer-issue-15161 (cached)
  proxy | 2026/05/29 02:49:02 [025] * auth'd git request previously retried, won't retry again. (cached)
updater | 2026/05/29 02:49:02 INFO Requirements to unlock own
  proxy | 2026/05/29 02:49:02 [027] GET https://registry.npmjs.org:443/dependabot-reproducer-issue-15161
  proxy | 2026/05/29 02:49:02 [027] 404 https://registry.npmjs.org:443/dependabot-reproducer-issue-15161 (cached)
updater | 2026/05/29 02:49:02 INFO Requirements update strategy bump_versions
  proxy | 2026/05/29 02:49:02 [027] * auth'd git request previously retried, won't retry again. (cached)
updater | 2026/05/29 02:49:02 INFO Updating cookie from 0.6.0 to 0.7.0
updater | 2026/05/29 02:49:02 INFO Started process PID: 1698 with command: {} git reset HEAD --hard {}
updater | 2026/05/29 02:49:02 INFO Process PID: 1698 completed with status: pid 1698 exit 0
updater | 2026/05/29 02:49:02 INFO Total execution time: 0.01 seconds
updater | 2026/05/29 02:49:02 INFO Started process PID: 1705 with command: {} git clean -fx {}
updater | 2026/05/29 02:49:02 INFO Process PID: 1705 completed with status: pid 1705 exit 0
updater | 2026/05/29 02:49:02 INFO Total execution time: 0.01 seconds
updater | 2026/05/29 02:49:02 INFO Started process PID: 1712 with command: node /opt/npm_and_yarn/dist/run.js
updater | 2026/05/29 02:49:03 INFO Process PID: 1712 completed with status: pid 1712 exit 0
updater | 2026/05/29 02:49:03 INFO Total execution time: 0.78 seconds
updater | 2026/05/29 02:49:03 INFO Started process PID: 1812 with command: {} corepack pnpm update cookie@0.7.0 --lockfile-only --no-save -r --config.minimumReleaseAge\=0 --config.minimumReleaseAgeStrict\=false {}
  proxy | 2026/05/29 02:49:04 [029] GET https://registry.npmjs.org:443/cookie
  proxy | 2026/05/29 02:49:04 [029] 200 https://registry.npmjs.org:443/cookie
  proxy | 2026/05/29 02:49:04 [031] GET https://registry.npmjs.org:443/cookie
  proxy | 2026/05/29 02:49:04 [031] 200 https://registry.npmjs.org:443/cookie (cached)
updater | 2026/05/29 02:49:04 INFO Process PID: 1812 completed with status: pid 1812 exit 0
updater | 2026/05/29 02:49:04 INFO Total execution time: 0.9 seconds
updater | 2026/05/29 02:49:04 INFO Started process PID: 1827 with command: {} corepack pnpm install --lockfile-only --config.minimumReleaseAge\=0 --config.minimumReleaseAgeStrict\=false {}
updater | 2026/05/29 02:49:04 INFO Process PID: 1827 completed with status: pid 1827 exit 0
updater | 2026/05/29 02:49:04 INFO Total execution time: 0.67 seconds
updater | 2026/05/29 02:49:04 INFO Started process PID: 1841 with command: {} git status --untracked-files all --porcelain v1 . {}
updater | 2026/05/29 02:49:04 INFO Process PID: 1841 completed with status: pid 1841 exit 0
updater | 2026/05/29 02:49:04 INFO Total execution time: 0.01 seconds
updater | 2026/05/29 02:49:04 INFO Started process PID: 1848 with command: {} git status --untracked-files all --porcelain v1 .yarn/cache {}
updater | 2026/05/29 02:49:04 INFO Process PID: 1848 completed with status: pid 1848 exit 0
updater | 2026/05/29 02:49:04 INFO Total execution time: 0.01 seconds
updater | 2026/05/29 02:49:04 INFO Started process PID: 1855 with command: {} git status --untracked-files all --porcelain v1 .yarn/install-state.gz {}
updater | 2026/05/29 02:49:04 INFO Process PID: 1855 completed with status: pid 1855 exit 0
updater | 2026/05/29 02:49:04 INFO Total execution time: 0.01 seconds
updater | 2026/05/29 02:49:04 INFO Submitting cookie pull request for creation
  proxy | 2026/05/29 02:49:05 [033] GET https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-15161/commits?per_page=100
  proxy | 2026/05/29 02:49:05 [033] * authenticating github api request with token for api.github.com
  proxy | 2026/05/29 02:49:05 [033] 200 https://api.github.com:443/repos/yeikel/dependabot-reproducer-issue-15161/commits?per_page=100
  proxy | 2026/05/29 02:49:05 [035] GET https://registry.npmjs.org:443/cookie/latest
  proxy | 2026/05/29 02:49:05 [035] 200 https://registry.npmjs.org:443/cookie/latest
  proxy | 2026/05/29 02:49:05 [037] GET https://api.github.com:443/repos/jshttp/cookie/releases?per_page=100
  proxy | 2026/05/29 02:49:05 [037] * authenticating github api request with token for api.github.com
  proxy | 2026/05/29 02:49:05 [037] 200 https://api.github.com:443/repos/jshttp/cookie/releases?per_page=100
  proxy | 2026/05/29 02:49:06 [039] GET https://api.github.com:443/repos/jshttp/cookie/contents/
  proxy | 2026/05/29 02:49:06 [039] * authenticating github api request with token for api.github.com
  proxy | 2026/05/29 02:49:06 [039] 200 https://api.github.com:443/repos/jshttp/cookie/contents/
  proxy | 2026/05/29 02:49:06 [041] GET https://github.com:443/jshttp/cookie.git/info/refs?service=git-upload-pack
  proxy | 2026/05/29 02:49:06 [041] * authenticating git server request (host: github.com)
  proxy | 2026/05/29 02:49:06 [041] 200 https://github.com:443/jshttp/cookie.git/info/refs?service=git-upload-pack
  proxy | 2026/05/29 02:49:06 [043] GET https://api.github.com:443/repos/jshttp/cookie/contents/?ref=v0.7.0
  proxy | 2026/05/29 02:49:06 [043] * authenticating github api request with token for api.github.com
  proxy | 2026/05/29 02:49:06 [043] 200 https://api.github.com:443/repos/jshttp/cookie/contents/?ref=v0.7.0
  proxy | 2026/05/29 02:49:06 [045] GET https://github.com:443/jshttp/cookie.git/info/refs?service=git-upload-pack
  proxy | 2026/05/29 02:49:06 [045] 200 https://github.com:443/jshttp/cookie.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/05/29 02:49:06 [047] GET https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.6.0
  proxy | 2026/05/29 02:49:06 [047] * authenticating github api request with token for api.github.com
  proxy | 2026/05/29 02:49:06 [047] 200 https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.6.0
  proxy | 2026/05/29 02:49:06 [049] GET https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.7.0
  proxy | 2026/05/29 02:49:06 [049] * authenticating github api request with token for api.github.com
  proxy | 2026/05/29 02:49:07 [049] 200 https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.7.0
  proxy | 2026/05/29 02:49:07 [051] GET https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.6.0
  proxy | 2026/05/29 02:49:07 [051] 200 https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.6.0 (cached)
  proxy | 2026/05/29 02:49:07 [053] GET https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.7.0
  proxy | 2026/05/29 02:49:07 [053] 200 https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.7.0 (cached)
  proxy | 2026/05/29 02:49:07 [055] GET https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.6.0
  proxy | 2026/05/29 02:49:07 [055] 200 https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.6.0 (cached)
  proxy | 2026/05/29 02:49:07 [057] GET https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.7.0
  proxy | 2026/05/29 02:49:07 [057] 200 https://api.github.com:443/repos/jshttp/cookie/commits?sha=v0.7.0 (cached)
  proxy | 2026/05/29 02:49:07 [059] GET https://registry.npmjs.org:443/cookie
  proxy | 2026/05/29 02:49:07 [059] 200 https://registry.npmjs.org:443/cookie (cached)
  proxy | 2026/05/29 02:49:07 [060] POST http://host.docker.internal:52117/update_jobs/cli/create_pull_request
{"data":{"base-commit-sha":"b076fc0b61fd58e0e19fa47bd3fb2721d9a499a7","dependencies":[{"name":"cookie","previous-requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"0.6.0","source":null}],"previous-version":"0.6.0","requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"0.7.0","source":null}],"version":"0.7.0","directory":"/"}],"updated-dependency-files":[{"content":"{\n  \"name\": \"dependabot-reproducer-issue-15161\",\n  \"version\": \"1.0.0\",\n  \"description\": \"Reproducer: pnpm minimumReleaseAge blocks Dependabot security updates\",\n  \"packageManager\": \"pnpm@11.4.0\",\n  \"dependencies\": {\n    \"cookie\": \"0.7.0\"\n  }\n}\n","content_encoding":"utf-8","deleted":false,"directory":"/","name":"package.json","operation":"update","support_file":false,"type":"file","mode":""},{"content":"lockfileVersion: '9.0'\n\nsettings:\n  autoInstallPeers: true\n  excludeLinksFromLockfile: false\n\nimporters:\n\n  .:\n    dependencies:\n      cookie:\n        specifier: 0.7.0\n        version: 0.7.0\n\npackages:\n\n  cookie@0.7.0:\n    resolution: {integrity: sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==}\n    engines: {node: '\u003e= 0.6'}\n\nsnapshots:\n\n  cookie@0.7.0: {}\n","content_encoding":"utf-8","deleted":false,"directory":"/","name":"pnpm-lock.yaml","operation":"update","support_file":false,"type":"file","mode":""}],"pr-title":"Bump cookie from 0.6.0 to 0.7.0","pr-body":"Bumps [cookie](https://github.com/jshttp/cookie) from 0.6.0 to 0.7.0.\n\u003cdetails\u003e\n\u003csummary\u003eRelease notes\u003c/summary\u003e\n\u003cp\u003e\u003cem\u003eSourced from \u003ca href=\"https://github.com/jshttp/cookie/releases\"\u003ecookie's releases\u003c/a\u003e.\u003c/em\u003e\u003c/p\u003e\n\u003cblockquote\u003e\n\u003ch2\u003e0.7.0\u003c/h2\u003e\n\u003cul\u003e\n\u003cli\u003eperf: parse cookies ~10% faster (\u003ca href=\"https://redirect.github.com/jshttp/cookie/issues/144\"\u003e#144\u003c/a\u003e by \u003ca href=\"https://github.com/kurtextrem\"\u003e\u003ccode\u003e@​kurtextrem\u003c/code\u003e\u003c/a\u003e and \u003ca href=\"https://redirect.github.com/jshttp/cookie/issues/170\"\u003e#170\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003efix: narrow the validation of cookies to match RFC6265 (\u003ca href=\"https://redirect.github.com/jshttp/cookie/issues/167\"\u003e#167\u003c/a\u003e by \u003ca href=\"https://github.com/bewinsnw\"\u003e\u003ccode\u003e@​bewinsnw\u003c/code\u003e\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003efix: add \u003ccode\u003emain\u003c/code\u003e to \u003ccode\u003epackage.json\u003c/code\u003e for rspack (\u003ca href=\"https://redirect.github.com/jshttp/cookie/issues/166\"\u003e#166\u003c/a\u003e by \u003ca href=\"https://github.com/proudparrot2\"\u003e\u003ccode\u003e@​proudparrot2\u003c/code\u003e\u003c/a\u003e)\u003c/li\u003e\n\u003c/ul\u003e\n\u003cp\u003e\u003ca href=\"https://github.com/jshttp/cookie/compare/v0.6.0...v0.7.0\"\u003ehttps://github.com/jshttp/cookie/compare/v0.6.0...v0.7.0\u003c/a\u003e\u003c/p\u003e\n\u003c/blockquote\u003e\n\u003c/details\u003e\n\u003cdetails\u003e\n\u003csummary\u003eCommits\u003c/summary\u003e\n\u003cul\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/ab057d6c06b94a7b1e3358e69a685ae49c97b627\"\u003e\u003ccode\u003eab057d6\u003c/code\u003e\u003c/a\u003e 0.7.0\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/5f02ca87688481dbcf155e49ca8b61732f30e542\"\u003e\u003ccode\u003e5f02ca8\u003c/code\u003e\u003c/a\u003e Migrate history to GitHub releases\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/a5d591ce8447dd63821779724f96ad3c774c8579\"\u003e\u003ccode\u003ea5d591c\u003c/code\u003e\u003c/a\u003e Migrate history to GitHub releases\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/51968f94b5e820adeceef505539fa193ffe2d105\"\u003e\u003ccode\u003e51968f9\u003c/code\u003e\u003c/a\u003e Skip isNaN\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/9e7ca51ade4b325307eedd6b4dec190983e9e2cc\"\u003e\u003ccode\u003e9e7ca51\u003c/code\u003e\u003c/a\u003e perf(parse): cache length, return early (\u003ca href=\"https://redirect.github.com/jshttp/cookie/issues/144\"\u003e#144\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/d6f39b0aab5521a8b118b466a515fd6eb0b9f65e\"\u003e\u003ccode\u003ed6f39b0\u003c/code\u003e\u003c/a\u003e Fix tests for old node\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/6bb701f14e59c5e768933bfae9b578db4ed26c6e\"\u003e\u003ccode\u003e6bb701f\u003c/code\u003e\u003c/a\u003e Remove failing scorecard\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/ca70da4ddccf7daab7ad7e86e8c83d6a0123ba73\"\u003e\u003ccode\u003eca70da4\u003c/code\u003e\u003c/a\u003e test(serialize): additional tests for name, domain and path RFC validations (...\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/47917c9c2c56887c53d68e23159a7e1c3f7cb958\"\u003e\u003ccode\u003e47917c9\u003c/code\u003e\u003c/a\u003e Iterate whitespace for perf (\u003ca href=\"https://redirect.github.com/jshttp/cookie/issues/170\"\u003e#170\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003e\u003ca href=\"https://github.com/jshttp/cookie/commit/927d48a18fc82828d3726e18927003db330247bb\"\u003e\u003ccode\u003e927d48a\u003c/code\u003e\u003c/a\u003e Add \u003ccode\u003emain\u003c/code\u003e to \u003ccode\u003epackage.json\u003c/code\u003e (\u003ca href=\"https://redirect.github.com/jshttp/cookie/issues/166\"\u003e#166\u003c/a\u003e)\u003c/li\u003e\n\u003cli\u003eAdditional commits viewable in \u003ca href=\"https://github.com/jshttp/cookie/compare/v0.6.0...v0.7.0\"\u003ecompare view\u003c/a\u003e\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/details\u003e\n\u003cdetails\u003e\n\u003csummary\u003eMaintainer changes\u003c/summary\u003e\n\u003cp\u003eThis version was pushed to npm by \u003ca href=\"https://www.npmjs.com/~blakeembrey\"\u003eblakeembrey\u003c/a\u003e, a new releaser for cookie since your current version.\u003c/p\u003e\n\u003c/details\u003e\n\u003cbr /\u003e\n","commit-message":"Bump cookie from 0.6.0 to 0.7.0\n\nBumps [cookie](https://github.com/jshttp/cookie) from 0.6.0 to 0.7.0.\n- [Release notes](https://github.com/jshttp/cookie/releases)\n- [Commits](https://github.com/jshttp/cookie/compare/v0.6.0...v0.7.0)","dependency-group":null},"type":"create_pull_request"}
  proxy | 2026/05/29 02:49:07 [060] 200 http://host.docker.internal:52117/update_jobs/cli/create_pull_request
{"data":[{"ecosystem":{"name":"npm_and_yarn","package_manager":{"name":"pnpm","version":"11.4.0","raw_version":"11.4.0"},"language":{"name":"node","version":"24.15.0","raw_version":"24.15.0"}}}],"type":"record_ecosystem_meta"}
  proxy | 2026/05/29 02:49:07 [061] POST http://host.docker.internal:52117/update_jobs/cli/record_ecosystem_meta
  proxy | 2026/05/29 02:49:07 [061] 200 http://host.docker.internal:52117/update_jobs/cli/record_ecosystem_meta
{"data":{"base-commit-sha":"b076fc0b61fd58e0e19fa47bd3fb2721d9a499a7"},"type":"mark_as_processed"}
  proxy | 2026/05/29 02:49:07 [062] PATCH http://host.docker.internal:52117/update_jobs/cli/mark_as_processed
  proxy | 2026/05/29 02:49:07 [062] 200 http://host.docker.internal:52117/update_jobs/cli/mark_as_processed
updater | 2026/05/29 02:49:07 INFO Finished job processing
updater | 2026/05/29 02:49:07 INFO Results:
updater | +------------------------------------------+
updater | |   Changes to Dependabot Pull Requests    |
updater | +---------+--------------------------------+
updater | | created | cookie ( from 0.6.0 to 0.7.0 ) |
updater | +---------+--------------------------------+
  proxy | 2026/05/29 02:49:07 Skipping sending metrics because api endpoint is empty
  proxy | 2026/05/29 02:49:07 9/28 calls cached (32%)
```
  
</details>

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
