### PR TITLE
Remove beta ecosystem flag handling for Deno

### DIFF
--- a/deno/lib/dependabot/deno/file_fetcher.rb
+++ b/deno/lib/dependabot/deno/file_fetcher.rb
@@ -23,13 +23,6 @@ module Dependabot
 
       sig { override.returns(T::Array[DependencyFile]) }
       def fetch_files
-        unless allow_beta_ecosystems?
-          raise Dependabot::DependencyFileNotFound.new(
-            nil,
-            "Deno ecosystem support is in beta. Set enable-beta-ecosystems to use it."
-          )
-        end
-
         fetched_files = []
         fetched_files << manifest_file
         fetched_files << lockfile if lockfile

--- a/deno/spec/dependabot/deno/file_fetcher_spec.rb
+++ b/deno/spec/dependabot/deno/file_fetcher_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe Dependabot::Deno::FileFetcher do
     )
   end
 
-  before do
-    allow(file_fetcher_instance).to receive(:allow_beta_ecosystems?).and_return(true)
-  end
-
   describe ".required_files_in?" do
     it "returns true when deno.json is present" do
       expect(described_class.required_files_in?(%w(deno.json))).to be true


### PR DESCRIPTION
### What are you trying to accomplish?

Remove the beta ecosystem flag gating for the Deno ecosystem in dependabot-core now that Deno is GA.

The `allow_beta_ecosystems?` check in `Deno::FileFetcher#fetch_files` previously prevented Deno from operating unless the `enable-beta-ecosystems` experiment was enabled. Since Deno has launched as GA, this gate is no longer needed.

### Anything you want to highlight for special attention from reviewers?

This is a straightforward removal — no behavioral change for users who already had the beta flag enabled. For users without the flag, Deno will now work unconditionally (as intended for GA).

### How will you know you've accomplished your goal?

- All existing Deno `file_fetcher_spec.rb` tests pass without the beta stub.
- RuboCop reports no offenses.
- Deno file fetching works without requiring `enable-beta-ecosystems`.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
