### PR TITLE
  Fix behavioral gap in prerelease detection found with Python and generalized to common

### DIFF
--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -323,11 +323,16 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def wants_prerelease?
-        return version_class.new(dependency.version).prerelease? if dependency.version
+        return true if dependency.numeric_version&.prerelease?
 
         dependency.requirements.any? do |req|
-          reqs = (req.fetch(:requirement) || "").split(",").map(&:strip)
-          reqs.any? { |r| r.match?(/[A-Za-z]/) }
+          req_string = req.fetch(:requirement) || ""
+          req_string.split(",").map(&:strip).any? do |r|
+            version_str = r.gsub(/^\s*[!<>=~^]+\s*/, "").strip
+            next false unless version_class.correct?(version_str)
+
+            version_class.new(version_str).prerelease?
+          end
         end
       end
 

--- a/common/spec/dependabot/package/package_latest_version_finder_spec.rb
+++ b/common/spec/dependabot/package/package_latest_version_finder_spec.rb
@@ -464,6 +464,182 @@ RSpec.describe Dependabot::Package::PackageLatestVersionFinder do
     end
   end
 
+  describe "#wants_prerelease?" do
+    subject(:wants_prerelease) { finder.send(:wants_prerelease?) }
+
+    # Minimal PEP 440 stub: post-releases are stable, a/b/rc/dev are pre-release.
+    # Avoids coupling common specs to the Python ecosystem gem.
+    let(:pep440_version_class) do
+      Class.new(Dependabot::Version) do
+        def self.correct?(version)
+          version.to_s.match?(/\A[\d]+(?:\.[\d]+)*(?:\.?(?:a|b|rc|dev|post|rev|r)\d*)?\z/)
+        end
+
+        def prerelease?
+          to_s.match?(/(?:a|b|rc|dev)\d*/)
+        end
+      end
+    end
+
+    let(:available_releases) { [] }
+    let(:dependency_files) { [requirements_file] }
+    let(:requirements_file) do
+      Dependabot::DependencyFile.new(
+        name: "requirements.txt",
+        content: "dummy"
+      )
+    end
+
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: dependency_name,
+        version: dependency_version,
+        requirements: dependency_requirements,
+        package_manager: "pep440_stub"
+      )
+    end
+
+    before do
+      allow(Dependabot::Utils).to receive(:version_class_for_package_manager).and_call_original
+      allow(Dependabot::Utils).to receive(:requirement_class_for_package_manager).and_call_original
+
+      allow(Dependabot::Utils).to receive(:version_class_for_package_manager)
+        .with("pep440_stub")
+        .and_return(pep440_version_class)
+      allow(Dependabot::Utils).to receive(:requirement_class_for_package_manager)
+        .with("pep440_stub")
+        .and_return(Gem::Requirement)
+    end
+
+    context "when the current version is a stable release" do
+      let(:dependency_version) { "2.0.0" }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: "==2.0.0", groups: [], source: nil }]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when the current version is a pre-release" do
+      let(:dependency_version) { "2.0.0a1" }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: "==2.0.0a1", groups: [], source: nil }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the current version is a post-release (stable)" do
+      let(:dependency_version) { "2.0.0.post1" }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: ">=2.0.0.post1", groups: [], source: nil }]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when the current version is a rev-release (stable)" do
+      let(:dependency_version) { "2.0.0.rev1" }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: ">=2.0.0.rev1", groups: [], source: nil }]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when requirements reference a pre-release version" do
+      let(:dependency_version) { "1.9.0" }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: ">=1.9.0,<2.0.0rc1", groups: [], source: nil }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when requirements reference a dev version" do
+      let(:dependency_version) { "1.0.0" }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: ">=1.0.0.dev0", groups: [], source: nil }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when requirements are stable with no pre-release markers" do
+      let(:dependency_version) { "1.0.0" }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: ">=1.0.0,<2.0.0", groups: [], source: nil }]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when the requirement is empty" do
+      let(:dependency_version) { "1.0.0" }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: nil, groups: [], source: nil }]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when the dependency has no pinned version but requirements reference a pre-release" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: ">=2.0.0b1", groups: [], source: nil }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the dependency has no pinned version and requirements are stable" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: ">=1.0.0", groups: [], source: nil }]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with Gem::Version style (default version class)" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: dependency_version,
+          requirements: dependency_requirements,
+          package_manager: "dummy"
+        )
+      end
+
+      context "when the current version has an alpha pre-release suffix" do
+        let(:dependency_version) { "1.0.0.alpha" }
+        let(:dependency_requirements) do
+          [{ file: "Gemfile", requirement: "~> 1.0.0.alpha", groups: [], source: nil }]
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "when the current version is stable" do
+        let(:dependency_version) { "1.0.0" }
+        let(:dependency_requirements) do
+          [{ file: "Gemfile", requirement: "~> 1.0", groups: [], source: nil }]
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "when requirement references a beta version" do
+        let(:dependency_version) { nil }
+        let(:dependency_requirements) do
+          [{ file: "Gemfile", requirement: ">= 2.0.0.beta1", groups: [], source: nil }]
+        end
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+
   describe "cooldown fallback to current version" do
     let(:dependency_version) { "6.0.0" }
 


### PR DESCRIPTION
 ### What are you trying to accomplish?
 
 Fix a behavioral gap in `PackageLatestVersionFinder#wants_prerelease?` where the base class used a naive `/[A-Za-z]/` regex to detect pre-release intent from requirement strings. This caused false positives for ecosystems like Python where stable version markers contain letters (e.g., `post1`, `rev1` in PEP 440).
 
 The fix replaces the regex heuristic with proper version parsing using each ecosystem's own `version_class`, making the detection accurate across all ecosystems.
 
 ### Why generalize to common instead of a Python-specific override?
 
 The old base class logic (`/[A-Za-z]/`) was already wrong for any ecosystem with non-pre-release alphabetic version segments. The new approach delegates to `version_class.prerelease?` which is the canonical per-ecosystem check. Ecosystems that need different behavior (npm, cargo, hex, gradle/maven) already override `wants_prerelease?` or `filter_prerelease_versions` entirely, so this change only affects ecosystems relying on the default implementation.
 
 ### How will you know you've accomplished your goal?
 
 - Python `post`-release versions no longer falsely trigger pre-release inclusion
 - All existing common spec tests pass (76 total)
 - The fix is ecosystem-agnostic: any ecosystem's Version class can correctly classify its own versions
 
 ### References
 
 - PEP 440 (Python versioning): https://peps.python.org/pep-0440/
 - Epic: Versioning tags audit for docs page

Issues addressing:
https://github.com/github/dependabot-updates/issues/6508 
 ### Checklist
 
 - [x] I have run the complete test suite to ensure all tests and linters pass.
 - [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
 - [x] I have written clear and descriptive commit messages.
 - [x] I have provided a detailed description of the changes in the pull request.
 - [x] I have ensured that the code is well-documented and easy to understand.