### PR TITLE
Disable `npmMinimalAgeGate` for Yarn Berry security updates

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -440,7 +440,8 @@ module Dependabot
             dependencies: dependencies,
             dependency_files: dependency_files,
             repo_contents_path: repo_contents_path,
-            credentials: credentials
+            credentials: credentials,
+            security_updates_only: options.fetch(:security_updates_only, false)
           ),
           T.nilable(Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater)
         )

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -30,15 +30,23 @@ module Dependabot
             dependencies: T::Array[Dependabot::Dependency],
             dependency_files: T::Array[Dependabot::DependencyFile],
             repo_contents_path: T.nilable(String),
-            credentials: T::Array[Dependabot::Credential]
+            credentials: T::Array[Dependabot::Credential],
+            security_updates_only: T::Boolean
           )
             .void
         end
-        def initialize(dependencies:, dependency_files:, repo_contents_path:, credentials:)
+        def initialize(
+          dependencies:,
+          dependency_files:,
+          repo_contents_path:,
+          credentials:,
+          security_updates_only: false
+        )
           @dependencies = dependencies
           @dependency_files = dependency_files
           @repo_contents_path = repo_contents_path
           @credentials = credentials
+          @security_updates_only = T.let(security_updates_only, T::Boolean)
           @error_handler = T.let(
             YarnErrorHandler.new(
               dependencies: dependencies,
@@ -222,7 +230,7 @@ module Dependabot
           # the lockfile.
 
           if top_level_dependency_updates.all? { |dep| requirements_changed?(dep[:name]) }
-            Helpers.run_yarn_command("install #{yarn_berry_args}".strip)
+            Helpers.run_yarn_command("install #{yarn_berry_args}".strip, env: yarn_time_gate_env)
 
             # Yarn berry resolves ranges to the latest matching version, which
             # may differ from Dependabot's target. If the lockfile resolved to a
@@ -237,7 +245,8 @@ module Dependabot
 
             Helpers.run_yarn_command(
               "up -R #{updates.join(' ')} #{yarn_berry_args}".strip,
-              fingerprint: "up -R <dependency_names> #{yarn_berry_args}".strip
+              fingerprint: "up -R <dependency_names> #{yarn_berry_args}".strip,
+              env: yarn_time_gate_env
             )
           end
           { yarn_lock.name => File.read(yarn_lock.name) }
@@ -291,7 +300,8 @@ module Dependabot
 
           Helpers.run_yarn_command(
             "up #{dep_name}@#{version} #{yarn_berry_args}".strip,
-            fingerprint: "up <dep>@<version> #{yarn_berry_args}".strip
+            fingerprint: "up <dep>@<version> #{yarn_berry_args}".strip,
+            env: yarn_time_gate_env
           )
 
           reqs.each do |req|
@@ -304,7 +314,7 @@ module Dependabot
           # Restore package.json and re-install to normalize lockfile descriptors,
           # same as yarn classic's replaceLockfileDeclaration flow.
           restore_package_jsons(saved_package_jsons)
-          Helpers.run_yarn_command("install #{yarn_berry_args}".strip)
+          Helpers.run_yarn_command("install #{yarn_berry_args}".strip, env: yarn_time_gate_env)
         end
 
         sig { returns(T::Hash[String, String]) }
@@ -351,6 +361,23 @@ module Dependabot
           end
 
           { yarn_lock.name => updated_content }
+        end
+
+        sig { returns(T::Boolean) }
+        def security_updates_only?
+          @security_updates_only
+        end
+
+        # Returns an env hash that disables Yarn Berry's npmMinimalAgeGate for security updates.
+        # While `yarn up --no-time-gate` achieves the same effect, that flag was only introduced
+        # in Yarn 4.15.x and would leave users on older Berry releases unprotected. The env var
+        # approach covers all Yarn Berry versions that support the feature and applies uniformly
+        # to every subcommand (install, up, add) without requiring per-command flag changes.
+        sig { returns(T.nilable(T::Hash[String, String])) }
+        def yarn_time_gate_env
+          return nil unless security_updates_only?
+
+          { "YARN_NPM_MINIMAL_AGE_GATE" => "0" }
         end
 
         sig { returns(String) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -362,10 +362,16 @@ module Dependabot
       end
 
       # Setup yarn and run a single yarn command returning stdout/stderr
-      sig { params(command: String, fingerprint: T.nilable(String)).returns(String) }
-      def self.run_yarn_command(command, fingerprint: nil)
+      sig do
+        params(
+          command: String,
+          fingerprint: T.nilable(String),
+          env: T.nilable(T::Hash[String, String])
+        ).returns(String)
+      end
+      def self.run_yarn_command(command, fingerprint: nil, env: nil)
         setup_yarn_berry
-        run_single_yarn_command(command, fingerprint: fingerprint)
+        run_single_yarn_command(command, fingerprint: fingerprint, env: env)
       end
 
       # Run single pnpm command returning stdout/stderr
@@ -382,14 +388,21 @@ module Dependabot
       end
 
       # Run single yarn command returning stdout/stderr
-      sig { params(command: String, fingerprint: T.nilable(String)).returns(String) }
-      def self.run_single_yarn_command(command, fingerprint: nil)
+      sig do
+        params(
+          command: String,
+          fingerprint: T.nilable(String),
+          env: T.nilable(T::Hash[String, String])
+        ).returns(String)
+      end
+      def self.run_single_yarn_command(command, fingerprint: nil, env: nil)
         if Dependabot::Experiments.enabled?(:enable_corepack_for_npm_and_yarn)
-          package_manager_run_command(YarnPackageManager::NAME, command, fingerprint: fingerprint)
+          package_manager_run_command(YarnPackageManager::NAME, command, fingerprint: fingerprint, env: env)
         else
           Dependabot::SharedHelpers.run_shell_command(
             "yarn #{command}",
-            fingerprint: "yarn #{fingerprint || command}"
+            fingerprint: "yarn #{fingerprint || command}",
+            env: env
           )
         end
       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
@@ -392,4 +392,77 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
       updated_yarn_lock_content
     end
   end
+
+  describe "security_updates_only flag" do
+    let(:files) { project_dependency_files("yarn_berry/workspace_subdependency_update") }
+    let(:dependency_name) { "lodash" }
+    let(:version) { "3.10.2" }
+    let(:previous_version) { "3.10.1" }
+    let(:requirements) { [] }
+    let(:previous_requirements) { [] }
+
+    context "when security_updates_only is true" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: files,
+          dependencies: dependencies,
+          credentials: credentials,
+          repo_contents_path: nil,
+          security_updates_only: true
+        )
+      end
+
+      it "sets YARN_NPM_MINIMAL_AGE_GATE=0 in yarn_time_gate_env" do
+        # Override any npmMinimalAgeGate set in .yarnrc.yml: security fixes must not be
+        # blocked by a release-age gate the user configured for regular updates.
+        expect(updater.send(:yarn_time_gate_env)).to eq({ "YARN_NPM_MINIMAL_AGE_GATE" => "0" })
+      end
+
+      it "passes YARN_NPM_MINIMAL_AGE_GATE=0 to yarn up in run_yarn_berry_top_level_updater" do
+        allow(updater).to receive(:write_temporary_dependency_files)
+        allow(updater).to receive(:pin_berry_versions_if_needed)
+        allow(updater).to receive(:requirements_changed?).and_return(false)
+        allow(File).to receive(:read).and_return("")
+
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_yarn_command) do |_cmd, **kwargs|
+          expect(kwargs[:env]).to include("YARN_NPM_MINIMAL_AGE_GATE" => "0")
+          ""
+        end
+
+        dep = { name: dependency_name, version: version, requirements: requirements }
+        yarn_lock_file = files.find { |f| f.name == "yarn.lock" }
+        updater.send(
+          :run_yarn_berry_top_level_updater,
+          top_level_dependency_updates: [dep],
+          yarn_lock: yarn_lock_file
+        )
+      end
+    end
+
+    context "when security_updates_only is false (default)" do
+      it "returns nil from yarn_time_gate_env" do
+        expect(updater.send(:yarn_time_gate_env)).to be_nil
+      end
+
+      it "does not pass YARN_NPM_MINIMAL_AGE_GATE to yarn commands" do
+        allow(updater).to receive(:write_temporary_dependency_files)
+        allow(updater).to receive(:pin_berry_versions_if_needed)
+        allow(updater).to receive(:requirements_changed?).and_return(false)
+        allow(File).to receive(:read).and_return("")
+
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_yarn_command) do |_cmd, **kwargs|
+          expect(kwargs[:env]).to be_nil
+          ""
+        end
+
+        dep = { name: dependency_name, version: version, requirements: requirements }
+        yarn_lock_file = files.find { |f| f.name == "yarn.lock" }
+        updater.send(
+          :run_yarn_berry_top_level_updater,
+          top_level_dependency_updates: [dep],
+          yarn_lock: yarn_lock_file
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

When a project sets `npmMinimalAgeGate` in `.yarnrc.yml`, Yarn Berry refuses to install packages that were published within the configured time window. This blocks security updates when the patched version was released too recently, preventing Dependabot from opening a fix PR at all.

```
updater | | lodash     | git_dependencies_not_reachable | {                                                                                                                                                                                                                                                                                                                                                                                         |
updater | |            |                                |   "dependency-urls": [                                                                                                                                                                                                                                                                                                                                                                    |
updater | |            |                                |     "[YN0016]: Remote not found, Detail: ➤ YN0000: · Yarn 4.14.1\n➤ YN0000: ┌ Resolution step\n::group::Resolution step\n➤ YN0016: │ lodash@npm:4.18.1: All versions satisfying \"4.18.1\" are quarantined\n::endgroup::\n➤ YN0016: lodash@npm:4.18.1: All versions satisfying \"4.18.1\" are quarantined\n➤ YN0000: └ Completed in 0s 237ms\n➤ YN0000: · Failed with errors in 0s 251ms" |
updater | |            |                                |   ]                                                                                                                                                                                                                                                                                                                                                                                       |
updater | |            |                                | }      

```

For security updates the age restriction should not apply, so `YARN_NPM_MINIMAL_AGE_GATE=0` is now injected into the environment for all Yarn Berry install and upgrade commands when security advisories are present. 

This is the same pattern already in place for npm (#15139) and pnpm(#15170)

Fixes #15137

### Anything you want to highlight for special attention from reviewers?

While Yarn 4.15.x introduced `--no-time-gate` command line flag, using the environment variable provides broader coverage as it works on all Yarn Berry versions that support `npmMinimalAgeGate` and prevents per-version logic

The env var `YARN_NPM_MINIMAL_AGE_GATE` follows Yarn Berry's standard convention for overriding `.yarnrc.yml` settings (YARN_ + uppercase camelCase key). This is equivalent to temporarily setting `npmMinimalAgeGate: 0` in `.yarnrc.yml` for the duration of the command.


### How will you know you've accomplished your goal?

#### Unit tests were added to yarn_lockfile_updater_spec.rb verifying that:

- YARN_NPM_MINIMAL_AGE_GATE=0 is present in the env passed to run_yarn_command when security_updates_only: true
 - The env is nil (no override) when security_updates_only: false

#### Tested using a reproducer 

Before: https://github.com/yeikel/dependabot-issue-15137/actions/runs/26723902790/job/78755756288

<details>
  <summary>Current logs</summary>

```
    cli | 2026/05/31 21:31:57 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2026/05/31 21:31:58 image ghcr.io/dependabot/proxy:latest is already up to date
    cli | 2026/05/31 21:31:58 using image ghcr.io/dependabot/proxy:latest at sha256:f72e108e50c3f208936f4d287a69c31299874a558c19de779526b5bc90513e8b
    cli | 2026/05/31 21:31:58 digest sha256:dc59066bb283217d8a3a29d42cde10bdf435a866b7a18ff4c750de4dd9395b49 for image ghcr.io/dependabot/dependabot-updater-npm does not exist remotely
  proxy | 2026/05/31 21:32:00 proxy starting, commit: 824e4800ce477028cb36d81e3ff5c3e96ffb8c06
  proxy | 2026/05/31 21:32:00 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/05/31 21:32:03 INFO Starting job processing
updater | 2026/05/31 21:32:03 INFO Job definition: {"job":{"command":"security","package-manager":"npm_and_yarn","allowed-updates":[{"dependency-type":"direct","update-type":"all"}],"debug":false,"dependency-groups":[],"dependencies":["lodash"],"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":{"allow-refresh-for-existing-pr-dependencies":true,"allow-refresh-group-with-all-dependencies":true,"azure-registry-backup":true,"enable-corepack-for-npm-and-yarn":true,"enable-enhanced-error-details-for-updater":true,"enable-exclude-paths-subdirectory-manifest-files":true,"enable-private-registry-for-corepack":true,"gradle-lockfile-updater":true,"proxy-cached":true,"record-ecosystem-versions":true,"record-update-job-unknown-error":true},"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c= 4.17.23"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c= 4.17.23"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c= 4.17.22"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c= 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 3.7.0 \u003c 4.17.19"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.7.0 \u003c 4.17.11"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.12"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.11"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.5"],"patched-versions":[],"unaffected-versions":[]}],"security-updates-only":true,"source":{"provider":"github","repo":"yeikel/dependabot-issue-15137","directories":["/."],"hostname":"github.com","api-endpoint":"https://api.github.com/"},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":true,"commit-message-options":{},"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":2700,"exclude-paths":null,"multi-ecosystem-update":false}}
  proxy | 2026/05/31 21:32:03 [002] GET https://github.com:443/yeikel/dependabot-issue-15137.git/info/refs?service=git-upload-pack
  proxy | 2026/05/31 21:32:03 [002] * authenticating git server request (host: github.com)
  proxy | 2026/05/31 21:32:03 [002] 200 https://github.com:443/yeikel/dependabot-issue-15137.git/info/refs?service=git-upload-pack
updater | 2026/05/31 21:32:06 INFO Started process PID: 1164 with command: {} git clone --no-tags --depth 1 --recurse-submodules --shallow-submodules https://github.com/yeikel/dependabot-issue-15137 /home/dependabot/dependabot-updater/repo {}
  proxy | 2026/05/31 21:32:06 [004] GET https://github.com:443/yeikel/dependabot-issue-15137/info/refs?service=git-upload-pack
  proxy | 2026/05/31 21:32:06 [004] * authenticating git server request (host: github.com)
  proxy | 2026/05/31 21:32:07 [004] 200 https://github.com:443/yeikel/dependabot-issue-15137/info/refs?service=git-upload-pack
  proxy | 2026/05/31 21:32:07 [006] POST https://github.com:443/yeikel/dependabot-issue-15137/git-upload-pack
  proxy | 2026/05/31 21:32:07 [006] * authenticating git server request (host: github.com)
  proxy | 2026/05/31 21:32:07 [006] 200 https://github.com:443/yeikel/dependabot-issue-15137/git-upload-pack
  proxy | 2026/05/31 21:32:07 [008] POST https://github.com:443/yeikel/dependabot-issue-15137/git-upload-pack
  proxy | 2026/05/31 21:32:07 [008] * authenticating git server request (host: github.com)
  proxy | 2026/05/31 21:32:07 [008] 200 https://github.com:443/yeikel/dependabot-issue-15137/git-upload-pack
updater | 2026/05/31 21:32:07 INFO Process PID: 1164 completed with status: pid 1164 exit 0
updater | 2026/05/31 21:32:07 INFO Total execution time: 0.65 seconds
updater | 2026/05/31 21:32:07 INFO Started process PID: 1203 with command: {} git -C /home/dependabot/dependabot-updater/repo ls-files --stage {}
updater | 2026/05/31 21:32:07 INFO Process PID: 1203 completed with status: pid 1203 exit 0
updater | 2026/05/31 21:32:07 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:32:07 INFO Started process PID: 1297 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/31 21:32:07 INFO Process PID: 1297 completed with status: pid 1297 exit 0
updater | 2026/05/31 21:32:07 INFO Total execution time: 0.1 seconds
updater | 2026/05/31 21:32:07 INFO Started process PID: 1418 with command: {} git rev-parse HEAD {}
updater | 2026/05/31 21:32:07 INFO Process PID: 1418 completed with status: pid 1418 exit 0
updater | 2026/05/31 21:32:07 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:32:07 INFO Started process PID: 1598 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/31 21:32:07 INFO Process PID: 1598 completed with status: pid 1598 exit 0
updater | 2026/05/31 21:32:07 INFO Total execution time: 0.04 seconds
updater | 2026/05/31 21:32:07 INFO Detected package manager: yarn
updater | 2026/05/31 21:32:07 INFO Resolving package manager for: yarn
updater | 2026/05/31 21:32:07 INFO Fetching version for package manager: yarn
updater | 2026/05/31 21:32:07 INFO Started process PID: 1630 with command: {} corepack yarn -v {}
updater | 2026/05/31 21:32:08 INFO Process PID: 1630 completed with status: pid 1630 exit 0
updater | 2026/05/31 21:32:08 INFO Total execution time: 0.69 seconds
updater | 2026/05/31 21:32:08 INFO Installed version of yarn: 4.9.2
updater | 2026/05/31 21:32:08 INFO Installed version for yarn: 4.9.2
updater | 2026/05/31 21:32:08 INFO Processing engine constraints for yarn
updater | 2026/05/31 21:32:08 INFO No version requirement found for yarn
updater | 2026/05/31 21:32:08 INFO Detected package manager: yarn
updater | 2026/05/31 21:32:08 INFO Resolving package manager for: yarn
updater | 2026/05/31 21:32:08 INFO Installed version for yarn: 4.9.2
updater | 2026/05/31 21:32:08 INFO Processing engine constraints for yarn
updater | 2026/05/31 21:32:08 INFO No version requirement found for yarn
updater | 2026/05/31 21:32:08 INFO Found "packageManager" : "yarn@4.14.1". Skipped checking "engines".
updater | 2026/05/31 21:32:08 INFO Requested version 4.14.1
updater | 2026/05/31 21:32:08 INFO Installing "yarn@4.14.1"
updater | 2026/05/31 21:32:08 INFO Started process PID: 1643 with command: {} corepack prepare yarn@4.14.1 --activate {}
  proxy | 2026/05/31 21:32:08 [010] GET https://repo.yarnpkg.com:443/4.14.1/packages/yarnpkg-cli/bin/yarn.js
  proxy | 2026/05/31 21:32:09 [010] 200 https://repo.yarnpkg.com:443/4.14.1/packages/yarnpkg-cli/bin/yarn.js
updater | 2026/05/31 21:32:09 INFO Process PID: 1643 completed with status: pid 1643 exit 0
updater | 2026/05/31 21:32:09 INFO Total execution time: 0.89 seconds
updater | 2026/05/31 21:32:09 INFO yarn@4.14.1 successfully installed.
updater | 2026/05/31 21:32:09 INFO Activating currently installed version of yarn: 4.14.1
updater | 2026/05/31 21:32:09 INFO Fetching version for package manager: yarn
updater | 2026/05/31 21:32:09 INFO Started process PID: 1656 with command: {} corepack yarn -v {}
updater | 2026/05/31 21:32:09 INFO Process PID: 1656 completed with status: pid 1656 exit 0
updater | 2026/05/31 21:32:09 INFO Total execution time: 0.29 seconds
updater | 2026/05/31 21:32:09 INFO Installed version of yarn: 4.14.1
  proxy | 2026/05/31 21:32:09 [011] POST http://host.docker.internal:52580/update_jobs/cli/record_ecosystem_versions
{"data":{"ecosystem_versions":{"package_managers":{"yarn":"4.14.1"}}},"type":"record_ecosystem_versions"}
  proxy | 2026/05/31 21:32:09 [011] 200 http://host.docker.internal:52580/update_jobs/cli/record_ecosystem_versions
updater | 2026/05/31 21:32:09 INFO Base commit SHA: fc0781db91ca81d72b53164c56db8435ca2f7e7b
updater | 2026/05/31 21:32:09 INFO Finished job processing
updater | 2026/05/31 21:32:09 INFO Starting job processing
updater | 2026/05/31 21:32:09 INFO Detected package manager: yarn
updater | 2026/05/31 21:32:09 INFO Resolving package manager for: yarn
updater | 2026/05/31 21:32:09 INFO Fetching version for package manager: yarn
updater | 2026/05/31 21:32:09 INFO Started process PID: 1669 with command: {} corepack yarn -v {}
updater | 2026/05/31 21:32:09 INFO Process PID: 1669 completed with status: pid 1669 exit 0
updater | 2026/05/31 21:32:09 INFO Total execution time: 0.25 seconds
updater | 2026/05/31 21:32:09 INFO Installed version of yarn: 4.14.1
updater | 2026/05/31 21:32:09 INFO Installed version for yarn: 4.14.1
updater | 2026/05/31 21:32:09 INFO Processing engine constraints for yarn
updater | 2026/05/31 21:32:09 INFO No version requirement found for yarn
updater | 2026/05/31 21:32:09 INFO Running node command: node -v
updater | 2026/05/31 21:32:09 INFO Started process PID: 1682 with command: {} node -v {}
updater | 2026/05/31 21:32:09 INFO Process PID: 1682 completed with status: pid 1682 exit 0
updater | 2026/05/31 21:32:09 INFO Total execution time: 0.0 seconds
updater | 2026/05/31 21:32:09 INFO Command executed successfully: node -v
updater | 2026/05/31 21:32:09 INFO Using node version: 24.15.0
updater | 2026/05/31 21:32:09 INFO Processing engine constraints for node
updater | 2026/05/31 21:32:09 INFO Started process PID: 1684 with command: node /opt/npm_and_yarn/dist/run.js
updater | 2026/05/31 21:32:11 INFO Process PID: 1684 completed with status: pid 1684 exit 0
updater | 2026/05/31 21:32:11 INFO Total execution time: 1.31 seconds
  proxy | 2026/05/31 21:32:11 [012] POST http://host.docker.internal:52580/update_jobs/cli/update_dependency_list
{"data":{"dependencies":[{"name":"lodash","requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"4.17.15","source":null}],"version":"4.17.15"}],"dependency_files":["/package.json","/yarn.lock"]},"type":"update_dependency_list"}
  proxy | 2026/05/31 21:32:11 [012] 200 http://host.docker.internal:52580/update_jobs/cli/update_dependency_list
{"data":{"metric":"updater.started","tags":{"operation":"create_security_pr"}},"type":"increment_metric"}
  proxy | 2026/05/31 21:32:11 [013] POST http://host.docker.internal:52580/update_jobs/cli/increment_metric
  proxy | 2026/05/31 21:32:11 [013] 200 http://host.docker.internal:52580/update_jobs/cli/increment_metric
updater | 2026/05/31 21:32:11 INFO Starting security update job for yeikel/dependabot-issue-15137
updater | 2026/05/31 21:32:11 INFO Checking if lodash 4.17.15 needs updating
  proxy | 2026/05/31 21:32:11 [015] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/31 21:32:11 [015] 200 https://registry.npmjs.org:443/lodash
  proxy | 2026/05/31 21:32:11 [017] HEAD https://registry.npmjs.org:443/lodash/-/lodash-4.18.1.tgz
  proxy | 2026/05/31 21:32:11 [017] 200 https://registry.npmjs.org:443/lodash/-/lodash-4.18.1.tgz
updater | 2026/05/31 21:32:11 INFO Latest version is 4.18.1
updater | 2026/05/31 21:32:11 INFO VulnerabilityAuditor: starting audit
updater | 2026/05/31 21:32:11 INFO VulnerabilityAuditor: missing lockfile
updater | 2026/05/31 21:32:11 INFO Requirements to unlock own
updater | 2026/05/31 21:32:11 INFO Requirements update strategy bump_versions
updater | 2026/05/31 21:32:11 INFO Updating lodash from 4.17.15 to 4.18.1
updater | 2026/05/31 21:32:11 INFO Started process PID: 1693 with command: {} git reset HEAD --hard {}
updater | 2026/05/31 21:32:11 INFO Process PID: 1693 completed with status: pid 1693 exit 0
updater | 2026/05/31 21:32:11 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:32:11 INFO Started process PID: 1700 with command: {} git clean -fx {}
updater | 2026/05/31 21:32:11 INFO Process PID: 1700 completed with status: pid 1700 exit 0
updater | 2026/05/31 21:32:11 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:32:11 INFO Started process PID: 1793 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:32:12 INFO Process PID: 1793 completed with status: pid 1793 exit 0
updater | 2026/05/31 21:32:12 INFO Total execution time: 0.28 seconds
updater | 2026/05/31 21:32:12 INFO Started process PID: 1806 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:32:12 INFO Process PID: 1806 completed with status: pid 1806 exit 0
updater | 2026/05/31 21:32:12 INFO Total execution time: 0.25 seconds
updater | 2026/05/31 21:32:12 INFO Started process PID: 1819 with command: {} corepack yarn config set enableImmutableInstalls false {}
updater | 2026/05/31 21:32:12 INFO Process PID: 1819 completed with status: pid 1819 exit 0
updater | 2026/05/31 21:32:12 INFO Total execution time: 0.27 seconds
updater | 2026/05/31 21:32:12 INFO Started process PID: 1832 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:32:12 INFO Process PID: 1832 completed with status: pid 1832 exit 0
updater | 2026/05/31 21:32:12 INFO Total execution time: 0.25 seconds
updater | 2026/05/31 21:32:12 INFO Started process PID: 1845 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:32:13 INFO Process PID: 1845 completed with status: pid 1845 exit 0
updater | 2026/05/31 21:32:13 INFO Total execution time: 0.27 seconds
updater | 2026/05/31 21:32:13 INFO Started process PID: 1858 with command: {} corepack yarn config set httpProxy http://172.18.0.2:1080 {}
updater | 2026/05/31 21:32:13 INFO Process PID: 1858 completed with status: pid 1858 exit 0
updater | 2026/05/31 21:32:13 INFO Total execution time: 0.26 seconds
updater | 2026/05/31 21:32:13 INFO Started process PID: 1871 with command: {} corepack yarn config set httpsProxy http://172.18.0.2:1080 {}
updater | 2026/05/31 21:32:13 INFO Process PID: 1871 completed with status: pid 1871 exit 0
updater | 2026/05/31 21:32:13 INFO Total execution time: 0.27 seconds
updater | 2026/05/31 21:32:13 INFO Started process PID: 1884 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:32:13 INFO Process PID: 1884 completed with status: pid 1884 exit 0
updater | 2026/05/31 21:32:13 INFO Total execution time: 0.27 seconds
updater | 2026/05/31 21:32:13 INFO Started process PID: 1897 with command: {} corepack yarn config set httpsCaFilePath /etc/ssl/certs/ca-certificates.crt {}
updater | 2026/05/31 21:32:14 INFO Process PID: 1897 completed with status: pid 1897 exit 0
updater | 2026/05/31 21:32:14 INFO Total execution time: 0.28 seconds
updater | 2026/05/31 21:32:14 INFO Started process PID: 1910 with command: {} corepack yarn install --mode\=skip-build {}
  proxy | 2026/05/31 21:32:14 [019] GET https://registry.yarnpkg.com:443/lodash
  proxy | 2026/05/31 21:32:14 [019] 200 https://registry.yarnpkg.com:443/lodash
updater | 2026/05/31 21:32:14 INFO Process PID: 1910 completed with status: pid 1910 exit 1
updater | 2026/05/31 21:32:14 INFO Total execution time: 0.52 seconds
updater | 2026/05/31 21:32:14 ERROR Error running package manager command: corepack yarn install --mode=skip-build, Error: ←[94m➤←[39m YN0000: · Yarn 4.14.1
updater | ←[94m➤←[39m ←[90mYN0000←[39m: ┌ Resolution step
updater | ::group::Resolution step
updater | ←[91m➤←[39m YN0016: │ ←[38;5;173mlodash←[39m←[38;5;37m@←[39m←[38;5;37mnpm:4.18.1←[39m: All versions satisfying "4.18.1" are quarantined
updater | ::endgroup::
updater | ←[91m➤←[39m YN0016: ←[38;5;173mlodash←[39m←[38;5;37m@←[39m←[38;5;37mnpm:4.18.1←[39m: All versions satisfying "4.18.1" are quarantined
updater | ←[94m➤←[39m ←[90mYN0000←[39m: └ Completed in 0s 237ms
{"data":{"error-type":"git_dependencies_not_reachable","error-details":{"dependency-urls":["[YN0016]: Remote not found, Detail: ➤ YN0000: · Yarn 4.14.1\n➤ YN0000: ┌ Resolution step\n::group::Resolution step\n➤ YN0016: │ lodash@npm:4.18.1: All versions satisfying \"4.18.1\" are quarantined\n::endgroup::\n➤ YN0016: lodash@npm:4.18.1: All versions satisfying \"4.18.1\" are quarantined\n➤ YN0000: └ Completed in 0s 237ms\n➤ YN0000: · Failed with errors in 0s 251ms"]}},"type":"record_update_job_error"}
updater | ←[91m➤←[39m YN0000: · Failed with errors in 0s 251ms
  proxy | 2026/05/31 21:32:14 [020] POST http://host.docker.internal:52580/update_jobs/cli/record_update_job_error
  proxy | 2026/05/31 21:32:14 [020] 200 http://host.docker.internal:52580/update_jobs/cli/record_update_job_error
updater | 2026/05/31 21:32:14 INFO Handled error whilst updating lodash: git_dependencies_not_reachable {"dependency-urls": ["[YN0016]: Remote not found, Detail: ➤ YN0000: · Yarn 4.14.1\n➤ YN0000: ┌ Resolution step\n::group::Resolution step\n➤ YN0016: │ lodash@npm:4.18.1: All versions satisfying \"4.18.1\" are quarantined\n::endgroup::\n➤ YN0016: lodash@npm:4.18.1: All versions satisfying \"4.18.1\" are quarantined\n➤ YN0000: └ Completed in 0s 237ms\n➤ YN0000: · Failed with errors in 0s 251ms"]}
{"data":[{"ecosystem":{"name":"npm_and_yarn","package_manager":{"name":"yarn","version":"4.14.1","raw_version":"4.14.1"},"language":{"name":"node","version":"24.15.0","raw_version":"24.15.0"}}}],"type":"record_ecosystem_meta"}
  proxy | 2026/05/31 21:32:14 [021] POST http://host.docker.internal:52580/update_jobs/cli/record_ecosystem_meta
  proxy | 2026/05/31 21:32:14 [021] 200 http://host.docker.internal:52580/update_jobs/cli/record_ecosystem_meta
  proxy | 2026/05/31 21:32:14 [022] PATCH http://host.docker.internal:52580/update_jobs/cli/mark_as_processed
{"data":{"base-commit-sha":"fc0781db91ca81d72b53164c56db8435ca2f7e7b"},"type":"mark_as_processed"}
  proxy | 2026/05/31 21:32:14 [022] 200 http://host.docker.internal:52580/update_jobs/cli/mark_as_processed
updater | 2026/05/31 21:32:14 INFO Finished job processing
updater | 2026/05/31 21:32:14 INFO Results:
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
updater | |                                                                                                                                                                                                      Dependencies failed to update                                                                                                                                                                                                      |
updater | +------------+--------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
updater | | Dependency | Error Type                     | Error Details                                                                                                                                                                                                                                                                                                                                                                             |
updater | +------------+--------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
updater | | lodash     | git_dependencies_not_reachable | {                                                                                                                                                                                                                                                                                                                                                                                         |
updater | |            |                                |   "dependency-urls": [                                                                                                                                                                                                                                                                                                                                                                    |
updater | |            |                                |     "[YN0016]: Remote not found, Detail: ➤ YN0000: · Yarn 4.14.1\n➤ YN0000: ┌ Resolution step\n::group::Resolution step\n➤ YN0016: │ lodash@npm:4.18.1: All versions satisfying \"4.18.1\" are quarantined\n::endgroup::\n➤ YN0016: lodash@npm:4.18.1: All versions satisfying \"4.18.1\" are quarantined\n➤ YN0000: └ Completed in 0s 237ms\n➤ YN0000: · Failed with errors in 0s 251ms" |
updater | |            |                                |   ]                                                                                                                                                                                                                                                                                                                                                                                       |
updater | |            |                                | }                                                                                                                                                                                                                                                                                                                                                                                         |
updater | +------------+--------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
  proxy | 2026/05/31 21:32:15 Skipping sending metrics because api endpoint is empty
  proxy | 2026/05/31 21:32:15 0/8 calls cached (0%)
    cli | 2026/05/31 21:32:14 updater failure: updater exited with code 1
```
  
</details>


<details>
  <summary>After logs</summary>

```
    cli | 2026/05/31 21:41:29 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2026/05/31 21:41:30 image ghcr.io/dependabot/proxy:latest is already up to date
    cli | 2026/05/31 21:41:30 using image ghcr.io/dependabot/proxy:latest at sha256:f72e108e50c3f208936f4d287a69c31299874a558c19de779526b5bc90513e8b
    cli | 2026/05/31 21:41:30 digest sha256:137b22c4d0274946e7570e5ba85af43020cd1f7a47539902a8e97322d21073c1 for image ghcr.io/dependabot/dependabot-updater-npm does not exist remotely
  proxy | 2026/05/31 21:41:33 proxy starting, commit: 824e4800ce477028cb36d81e3ff5c3e96ffb8c06
  proxy | 2026/05/31 21:41:33 Listening (:1080)
updater | Updating certificates in /etc/ssl/certs...
updater | rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
updater | 1 added, 0 removed; done.
updater | Running hooks in /etc/ca-certificates/update.d...
updater | done.
updater | fetch_files command is no longer used directly
updater | 2026/05/31 21:41:36 INFO Starting job processing
updater | 2026/05/31 21:41:36 INFO Job definition: {"job":{"command":"security","package-manager":"npm_and_yarn","allowed-updates":[{"dependency-type":"direct","update-type":"all"}],"debug":false,"dependency-groups":[],"dependencies":["lodash"],"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":{"allow-refresh-for-existing-pr-dependencies":true,"allow-refresh-group-with-all-dependencies":true,"azure-registry-backup":true,"enable-corepack-for-npm-and-yarn":true,"enable-enhanced-error-details-for-updater":true,"enable-exclude-paths-subdirectory-manifest-files":true,"enable-private-registry-for-corepack":true,"gradle-lockfile-updater":true,"proxy-cached":true,"record-ecosystem-versions":true,"record-update-job-unknown-error":true},"ignore-conditions":[],"lockfile-only":false,"requirements-update-strategy":null,"security-advisories":[{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c= 4.17.23"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c= 4.17.23"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c= 4.17.22"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.0.0 \u003c 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c= 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.21"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 3.7.0 \u003c 4.17.19"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003e= 4.7.0 \u003c 4.17.11"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.12"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.11"],"patched-versions":[],"unaffected-versions":[]},{"dependency-name":"lodash","affected-versions":["\u003c 4.17.5"],"patched-versions":[],"unaffected-versions":[]}],"security-updates-only":true,"source":{"provider":"github","repo":"yeikel/dependabot-issue-15137","directories":["/."],"hostname":"github.com","api-endpoint":"https://api.github.com/"},"update-subdependencies":false,"updating-a-pull-request":false,"vendor-dependencies":false,"reject-external-code":false,"repo-private":true,"commit-message-options":{},"credentials-metadata":[{"host":"github.com","type":"git_source"}],"max-updater-run-time":2700,"exclude-paths":null,"multi-ecosystem-update":false}}
  proxy | 2026/05/31 21:41:36 [002] GET https://github.com:443/yeikel/dependabot-issue-15137.git/info/refs?service=git-upload-pack
  proxy | 2026/05/31 21:41:36 [002] * authenticating git server request (host: github.com)
  proxy | 2026/05/31 21:41:36 [002] 200 https://github.com:443/yeikel/dependabot-issue-15137.git/info/refs?service=git-upload-pack
updater | 2026/05/31 21:41:36 INFO Started process PID: 1162 with command: {} git clone --no-tags --depth 1 --recurse-submodules --shallow-submodules https://github.com/yeikel/dependabot-issue-15137 /home/dependabot/dependabot-updater/repo {}
  proxy | 2026/05/31 21:41:36 [004] GET https://github.com:443/yeikel/dependabot-issue-15137/info/refs?service=git-upload-pack
  proxy | 2026/05/31 21:41:36 [004] * authenticating git server request (host: github.com)
  proxy | 2026/05/31 21:41:36 [004] 200 https://github.com:443/yeikel/dependabot-issue-15137/info/refs?service=git-upload-pack
  proxy | 2026/05/31 21:41:36 [006] POST https://github.com:443/yeikel/dependabot-issue-15137/git-upload-pack
  proxy | 2026/05/31 21:41:36 [006] * authenticating git server request (host: github.com)
  proxy | 2026/05/31 21:41:36 [006] 200 https://github.com:443/yeikel/dependabot-issue-15137/git-upload-pack
  proxy | 2026/05/31 21:41:37 [008] POST https://github.com:443/yeikel/dependabot-issue-15137/git-upload-pack
  proxy | 2026/05/31 21:41:37 [008] * authenticating git server request (host: github.com)
  proxy | 2026/05/31 21:41:37 [008] 200 https://github.com:443/yeikel/dependabot-issue-15137/git-upload-pack
updater | 2026/05/31 21:41:37 INFO Process PID: 1162 completed with status: pid 1162 exit 0
updater | 2026/05/31 21:41:37 INFO Total execution time: 0.58 seconds
updater | 2026/05/31 21:41:37 INFO Started process PID: 1201 with command: {} git -C /home/dependabot/dependabot-updater/repo ls-files --stage {}
updater | 2026/05/31 21:41:37 INFO Process PID: 1201 completed with status: pid 1201 exit 0
updater | 2026/05/31 21:41:37 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:41:37 INFO Started process PID: 1294 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/31 21:41:37 INFO Process PID: 1294 completed with status: pid 1294 exit 0
updater | 2026/05/31 21:41:37 INFO Total execution time: 0.04 seconds
updater | 2026/05/31 21:41:37 INFO Started process PID: 1414 with command: {} git rev-parse HEAD {}
updater | 2026/05/31 21:41:37 INFO Process PID: 1414 completed with status: pid 1414 exit 0
updater | 2026/05/31 21:41:37 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:41:37 INFO Started process PID: 1594 with command: {} git lfs pull --include .yarn,./yarn/cache {}
updater | 2026/05/31 21:41:37 INFO Process PID: 1594 completed with status: pid 1594 exit 0
updater | 2026/05/31 21:41:37 INFO Total execution time: 0.03 seconds
updater | 2026/05/31 21:41:37 INFO Detected package manager: yarn
updater | 2026/05/31 21:41:37 INFO Resolving package manager for: yarn
updater | 2026/05/31 21:41:37 INFO Fetching version for package manager: yarn
updater | 2026/05/31 21:41:37 INFO Started process PID: 1627 with command: {} corepack yarn -v {}
updater | 2026/05/31 21:41:37 INFO Process PID: 1627 completed with status: pid 1627 exit 0
updater | 2026/05/31 21:41:37 INFO Total execution time: 0.27 seconds
updater | 2026/05/31 21:41:37 INFO Installed version of yarn: 4.9.2
updater | 2026/05/31 21:41:37 INFO Installed version for yarn: 4.9.2
updater | 2026/05/31 21:41:37 INFO Processing engine constraints for yarn
updater | 2026/05/31 21:41:37 INFO No version requirement found for yarn
updater | 2026/05/31 21:41:37 INFO Detected package manager: yarn
updater | 2026/05/31 21:41:37 INFO Resolving package manager for: yarn
updater | 2026/05/31 21:41:37 INFO Installed version for yarn: 4.9.2
updater | 2026/05/31 21:41:37 INFO Processing engine constraints for yarn
updater | 2026/05/31 21:41:37 INFO No version requirement found for yarn
updater | 2026/05/31 21:41:37 INFO Found "packageManager" : "yarn@4.14.1". Skipped checking "engines".
updater | 2026/05/31 21:41:37 INFO Requested version 4.14.1
updater | 2026/05/31 21:41:37 INFO Installing "yarn@4.14.1"
updater | 2026/05/31 21:41:37 INFO Started process PID: 1640 with command: {} corepack prepare yarn@4.14.1 --activate {}
  proxy | 2026/05/31 21:41:37 [010] GET https://repo.yarnpkg.com:443/4.14.1/packages/yarnpkg-cli/bin/yarn.js
  proxy | 2026/05/31 21:41:38 [010] 200 https://repo.yarnpkg.com:443/4.14.1/packages/yarnpkg-cli/bin/yarn.js
updater | 2026/05/31 21:41:38 INFO Process PID: 1640 completed with status: pid 1640 exit 0
updater | 2026/05/31 21:41:38 INFO Total execution time: 0.45 seconds
updater | 2026/05/31 21:41:38 INFO yarn@4.14.1 successfully installed.
updater | 2026/05/31 21:41:38 INFO Activating currently installed version of yarn: 4.14.1
updater | 2026/05/31 21:41:38 INFO Fetching version for package manager: yarn
updater | 2026/05/31 21:41:38 INFO Started process PID: 1653 with command: {} corepack yarn -v {}
updater | 2026/05/31 21:41:38 INFO Process PID: 1653 completed with status: pid 1653 exit 0
updater | 2026/05/31 21:41:38 INFO Total execution time: 0.24 seconds
updater | 2026/05/31 21:41:38 INFO Installed version of yarn: 4.14.1
  proxy | 2026/05/31 21:41:38 [011] POST http://host.docker.internal:53139/update_jobs/cli/record_ecosystem_versions
{"data":{"ecosystem_versions":{"package_managers":{"yarn":"4.14.1"}}},"type":"record_ecosystem_versions"}
  proxy | 2026/05/31 21:41:38 [011] 200 http://host.docker.internal:53139/update_jobs/cli/record_ecosystem_versions
updater | 2026/05/31 21:41:38 INFO Base commit SHA: fc0781db91ca81d72b53164c56db8435ca2f7e7b
updater | 2026/05/31 21:41:38 INFO Finished job processing
updater | 2026/05/31 21:41:38 INFO Starting job processing
updater | 2026/05/31 21:41:38 INFO Detected package manager: yarn
updater | 2026/05/31 21:41:38 INFO Resolving package manager for: yarn
updater | 2026/05/31 21:41:38 INFO Fetching version for package manager: yarn
updater | 2026/05/31 21:41:38 INFO Started process PID: 1666 with command: {} corepack yarn -v {}
updater | 2026/05/31 21:41:38 INFO Process PID: 1666 completed with status: pid 1666 exit 0
updater | 2026/05/31 21:41:38 INFO Total execution time: 0.25 seconds
updater | 2026/05/31 21:41:38 INFO Installed version of yarn: 4.14.1
updater | 2026/05/31 21:41:38 INFO Installed version for yarn: 4.14.1
updater | 2026/05/31 21:41:38 INFO Processing engine constraints for yarn
updater | 2026/05/31 21:41:38 INFO No version requirement found for yarn
updater | 2026/05/31 21:41:38 INFO Running node command: node -v
updater | 2026/05/31 21:41:38 INFO Started process PID: 1679 with command: {} node -v {}
updater | 2026/05/31 21:41:38 INFO Process PID: 1679 completed with status: pid 1679 exit 0
updater | 2026/05/31 21:41:38 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:41:38 INFO Command executed successfully: node -v
updater | 2026/05/31 21:41:38 INFO Using node version: 24.15.0
updater | 2026/05/31 21:41:38 INFO Processing engine constraints for node
updater | 2026/05/31 21:41:38 INFO Started process PID: 1681 with command: node /opt/npm_and_yarn/dist/run.js
updater | 2026/05/31 21:41:39 INFO Process PID: 1681 completed with status: pid 1681 exit 0
updater | 2026/05/31 21:41:39 INFO Total execution time: 0.65 seconds
  proxy | 2026/05/31 21:41:39 [012] POST http://host.docker.internal:53139/update_jobs/cli/update_dependency_list
{"data":{"dependencies":[{"name":"lodash","requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"4.17.15","source":null}],"version":"4.17.15"}],"dependency_files":["/package.json","/yarn.lock"]},"type":"update_dependency_list"}
  proxy | 2026/05/31 21:41:39 [012] 200 http://host.docker.internal:53139/update_jobs/cli/update_dependency_list
{"data":{"metric":"updater.started","tags":{"operation":"create_security_pr"}},"type":"increment_metric"}
  proxy | 2026/05/31 21:41:39 [013] POST http://host.docker.internal:53139/update_jobs/cli/increment_metric
  proxy | 2026/05/31 21:41:39 [013] 200 http://host.docker.internal:53139/update_jobs/cli/increment_metric
updater | 2026/05/31 21:41:39 INFO Starting security update job for yeikel/dependabot-issue-15137
updater | 2026/05/31 21:41:39 INFO Checking if lodash 4.17.15 needs updating
  proxy | 2026/05/31 21:41:39 [015] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/31 21:41:39 [015] 200 https://registry.npmjs.org:443/lodash
  proxy | 2026/05/31 21:41:39 [017] HEAD https://registry.npmjs.org:443/lodash/-/lodash-4.18.1.tgz
  proxy | 2026/05/31 21:41:39 [017] 200 https://registry.npmjs.org:443/lodash/-/lodash-4.18.1.tgz
updater | 2026/05/31 21:41:39 INFO Latest version is 4.18.1
updater | 2026/05/31 21:41:39 INFO VulnerabilityAuditor: starting audit
updater | 2026/05/31 21:41:39 INFO VulnerabilityAuditor: missing lockfile
updater | 2026/05/31 21:41:39 INFO Requirements to unlock own
updater | 2026/05/31 21:41:39 INFO Requirements update strategy bump_versions
updater | 2026/05/31 21:41:39 INFO Updating lodash from 4.17.15 to 4.18.1
updater | 2026/05/31 21:41:39 INFO Started process PID: 1690 with command: {} git reset HEAD --hard {}
updater | 2026/05/31 21:41:39 INFO Process PID: 1690 completed with status: pid 1690 exit 0
updater | 2026/05/31 21:41:39 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:41:39 INFO Started process PID: 1697 with command: {} git clean -fx {}
updater | 2026/05/31 21:41:39 INFO Process PID: 1697 completed with status: pid 1697 exit 0
updater | 2026/05/31 21:41:39 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:41:39 INFO Started process PID: 1791 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:41:40 INFO Process PID: 1791 completed with status: pid 1791 exit 0
updater | 2026/05/31 21:41:40 INFO Total execution time: 0.26 seconds
updater | 2026/05/31 21:41:40 INFO Started process PID: 1804 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:41:40 INFO Process PID: 1804 completed with status: pid 1804 exit 0
updater | 2026/05/31 21:41:40 INFO Total execution time: 0.26 seconds
updater | 2026/05/31 21:41:40 INFO Started process PID: 1817 with command: {} corepack yarn config set enableImmutableInstalls false {}
updater | 2026/05/31 21:41:40 INFO Process PID: 1817 completed with status: pid 1817 exit 0
updater | 2026/05/31 21:41:40 INFO Total execution time: 0.28 seconds
updater | 2026/05/31 21:41:40 INFO Started process PID: 1830 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:41:41 INFO Process PID: 1830 completed with status: pid 1830 exit 0
updater | 2026/05/31 21:41:41 INFO Total execution time: 0.26 seconds
updater | 2026/05/31 21:41:41 INFO Started process PID: 1843 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:41:41 INFO Process PID: 1843 completed with status: pid 1843 exit 0
updater | 2026/05/31 21:41:41 INFO Total execution time: 0.25 seconds
updater | 2026/05/31 21:41:41 INFO Started process PID: 1856 with command: {} corepack yarn config set httpProxy http://172.18.0.2:1080 {}
updater | 2026/05/31 21:41:41 INFO Process PID: 1856 completed with status: pid 1856 exit 0
updater | 2026/05/31 21:41:41 INFO Total execution time: 0.26 seconds
updater | 2026/05/31 21:41:41 INFO Started process PID: 1869 with command: {} corepack yarn config set httpsProxy http://172.18.0.2:1080 {}
updater | 2026/05/31 21:41:41 INFO Process PID: 1869 completed with status: pid 1869 exit 0
updater | 2026/05/31 21:41:41 INFO Total execution time: 0.26 seconds
updater | 2026/05/31 21:41:41 INFO Started process PID: 1882 with command: {} corepack yarn --version {}
updater | 2026/05/31 21:41:42 INFO Process PID: 1882 completed with status: pid 1882 exit 0
updater | 2026/05/31 21:41:42 INFO Total execution time: 0.24 seconds
updater | 2026/05/31 21:41:42 INFO Started process PID: 1895 with command: {} corepack yarn config set httpsCaFilePath /etc/ssl/certs/ca-certificates.crt {}
updater | 2026/05/31 21:41:42 INFO Process PID: 1895 completed with status: pid 1895 exit 0
updater | 2026/05/31 21:41:42 INFO Total execution time: 0.26 seconds
updater | 2026/05/31 21:41:42 INFO Started process PID: 1908 with command: {"YARN_NPM_MINIMAL_AGE_GATE" => "0"} corepack yarn install --mode\=skip-build {}
  proxy | 2026/05/31 21:41:42 [019] GET https://registry.yarnpkg.com:443/lodash
  proxy | 2026/05/31 21:41:42 [019] 200 https://registry.yarnpkg.com:443/lodash
  proxy | 2026/05/31 21:41:42 [021] GET https://registry.yarnpkg.com:443/lodash/-/lodash-4.18.1.tgz
  proxy | 2026/05/31 21:41:42 [021] 200 https://registry.yarnpkg.com:443/lodash/-/lodash-4.18.1.tgz
updater | 2026/05/31 21:41:43 INFO Process PID: 1908 completed with status: pid 1908 exit 0
updater | 2026/05/31 21:41:43 INFO Total execution time: 0.88 seconds
updater | 2026/05/31 21:41:43 INFO Started process PID: 1923 with command: {} git status --untracked-files all --porcelain v1 . {}
updater | 2026/05/31 21:41:43 INFO Process PID: 1923 completed with status: pid 1923 exit 0
updater | 2026/05/31 21:41:43 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:41:43 INFO Started process PID: 1931 with command: {} git status --untracked-files all --porcelain v1 .yarn/cache {}
updater | 2026/05/31 21:41:43 INFO Process PID: 1931 completed with status: pid 1931 exit 0
updater | 2026/05/31 21:41:43 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:41:43 INFO Started process PID: 1938 with command: {} git status --untracked-files all --porcelain v1 .yarn/install-state.gz {}
updater | 2026/05/31 21:41:43 INFO Process PID: 1938 completed with status: pid 1938 exit 0
updater | 2026/05/31 21:41:43 INFO Total execution time: 0.01 seconds
updater | 2026/05/31 21:41:43 INFO Submitting lodash pull request for creation
  proxy | 2026/05/31 21:41:43 [023] GET https://api.github.com:443/repos/yeikel/dependabot-issue-15137/commits?per_page=100
  proxy | 2026/05/31 21:41:43 [023] * authenticating github api request with token for api.github.com
  proxy | 2026/05/31 21:41:43 [023] 200 https://api.github.com:443/repos/yeikel/dependabot-issue-15137/commits?per_page=100
  proxy | 2026/05/31 21:41:43 [025] GET https://registry.npmjs.org:443/lodash/latest
  proxy | 2026/05/31 21:41:43 [025] 200 https://registry.npmjs.org:443/lodash/latest
  proxy | 2026/05/31 21:41:43 [027] GET https://api.github.com:443/repos/lodash/lodash/releases?per_page=100
  proxy | 2026/05/31 21:41:43 [027] * authenticating github api request with token for api.github.com
  proxy | 2026/05/31 21:41:44 [027] 200 https://api.github.com:443/repos/lodash/lodash/releases?per_page=100
  proxy | 2026/05/31 21:41:44 [029] GET https://api.github.com:443/repos/lodash/lodash/contents/
  proxy | 2026/05/31 21:41:44 [029] * authenticating github api request with token for api.github.com
  proxy | 2026/05/31 21:41:44 [029] 200 https://api.github.com:443/repos/lodash/lodash/contents/
  proxy | 2026/05/31 21:41:44 [031] GET https://api.github.com:443/repos/lodash/lodash/contents/doc
  proxy | 2026/05/31 21:41:44 [031] * authenticating github api request with token for api.github.com
  proxy | 2026/05/31 21:41:44 [031] 200 https://api.github.com:443/repos/lodash/lodash/contents/doc
  proxy | 2026/05/31 21:41:44 [033] GET https://github.com:443/lodash/lodash.git/info/refs?service=git-upload-pack
  proxy | 2026/05/31 21:41:44 [033] * authenticating git server request (host: github.com)
  proxy | 2026/05/31 21:41:44 [033] 200 https://github.com:443/lodash/lodash.git/info/refs?service=git-upload-pack
  proxy | 2026/05/31 21:41:44 [035] GET https://api.github.com:443/repos/lodash/lodash/contents/?ref=4.18.1
  proxy | 2026/05/31 21:41:44 [035] * authenticating github api request with token for api.github.com
  proxy | 2026/05/31 21:41:44 [035] 200 https://api.github.com:443/repos/lodash/lodash/contents/?ref=4.18.1
  proxy | 2026/05/31 21:41:44 [037] GET https://api.github.com:443/repos/lodash/lodash/contents/doc?ref=4.18.1
  proxy | 2026/05/31 21:41:44 [037] * authenticating github api request with token for api.github.com
  proxy | 2026/05/31 21:41:44 [037] 200 https://api.github.com:443/repos/lodash/lodash/contents/doc?ref=4.18.1
  proxy | 2026/05/31 21:41:44 [039] GET https://github.com:443/lodash/lodash.git/info/refs?service=git-upload-pack
  proxy | 2026/05/31 21:41:44 [039] 200 https://github.com:443/lodash/lodash.git/info/refs?service=git-upload-pack (cached)
  proxy | 2026/05/31 21:41:45 [041] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15
  proxy | 2026/05/31 21:41:45 [041] * authenticating github api request with token for api.github.com
  proxy | 2026/05/31 21:41:45 [041] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15
  proxy | 2026/05/31 21:41:45 [043] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1
  proxy | 2026/05/31 21:41:45 [043] * authenticating github api request with token for api.github.com
  proxy | 2026/05/31 21:41:45 [043] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1
  proxy | 2026/05/31 21:41:45 [045] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15
  proxy | 2026/05/31 21:41:45 [045] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15 (cached)
  proxy | 2026/05/31 21:41:45 [047] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1
  proxy | 2026/05/31 21:41:45 [047] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1 (cached)
  proxy | 2026/05/31 21:41:45 [049] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15
  proxy | 2026/05/31 21:41:45 [049] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.17.15 (cached)
  proxy | 2026/05/31 21:41:45 [051] GET https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1
  proxy | 2026/05/31 21:41:45 [051] 200 https://api.github.com:443/repos/lodash/lodash/commits?sha=4.18.1 (cached)
  proxy | 2026/05/31 21:41:46 [053] GET https://registry.npmjs.org:443/lodash
  proxy | 2026/05/31 21:41:46 [053] 200 https://registry.npmjs.org:443/lodash (cached)
  proxy | 2026/05/31 21:41:46 [054] POST http://host.docker.internal:53139/update_jobs/cli/create_pull_request
{"data":{"base-commit-sha":"fc0781db91ca81d72b53164c56db8435ca2f7e7b","dependencies":[{"name":"lodash","previous-requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"4.17.15","source":null}],"previous-version":"4.17.15","requirements":[{"file":"package.json","groups":["dependencies"],"requirement":"4.18.1","source":null}],"version":"4.18.1","directory":"/"}],"updated-dependency-files":[{"content":"{\n  \"name\": \"dependabot-issue-15137\",\n  \"packageManager\": \"yarn@4.14.1\",\n  \"dependencies\": {\n    \"lodash\": \"4.18.1\"\n  
< Omitted to work arround "Body is too long" GitHub limits >
github.com/lodash/lodash/releases)\n- [Commits](https://github.com/lodash/lodash/compare/4.17.15...4.18.1)","dependency-group":null},"type":"create_pull_request"}
  proxy | 2026/05/31 21:41:46 [054] 200 http://host.docker.internal:53139/update_jobs/cli/create_pull_request
  proxy | 2026/05/31 21:41:46 [055] POST http://host.docker.internal:53139/update_jobs/cli/record_ecosystem_meta
{"data":[{"ecosystem":{"name":"npm_and_yarn","package_manager":{"name":"yarn","version":"4.14.1","raw_version":"4.14.1"},"language":{"name":"node","version":"24.15.0","raw_version":"24.15.0"}}}],"type":"record_ecosystem_meta"}
  proxy | 2026/05/31 21:41:46 [055] 200 http://host.docker.internal:53139/update_jobs/cli/record_ecosystem_meta
{"data":{"base-commit-sha":"fc0781db91ca81d72b53164c56db8435ca2f7e7b"},"type":"mark_as_processed"}
  proxy | 2026/05/31 21:41:46 [056] PATCH http://host.docker.internal:53139/update_jobs/cli/mark_as_processed
  proxy | 2026/05/31 21:41:46 [056] 200 http://host.docker.internal:53139/update_jobs/cli/mark_as_processed
updater | 2026/05/31 21:41:46 INFO Finished job processing
updater | 2026/05/31 21:41:46 INFO Results:
updater | +---------------------------------------------+
updater | |     Changes to Dependabot Pull Requests     |
updater | +---------+-----------------------------------+
updater | | created | lodash ( from 4.17.15 to 4.18.1 ) |
updater | +---------+-----------------------------------+
  proxy | 2026/05/31 21:41:46 Skipping sending metrics because api endpoint is empty
  proxy | 2026/05/31 21:41:46 6/25 calls cached (24%)
```
  
</details>

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
