### PR TITLE
Identify Dependabot commits by author name in PR name prefixer

### DIFF
--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -333,9 +333,15 @@ module Dependabot
         end
       end
 
-      sig { returns(String) }
-      def dependabot_email
-        "support@dependabot.com"
+      # Identify Dependabot's own commits by the bot author name rather than a
+      # hardcoded email. The previously used `support@dependabot.com` address is
+      # a pre-acquisition leftover that is no longer used for commits, and the
+      # author email is configurable for self-hosted setups, so matching on it
+      # is unreliable. This mirrors the author-name check already used for
+      # GitHub commits.
+      sig { params(author_name: T.nilable(String)).returns(T::Boolean) }
+      def dependabot_author?(author_name)
+        !!author_name&.include?("dependabot")
       end
 
       sig { returns(T::Array[String]) }
@@ -354,7 +360,7 @@ module Dependabot
           gitlab_client_for_source.commits(source.repo)
 
         @recent_gitlab_commit_messages
-          .reject { |c| c.author_email == dependabot_email }
+          .reject { |c| dependabot_author?(c.author_name) }
           .reject { |c| c.message&.start_with?("merge !") }
           .filter_map(&:message)
           .map(&:strip)
@@ -366,7 +372,7 @@ module Dependabot
           azure_client_for_source.commits
 
         @recent_azure_commit_messages
-          .reject { |c| azure_commit_author_email(c) == dependabot_email }
+          .reject { |c| dependabot_author?(azure_commit_author_name(c)) }
           .reject { |c| c.fetch("comment")&.start_with?("Merge") }
           .filter_map { |c| c.fetch("comment") }
           .map(&:strip)
@@ -378,7 +384,7 @@ module Dependabot
           bitbucket_client_for_source.commits(source.repo)
 
         @recent_bitbucket_commit_messages
-          .reject { |c| bitbucket_commit_author_email(c) == dependabot_email }
+          .reject { |c| dependabot_author?(bitbucket_commit_author_name(c)) }
           .filter_map { |c| c.fetch("message", nil) }
           .reject { |m| m.start_with?("Merge") }
           .map(&:strip)
@@ -389,7 +395,7 @@ module Dependabot
         @recent_codecommit_commit_messages ||=
           T.unsafe(codecommit_client_for_source).commits
         @recent_codecommit_commit_messages.commits
-                                          .reject { |c| c.author.email == dependabot_email }
+                                          .reject { |c| dependabot_author?(c.author.name) }
                                           .reject { |c| c.message&.start_with?("Merge") }
                                           .filter_map(&:message)
                                           .map(&:strip)
@@ -451,7 +457,7 @@ module Dependabot
           )
 
         @recent_gitlab_commit_messages
-          .find { |c| c.author_email == dependabot_email }
+          .find { |c| dependabot_author?(c.author_name) }
           &.message
           &.strip
       end
@@ -465,7 +471,7 @@ module Dependabot
           )
 
         @recent_azure_commit_messages
-          .find { |c| azure_commit_author_email(c) == dependabot_email }
+          .find { |c| dependabot_author?(azure_commit_author_name(c)) }
           &.message
           &.strip
       end
@@ -479,7 +485,7 @@ module Dependabot
           )
 
         @recent_bitbucket_commit_messages
-          .find { |c| bitbucket_commit_author_email(c) == dependabot_email }
+          .find { |c| dependabot_author?(bitbucket_commit_author_name(c)) }
           &.fetch("message", nil)
           &.strip
       end
@@ -493,20 +499,20 @@ module Dependabot
           )
 
         @recent_codecommit_commit_messages.commits
-                                          .find { |c| c.author.email == dependabot_email }
+                                          .find { |c| dependabot_author?(c.author.name) }
                                           &.message
                                           &.strip
       end
 
       sig { params(commit: T::Hash[String, T::Hash[String, String]]).returns(String) }
-      def azure_commit_author_email(commit)
-        commit.fetch("author").fetch("email", "")
+      def azure_commit_author_name(commit)
+        commit.fetch("author").fetch("name", "")
       end
 
       sig { params(commit: T::Hash[String, T::Hash[String, String]]).returns(String) }
-      def bitbucket_commit_author_email(commit)
-        matches = commit.fetch("author").fetch("raw").match(/<(.*)>/)
-        matches ? T.must(matches[1]) : ""
+      def bitbucket_commit_author_name(commit)
+        # The raw author is a "Name <email>" string; keep the part before "<email>".
+        commit.fetch("author").fetch("raw").split("<", 2).first.to_s.strip
       end
 
       sig { returns(Dependabot::Clients::GithubWithRetries) }

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -339,9 +339,15 @@ module Dependabot
         end
       end
 
-      sig { returns(String) }
-      def dependabot_email
-        "support@dependabot.com"
+      # Identify Dependabot's own commits by the bot author name rather than a
+      # hardcoded email. The previously used `support@dependabot.com` address is
+      # a pre-acquisition leftover that is no longer used for commits, and the
+      # author email is configurable for self-hosted setups, so matching on it
+      # is unreliable. This mirrors the author-name check already used for
+      # GitHub commits.
+      sig { params(author_name: T.nilable(String)).returns(T::Boolean) }
+      def dependabot_author?(author_name)
+        !!author_name&.include?("dependabot")
       end
 
       sig { returns(T::Array[String]) }
@@ -356,7 +362,7 @@ module Dependabot
       sig { returns(T::Array[String]) }
       def recent_gitlab_commit_messages
         recent_gitlab_commits
-          .reject { |commit| commit.author_email == dependabot_email }
+          .reject { |commit| dependabot_author?(commit.author_name) }
           .reject { |commit| commit.message&.start_with?("merge !") }
           .filter_map(&:message)
           .map(&:strip)
@@ -365,7 +371,7 @@ module Dependabot
       sig { returns(T::Array[String]) }
       def recent_azure_commit_messages
         recent_azure_commits
-          .reject { |commit| commit.author_email == dependabot_email }
+          .reject { |commit| dependabot_author?(commit.author_name) }
           .reject { |commit| commit.message&.start_with?("Merge") }
           .filter_map(&:message)
           .map(&:strip)
@@ -374,7 +380,7 @@ module Dependabot
       sig { returns(T::Array[String]) }
       def recent_bitbucket_commit_messages
         recent_bitbucket_commits
-          .reject { |commit| commit.author_email == dependabot_email }
+          .reject { |commit| dependabot_author?(commit.author_name) }
           .filter_map(&:message)
           .reject { |m| m.start_with?("Merge") }
           .map(&:strip)
@@ -383,7 +389,7 @@ module Dependabot
       sig { returns(T::Array[String]) }
       def recent_codecommit_commit_messages
         recent_codecommit_commits
-          .reject { |commit| commit.author_email == dependabot_email }
+          .reject { |commit| dependabot_author?(commit.author_name) }
           .reject { |commit| commit.message&.start_with?("Merge") }
           .filter_map(&:message)
           .map(&:strip)
@@ -419,7 +425,7 @@ module Dependabot
       def last_github_dependabot_commit_message
         recent_github_commits
           .reject { |commit| commit.message&.start_with?("Merge") }
-          .find { |commit| commit.author_name&.include?("dependabot") }
+          .find { |commit| dependabot_author?(commit.author_name) }
           &.message
           &.strip
       end
@@ -437,7 +443,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def last_gitlab_dependabot_commit_message
         recent_gitlab_commits
-          .find { |commit| commit.author_email == dependabot_email }
+          .find { |commit| dependabot_author?(commit.author_name) }
           &.message
           &.strip
       end
@@ -445,7 +451,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def last_azure_dependabot_commit_message
         recent_azure_commits
-          .find { |commit| commit.author_email == dependabot_email }
+          .find { |commit| dependabot_author?(commit.author_name) }
           &.message
           &.strip
       end
@@ -453,7 +459,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def last_bitbucket_dependabot_commit_message
         recent_bitbucket_commits
-          .find { |commit| commit.author_email == dependabot_email }
+          .find { |commit| dependabot_author?(commit.author_name) }
           &.message
           &.strip
       end
@@ -461,7 +467,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def last_codecommit_dependabot_commit_message
         recent_codecommit_commits
-          .find { |commit| commit.author_email == dependabot_email }
+          .find { |commit| dependabot_author?(commit.author_name) }
           &.message
           &.strip
       end
@@ -494,7 +500,8 @@ module Dependabot
         @recent_codecommit_commits = (output.commits || []).map do |commit|
           RecentCommit.new(
             message: commit.message,
-            author_email: commit.author&.email
+            author_email: commit.author&.email,
+            author_name: commit.author&.name
           )
         end
       end
@@ -516,7 +523,8 @@ module Dependabot
       def parse_gitlab_commit(commit)
         RecentCommit.new(
           message: gitlab_optional_string(commit, "message", "commit message"),
-          author_email: gitlab_optional_string(commit, "author_email", "author email")
+          author_email: gitlab_optional_string(commit, "author_email", "author email"),
+          author_name: gitlab_optional_string(commit, "author_name", "author name")
         )
       end
 
@@ -525,7 +533,8 @@ module Dependabot
         author = object_hash(commit, "author", "Azure author")
         RecentCommit.new(
           message: object_optional_string(commit, "comment", "Azure commit message"),
-          author_email: object_optional_string(author, "email", "Azure author email")
+          author_email: object_optional_string(author, "email", "Azure author email"),
+          author_name: object_optional_string(author, "name", "Azure author name")
         )
       end
 
@@ -536,7 +545,9 @@ module Dependabot
         matches = raw_author&.match(/<(.*)>/)
         RecentCommit.new(
           message: object_optional_string(commit, "message", "Bitbucket commit message"),
-          author_email: matches ? T.must(matches[1]) : nil
+          author_email: matches ? T.must(matches[1]) : nil,
+          # The raw author is a "Name <email>" string; keep the part before "<email>".
+          author_name: raw_author&.split("<", 2)&.first&.strip
         )
       end
 

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -201,6 +201,32 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
       end
     end
 
+    context "when the last GitLab commit was authored by Dependabot" do
+      let(:source) do
+        Dependabot::Source.new(provider: "gitlab", repo: "gocardless/bump")
+      end
+      let(:watched_repo_url) do
+        "https://gitlab.com/api/v4/projects/" \
+          "#{CGI.escape(source.repo)}/repository"
+      end
+
+      before do
+        stub_request(:get, watched_repo_url + "/commits")
+          .to_return(
+            status: 200,
+            body: fixture("gitlab", "commits_dependabot.json"),
+            headers: json_header
+          )
+      end
+
+      # The Dependabot commit is identified by the bot author name, not by the
+      # legacy `support@dependabot.com` email (which is no longer used and is
+      # configurable for self-hosted setups), so its `fix(deps)` prefix style is
+      # reused. Matching on the old email would miss the commit and fall back to
+      # detecting a generic `build(deps)` prefix from the other commits.
+      it { is_expected.to eq("fix(deps): ") }
+    end
+
     context "when using angular commits" do
       before do
         stub_request(:get, watched_repo_url + "/commits?per_page=100")

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -336,6 +336,32 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
       end
     end
 
+    context "when the last GitLab commit was authored by Dependabot" do
+      let(:source) do
+        Dependabot::Source.new(provider: "gitlab", repo: "gocardless/bump")
+      end
+      let(:watched_repo_url) do
+        "https://gitlab.com/api/v4/projects/" \
+          "#{CGI.escape(source.repo)}/repository"
+      end
+
+      before do
+        stub_request(:get, watched_repo_url + "/commits")
+          .to_return(
+            status: 200,
+            body: fixture("gitlab", "commits_dependabot.json"),
+            headers: json_header
+          )
+      end
+
+      # The Dependabot commit is identified by the bot author name, not by the
+      # legacy `support@dependabot.com` email (which is no longer used and is
+      # configurable for self-hosted setups), so its `fix(deps)` prefix style is
+      # reused. Matching on the old email would miss the commit and fall back to
+      # detecting a generic `build(deps)` prefix from the other commits.
+      it { is_expected.to eq("fix(deps): ") }
+    end
+
     context "when using angular commits" do
       before do
         stub_request(:get, watched_repo_url + "/commits?per_page=100")

--- a/common/spec/fixtures/gitlab/commits_dependabot.json
+++ b/common/spec/fixtures/gitlab/commits_dependabot.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "9b1f3c2a5d7e4f6081a2b3c4d5e6f7081923a4b5",
+    "short_id": "9b1f3c2a",
+    "title": "fix(deps): bump business from 1.4.0 to 1.5.0",
+    "created_at": "2024-01-15T09:12:00.000Z",
+    "parent_ids": [
+      "4811450c1905ca49b3f156a8e6d9ac30893bd942"
+    ],
+    "message": "fix(deps): bump business from 1.4.0 to 1.5.0\n",
+    "author_name": "dependabot[bot]",
+    "author_email": "49699333+dependabot[bot]@users.noreply.github.com",
+    "authored_date": "2024-01-15T09:12:00.000Z",
+    "committer_name": "dependabot[bot]",
+    "committer_email": "49699333+dependabot[bot]@users.noreply.github.com",
+    "committed_date": "2024-01-15T09:12:00.000Z"
+  },
+  {
+    "id": "4811450c1905ca49b3f156a8e6d9ac30893bd942",
+    "short_id": "4811450c",
+    "title": "Add separate room assignment model",
+    "created_at": "2018-06-06T21:34:41.000Z",
+    "parent_ids": [
+      "d9d39a70cd3ff6e57c8cbd99a61e0b9faf270a9e"
+    ],
+    "message": "Add separate room assignment model\n",
+    "author_name": "Oren Kanner",
+    "author_email": "okanner@gmail.com",
+    "authored_date": "2018-01-25T17:51:08.000Z",
+    "committer_name": "Oren Kanner",
+    "committer_email": "okanner@gmail.com",
+    "committed_date": "2018-06-06T21:34:41.000Z"
+  }
+]

--- a/sorbet/rbi/shims/aws-sdk-codecommit.rbi
+++ b/sorbet/rbi/shims/aws-sdk-codecommit.rbi
@@ -24,6 +24,9 @@ module Aws
 
       class UserInfo
         sig { returns(T.nilable(String)) }
+        attr_reader :name
+
+        sig { returns(T.nilable(String)) }
         attr_reader :email
 
         sig { returns(T.nilable(String)) }


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #6968.

The PR name prefixer identifies Dependabot's own commits in order to (1) reuse the prefix style of the last Dependabot commit and (2) exclude Dependabot commits when sampling the repository's commit convention. For GitLab, Azure, Bitbucket, and CodeCommit it did this by matching the hardcoded `support@dependabot.com` author email.

As noted in #6968, that address is a pre-acquisition leftover that is no longer used for commits, and on self-hosted setups the author email is operator-configurable — so the email match silently fails. When it does, the prefixer can no longer reuse the last Dependabot commit's style, and Dependabot's own commits leak into the sample used to detect the repository's convention.

This switches those four providers to identify Dependabot commits by the bot **author name** (`dependabot[bot]`), which sidesteps the "which email is correct?" question entirely and is robust to the configurable/changed email.

### Anything you want to highlight for special attention from reviewers?

- GitHub already identifies Dependabot commits by author name / bot type (`author.name.include?("dependabot")`), so this aligns the other four providers with that existing behavior rather than introducing a new mechanism.
- The now-unused private helpers `dependabot_email`, `azure_commit_author_email`, and `bitbucket_commit_author_email` are removed / renamed to their author-name equivalents. They were only referenced within `pr_name_prefixer.rb`.

### How will you know you've accomplished your goal?

Added a regression spec: given a GitLab history whose latest commit is authored by `dependabot[bot]` with a `fix(deps):` prefix (and the current `…@users.noreply.github.com` email, not `support@dependabot.com`), the prefixer now reuses `fix(deps): `. Against the previous email-based code the same spec fails — it misses the commit and falls back to a generic `build(deps): `.

- `bundle exec rspec spec/dependabot/pull_request_creator/` → 476 examples, 0 failures
- `bundle exec rubocop` on the changed files → no offenses

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
