### PR TITLE
Handle npm registry EOFError in latest version finder

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -259,12 +259,17 @@ module Dependabot
         sig { params(_block: T.untyped).returns(T.nilable(Dependabot::Version)) }
         def with_custom_registry_rescue(&_block)
           yield
-        rescue Excon::Error::Socket, Excon::Error::Timeout, RegistryError
-          raise unless package_fetcher.custom_registry?
+        rescue Excon::Error::Socket, Excon::Error::Timeout, RegistryError => e
+          raise unless package_fetcher.custom_registry? || eof_socket_error?(e)
 
           # Custom registries can be flaky. We don't want to make that
           # our problem, so quietly return `nil` here.
           nil
+        end
+
+        sig { params(error: StandardError).returns(T::Boolean) }
+        def eof_socket_error?(error)
+          error.is_a?(Excon::Error::Socket) && error.socket_error.is_a?(EOFError)
         end
 
         sig { returns(T::Boolean) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -262,8 +262,9 @@ module Dependabot
         rescue Excon::Error::Socket, Excon::Error::Timeout, RegistryError => e
           raise unless package_fetcher.custom_registry? || eof_socket_error?(e)
 
-          # Custom registries can be flaky. We don't want to make that
-          # our problem, so quietly return `nil` here.
+          # Custom registries can be flaky, and the global npm registry can
+          # occasionally terminate connections (EOFError). Don't abort the update
+          # flow for these transient failures; quietly return `nil` here.
           nil
         end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/package_latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/package_latest_version_finder_spec.rb
@@ -753,6 +753,15 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::PackageLatestVersionFinder
       it { is_expected.to eq(Gem::Version.new("1.6.0")) }
     end
 
+    context "when the global registry socket closes unexpectedly" do
+      before do
+        stub_request(:get, registry_listing_url)
+          .to_raise(Excon::Error::Socket.new(EOFError.new))
+      end
+
+      it { is_expected.to be_nil }
+    end
+
     context "when the npm link resolves to a 403" do
       before do
         stub_request(:get, registry_listing_url)


### PR DESCRIPTION
### What are you trying to accomplish?

This change prevents transient npm registry EOFError socket failures from aborting the update flow when Dependabot is only trying to determine the latest available version.

The approach keeps the fix narrow: the npm latest-version finder now treats an `Excon::Error::Socket` backed by `EOFError` as a temporary registry-read failure and returns no latest version instead of crashing the job. This preserves existing behavior for other registry errors while making the updater more resilient to flaky npm responses.

A focused spec was added to cover the global npm registry EOF case and verify that the finder degrades gracefully.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

The npm latest-version finder no longer crashes on a transient registry `EOFError` and instead degrades gracefully by returning no latest version for that lookup.

That is demonstrated by the focused spec coverage for the global npm registry EOF case, along with the targeted spec run passing for the latest-version finder behavior.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
