### PR TITLE
Fix Maven test-jar artifact URL construction

### DIFF
--- a/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
@@ -77,11 +77,11 @@ module Dependabot
           type = dependency.requirements.first&.dig(:metadata, :packaging_type) || "jar"
           classifier = dependency.requirements.first&.dig(:metadata, :classifier)
 
-          # Maven's test-jar type is actually published with classifier "tests" and extension "jar"
+          # Maven's test-jar type is published as a normal .jar with the "tests" classifier.
           # See: https://maven.apache.org/guides/mini/guide-attached-tests.html
-          if type == "test-jar" && classifier.nil?
-            classifier = "tests"
+          if type == "test-jar"
             type = "jar"
+            classifier ||= "tests"
           end
 
           actual_classifier = classifier.nil? ? "" : "-#{classifier}"

--- a/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
@@ -76,6 +76,14 @@ module Dependabot
           base_url = dependency_base_url(repository_url)
           type = dependency.requirements.first&.dig(:metadata, :packaging_type) || "jar"
           classifier = dependency.requirements.first&.dig(:metadata, :classifier)
+
+          # Maven's test-jar type is actually published with classifier "tests" and extension "jar"
+          # See: https://maven.apache.org/guides/mini/guide-attached-tests.html
+          if type == "test-jar" && classifier.nil?
+            classifier = "tests"
+            type = "jar"
+          end
+
           actual_classifier = classifier.nil? ? "" : "-#{classifier}"
 
           "#{base_url}/#{version}/#{artifact_id}-#{version}#{actual_classifier}.#{type}"

--- a/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
@@ -128,6 +128,29 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
       end
     end
 
+    context "with test-jar type" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: dependency_version,
+          requirements: [{
+            requirement: "23.3-jre",
+            file: "pom.xml",
+            groups: ["dependencies"],
+            source: nil,
+            metadata: { packaging_type: "test-jar" }
+          }],
+          package_manager: "maven"
+        )
+      end
+
+      it "converts test-jar to tests classifier with jar extension" do
+        url = client.dependency_files_url(maven_central, version)
+
+        expect(url).to eq("#{maven_central}/com/google/guava/guava/23.6-jre/guava-23.6-jre-tests.jar")
+      end
+    end
+
     context "without packaging_type metadata" do
       let(:dependency) do
         Dependabot::Dependency.new(

--- a/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
@@ -129,6 +129,8 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
     end
 
     context "with test-jar type" do
+      let(:dependency_metadata) { { packaging_type: "test-jar" } }
+
       let(:dependency) do
         Dependabot::Dependency.new(
           name: dependency_name,
@@ -138,7 +140,7 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
             file: "pom.xml",
             groups: ["dependencies"],
             source: nil,
-            metadata: { packaging_type: "test-jar" }
+            metadata: dependency_metadata
           }],
           package_manager: "maven"
         )
@@ -148,6 +150,16 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
         url = client.dependency_files_url(maven_central, version)
 
         expect(url).to eq("#{maven_central}/com/google/guava/guava/23.6-jre/guava-23.6-jre-tests.jar")
+      end
+
+      context "when classifier is explicitly provided" do
+        let(:dependency_metadata) { { packaging_type: "test-jar", classifier: "tests" } }
+
+        it "still uses jar extension" do
+          url = client.dependency_files_url(maven_central, version)
+
+          expect(url).to eq("#{maven_central}/com/google/guava/guava/23.6-jre/guava-23.6-jre-tests.jar")
+        end
       end
     end
 


### PR DESCRIPTION
Maven's test-jar type is published with classifier 'tests' and extension 'jar',
not as a '.test-jar' extension. This was causing 404 errors when Dependabot
tried to check for updates on dependencies with <type>test-jar</type>.

The fix converts test-jar type to use the 'tests' classifier with 'jar' extension,
matching Maven's standard behavior as documented in: https://maven.apache.org/guides/mini/guide-attached-tests.html

Fixes #14844
Fixes #10148

Co-authored-by: IBM Bob IDE 1.0.3

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
