### PR TITLE
uv: Remove dead add_auth_env_vars code and add credential matching diagnostics

### DIFF
--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -482,23 +482,22 @@ module Dependabot
         # themselves and for dry-run.
         sig { returns(T::Hash[String, String]) }
         def pyproject_index_env_vars
-          env_vars = T.let({}, T::Hash[String, String])
-
           python_index_creds = credentials.select { |cred| cred["type"] == "python_index" }
-          python_index_creds.each { |cred| add_index_auth_env_vars(cred, env_vars) }
-
-          env_vars
+          python_index_creds.each_with_object(T.let({}, T::Hash[String, String])) do |cred, env_vars|
+            env_vars.merge!(index_auth_env_vars_for(cred))
+          end
         end
 
-        sig { params(cred: Dependabot::Credential, env_vars: T::Hash[String, String]).void }
-        def add_index_auth_env_vars(cred, env_vars)
+        sig { params(cred: Dependabot::Credential).returns(T::Hash[String, String]) }
+        def index_auth_env_vars_for(cred)
+          env_vars = T.let({}, T::Hash[String, String])
           index_name = find_index_name_for_credential(cred)
 
           unless index_name
             Dependabot.logger.debug(
               "python_index credential did not match a [[tool.uv.index]] entry; skipping UV_INDEX_* env vars"
             )
-            return
+            return env_vars
           end
 
           env_name = index_name.upcase.gsub(/[^A-Z0-9]/, "_")
@@ -508,9 +507,10 @@ module Dependabot
           env_vars["UV_INDEX_#{env_name}_USERNAME"] = username if username
           env_vars["UV_INDEX_#{env_name}_PASSWORD"] = password if password
 
-          return unless username || password
+          return env_vars unless username || password
 
           Dependabot.logger.debug("Configured uv auth env vars for a matched [[tool.uv.index]] entry")
+          env_vars
         end
 
         sig { params(credential: Dependabot::Credential).returns(T.nilable(String)) }

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -490,6 +490,7 @@ module Dependabot
           env_vars
         end
 
+        sig { params(cred: Dependabot::Credential, env_vars: T::Hash[String, String]).void }
         def add_index_auth_env_vars(cred, env_vars)
           index_name = find_index_name_for_credential(cred)
 
@@ -501,12 +502,13 @@ module Dependabot
           end
 
           env_name = index_name.upcase.gsub(/[^A-Z0-9]/, "_")
+          username = cred["username"]
           password = cred["password"] || cred["token"]
 
-          env_vars["UV_INDEX_#{env_name}_USERNAME"] = cred["username"] if cred["username"]
+          env_vars["UV_INDEX_#{env_name}_USERNAME"] = username if username
           env_vars["UV_INDEX_#{env_name}_PASSWORD"] = password if password
 
-          return unless cred["username"] || password
+          return unless username || password
 
           Dependabot.logger.info("Configured uv auth env vars for a matched [[tool.uv.index]] entry")
         end

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -485,31 +485,30 @@ module Dependabot
           env_vars = {}
 
           python_index_creds = credentials.select { |cred| cred["type"] == "python_index" }
-
-          python_index_creds.each do |cred|
-            index_name = find_index_name_for_credential(cred)
-
-            unless index_name
-              Dependabot.logger.debug(
-                "python_index credential did not match a [[tool.uv.index]] entry; skipping UV_INDEX_* env vars"
-              )
-              next
-            end
-
-            env_name = index_name.upcase.gsub(/[^A-Z0-9]/, "_")
-
-            env_vars["UV_INDEX_#{env_name}_USERNAME"] = cred["username"] if cred["username"]
-
-            if cred["password"] || cred["token"]
-              env_vars["UV_INDEX_#{env_name}_PASSWORD"] = cred["password"] || cred["token"]
-            end
-
-            if cred["username"] || cred["password"] || cred["token"]
-              Dependabot.logger.info("Configured uv auth env vars for a matched [[tool.uv.index]] entry")
-            end
-          end
+          python_index_creds.each { |cred| add_index_auth_env_vars(cred, env_vars) }
 
           env_vars
+        end
+
+        def add_index_auth_env_vars(cred, env_vars)
+          index_name = find_index_name_for_credential(cred)
+
+          unless index_name
+            Dependabot.logger.debug(
+              "python_index credential did not match a [[tool.uv.index]] entry; skipping UV_INDEX_* env vars"
+            )
+            return
+          end
+
+          env_name = index_name.upcase.gsub(/[^A-Z0-9]/, "_")
+          password = cred["password"] || cred["token"]
+
+          env_vars["UV_INDEX_#{env_name}_USERNAME"] = cred["username"] if cred["username"]
+          env_vars["UV_INDEX_#{env_name}_PASSWORD"] = password if password
+
+          return unless cred["username"] || password
+
+          Dependabot.logger.info("Configured uv auth env vars for a matched [[tool.uv.index]] entry")
         end
 
         sig { params(credential: Dependabot::Credential).returns(T.nilable(String)) }

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -491,8 +491,7 @@ module Dependabot
 
             unless index_name
               Dependabot.logger.debug(
-                "python_index credential did not match any [[tool.uv.index]] entry in pyproject.toml — " \
-                "authentication will rely on the proxy if available"
+                "python_index credential did not match a [[tool.uv.index]] entry; relying on proxy auth"
               )
               next
             end
@@ -501,11 +500,8 @@ module Dependabot
 
             env_vars["UV_INDEX_#{env_name}_USERNAME"] = cred["username"] if cred["username"]
 
-            if cred["password"]
-              env_vars["UV_INDEX_#{env_name}_PASSWORD"] = cred["password"]
-              Dependabot.logger.info("Configured uv auth env vars for index '#{index_name}'")
-            elsif cred["token"]
-              env_vars["UV_INDEX_#{env_name}_PASSWORD"] = cred["token"]
+            if cred["password"] || cred["token"]
+              env_vars["UV_INDEX_#{env_name}_PASSWORD"] = cred["password"] || cred["token"]
               Dependabot.logger.info("Configured uv auth env vars for index '#{index_name}'")
             end
           end

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -491,7 +491,7 @@ module Dependabot
 
             unless index_name
               Dependabot.logger.debug(
-                "python_index credential did not match a [[tool.uv.index]] entry; relying on proxy auth"
+                "python_index credential did not match a [[tool.uv.index]] entry; skipping UV_INDEX_* env vars"
               )
               next
             end
@@ -502,7 +502,10 @@ module Dependabot
 
             if cred["password"] || cred["token"]
               env_vars["UV_INDEX_#{env_name}_PASSWORD"] = cred["password"] || cred["token"]
-              Dependabot.logger.info("Configured uv auth env vars for index '#{index_name}'")
+            end
+
+            if cred["username"] || cred["password"] || cred["token"]
+              Dependabot.logger.info("Configured uv auth env vars for a matched [[tool.uv.index]] entry")
             end
           end
 

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -484,22 +484,29 @@ module Dependabot
         def pyproject_index_env_vars
           env_vars = {}
 
-          matched_credentials = credentials
-                                .select { |cred| cred["type"] == "python_index" }
-                                .filter_map do |cred|
-                                  index_name = find_index_name_for_credential(cred)
-                                  [cred, index_name] if index_name
-                                end
+          python_index_creds = credentials.select { |cred| cred["type"] == "python_index" }
 
-          matched_credentials.each do |cred, index_name|
+          python_index_creds.each do |cred|
+            index_name = find_index_name_for_credential(cred)
+
+            unless index_name
+              Dependabot.logger.debug(
+                "python_index credential did not match any [[tool.uv.index]] entry in pyproject.toml — " \
+                "authentication will rely on the proxy if available"
+              )
+              next
+            end
+
             env_name = index_name.upcase.gsub(/[^A-Z0-9]/, "_")
 
             env_vars["UV_INDEX_#{env_name}_USERNAME"] = cred["username"] if cred["username"]
 
             if cred["password"]
               env_vars["UV_INDEX_#{env_name}_PASSWORD"] = cred["password"]
+              Dependabot.logger.info("Configured uv auth env vars for index '#{index_name}'")
             elsif cred["token"]
               env_vars["UV_INDEX_#{env_name}_PASSWORD"] = cred["token"]
+              Dependabot.logger.info("Configured uv auth env vars for index '#{index_name}'")
             end
           end
 

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -510,7 +510,7 @@ module Dependabot
 
           return unless username || password
 
-          Dependabot.logger.info("Configured uv auth env vars for a matched [[tool.uv.index]] entry")
+          Dependabot.logger.debug("Configured uv auth env vars for a matched [[tool.uv.index]] entry")
         end
 
         sig { params(credential: Dependabot::Credential).returns(T.nilable(String)) }

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -482,7 +482,7 @@ module Dependabot
         # themselves and for dry-run.
         sig { returns(T::Hash[String, String]) }
         def pyproject_index_env_vars
-          env_vars = {}
+          env_vars = T.let({}, T::Hash[String, String])
 
           python_index_creds = credentials.select { |cred| cred["type"] == "python_index" }
           python_index_creds.each { |cred| add_index_auth_env_vars(cred, env_vars) }

--- a/uv/lib/dependabot/uv/file_updater/pyproject_preparer.rb
+++ b/uv/lib/dependabot/uv/file_updater/pyproject_preparer.rb
@@ -17,10 +17,9 @@ module Dependabot
       class PyprojectPreparer
         extend T::Sig
 
-        sig { params(pyproject_content: String, lockfile: T.nilable(Dependabot::DependencyFile)).void }
-        def initialize(pyproject_content:, lockfile: nil)
+        sig { params(pyproject_content: String).void }
+        def initialize(pyproject_content:)
           @pyproject_content = pyproject_content
-          @lockfile = lockfile
           @lines = T.let(pyproject_content.split("\n"), T::Array[String])
         end
 
@@ -47,11 +46,6 @@ module Dependabot
           # No special sanitization needed for UV files at this point
           @pyproject_content
         end
-
-        private
-
-        sig { returns(T.nilable(Dependabot::DependencyFile)) }
-        attr_reader :lockfile
       end
     end
   end

--- a/uv/lib/dependabot/uv/file_updater/pyproject_preparer.rb
+++ b/uv/lib/dependabot/uv/file_updater/pyproject_preparer.rb
@@ -17,8 +17,6 @@ module Dependabot
       class PyprojectPreparer
         extend T::Sig
 
-        Credentials = T.type_alias { T::Array[T::Hash[String, String]] }
-
         sig { params(pyproject_content: String, lockfile: T.nilable(Dependabot::DependencyFile)).void }
         def initialize(pyproject_content:, lockfile: nil)
           @pyproject_content = pyproject_content
@@ -44,26 +42,6 @@ module Dependabot
           @pyproject_content = updated_lines.join("\n")
         end
 
-        sig { params(credentials: T.nilable(Credentials)).returns(T.nilable(Credentials)) }
-        def add_auth_env_vars(credentials)
-          return unless credentials
-
-          credentials.each do |credential|
-            next unless credential["type"] == "python_index"
-
-            token = credential["token"]
-            index_url = credential["index-url"]
-
-            next unless token && index_url
-
-            # Set environment variables for uv auth
-            ENV["UV_INDEX_URL_TOKEN_#{sanitize_env_name(index_url)}"] = token
-
-            # Also set pip-style credentials for compatibility
-            ENV["PIP_INDEX_URL"] ||= "https://#{token}@#{index_url.gsub(%r{^https?://}, '')}"
-          end
-        end
-
         sig { returns(String) }
         def sanitize
           # No special sanitization needed for UV files at this point
@@ -74,11 +52,6 @@ module Dependabot
 
         sig { returns(T.nilable(Dependabot::DependencyFile)) }
         attr_reader :lockfile
-
-        sig { params(url: String).returns(String) }
-        def sanitize_env_name(url)
-          url.gsub(%r{^https?://}, "").gsub(/[^a-zA-Z0-9]/, "_").upcase
-        end
       end
     end
   end

--- a/uv/spec/dependabot/uv/file_updater/pyproject_preparer_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/pyproject_preparer_spec.rb
@@ -8,39 +8,10 @@ require "dependabot/uv/file_updater/pyproject_preparer"
 
 RSpec.describe Dependabot::Uv::FileUpdater::PyprojectPreparer do
   let(:preparer) do
-    described_class.new(pyproject_content: pyproject_content, lockfile: lockfile)
+    described_class.new(pyproject_content: pyproject_content)
   end
 
   let(:pyproject_content) { fixture("pyproject_files", "uv_simple.toml") }
-  let(:lockfile_content) { fixture("uv_locks", "simple.lock") }
-
-  let(:lockfile) do
-    Dependabot::DependencyFile.new(
-      name: "uv.lock",
-      content: lockfile_content
-    )
-  end
-
-  let(:dependency) do
-    Dependabot::Dependency.new(
-      name: "requests",
-      version: "2.26.0",
-      requirements: [{
-        file: "pyproject.toml",
-        requirement: ">=2.26.0",
-        groups: [],
-        source: nil
-      }],
-      previous_version: "2.32.3",
-      previous_requirements: [{
-        file: "pyproject.toml",
-        requirement: ">=2.31.0",
-        groups: [],
-        source: nil
-      }],
-      package_manager: "uv"
-    )
-  end
 
   describe "#sanitize" do
     subject(:sanitized_content) { preparer.sanitize }

--- a/uv/spec/dependabot/uv/file_updater/pyproject_preparer_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/pyproject_preparer_spec.rb
@@ -42,37 +42,6 @@ RSpec.describe Dependabot::Uv::FileUpdater::PyprojectPreparer do
     )
   end
 
-  describe "#add_auth_env_vars" do
-    it "adds auth env vars when a token is present" do
-      preparer.add_auth_env_vars(
-        [
-          {
-            "type" => "python_index",
-            "index-url" => "some.internal.registry.com/pypi/",
-            "token" => "hello:world"
-          }
-        ]
-      )
-      expect(ENV.delete("UV_INDEX_URL_TOKEN_SOME_INTERNAL_REGISTRY_COM_PYPI_")).to eq("hello:world")
-      expect(ENV.delete("PIP_INDEX_URL")).to eq("https://hello:world@some.internal.registry.com/pypi/")
-    end
-
-    it "has no effect when a token is not present" do
-      preparer.add_auth_env_vars(
-        [
-          {
-            "index-url" => "https://some.internal.registry.com/pypi/"
-          }
-        ]
-      )
-      expect(ENV.fetch("UV_INDEX_URL_TOKEN_SOME_INTERNAL_REGISTRY_COM_PYPI_", nil)).to be_nil
-    end
-
-    it "doesn't break when there are no credentials" do
-      expect { preparer.add_auth_env_vars(nil) }.not_to raise_error
-    end
-  end
-
   describe "#sanitize" do
     subject(:sanitized_content) { preparer.sanitize }
 


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

**Primary change: remove dead code.** The uv ecosystem's `PyprojectPreparer#add_auth_env_vars` sets `UV_INDEX_URL_TOKEN_*` env vars that uv does not recognize, and it is **never called from any production code path**. Its mere existence led to an incorrect root cause analysis in #15207. The real OIDC auth for uv is handled by the Dependabot proxy at the HTTP level — not by env vars in the updater.

This PR deletes that dead method (plus its only-used-by-it `Credentials` type alias and `sanitize_env_name` helper) and the specs that covered it.

**Secondary, minor:** a small amount of `debug`/`info` diagnostic logging in the *existing, live* `LockFileUpdater#pyproject_index_env_vars` path to make credential→index matching observable. This is a low-stakes log-only change and does not alter behavior.

<!-- What issues does this affect or fix? -->

Refs #15207

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

**Please focus review on the dead-code removal** (`pyproject_preparer.rb` + spec) — that's the substance of this PR.

- Removal is **uv-only** — the Python/Poetry ecosystem has its own actively-used `add_auth_env_vars`, which is untouched.
- `Credentials` type alias and `sanitize_env_name` were only referenced by the removed method.

The logging in `lock_file_updater.rb` is intentionally minimal and secret-safe (no raw URLs or tokens). It's a diagnostic nicety, not the goal of the PR — please don't block on log-message wording. If reviewers would prefer it dropped to keep the PR purely a deletion, I'm happy to remove it.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

- Repo-wide grep confirms **zero** production callers of the removed method.
- All existing `pyproject_index_env_vars` specs pass unchanged — behavior is identical.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
