### PR TITLE
Support package-scoped NuGet release notes

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGeneratorTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGeneratorTests.cs
@@ -171,6 +171,89 @@ public class DetailedPullRequestBodyGeneratorTests
     }
 
     [Fact]
+    public async Task GeneratePrBody_GitHub_PackageScopedReleases()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "This.Package", OldVersion = NuGetVersion.Parse("1.1.2"), NewVersion = NuGetVersion.Parse("3.1.1"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "This.Package",
+                    PreviousVersion = "1.1.2",
+                    Version = "3.1.1",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "3.1.1",
+                            Source = new()
+                            {
+                                SourceUrl = "https://github.com/Some.Owner/Some.Repo",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [
+                ("https://api.github.com/repos/Some.Owner/Some.Repo/releases?per_page=100", """
+                    [
+                      {
+                        "name": "This.Package v3.1.1",
+                        "tag_name": "This.Package-v3.1.1",
+                        "body": "* this package point 3"
+                      },
+                      {
+                        "name": "Another.Package v2.1.1",
+                        "tag_name": "Another.Package-v2.1.1",
+                        "body": "* another package point"
+                      },
+                      {
+                        "name": "v2.5.0",
+                        "tag_name": "v2.5.0",
+                        "body": "* repo point"
+                      },
+                      {
+                        "name": "This.Package v2.0.0",
+                        "tag_name": "This.Package-v2.0.0",
+                        "body": "* this package point 2"
+                      },
+                      {
+                        "name": "v1.1.2",
+                        "tag_name": "v1.1.2",
+                        "body": "* old repo point"
+                      }
+                    ]
+                    """)
+            ],
+            expectedBody: """
+                Updated [This.Package](https://github.com/Some.Owner/Some.Repo) from 1.1.2 to 3.1.1.
+
+                <details>
+                <summary>Release notes</summary>
+
+                _Sourced from [This.Package's releases](https://github.com/Some.Owner/Some.Repo/releases)._
+
+                ## 3.1.1
+
+                * this package point 3
+
+                ## 2.5.0
+
+                * repo point
+
+                ## 2.0.0
+
+                * this package point 2
+
+                Commits viewable in [compare view](https://github.com/Some.Owner/Some.Repo/compare/v1.1.2...This.Package-v3.1.1).
+                </details>
+                """
+        );
+    }
+
+    [Fact]
     public async Task GeneratePrBody_GitHub_EmptyApiResponses()
     {
         await TestAsync(
@@ -323,6 +406,99 @@ public class DetailedPullRequestBodyGeneratorTests
                 ## 1.0.1
 
                 Commits viewable in [compare view](https://gitlab.com/Some.Owner/Some.Dependency/-/compare/1.0.0...2.0.0).
+                </details>
+                """
+        );
+    }
+
+    [Fact]
+    public async Task GeneratePrBody_GitLab_PackageScopedReleases()
+    {
+        await TestAsync(
+            updateOperationsPerformed: [
+                new DirectUpdate() { DependencyName = "This.Package", OldVersion = NuGetVersion.Parse("1.1.2"), NewVersion = NuGetVersion.Parse("3.1.1"), UpdatedFiles = [] },
+            ],
+            updatedDependencies: [
+                new ReportedDependency()
+                {
+                    Name = "This.Package",
+                    PreviousVersion = "1.1.2",
+                    Version = "3.1.1",
+                    Requirements = [
+                        new ReportedRequirement()
+                        {
+                            File = "",
+                            Requirement = "3.1.1",
+                            Source = new()
+                            {
+                                SourceUrl = "https://gitlab.com/Some.Owner/Some.Repo",
+                            },
+                        }
+                    ],
+                }
+            ],
+            httpResponses: [
+                ("https://gitlab.com/api/v4/projects/Some.Owner%2FSome.Repo/repository/tags", """
+                    [
+                      {
+                        "name": "This.Package v3.1.1",
+                        "release": {
+                          "tag_name": "This.Package-v3.1.1",
+                          "description": "* this package point 3"
+                        }
+                      },
+                      {
+                        "name": "Another.Package v2.1.1",
+                        "release": {
+                          "tag_name": "Another.Package-v2.1.1",
+                          "description": "* another package point"
+                        }
+                      },
+                      {
+                        "name": "v2.5.0",
+                        "release": {
+                          "tag_name": "v2.5.0",
+                          "description": "* repo point"
+                        }
+                      },
+                      {
+                        "name": "This.Package v2.0.0",
+                        "release": {
+                          "tag_name": "This.Package-v2.0.0",
+                          "description": "* this package point 2"
+                        }
+                      },
+                      {
+                        "name": "v1.1.2",
+                        "release": {
+                          "tag_name": "v1.1.2",
+                          "description": "* old repo point"
+                        }
+                      }
+                    ]
+                    """)
+            ],
+            expectedBody: """
+                Updated [This.Package](https://gitlab.com/Some.Owner/Some.Repo) from 1.1.2 to 3.1.1.
+
+                <details>
+                <summary>Release notes</summary>
+
+                _Sourced from [This.Package's releases](https://gitlab.com/Some.Owner/Some.Repo/-/releases)._
+
+                ## 3.1.1
+
+                * this package point 3
+
+                ## 2.5.0
+
+                * repo point
+
+                ## 2.0.0
+
+                * this package point 2
+
+                Commits viewable in [compare view](https://gitlab.com/Some.Owner/Some.Repo/-/compare/v1.1.2...This.Package-v3.1.1).
                 </details>
                 """
         );

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/IPackageDetailFinderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/IPackageDetailFinderTests.cs
@@ -12,6 +12,8 @@ public class IPackageDetailFinderTests
     [InlineData("version-one.zero.zero", "v1.0.0", "1.0.0")]
     [InlineData("v-one.zero.zero", "v-one.zero.zero", null)]
     [InlineData("Stable", "version-1.0.0", "1.0.0")]
+    [InlineData("NUnit version 4.6.1", "v4.6.1", "4.6.1")]
+    [InlineData("4.0.262.0", "4.0.262.0", "4.0.262.0")]
     [InlineData("some.package/1.0.0", "some.package/1.0.0", "1.0.0")]
     [InlineData("some.package 1.0.0", "some.package 1.0.0", "1.0.0")]
     public void GetVersionFromNames(string releaseName, string tagName, string? expectedVersion)
@@ -33,6 +35,11 @@ public class IPackageDetailFinderTests
     [InlineData("some.package", "other.package v2.0.0", "some.package-v1.0.0", "1.0.0")]
     [InlineData("some.package", "packages/some.package/1.0.0", "other.package v2.0.0", "1.0.0")]
     [InlineData("some.package", "other.package v2.0.0", "v1.0.0", "2.0.0")]
+    [InlineData("Azure.AI.VoiceLive", "Azure.AI.VoiceLive_1.1.0", "Azure.AI.VoiceLive_1.1.0", "1.1.0")]
+    [InlineData("Microsoft.Azure.Functions.Worker.Extensions.CosmosDB", "Microsoft.Azure.Functions.Worker.Extensions.CosmosDB 4.16.1", "cosmosdb-extension-4.16.1", "4.16.1")]
+    [InlineData("Microsoft.NET.Sdk.Functions", "Microsoft.Net.Sdk.Functions 4.1.0", "4.1.0", "4.1.0")]
+    [InlineData("System.CommandLine", "System.CommandLine v2.0.2", "v2.0.2", "2.0.2")]
+    [InlineData("AWSSDK.S3", "4.0.262.0", "4.0.262.0", "4.0.262.0")]
     public void GetVersionFromNames_WithDependencyName(string dependencyName, string releaseName, string tagName, string expectedVersion)
     {
         var actualVersion = IPackageDetailFinder.GetVersionFromNames(releaseName, tagName, dependencyName);
@@ -44,6 +51,9 @@ public class IPackageDetailFinderTests
     [Theory]
     [InlineData("some.package", "other.package v1.0.0", "v1.0.0", true)]
     [InlineData("some.package", "some.package v1.0.0", "v1.0.0", false)]
+    [InlineData("some.package", "Azure.AI.VoiceLive_1.1.0", "v1.1.0", true)]
+    [InlineData("some.package", "System.CommandLine v2.0.2", "v2.0.2", true)]
+    [InlineData("some.package", "BenchmarkDotNet v0.15.8", "v0.15.8", false)]
     [InlineData("some.package", "release 1.0.0", "v1.0.0", false)]
     public void HasPackageScopedVersionForOtherDependency(string dependencyName, string releaseName, string tagName, bool expectedResult)
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/IPackageDetailFinderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/IPackageDetailFinderTests.cs
@@ -27,4 +27,28 @@ public class IPackageDetailFinderTests
             Assert.Equal(expectedVersion, actualVersion.ToString());
         }
     }
+
+    [Theory]
+    [InlineData("some.package", "some.package v1.0.0", "other.package v2.0.0", "1.0.0")]
+    [InlineData("some.package", "other.package v2.0.0", "some.package-v1.0.0", "1.0.0")]
+    [InlineData("some.package", "packages/some.package/1.0.0", "other.package v2.0.0", "1.0.0")]
+    [InlineData("some.package", "other.package v2.0.0", "v1.0.0", "2.0.0")]
+    public void GetVersionFromNames_WithDependencyName(string dependencyName, string releaseName, string tagName, string expectedVersion)
+    {
+        var actualVersion = IPackageDetailFinder.GetVersionFromNames(releaseName, tagName, dependencyName);
+
+        Assert.NotNull(actualVersion);
+        Assert.Equal(expectedVersion, actualVersion.ToString());
+    }
+
+    [Theory]
+    [InlineData("some.package", "other.package v1.0.0", "v1.0.0", true)]
+    [InlineData("some.package", "some.package v1.0.0", "v1.0.0", false)]
+    [InlineData("some.package", "release 1.0.0", "v1.0.0", false)]
+    public void HasPackageScopedVersionForOtherDependency(string dependencyName, string releaseName, string tagName, bool expectedResult)
+    {
+        var actualResult = IPackageDetailFinder.HasPackageScopedVersionForOtherDependency(releaseName, tagName, dependencyName);
+
+        Assert.Equal(expectedResult, actualResult);
+    }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/AzurePackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/AzurePackageDetailFinder.cs
@@ -20,7 +20,7 @@ internal class AzurePackageDetailFinder : IPackageDetailFinder
         return "commits";
     }
 
-    public Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, NuGetVersion oldVersion, NuGetVersion newVersion)
+    public Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, string dependencyName, NuGetVersion oldVersion, NuGetVersion newVersion)
     {
         // azure devops doesn't support direct tag listing
         return Task.FromResult(new Dictionary<NuGetVersion, (string TagName, string? Details)>());

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGenerator.cs
@@ -91,7 +91,7 @@ internal class DetailedPullRequestBodyGenerator : IPullRequestBodyGenerator, IDi
                         updateOperation.OldVersion is not null)
                     {
                         var repoName = uri.LocalPath.TrimStart('/');
-                        var versionsAndDetails = await packageDetailFinder.GetReleaseDataForVersionsAsync(repoName, updateOperation.OldVersion, updateOperation.NewVersion);
+                        var versionsAndDetails = await packageDetailFinder.GetReleaseDataForVersionsAsync(repoName, updateOperation.DependencyName, updateOperation.OldVersion, updateOperation.NewVersion);
                         var ordered = versionsAndDetails
                             .Where(kv => kv.Key != updateOperation.OldVersion)
                             .OrderByDescending(kv => kv.Key)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitHubPackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitHubPackageDetailFinder.cs
@@ -28,9 +28,11 @@ internal class GitHubPackageDetailFinder : IPackageDetailFinder
         return "commits";
     }
 
-    public async Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, NuGetVersion oldVersion, NuGetVersion newVersion)
+    public async Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, string dependencyName, NuGetVersion oldVersion, NuGetVersion newVersion)
     {
         var result = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var packageScopedResult = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var otherPackageScopedResult = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
         var url = $"https://api.github.com/repos/{repoName}/releases?per_page=100";
         var jsonOption = await _httpFetcher.GetJsonElementAsync(url);
         if (jsonOption is null)
@@ -75,7 +77,10 @@ internal class GitHubPackageDetailFinder : IPackageDetailFinder
             var tagName = tagNameElement.GetString()!;
 
             // find matching version
-            var correspondingVersion = IPackageDetailFinder.GetVersionFromNames(releaseName, tagName);
+            var packageScopedVersion = IPackageDetailFinder.GetPackageScopedVersionFromNames(releaseName, tagName, dependencyName);
+            var correspondingVersion = packageScopedVersion ?? IPackageDetailFinder.GetVersionFromNames(releaseName, tagName);
+            var isOtherPackageScopedVersion = packageScopedVersion is null &&
+                IPackageDetailFinder.HasPackageScopedVersionForOtherDependency(releaseName, tagName, dependencyName);
             if (correspondingVersion is null)
             {
                 continue;
@@ -90,8 +95,34 @@ internal class GitHubPackageDetailFinder : IPackageDetailFinder
                 }
 
                 var body = bodyElement.GetString()!;
-                result[correspondingVersion] = (tagName, body);
+                if (packageScopedVersion is not null)
+                {
+                    packageScopedResult[correspondingVersion] = (tagName, body);
+                }
+                else if (isOtherPackageScopedVersion)
+                {
+                    otherPackageScopedResult[correspondingVersion] = (tagName, body);
+                }
+                else
+                {
+                    result[correspondingVersion] = (tagName, body);
+                }
             }
+        }
+
+        if (packageScopedResult.Count > 0)
+        {
+            foreach (var packageScopedDetails in packageScopedResult)
+            {
+                result[packageScopedDetails.Key] = packageScopedDetails.Value;
+            }
+
+            return result;
+        }
+
+        foreach (var otherPackageScopedDetails in otherPackageScopedResult)
+        {
+            result[otherPackageScopedDetails.Key] = otherPackageScopedDetails.Value;
         }
 
         return result;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitHubPackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitHubPackageDetailFinder.cs
@@ -30,25 +30,25 @@ internal class GitHubPackageDetailFinder : IPackageDetailFinder
 
     public async Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, string dependencyName, NuGetVersion oldVersion, NuGetVersion newVersion)
     {
-        var result = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
-        var packageScopedResult = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
-        var otherPackageScopedResult = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var versionReleaseData = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var packageScopedVersionReleaseData = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var otherPackageScopedVersionReleaseData = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
         var url = $"https://api.github.com/repos/{repoName}/releases?per_page=100";
         var jsonOption = await _httpFetcher.GetJsonElementAsync(url);
         if (jsonOption is null)
         {
-            return result;
+            return versionReleaseData;
         }
 
         var json = jsonOption.Value;
         if (json.ValueKind != JsonValueKind.Array)
         {
-            return result;
+            return versionReleaseData;
         }
 
         if (json.GetArrayLength() == 0)
         {
-            return result;
+            return versionReleaseData;
         }
 
         foreach (var releaseObject in json.EnumerateArray())
@@ -97,35 +97,35 @@ internal class GitHubPackageDetailFinder : IPackageDetailFinder
                 var body = bodyElement.GetString()!;
                 if (packageScopedVersion is not null)
                 {
-                    packageScopedResult[correspondingVersion] = (tagName, body);
+                    packageScopedVersionReleaseData[correspondingVersion] = (tagName, body);
                 }
                 else if (isOtherPackageScopedVersion)
                 {
-                    otherPackageScopedResult[correspondingVersion] = (tagName, body);
+                    otherPackageScopedVersionReleaseData[correspondingVersion] = (tagName, body);
                 }
                 else
                 {
-                    result[correspondingVersion] = (tagName, body);
+                    versionReleaseData[correspondingVersion] = (tagName, body);
                 }
             }
         }
 
-        if (packageScopedResult.Count > 0)
+        if (packageScopedVersionReleaseData.Count > 0)
         {
-            foreach (var packageScopedDetails in packageScopedResult)
+            foreach (var packageScopedDetails in packageScopedVersionReleaseData)
             {
-                result[packageScopedDetails.Key] = packageScopedDetails.Value;
+                versionReleaseData[packageScopedDetails.Key] = packageScopedDetails.Value;
             }
 
-            return result;
+            return versionReleaseData;
         }
 
-        foreach (var otherPackageScopedDetails in otherPackageScopedResult)
+        foreach (var otherPackageScopedDetails in otherPackageScopedVersionReleaseData)
         {
-            result[otherPackageScopedDetails.Key] = otherPackageScopedDetails.Value;
+            versionReleaseData[otherPackageScopedDetails.Key] = otherPackageScopedDetails.Value;
         }
 
-        return result;
+        return versionReleaseData;
     }
 
     public string GetReleasesUrlPath() => "releases";

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitLabPackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitLabPackageDetailFinder.cs
@@ -30,25 +30,25 @@ internal class GitLabPackageDetailFinder : IPackageDetailFinder
 
     public async Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, string dependencyName, NuGetVersion oldVersion, NuGetVersion newVersion)
     {
-        var result = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
-        var packageScopedResult = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
-        var otherPackageScopedResult = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var versionReleaseData = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var packageScopedVersionReleaseData = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var otherPackageScopedVersionReleaseData = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
         var url = $"https://gitlab.com/api/v4/projects/{Uri.EscapeDataString(repoName)}/repository/tags";
         var jsonOption = await _httpFetcher.GetJsonElementAsync(url);
         if (jsonOption is null)
         {
-            return result;
+            return versionReleaseData;
         }
 
         var json = jsonOption.Value;
         if (json.ValueKind != JsonValueKind.Array)
         {
-            return result;
+            return versionReleaseData;
         }
 
         if (json.GetArrayLength() == 0)
         {
-            return result;
+            return versionReleaseData;
         }
 
         foreach (var responseObject in json.EnumerateArray())
@@ -103,35 +103,35 @@ internal class GitLabPackageDetailFinder : IPackageDetailFinder
             {
                 if (packageScopedVersion is not null)
                 {
-                    packageScopedResult[correspondingVersion] = (resultTag, description);
+                    packageScopedVersionReleaseData[correspondingVersion] = (resultTag, description);
                 }
                 else if (isOtherPackageScopedVersion)
                 {
-                    otherPackageScopedResult[correspondingVersion] = (resultTag, description);
+                    otherPackageScopedVersionReleaseData[correspondingVersion] = (resultTag, description);
                 }
                 else
                 {
-                    result[correspondingVersion] = (resultTag, description);
+                    versionReleaseData[correspondingVersion] = (resultTag, description);
                 }
             }
         }
 
-        if (packageScopedResult.Count > 0)
+        if (packageScopedVersionReleaseData.Count > 0)
         {
-            foreach (var packageScopedDetails in packageScopedResult)
+            foreach (var packageScopedDetails in packageScopedVersionReleaseData)
             {
-                result[packageScopedDetails.Key] = packageScopedDetails.Value;
+                versionReleaseData[packageScopedDetails.Key] = packageScopedDetails.Value;
             }
 
-            return result;
+            return versionReleaseData;
         }
 
-        foreach (var otherPackageScopedDetails in otherPackageScopedResult)
+        foreach (var otherPackageScopedDetails in otherPackageScopedVersionReleaseData)
         {
-            result[otherPackageScopedDetails.Key] = otherPackageScopedDetails.Value;
+            versionReleaseData[otherPackageScopedDetails.Key] = otherPackageScopedDetails.Value;
         }
 
-        return result;
+        return versionReleaseData;
     }
 
     public string GetReleasesUrlPath() => "-/releases";

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitLabPackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/GitLabPackageDetailFinder.cs
@@ -28,9 +28,11 @@ internal class GitLabPackageDetailFinder : IPackageDetailFinder
         return "-/commits";
     }
 
-    public async Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, NuGetVersion oldVersion, NuGetVersion newVersion)
+    public async Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, string dependencyName, NuGetVersion oldVersion, NuGetVersion newVersion)
     {
         var result = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var packageScopedResult = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
+        var otherPackageScopedResult = new Dictionary<NuGetVersion, (string TagName, string? Details)>();
         var url = $"https://gitlab.com/api/v4/projects/{Uri.EscapeDataString(repoName)}/repository/tags";
         var jsonOption = await _httpFetcher.GetJsonElementAsync(url);
         if (jsonOption is null)
@@ -85,7 +87,10 @@ internal class GitLabPackageDetailFinder : IPackageDetailFinder
             }
 
             // find matching version
-            var correspondingVersion = IPackageDetailFinder.GetVersionFromNames(releaseName, tagName);
+            var packageScopedVersion = IPackageDetailFinder.GetPackageScopedVersionFromNames(releaseName, tagName, dependencyName);
+            var correspondingVersion = packageScopedVersion ?? IPackageDetailFinder.GetVersionFromNames(releaseName, tagName);
+            var isOtherPackageScopedVersion = packageScopedVersion is null &&
+                IPackageDetailFinder.HasPackageScopedVersionForOtherDependency(releaseName, tagName, dependencyName);
             if (correspondingVersion is null)
             {
                 continue;
@@ -96,8 +101,34 @@ internal class GitLabPackageDetailFinder : IPackageDetailFinder
                 correspondingVersion >= oldVersion &&
                 correspondingVersion <= newVersion)
             {
-                result[correspondingVersion] = (resultTag, description);
+                if (packageScopedVersion is not null)
+                {
+                    packageScopedResult[correspondingVersion] = (resultTag, description);
+                }
+                else if (isOtherPackageScopedVersion)
+                {
+                    otherPackageScopedResult[correspondingVersion] = (resultTag, description);
+                }
+                else
+                {
+                    result[correspondingVersion] = (resultTag, description);
+                }
             }
+        }
+
+        if (packageScopedResult.Count > 0)
+        {
+            foreach (var packageScopedDetails in packageScopedResult)
+            {
+                result[packageScopedDetails.Key] = packageScopedDetails.Value;
+            }
+
+            return result;
+        }
+
+        foreach (var otherPackageScopedDetails in otherPackageScopedResult)
+        {
+            result[otherPackageScopedDetails.Key] = otherPackageScopedDetails.Value;
         }
 
         return result;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IPackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IPackageDetailFinder.cs
@@ -28,12 +28,8 @@ internal partial interface IPackageDetailFinder
     {
         foreach (var candidateName in new[] { releaseName, tagName }.Where(n => n is not null).Cast<string>())
         {
-            var trimmedCandidateName = candidateName.Trim();
-            var match = Regex.Match(
-                trimmedCandidateName,
-                $@"(?:^|[\s/_-]){Regex.Escape(dependencyName)}[\s/_-]+v?(?<version>[0-9][A-Za-z0-9.+-]*)$",
-                RegexOptions.IgnoreCase);
-            if (!match.Success)
+            var match = GetPackageScopedNameMatch(candidateName, dependencyName);
+            if (match is null)
             {
                 continue;
             }
@@ -72,6 +68,18 @@ internal partial interface IPackageDetailFinder
         }
 
         return false;
+    }
+
+    private static Match? GetPackageScopedNameMatch(string candidateName, string dependencyName)
+    {
+        var match = PackageScopedNamePattern.Match(candidateName.Trim());
+        if (!match.Success ||
+            !match.Groups["dependency"].Value.Equals(dependencyName, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return match;
     }
 
     private static NuGetVersion? GetRepoScopedVersionFromNames(string? releaseName, string? tagName)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IPackageDetailFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IPackageDetailFinder.cs
@@ -8,13 +8,77 @@ internal partial interface IPackageDetailFinder
 {
     string GetReleasesUrlPath();
     string GetCompareUrlPath(string? oldTag, string? newTag);
-    Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, NuGetVersion oldVersion, NuGetVersion newVersion);
+    Task<Dictionary<NuGetVersion, (string TagName, string? Details)>> GetReleaseDataForVersionsAsync(string repoName, string dependencyName, NuGetVersion oldVersion, NuGetVersion newVersion);
 
-    internal static NuGetVersion? GetVersionFromNames(string? releaseName, string? tagName)
+    internal static NuGetVersion? GetVersionFromNames(string? releaseName, string? tagName, string? dependencyName = null)
+    {
+        if (dependencyName is not null)
+        {
+            var packageScopedVersion = GetPackageScopedVersionFromNames(releaseName, tagName, dependencyName);
+            if (packageScopedVersion is not null)
+            {
+                return packageScopedVersion;
+            }
+        }
+
+        return GetRepoScopedVersionFromNames(releaseName, tagName);
+    }
+
+    internal static NuGetVersion? GetPackageScopedVersionFromNames(string? releaseName, string? tagName, string dependencyName)
     {
         foreach (var candidateName in new[] { releaseName, tagName }.Where(n => n is not null).Cast<string>())
         {
-            var trimmedName = NamePrefixPattern.Replace(candidateName, string.Empty);
+            var trimmedCandidateName = candidateName.Trim();
+            var match = Regex.Match(
+                trimmedCandidateName,
+                $@"(?:^|[\s/_-]){Regex.Escape(dependencyName)}[\s/_-]+v?(?<version>[0-9][A-Za-z0-9.+-]*)$",
+                RegexOptions.IgnoreCase);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var version = match.Groups["version"].Value;
+            if (NuGetVersion.TryParse(version, out var versionFromPackageScopedName))
+            {
+                return versionFromPackageScopedName;
+            }
+        }
+
+        return null;
+    }
+
+    internal static bool HasPackageScopedVersionForOtherDependency(string? releaseName, string? tagName, string dependencyName)
+    {
+        foreach (var candidateName in new[] { releaseName, tagName }.Where(n => n is not null).Cast<string>())
+        {
+            var trimmedCandidateName = candidateName.Trim();
+            var match = PackageScopedNamePattern.Match(trimmedCandidateName);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var matchedDependencyName = match.Groups["dependency"].Value;
+            var version = match.Groups["version"].Value;
+            if (!matchedDependencyName.Contains('.') ||
+                matchedDependencyName.Equals(dependencyName, StringComparison.OrdinalIgnoreCase) ||
+                !NuGetVersion.TryParse(version, out _))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static NuGetVersion? GetRepoScopedVersionFromNames(string? releaseName, string? tagName)
+    {
+        foreach (var candidateName in new[] { releaseName, tagName }.Where(n => n is not null).Cast<string>())
+        {
+            var trimmedName = NamePrefixPattern.Replace(candidateName.Trim(), string.Empty);
             if (NuGetVersion.TryParse(trimmedName, out var versionFromTrimmed))
             {
                 return versionFromTrimmed;
@@ -27,5 +91,10 @@ internal partial interface IPackageDetailFinder
     [GeneratedRegex(@"^[^0-9]*")]
     private static partial Regex NamePrefixRemover();
 
+    [GeneratedRegex(@"(?:^|[\s/_-])(?<dependency>[A-Za-z0-9_.-]+)[\s/_-]+v?(?<version>[0-9][A-Za-z0-9.+-]*)$", RegexOptions.IgnoreCase)]
+    private static partial Regex PackageScopedNameMatcher();
+
     private static readonly Regex NamePrefixPattern = NamePrefixRemover();
+
+    private static readonly Regex PackageScopedNamePattern = PackageScopedNameMatcher();
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #15210.

Dependabot's NuGet PR body generation currently treats source repository releases as repo/version-scoped. That means a package update can show the source releases link but omit release note bodies when a shared source repository publishes package-scoped releases such as `This.Package v3.1.1` and `Another.Package v2.1.1`.

This change makes NuGet release-note matching dependency-aware for GitHub and GitLab sources. It prefers release names/tags scoped to the dependency being updated while preserving existing repo-level release behavior.

### Anything you want to highlight for special attention from reviewers?

The matching is intentionally conservative for compatibility:

- target package releases are included, e.g. `This.Package v3.1.1`
- generic repo-level releases are still included, e.g. `v2.5.0`
- other package-scoped releases are excluded only when target package-scoped releases are present, e.g. `Another.Package v2.1.1`
- if no target package-scoped releases are found, the old repo-scoped behavior is preserved

### How will you know you've accomplished your goal?

Added regression coverage for GitHub and GitLab PR body generation with mixed release histories containing target package releases, other package releases, and generic repo releases. Also added parser coverage for dependency-aware version extraction and other-package detection.

Focused Docker test run:

```console
docker run --rm ... ghcr.io/dependabot/dependabot-updater-nuget:latest dotnet test ./NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj --filter FullyQualifiedName~PullRequestBodyGenerator --logger console;verbosity=normal
```

Result: 33 passed.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.