### PR TITLE
Fix multi-ecosystem group file contamination

### DIFF
--- a/updater/.rubocop.yml
+++ b/updater/.rubocop.yml
@@ -11,4 +11,5 @@ Sorbet/ForbidTUnsafe:
     - lib/dependabot/update_graph_command.rb
     - lib/dependabot/updater/error_handler.rb
     - lib/dependabot/updater/group_dependency_selector.rb
+    - lib/dependabot/updater/group_update_creation.rb
     - lib/dependabot/updater/pattern_specificity_calculator.rb

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -134,7 +134,20 @@ module Dependabot
 
           next unless lead_dependency
 
-          dependency_change = create_change_for(lead_dependency, updated_dependencies, dependency_files, group)
+          # Filter updated_dependencies to only include those that match the group.
+          # This prevents file contamination where lockfiles include transitive dependencies
+          # that don't match the group pattern. We filter before file generation rather than
+          # after to ensure the FileUpdater only sees group-eligible dependencies.
+          group_eligible_dependencies = filter_dependencies_for_group(
+            updated_dependencies,
+            group,
+            job.source.directory || "."
+          )
+
+          # Skip if no group-eligible dependencies remain
+          next if group_eligible_dependencies.empty?
+
+          dependency_change = create_change_for(lead_dependency, group_eligible_dependencies, dependency_files, group)
 
           # Move on to the next dependency using the existing files if we
           # could not create a change for any reason
@@ -699,6 +712,56 @@ module Dependabot
           "All versions ignored for #{dependency.name} in group #{group.name} but security advisories exist"
         )
         record_security_update_ignored(checker)
+      end
+
+      # Filters dependencies to only include those eligible for the given group.
+      # Uses the same logic as GroupDependencySelector to ensure consistency.
+      sig do
+        params(
+          dependencies: T::Array[Dependabot::Dependency],
+          group: Dependabot::DependencyGroup,
+          directory: String
+        ).returns(T::Array[Dependabot::Dependency])
+      end
+      def filter_dependencies_for_group(dependencies, group, directory)
+        group_eligible = T.let([], T::Array[Dependabot::Dependency])
+        filtered_out = T.let([], T::Array[Dependabot::Dependency])
+
+        dependencies.each do |dep|
+          if group_contains_dependency?(dep, directory, group) && allowed_by_job_config?(dep)
+            group_eligible << dep
+          else
+            filtered_out << dep
+          end
+        end
+
+        # Log if we filtered out any dependencies
+        if filtered_out.any?
+          Dependabot.logger.info(
+            "[group=#{group.name}, directory=#{directory}] " \
+            "Filtered out #{filtered_out.length} non-group dependencies before file generation: " \
+            "#{filtered_out.map(&:name).join(', ')}"
+          )
+        end
+
+        group_eligible
+      end
+
+      sig { params(dep: Dependabot::Dependency, directory: String, group: Dependabot::DependencyGroup).returns(T::Boolean) }
+      def group_contains_dependency?(dep, directory, group)
+        if group.respond_to?(:contains_dependency?)
+          T.unsafe(group).contains_dependency?(dep, directory: directory)
+        else
+          group.contains?(dep)
+        end
+      end
+
+      sig { params(dep: Dependabot::Dependency).returns(T::Boolean) }
+      def allowed_by_job_config?(dep)
+        ignore_conditions = job.ignore_conditions_for(dep)
+        return false if ignore_conditions.any?(Dependabot::Config::IgnoreCondition::ALL_VERSIONS)
+
+        job.allowed_update?(dep, check_previous_version: true)
       end
     end
     # rubocop:enable Metrics/ModuleLength

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -845,7 +845,7 @@ module Dependabot
 
         # Helper to check if a group contains a dependency
         contains_checker = T.let(
-          proc { |g, dependency, dir|
+          Kernel.proc { |g, dependency, dir|
             if g.respond_to?(:contains_dependency?)
               T.unsafe(g).contains_dependency?(dependency, directory: dir)
             else

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -5,6 +5,7 @@ require "sorbet-runtime"
 
 require "dependabot/dependency_change_builder"
 require "dependabot/updater/dependency_group_change_batch"
+require "dependabot/updater/pattern_specificity_calculator"
 require "dependabot/workspace"
 require "dependabot/updater/security_update_helpers"
 require "dependabot/notices"
@@ -27,6 +28,9 @@ module Dependabot
       extend T::Helpers
       include PullRequestHelpers
       include SecurityUpdateHelpers
+
+      # Maximum number of dependency names to include in log messages to prevent log bloat
+      MAX_DEPENDENCIES_TO_LOG = 10
 
       abstract!
 
@@ -146,6 +150,15 @@ module Dependabot
 
           # Skip if no group-eligible dependencies remain
           next if group_eligible_dependencies.empty?
+
+          # Validate that the lead dependency wasn't filtered out
+          # If it was, we can't proceed since create_change_for requires a valid lead
+          unless group_eligible_dependencies.include?(lead_dependency)
+            Dependabot.logger.info(
+              "Skipping update for #{dependency.name}: lead dependency was filtered out"
+            )
+            next
+          end
 
           dependency_change = create_change_for(lead_dependency, group_eligible_dependencies, dependency_files, group)
 
@@ -715,7 +728,13 @@ module Dependabot
       end
 
       # Filters dependencies to only include those eligible for the given group.
-      # Uses the same logic as GroupDependencySelector to ensure consistency.
+      # Applies the same filtering logic as GroupDependencySelector:
+      # 1. Group membership check (contains_dependency? or contains?)
+      # 2. Configuration compliance check (allowed_by_job_config?)
+      # 3. More-specific-group check (dependency_belongs_to_more_specific_group?)
+      #
+      # Note: This filtering occurs BEFORE file generation to prevent lockfile
+      # contamination, unlike GroupDependencySelector which filters AFTER.
       sig do
         params(
           dependencies: T::Array[Dependabot::Dependency],
@@ -729,18 +748,30 @@ module Dependabot
 
         dependencies.each do |dep|
           if group_contains_dependency?(dep, directory, group) && allowed_by_job_config?(dep)
-            group_eligible << dep
+            if dependency_belongs_to_more_specific_group?(dep, directory, group)
+              filtered_out << dep
+            else
+              group_eligible << dep
+            end
           else
             filtered_out << dep
           end
         end
 
-        # Log if we filtered out any dependencies
+        # Log if we filtered out any dependencies (limit names to avoid log bloat)
         if filtered_out.any?
+          names = filtered_out.map(&:name)
+          display_names = if names.length > MAX_DEPENDENCIES_TO_LOG
+                            "#{names.first(MAX_DEPENDENCIES_TO_LOG).join(', ')} " \
+                              "(and #{names.length - MAX_DEPENDENCIES_TO_LOG} more)"
+                          else
+                            names.join(', ')
+                          end
+
           Dependabot.logger.info(
             "[group=#{group.name}, directory=#{directory}] " \
             "Filtered out #{filtered_out.length} non-group dependencies before file generation: " \
-            "#{filtered_out.map(&:name).join(', ')}"
+            "#{display_names}"
           )
         end
 
@@ -762,6 +793,34 @@ module Dependabot
         return false if ignore_conditions.any?(Dependabot::Config::IgnoreCondition::ALL_VERSIONS)
 
         job.allowed_update?(dep, check_previous_version: true)
+      end
+
+      sig { params(dep: Dependabot::Dependency, directory: String, group: Dependabot::DependencyGroup).returns(T::Boolean) }
+      def dependency_belongs_to_more_specific_group?(dep, directory, group)
+        specificity_calculator = PatternSpecificityCalculator.new
+        
+        # Helper to check if a group contains a dependency
+        contains_checker = T.let(
+          proc { |g, dependency, dir|
+            if g.respond_to?(:contains_dependency?)
+              T.unsafe(g).contains_dependency?(dependency, directory: dir)
+            else
+              g.contains?(dependency)
+            end
+          },
+          T.proc.params(
+            g: Dependabot::DependencyGroup,
+            dep: Dependabot::Dependency,
+            dir: T.nilable(String)
+          ).returns(T::Boolean)
+        )
+
+        # Note: This doesn't include update_type or applies_to filtering like GroupDependencySelector
+        # because we don't have access to the full update context here. This is a simplified version
+        # that only checks group pattern specificity.
+        specificity_calculator.dependency_belongs_to_more_specific_group?(
+          group, dep, dependency_snapshot.groups, contains_checker, directory, applies_to: nil, update_type: nil
+        )
       end
     end
     # rubocop:enable Metrics/ModuleLength

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -138,27 +138,15 @@ module Dependabot
 
           next unless lead_dependency
 
-          # Filter updated_dependencies to only include those that match the group.
-          # This prevents file contamination where lockfiles include transitive dependencies
-          # that don't match the group pattern. We filter before file generation rather than
-          # after to ensure the FileUpdater only sees group-eligible dependencies.
-          group_eligible_dependencies = filter_dependencies_for_group(
+          # Filter and validate dependencies for the group
+          group_eligible_dependencies = filter_and_validate_dependencies(
             updated_dependencies,
+            lead_dependency,
             group,
             job.source.directory || "."
           )
 
-          # Skip if no group-eligible dependencies remain
-          next if group_eligible_dependencies.empty?
-
-          # Validate that the lead dependency wasn't filtered out
-          # If it was, we can't proceed since create_change_for requires a valid lead
-          unless group_eligible_dependencies.include?(lead_dependency)
-            Dependabot.logger.info(
-              "Skipping update for #{dependency.name}: lead dependency was filtered out"
-            )
-            next
-          end
+          next unless group_eligible_dependencies
 
           dependency_change = create_change_for(lead_dependency, group_eligible_dependencies, dependency_files, group)
 
@@ -727,6 +715,38 @@ module Dependabot
         record_security_update_ignored(checker)
       end
 
+      # Filters dependencies and validates the lead dependency is present.
+      # Returns nil if filtering fails or lead dependency is filtered out.
+      sig do
+        params(
+          dependencies: T::Array[Dependabot::Dependency],
+          lead_dependency: Dependabot::Dependency,
+          group: Dependabot::DependencyGroup,
+          directory: String
+        ).returns(T.nilable(T::Array[Dependabot::Dependency]))
+      end
+      def filter_and_validate_dependencies(dependencies, lead_dependency, group, directory)
+        # Filter updated_dependencies to only include those that match the group.
+        # This prevents file contamination where lockfiles include transitive dependencies
+        # that don't match the group pattern. We filter before file generation rather than
+        # after to ensure the FileUpdater only sees group-eligible dependencies.
+        group_eligible = filter_dependencies_for_group(dependencies, group, directory)
+
+        # Skip if no group-eligible dependencies remain
+        return nil if group_eligible.empty?
+
+        # Validate that the lead dependency wasn't filtered out
+        # If it was, we can't proceed since create_change_for requires a valid lead
+        unless group_eligible.include?(lead_dependency)
+          Dependabot.logger.info(
+            "Skipping update for #{lead_dependency.name}: lead dependency was filtered out"
+          )
+          return nil
+        end
+
+        group_eligible
+      end
+
       # Filters dependencies to only include those eligible for the given group.
       # Applies the same filtering logic as GroupDependencySelector:
       # 1. Group membership check (contains_dependency? or contains?)
@@ -743,39 +763,63 @@ module Dependabot
         ).returns(T::Array[Dependabot::Dependency])
       end
       def filter_dependencies_for_group(dependencies, group, directory)
+        group_eligible, filtered_out = partition_dependencies_by_group(dependencies, group, directory)
+        log_filtered_dependencies(filtered_out, group, directory) if filtered_out.any?
+        group_eligible
+      end
+
+      sig do
+        params(
+          dependencies: T::Array[Dependabot::Dependency],
+          group: Dependabot::DependencyGroup,
+          directory: String
+        ).returns([T::Array[Dependabot::Dependency], T::Array[Dependabot::Dependency]])
+      end
+      def partition_dependencies_by_group(dependencies, group, directory)
         group_eligible = T.let([], T::Array[Dependabot::Dependency])
         filtered_out = T.let([], T::Array[Dependabot::Dependency])
 
         dependencies.each do |dep|
-          if group_contains_dependency?(dep, directory, group) && allowed_by_job_config?(dep)
-            if dependency_belongs_to_more_specific_group?(dep, directory, group)
-              filtered_out << dep
-            else
-              group_eligible << dep
-            end
+          if dependency_eligible_for_group?(dep, directory, group)
+            group_eligible << dep
           else
             filtered_out << dep
           end
         end
 
-        # Log if we filtered out any dependencies (limit names to avoid log bloat)
-        if filtered_out.any?
-          names = filtered_out.map(&:name)
-          display_names = if names.length > MAX_DEPENDENCIES_TO_LOG
-                            "#{names.first(MAX_DEPENDENCIES_TO_LOG).join(', ')} " \
-                              "(and #{names.length - MAX_DEPENDENCIES_TO_LOG} more)"
-                          else
-                            names.join(', ')
-                          end
+        [group_eligible, filtered_out]
+      end
 
-          Dependabot.logger.info(
-            "[group=#{group.name}, directory=#{directory}] " \
-            "Filtered out #{filtered_out.length} non-group dependencies before file generation: " \
-            "#{display_names}"
-          )
-        end
+      sig { params(dep: Dependabot::Dependency, directory: String, group: Dependabot::DependencyGroup).returns(T::Boolean) }
+      def dependency_eligible_for_group?(dep, directory, group)
+        return false unless group_contains_dependency?(dep, directory, group)
+        return false unless allowed_by_job_config?(dep)
+        return false if dependency_belongs_to_more_specific_group?(dep, directory, group)
 
-        group_eligible
+        true
+      end
+
+      sig do
+        params(
+          filtered_out: T::Array[Dependabot::Dependency],
+          group: Dependabot::DependencyGroup,
+          directory: String
+        ).void
+      end
+      def log_filtered_dependencies(filtered_out, group, directory)
+        names = filtered_out.map(&:name)
+        display_names = if names.length > MAX_DEPENDENCIES_TO_LOG
+                          "#{names.first(MAX_DEPENDENCIES_TO_LOG).join(', ')} " \
+                            "(and #{names.length - MAX_DEPENDENCIES_TO_LOG} more)"
+                        else
+                          names.join(", ")
+                        end
+
+        Dependabot.logger.info(
+          "[group=#{group.name}, directory=#{directory}] " \
+          "Filtered out #{filtered_out.length} non-group dependencies before file generation: " \
+          "#{display_names}"
+        )
       end
 
       sig { params(dep: Dependabot::Dependency, directory: String, group: Dependabot::DependencyGroup).returns(T::Boolean) }
@@ -798,7 +842,7 @@ module Dependabot
       sig { params(dep: Dependabot::Dependency, directory: String, group: Dependabot::DependencyGroup).returns(T::Boolean) }
       def dependency_belongs_to_more_specific_group?(dep, directory, group)
         specificity_calculator = PatternSpecificityCalculator.new
-        
+
         # Helper to check if a group contains a dependency
         contains_checker = T.let(
           proc { |g, dependency, dir|
@@ -815,7 +859,7 @@ module Dependabot
           ).returns(T::Boolean)
         )
 
-        # Note: This doesn't include update_type or applies_to filtering like GroupDependencySelector
+        # NOTE: This doesn't include update_type or applies_to filtering like GroupDependencySelector
         # because we don't have access to the full update context here. This is a simplified version
         # that only checks group pattern specificity.
         specificity_calculator.dependency_belongs_to_more_specific_group?(

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -911,6 +911,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
     before do
       allow(job).to receive_messages(ignore_conditions_for: [], allowed_update?: true)
+      allow(dependency_snapshot).to receive(:groups).and_return([group])
     end
 
     it "filters out dependencies that don't match the group pattern" do

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -890,4 +890,58 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
       end
     end
   end
+
+  describe "#filter_dependencies_for_group" do
+    let(:vite_dependency) do
+      instance_double(Dependabot::Dependency, name: "vite", version: "4.0.0")
+    end
+
+    let(:react_dependency) do
+      instance_double(Dependabot::Dependency, name: "react", version: "18.0.0")
+    end
+
+    let(:group) do
+      Dependabot::DependencyGroup.new(
+        name: "vite-group",
+        rules: { "patterns" => ["vite*"] }
+      )
+    end
+
+    let(:directory) { "/" }
+
+    before do
+      allow(job).to receive_messages(ignore_conditions_for: [], allowed_update?: true)
+    end
+
+    it "filters out dependencies that don't match the group pattern" do
+      dependencies = [vite_dependency, react_dependency]
+      result = test_instance.send(:filter_dependencies_for_group, dependencies, group, directory)
+
+      expect(result).to eq([vite_dependency])
+      expect(result).not_to include(react_dependency)
+    end
+
+    it "returns all dependencies when all match the pattern" do
+      dependencies = [vite_dependency]
+      result = test_instance.send(:filter_dependencies_for_group, dependencies, group, directory)
+
+      expect(result).to eq([vite_dependency])
+    end
+
+    it "returns empty array when no dependencies match" do
+      dependencies = [react_dependency]
+      result = test_instance.send(:filter_dependencies_for_group, dependencies, group, directory)
+
+      expect(result).to eq([])
+    end
+
+    it "filters out dependencies not allowed by job config" do
+      dependencies = [vite_dependency]
+      allow(job).to receive(:allowed_update?).with(vite_dependency, check_previous_version: true).and_return(false)
+
+      result = test_instance.send(:filter_dependencies_for_group, dependencies, group, directory)
+
+      expect(result).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes an issue where multi-ecosystem grouped update PRs show different dependencies in the PR body versus the "Files changed" tab. Specifically, when a grouped update includes multiple package ecosystems (e.g., `vite` group with both `bundler` and `npm_and_yarn`), transitive dependencies that don't match the group pattern contaminate the lockfile diffs even though they don't appear in the PR body.

**Root Cause:** The `GroupDependencySelector` filtering happens AFTER file generation. The flow is:
1. `compile_updates_for` calls `update_checker.updated_dependencies(:all)` which returns ALL transitive dependencies
2. `create_change_for` → `DependencyChangeBuilder` generates lockfiles including ALL dependencies
3. `GroupDependencySelector#filter_to_group!` filters the dependency list but NOT the already-generated files

**Solution:** Filter dependencies BEFORE passing to `create_change_for` so `FileUpdater` only sees group-eligible dependencies.

### Anything you want to highlight for special attention from reviewers?

The implementation follows the existing `GroupDependencySelector` patterns closely:
- Uses the same filtering logic (`group_contains_dependency?` + `allowed_by_job_config?`)
- Handles both the new `contains_dependency?(dep, directory:)` and legacy `contains?(dep)` APIs
- Added to `Sorbet/ForbidTUnsafe` exclusion list (same as `GroupDependencySelector`) because we need `T.unsafe` for the polymorphic group API

**Directory default:** Uses `"."` to match `GroupDependencySelector` line 202, not `"/"`.

### How will you know you've accomplished your goal?

**Manual verification:** Can be tested with a multi-ecosystem grouped update (e.g., `vite` group including both bundler and npm dependencies) to verify that only group-matching dependencies appear in both the PR body AND the file diffs.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
