### PR TITLE
fix(go_modules): include advisory pseudo-version boundaries for security fix resolution

### DIFF
--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -253,6 +253,11 @@ module Dependabot
         def fetch_lowest_security_fix_version(language_version: nil)
           relevant_versions = available_versions_details
           relevant_versions = filter_prerelease_versions(relevant_versions)
+          # Add pseudo-versions from advisory boundaries after the prerelease filter.
+          # The Go proxy only indexes tagged releases, so commit-based pseudo-version
+          # fix boundaries won't appear in the version list. They're not traditional
+          # prereleases and must always be considered as candidates.
+          relevant_versions += pseudo_versions_from_advisory_boundaries
           relevant_versions = Dependabot::UpdateCheckers::VersionFilters.filter_vulnerable_versions(
             relevant_versions,
             security_advisories
@@ -263,6 +268,34 @@ module Dependabot
           relevant_versions.min_by(&:version)&.version
         end
         # rubocop:enable Lint/UnusedMethodArgument
+
+        # When an advisory's fix boundary is a pseudo-version (e.g. "< 2.3.1-0.20260320110106-0b84568fffcc"),
+        # the Go module proxy won't include it in its version list. Extract those pseudo-versions
+        # from the advisory requirement strings so they can be considered as fix candidates.
+        # Only pseudo-versions strictly greater than the current version are returned to avoid
+        # unnecessary processing of versions that would be discarded by filter_lower_versions anyway.
+        sig { returns(T::Array[Dependabot::Package::PackageRelease]) }
+        def pseudo_versions_from_advisory_boundaries
+          current = dependency.numeric_version
+
+          security_advisories.flat_map do |advisory|
+            advisory.vulnerable_version_strings.filter_map do |req_string|
+              # Parse requirement strings like "< 2.3.1-0.20260320110106-0b84568fffcc"
+              # to extract the version that represents the fix boundary.
+              version_str = req_string.to_s.gsub(/\A\s*[<>=!]+\s*v?/, "").strip
+              next unless PSEUDO_VERSION_REGEX.match?(version_str)
+              next unless version_class.correct?(version_str)
+
+              candidate = version_class.new(version_str)
+              next if current && candidate <= current
+
+              Dependabot::Package::PackageRelease.new(
+                version: candidate,
+                details: { "version_string" => version_str }
+              )
+            end
+          end
+        end
 
         sig { returns(T::Boolean) }
         def wants_prerelease?

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -279,22 +279,25 @@ module Dependabot
           current = dependency.numeric_version
 
           security_advisories.flat_map do |advisory|
-            advisory.vulnerable_version_strings.filter_map do |req_string|
-              # Parse requirement strings like "< 2.3.1-0.20260320110106-0b84568fffcc"
-              # to extract the version that represents the fix boundary.
-              version_str = req_string.to_s.gsub(/\A\s*[<>=!]+\s*v?/, "").strip
-              next unless PSEUDO_VERSION_REGEX.match?(version_str)
-              next unless version_class.correct?(version_str)
+            advisory.vulnerable_version_strings.flat_map do |req_string|
+              # Parse each constraint in requirement strings like
+              # ">= 1.1.0, < 2.3.1-0.20260320110106-0b84568fffcc" and extract
+              # any pseudo-version boundary that represents a possible fix.
+              req_string.to_s.split(",").filter_map do |constraint|
+                version_str = constraint.gsub(/\A\s*[<>=!~^]+\s*v?/, "").strip
+                next unless PSEUDO_VERSION_REGEX.match?(version_str)
+                next unless version_class.correct?(version_str)
 
-              candidate = version_class.new(version_str)
-              next if current && candidate <= current
+                candidate = version_class.new(version_str)
+                next if current && candidate <= current
 
-              Dependabot::Package::PackageRelease.new(
-                version: candidate,
-                details: { "version_string" => version_str }
-              )
+                Dependabot::Package::PackageRelease.new(
+                  version: candidate,
+                  details: { "version_string" => version_str }
+                )
+              end
             end
-          end
+          end.uniq(&:version)
         end
 
         sig { returns(T::Boolean) }

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -576,5 +576,23 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
           .to eq(Dependabot::GoModules::Version.new(fix_pseudo_version))
       end
     end
+
+    context "when the advisory boundary is a pseudo-version in a multi-constraint range" do
+      let(:fix_pseudo_version) { "1.2.1-0.20260320110106-0b84568fffcc" }
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency_name,
+            package_manager: "go_modules",
+            vulnerable_versions: [">= 0, < #{fix_pseudo_version}"]
+          )
+        ]
+      end
+
+      it "returns the pseudo-version from the upper bound as the fix version" do
+        expect(finder.lowest_security_fix_version)
+          .to eq(Dependabot::GoModules::Version.new(fix_pseudo_version))
+      end
+    end
   end
 end

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -554,5 +554,27 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
         expect(finder.lowest_security_fix_version).not_to eq(Dependabot::GoModules::Version.new("1.2.0-pre2"))
       end
     end
+
+    context "when the advisory boundary is a pseudo-version not listed by the Go proxy" do
+      # The Go proxy only indexes tagged releases. When an advisory references a pseudo-version
+      # as the fix boundary (e.g. "< 1.2.1-0.20260320110106-0b84568fffcc"), the pseudo-version
+      # will not appear in the proxy's version list. In this case all proxy versions are still
+      # vulnerable, and Dependabot must surface the pseudo-version from the advisory itself.
+      let(:fix_pseudo_version) { "1.2.1-0.20260320110106-0b84568fffcc" }
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency_name,
+            package_manager: "go_modules",
+            vulnerable_versions: ["< #{fix_pseudo_version}"]
+          )
+        ]
+      end
+
+      it "returns the pseudo-version from the advisory boundary as the fix version" do
+        expect(finder.lowest_security_fix_version)
+          .to eq(Dependabot::GoModules::Version.new(fix_pseudo_version))
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes a false “no allowed non-vulnerable version” outcome for Go module security updates when the advisory boundary is a pseudo-version.

Dependabot currently relies on versions returned by the Go proxy, but proxy listings only include tagged releases and can omit pseudo-version boundaries used in advisories. In those cases, security fix resolution can fail even when the advisory itself provides a valid fix boundary.

The approach is to treat advisory pseudo-version boundaries as explicit fix candidates during lowest security fix calculation, while keeping the existing filtering semantics intact. To keep this efficient, only advisory-derived pseudo-versions greater than the current dependency version are considered. This preserves behavior for normal tagged flows, resolves pseudo-version-only advisory cases, and avoids unnecessary extra processing.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

I validated the fix by reproducing the issue in this workflow run: 
https://github.com/thavaahariharangit/tspascoal-repro-go-hydra/actions/runs/26890304695/job/79314108617

Before the fix, Dependabot could not resolve a non-vulnerable version:
```
updater | 2026/06/03 14:09:36 INFO <job_1395222632> The latest possible version of github.com/ory/hydra/v2 that can be installed is 2.1.0-pre.2
2026/06/03 14:09:36 INFO <job_1395222632> Dependabot could not find an allowed non-vulnerable version
```

After the fix, Dependabot successfully created an update PR to a valid pseudo-version security fix:
```
updater | +-----------------------------------------------------------------------------------------------+
updater | |                              Changes to Dependabot Pull Requests                              |
updater | +---------+-------------------------------------------------------------------------------------+
updater | | created | github.com/ory/hydra/v2 ( from 2.1.0-pre.2 to 2.3.1-0.20260320110106-0b84568fffcc ) |
updater | +---------+-------------------------------------------------------------------------------------+
```


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
