### PR TITLE
Fix Gradle/Maven prerelease detection gaps

### DIFF
--- a/gradle/lib/dependabot/gradle/version.rb
+++ b/gradle/lib/dependabot/gradle/version.rb
@@ -25,12 +25,15 @@ module Dependabot
         T::Hash[String, T::Hash[Symbol, Integer]]
       )
       NAMED_QUALIFIERS_HIERARCHY = T.let(
+        # Pragmatic (not spec-exact) ranking; preview≈rc, experimental/unstable≈alpha.
         {
+          "dev" => 0,
           "a" => 1, "alpha" => 1,
-          "b" => 2, "beta"      => 2,
+          "experimental" => 1, "unstable" => 1,
+          "b" => 2, "beta" => 2,
           "m" => 3, "milestone" => 3,
-          "rc" => 4, "cr" => 4, "pr" => 4, "pre" => 4,
-          "snapshot" => 5, "dev" => 5,
+          "rc" => 4, "cr" => 4, "pr" => 4, "pre" => 4, "preview" => 4,
+          "snapshot" => 5,
           "ga" => 6, "" => 6, "final" => 6,
           "sp" => 7
         }.freeze,

--- a/gradle/spec/dependabot/gradle/version_spec.rb
+++ b/gradle/spec/dependabot/gradle/version_spec.rb
@@ -127,6 +127,24 @@ RSpec.describe Dependabot::Gradle::Version do
 
       it { is_expected.to be(true) }
     end
+
+    context "with a preview token" do
+      let(:version_string) { "1.0.0-preview" }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with an experimental token" do
+      let(:version_string) { "1.0.0-experimental" }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with an unstable token" do
+      let(:version_string) { "1.0.0-unstable" }
+
+      it { is_expected.to be(true) }
+    end
   end
 
   describe "#<=>" do
@@ -194,6 +212,13 @@ RSpec.describe Dependabot::Gradle::Version do
         let(:other_version) { described_class.new("1.0.0a1") }
 
         it { is_expected.to eq(1) }
+      end
+
+      context "when comparing dev to alpha (dev < alpha)" do
+        let(:version) { described_class.new("1.0.0-dev1") }
+        let(:other_version) { described_class.new("1.0.0-alpha1") }
+
+        it { is_expected.to eq(-1) }
       end
 
       context "when the other version is non-numeric" do

--- a/maven/lib/dependabot/maven/shared/shared_version_finder.rb
+++ b/maven/lib/dependabot/maven/shared/shared_version_finder.rb
@@ -26,23 +26,19 @@ module Dependabot
         /ix
 
         # Common Maven pre-release qualifiers.
-        # They often indicate versions that are not yet stable but that are released to the public for testing.
+        # Indicate versions not yet stable but released for testing.
         # Examples: 1.0.0-RC1, 2.0.0-ALPHA2, 3.1.0-BETA, 4.0.0-DEV5, etc.
         # See https://maven.apache.org/guides/mini/guide-naming-conventions.html#version-identifier
         MAVEN_PRE_RELEASE_QUALIFIERS = /
             # Must be at start OR preceded by a delimiter
             (?: \A | [-._])(
-              # --- Qualifiers that usually REQUIRE a number ---
-              # Examples: "RC1", "BETA2", "M3", "ALPHA-1", "EAP.2"
-              # The number differentiates multiple pre-releases; a version like "1.0.0-RC"
-              (?i)(?:RC|CR|M|MILESTONE|ALPHA|BETA|EA|EAP)(?:[-._]?\d+)?
-              |
-              # --- Qualifiers that do NOT usually have numbers ---
-              DEV|
-              PREVIEW|
-              PRERELEASE|
-              EXPERIMENTAL|
-              UNSTABLE
+              # Pre-release qualifiers, each with an optional numeric suffix
+              # (e.g., RC1, BETA2, DEV, PREVIEW1)
+              (?:
+                RC | CR | M | MILESTONE | ALPHA | BETA | EA | EAP |
+                DEV | PREVIEW | PRERELEASE | EXPERIMENTAL | UNSTABLE
+              )
+              (?:[-._]?\d+)?
             )$
           /ix
 
@@ -109,9 +105,17 @@ module Dependabot
 
         sig { returns(T::Boolean) }
         def wants_prerelease?
-          return false unless dependency.numeric_version
+          return true if dependency.numeric_version&.prerelease?
 
-          dependency.numeric_version&.prerelease? || false
+          dependency.requirements.any? do |req|
+            req_string = T.cast(req.fetch(:requirement), T.nilable(String)).to_s
+            req_string.split(",").any? do |segment|
+              normalized = segment.strip.gsub(/\A[\[\(]\s*/, "")
+                                  .gsub(/\s*[\]\)]\z/, "")
+              normalized.match?(MAVEN_PRE_RELEASE_QUALIFIERS) ||
+                normalized.match?(MAVEN_SNAPSHOT_QUALIFIER)
+            end
+          end
         end
 
         sig { returns(T::Boolean) }

--- a/maven/spec/dependabot/maven/shared/shared_version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_version_finder_spec.rb
@@ -813,6 +813,156 @@ RSpec.describe Dependabot::Maven::Shared::SharedVersionFinder do
 
       it { is_expected.to be false }
     end
+
+    context "when the dependency has no version but requirements reference a prerelease" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "1.0.0-alpha1",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the dependency is stable but requirements reference a prerelease" do
+      let(:dependency_version) { "1.0.0" }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "1.0.0-beta1",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the requirement contains a numbered DEV qualifier" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "1.0.0-DEV5",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the requirement contains a numbered PREVIEW qualifier" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "1.0.0-PREVIEW1",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the requirement contains a numbered EXPERIMENTAL qualifier" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "1.0.0-EXPERIMENTAL2",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the requirement contains a dot-separated number qualifier" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "1.0.0-DEV.5",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the requirement contains a stable version" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "1.0.0",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when the requirement contains a RELEASE qualifier" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "1.0.0.RELEASE",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when the requirement is a Maven range with brackets containing a prerelease" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "[1.0.0-alpha1, 2.0.0)",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the requirement contains a SNAPSHOT qualifier" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "pom.xml",
+          requirement: "1.0.0-SNAPSHOT",
+          groups: [],
+          source: nil,
+          metadata: { packaging_type: "jar" }
+        }]
+      end
+
+      it { is_expected.to be true }
+    end
   end
 
   describe "#wants_date_based_version?" do


### PR DESCRIPTION
### What are you trying to accomplish?

As part of the epic #6508, found gaps in prerelease detection applicable to the Gradle/Maven ecosystem. This PR fixes 4 behavioral gaps in the version hierarchy and shared version finder.

<!-- What issues does this affect or fix? -->

## Fixes Applied (4 files, 4 gaps)

### Gap 1: `dev` ordering → `gradle/version.rb`

- **Fix**: `"dev" => 0` (was 5, same as snapshot). Now correctly sorts below alpha per Maven spec.
- **Safe**: `dev` is still detected as prerelease (0 < 6). Ordering now matches upstream.

### Gap 2: Extended qualifiers not detected → `gradle/version.rb`

- **Fix**: Added `"experimental" => 1`, `"unstable" => 1`, `"preview" => 4` to `NAMED_QUALIFIERS_HIERARCHY`.
- **Safe**: Pragmatic additions matching real-world Gradle packages (e.g., Kotlin `-experimental`, Jetpack Compose `-dev`, gRPC `-preview`). Now `Version#prerelease?` correctly identifies these qualifiers.

### Gap 3: Numbered variants not matched → `maven/shared/shared_version_finder.rb`

- **Fix**: Consolidated all qualifiers into one regex group with optional `(?:[-._]?\d+)?`. Now `DEV5`, `PREVIEW1`, `EXPERIMENTAL2` all match.
- **Safe**: Existing qualifiers (RC, ALPHA, etc.) unchanged. Purely additive.

### Gap 4: `wants_prerelease?` doesn't scan requirements → `maven/shared/shared_version_finder.rb`

- **Fix**: Rewrote to scan requirement strings (with bracket stripping for Maven ranges like `[1.0.0-alpha1, 2.0.0)`) using `MAVEN_PRE_RELEASE_QUALIFIERS` regex.
- **Safe**: Avoids `super` (which can raise on malformed versions). Uses the already-proven regex. Works for both nil and stable current versions.

## Not Fixed (intentionally excluded)

### Gap 5: `VERSION_PATTERN` too permissive

- Accepts malformed shapes like `1.`, `1..2`, empty strings. Higher risk to tighten. 

### References
- https://maven.apache.org/pom.html#Version_Order_Specification
- https://github.com/apache/maven/blob/master/compat/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java
- https://docs.gradle.org/current/userguide/single_versions.html

***Code references***
- `gradle/lib/dependabot/gradle/version.rb:27-40` (NAMED_QUALIFIERS_HIERARCHY)
- `maven/lib/dependabot/maven/shared/shared_version_finder.rb:32-44` (MAVEN_PRE_RELEASE_QUALIFIERS)
- `maven/lib/dependabot/maven/shared/shared_version_finder.rb:107-118` (wants_prerelease?)

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.