### PR TITLE
Add an experimental GitHub Action summary for graph jobs

### DIFF
--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -48,7 +48,10 @@ module Dependabot
       # Ensure that we shut down the open telemetry exporter.
       ::Dependabot::OpenTelemetry.shutdown
       Dependabot.logger.formatter = Dependabot::Logger::BasicFormatter.new
+      # Append summary to logs
       Dependabot.logger.info(service.summary) unless service.noop?
+      # Write a summary.md file if we are running in Actions
+      service.write_workflow_summary(command: job.command, package_manager: job.package_manager)
       raise Dependabot::RunFailure if Dependabot::Environment.github_actions? && service.failure?
     end
 

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -138,6 +138,8 @@ module Dependabot
     # This method writes the information into a collection we can use to generate a summary markdown file in actions
     sig { params(directory: String, status: String, details: String).void }
     def record_workflow_result(directory:, status:, details:)
+      return unless Experiments.enabled?(:workflow_job_summaries)
+
       workflow_summary.record_result(directory: directory, status: status, details: details)
     end
 

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -135,11 +135,13 @@ module Dependabot
       client.create_dependency_submission(dependency_submission.payload)
     end
 
+    # This method writes the information into a collection we can use to generate a summary markdown file in actions
     sig { params(directory: String, status: String, details: String).void }
     def record_workflow_result(directory:, status:, details:)
       workflow_summary.record_result(directory: directory, status: status, details: details)
     end
 
+    # This method finalises the workflow summary and stores it in an output file
     sig { params(command: String, package_manager: String).void }
     def write_workflow_summary(command:, package_manager:)
       workflow_summary.write(command: command, package_manager: package_manager)

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -9,6 +9,7 @@ require "dependabot/api_client"
 require "dependabot/errors"
 require "dependabot/opentelemetry"
 require "dependabot/experiments"
+require "dependabot/workflow_summary"
 
 # This class provides an output adapter for the Dependabot Service which manages
 # communication with the private API as well as consolidated error handling.
@@ -27,12 +28,16 @@ module Dependabot
     sig { returns(T::Array[T::Array[T.untyped]]) }
     attr_reader :errors
 
+    sig { returns(Dependabot::WorkflowSummary) }
+    attr_reader :workflow_summary
+
     sig { params(client: Dependabot::ApiClient).void }
     def initialize(client:)
       @client = client
       @pull_requests = T.let([], T::Array[T.untyped])
       @errors = T.let([], T::Array[T.untyped])
       @threads = T.let([], T::Array[T.untyped])
+      @workflow_summary = T.let(Dependabot::WorkflowSummary.new, Dependabot::WorkflowSummary)
     end
 
     def_delegators :client,
@@ -128,6 +133,16 @@ module Dependabot
     sig { params(dependency_submission: GithubApi::DependencySubmission).void }
     def create_dependency_submission(dependency_submission:)
       client.create_dependency_submission(dependency_submission.payload)
+    end
+
+    sig { params(directory: String, status: String, details: String).void }
+    def record_workflow_result(directory:, status:, details:)
+      workflow_summary.record_result(directory: directory, status: status, details: details)
+    end
+
+    sig { params(command: String, package_manager: String).void }
+    def write_workflow_summary(command:, package_manager:)
+      workflow_summary.write(command: command, package_manager: package_manager)
     end
 
     # This method wraps the Sentry client as the Application error tracker

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -56,6 +56,13 @@ module Dependabot
         # block the overall job.
         process_directory(branch:, directory:)
       end
+    rescue StandardError => e
+      service.record_workflow_result(
+        directory: "(unknown)",
+        status: "Failed",
+        details: "unexpected error: #{e.class}"
+      )
+      raise
     end
 
     private
@@ -76,7 +83,7 @@ module Dependabot
     attr_reader :error_handler
 
     sig { params(branch: String, directory: String).void }
-    def process_directory(branch:, directory:) # rubocop:disable Metrics/MethodLength
+    def process_directory(branch:, directory:) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
       directory_source = create_source_for(directory)
       directory_dependency_files = dependency_files_for(directory)
 
@@ -93,6 +100,8 @@ module Dependabot
 
       Dependabot.logger.info("Dependency submission payload:\n#{JSON.pretty_generate(submission.payload)}")
       service.create_dependency_submission(dependency_submission: submission)
+
+      record_workflow_result(directory, submission.status, submission.reason || submission.resolved_dependencies.size)
     rescue Dependabot::UnexpectedExternalCode
       # If this has been raised, then the directory is trying to use a private registry with an ecosystem
       # that requires the `insecure-external-code-execution: allow` flag.
@@ -123,6 +132,20 @@ module Dependabot
           "unexpected_external_code"
         )
       )
+
+      # TODO: DRY out error message/logging
+      record_workflow_result(
+        directory,
+        GithubApi::DependencySubmission::SnapshotStatus::FAILED,
+        <<~ERR
+            Dependabot refused to execute external code
+
+            This directory is configured to use a private registry but does not allow insecure code execution via your Dependabot configuration.
+
+            Please set `insecure-external-code-execution: allow` in the config if you trust your dependencies'
+          supply chain or remove the private registry from this directory.
+        ERR
+      )
     rescue Dependabot::ApiError, Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
       # If the submission API is down, we should raise this as a specific error type for visibility.
       error_handler.handle_job_error(
@@ -130,14 +153,25 @@ module Dependabot
           "Unable to submit data to the Dependency Snapshot API"
         )
       )
+      record_workflow_result(
+        directory,
+        GithubApi::DependencySubmission::SnapshotStatus::FAILED,
+        "Unable to submit data to the Dependency Snapshot API"
+      )
     rescue Dependabot::DependabotError => e
       error_handler.handle_job_error(error: e)
+
+      error_details = Dependabot.updater_error_details(e) || { "error-type": "unknown_error" }
+      record_workflow_result(
+        directory,
+        GithubApi::DependencySubmission::SnapshotStatus::FAILED,
+        error_details.fetch(:"error-type")
+      )
 
       # If we are not running in Actions, there's nothing more to do.
       return unless Dependabot::Environment.github_actions?
 
       # Send an empty submission so the snapshot service has a record that the job id has been completed.
-      error_details = Dependabot.updater_error_details(e) || { "error-type": "unknown_error" }
       empty_submission = empty_submission(
         branch,
         T.must(directory_source),
@@ -262,6 +296,38 @@ module Dependabot
           )
           branch.strip.sub("origin/", "refs/heads/")
         end
+      end
+    end
+
+    sig do
+      params(
+        directory: String,
+        status: GithubApi::DependencySubmission::SnapshotStatus,
+        details: T.any(String, Integer)
+      ).void
+    end
+    def record_workflow_result(directory, status, details)
+      detail_str = if details.is_a?(Integer)
+                     "#{details} dependencies"
+                   else
+                     details
+                   end
+
+      service.record_workflow_result(
+        directory: directory,
+        status: status_label(status),
+        details: detail_str
+      )
+    end
+
+    sig { params(status: GithubApi::DependencySubmission::SnapshotStatus).returns(String) }
+    def status_label(status)
+      case status.serialize
+      when "ok" then "Success"
+      when "degraded" then "Degraded"
+      when "failed" then "Failed"
+      when "skipped" then "Skipped"
+      else status.serialize
       end
     end
   end

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -19,6 +19,14 @@ module Dependabot
   class UpdateGraphProcessor
     extend T::Sig
 
+    UNEXPECTED_EXTERNAL_CODE_MESSAGE = <<~MSG
+      Dependabot refused to execute external code
+
+      This directory is configured to use a private registry but does not allow insecure code execution via your Dependabot configuration.
+
+      Please set `insecure-external-code-execution: allow` in the config if you trust your dependencies' supply chain or remove the private registry from this directory.
+    MSG
+
     # To do work, this class needs three arguments:
     # - The Dependabot::Service to send events and outcomes to
     # - The Dependabot::Job that describes the work to be done
@@ -109,14 +117,7 @@ module Dependabot
       # The default policy is denied, so this outcome represents a misconfiguration for the directory.
       # We should record this failure and allow other directories in the job to continue, as they may
       # not be misconfigured.
-      Dependabot.logger.info(<<~LOG)
-        Skipping directory #{directory} — Dependabot refused to execute external code
-
-        This directory is configured to use a private registry but does not allow insecure code execution via your Dependabot configuration.
-
-        Please set `insecure-external-code-execution: allow` in the config if you trust your dependencies'
-        supply chain or remove the private registry from this directory.
-      LOG
+      Dependabot.logger.info("Skipping directory #{directory} — #{UNEXPECTED_EXTERNAL_CODE_MESSAGE}")
       service.record_update_job_error(
         error_type: "unexpected_external_code",
         error_details: { message: "Cannot process directory #{directory} without external code execution" }
@@ -133,18 +134,10 @@ module Dependabot
         )
       )
 
-      # TODO: DRY out error message/logging
       record_workflow_result(
         directory,
         GithubApi::DependencySubmission::SnapshotStatus::FAILED,
-        <<~ERR
-            Dependabot refused to execute external code
-
-            This directory is configured to use a private registry but does not allow insecure code execution via your Dependabot configuration.
-
-            Please set `insecure-external-code-execution: allow` in the config if you trust your dependencies'
-          supply chain or remove the private registry from this directory.
-        ERR
+        UNEXPECTED_EXTERNAL_CODE_MESSAGE
       )
     rescue Dependabot::ApiError, Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
       # If the submission API is down, we should raise this as a specific error type for visibility.
@@ -161,15 +154,15 @@ module Dependabot
     rescue Dependabot::DependabotError => e
       error_handler.handle_job_error(error: e)
 
+      # If we are not running in Actions, there's nothing more to do.
+      return unless Dependabot::Environment.github_actions?
+
       error_details = Dependabot.updater_error_details(e) || { "error-type": "unknown_error" }
       record_workflow_result(
         directory,
         GithubApi::DependencySubmission::SnapshotStatus::FAILED,
-        error_details.fetch(:"error-type")
+        error_details.dig(:"error-detail", "message") || "An unknown error occurred, please check the logs for details."
       )
-
-      # If we are not running in Actions, there's nothing more to do.
-      return unless Dependabot::Environment.github_actions?
 
       # Send an empty submission so the snapshot service has a record that the job id has been completed.
       empty_submission = empty_submission(

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -109,7 +109,11 @@ module Dependabot
       Dependabot.logger.info("Dependency submission payload:\n#{JSON.pretty_generate(submission.payload)}")
       service.create_dependency_submission(dependency_submission: submission)
 
-      record_workflow_result(directory, submission.status, submission.reason || submission.resolved_dependencies.size)
+      record_workflow_result(
+        directory,
+        submission.status,
+        "Found #{submission.resolved_dependencies.size} dependencies"
+      )
     rescue Dependabot::UnexpectedExternalCode
       # If this has been raised, then the directory is trying to use a private registry with an ecosystem
       # that requires the `insecure-external-code-execution: allow` flag.
@@ -146,6 +150,7 @@ module Dependabot
           "Unable to submit data to the Dependency Snapshot API"
         )
       )
+
       record_workflow_result(
         directory,
         GithubApi::DependencySubmission::SnapshotStatus::FAILED,
@@ -264,6 +269,14 @@ module Dependabot
         warn_title: "dependency graph incomplete",
         warn_description: "The dependency graph may be incomplete. #{error_message}"
       )
+
+      service.record_workflow_result(
+        directory: T.must(source.directory),
+        status: GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.to_s,
+        details: <<~MSG
+          The dependency graph may be incomplete: #{error_message}
+        MSG
+      )
     end
 
     sig { params(error: T.nilable(StandardError), source: Dependabot::Source).void }
@@ -296,20 +309,14 @@ module Dependabot
       params(
         directory: String,
         status: GithubApi::DependencySubmission::SnapshotStatus,
-        details: T.any(String, Integer)
+        details: String
       ).void
     end
     def record_workflow_result(directory, status, details)
-      detail_str = if details.is_a?(Integer)
-                     "#{details} dependencies"
-                   else
-                     details
-                   end
-
       service.record_workflow_result(
         directory: directory,
         status: status_label(status),
-        details: detail_str
+        details: details
       )
     end
 

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -163,10 +163,11 @@ module Dependabot
       return unless Dependabot::Environment.github_actions?
 
       error_details = Dependabot.updater_error_details(e) || { "error-type": "unknown_error" }
+      detail_message = error_details.dig(:"error-detail", :message)
       record_workflow_result(
         directory,
         GithubApi::DependencySubmission::SnapshotStatus::FAILED,
-        error_details.dig(:"error-detail", "message") || "An unknown error occurred, please check the logs for details."
+        detail_message.is_a?(String) ? detail_message : "An unknown error occurred, please check the logs for details."
       )
 
       # Send an empty submission so the snapshot service has a record that the job id has been completed.

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -67,7 +67,7 @@ module Dependabot
     rescue StandardError => e
       service.record_workflow_result(
         directory: "(unknown)",
-        status: "Failed",
+        status: GithubApi::DependencySubmission::SnapshotStatus::FAILED.serialize,
         details: "unexpected error: #{e.class}"
       )
       raise
@@ -273,7 +273,7 @@ module Dependabot
 
       service.record_workflow_result(
         directory: T.must(source.directory),
-        status: GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.to_s,
+        status: GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.serialize,
         details: <<~MSG
           The dependency graph may be incomplete: #{error_message}
         MSG
@@ -316,20 +316,9 @@ module Dependabot
     def record_workflow_result(directory, status, details)
       service.record_workflow_result(
         directory: directory,
-        status: status_label(status),
+        status: status.serialize,
         details: details
       )
-    end
-
-    sig { params(status: GithubApi::DependencySubmission::SnapshotStatus).returns(String) }
-    def status_label(status)
-      case status.serialize
-      when "ok" then "Success"
-      when "degraded" then "Degraded"
-      when "failed" then "Failed"
-      when "skipped" then "Skipped"
-      else status.serialize
-      end
     end
   end
 end

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -39,7 +39,6 @@ module Dependabot
       return unless Dependabot::Environment.github_actions?
 
       path = summary_path
-      return unless path
 
       if @results.empty?
         # Ensure we write an empty file even if no summary is required

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -1,0 +1,101 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/environment"
+
+module Dependabot
+  # Builds and writes a GitHub Actions Job Summary markdown file.
+  # The summary is written to the output directory where it can be extracted
+  # by the dependabot-action and appended to $GITHUB_STEP_SUMMARY.
+  class WorkflowSummary
+    extend T::Sig
+
+    SUMMARY_FILENAME = "summary.md"
+
+    class DirectoryResult < T::Struct
+      const :directory, String
+      const :status, String
+      const :details, String
+    end
+
+    sig { void }
+    def initialize
+      @results = T.let([], T::Array[DirectoryResult])
+    end
+
+    sig { params(directory: String, status: String, details: String).void }
+    def record_result(directory:, status:, details:)
+      @results << DirectoryResult.new(
+        directory: directory,
+        status: status,
+        details: details
+      )
+    end
+
+    sig { params(command: String, package_manager: String).void }
+    def write(command:, package_manager:)
+      return unless Dependabot::Environment.github_actions?
+
+      path = summary_path
+      return unless path
+
+      if @results.empty?
+        # Ensure we write an empty file even if no summary is required
+        File.write(path, "")
+        return
+      end
+
+      markdown = build_markdown(command: command, package_manager: package_manager)
+      File.write(path, markdown)
+      Dependabot.logger.info("Workflow summary written to #{path}")
+    end
+
+    sig { params(command: String, package_manager: String).returns(String) }
+    def build_markdown(command:, package_manager:)
+      lines = []
+      lines << "## #{heading(command: command, package_manager: package_manager)}"
+      lines << ""
+      lines << "| Directory | Status | Details |"
+      lines << "|-----------|--------|---------|"
+
+      @results.each do |result|
+        status_icon = status_emoji(result.status)
+        # Ensure we render any line breaks in longer detail messages.
+        sanitized_details = result.details.strip.gsub(/\s*\n\s*/, "<br>")
+        lines << "| `#{result.directory}` | #{status_icon} #{result.status} | #{sanitized_details} |"
+      end
+
+      lines << ""
+      lines.join("\n")
+    end
+
+    private
+
+    sig { params(command: String, package_manager: String).returns(String) }
+    def heading(command:, package_manager:)
+      job_type = command == "graph" ? "Dependency Graph Snapshot" : "Dependency Update"
+      "#{job_type} — #{package_manager}"
+    end
+
+    sig { returns(T.nilable(String)) }
+    def summary_path
+      output_path = Dependabot::Environment.output_path
+      File.join(File.dirname(output_path), SUMMARY_FILENAME)
+    rescue StandardError
+      nil
+    end
+
+    sig { params(status: String).returns(String) }
+    def status_emoji(status)
+      case status.downcase
+      when "success" then "✅"
+      when "degraded" then "⚠️"
+      when "failed" then "❌"
+      when "skipped" then "⏭️"
+      else "❓"
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -60,7 +60,7 @@ module Dependabot
       lines << "| Directory | Status | Details |"
       lines << "|-----------|--------|---------|"
 
-      @results.each do |result|
+      @results.sort_by(&:directory).each do |result|
         status_icon = status_emoji(result.status)
         # Ensure we render any line breaks in longer detail messages.
         sanitized_details = result.details.strip.gsub(/\s*\n\s*/, "<br>")
@@ -91,7 +91,7 @@ module Dependabot
     def status_emoji(status)
       case status.downcase
       when "success" then "✅"
-      when "degraded" then "⚠️"
+      when "degraded", "warning" then "⚠️"
       when "failed" then "❌"
       when "skipped" then "⏭️"
       else "❓"

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -60,11 +60,20 @@ module Dependabot
       lines << "| Directory | Status | Details |"
       lines << "|-----------|--------|---------|"
 
-      @results.sort_by(&:directory).each do |result|
-        status_icon = status_emoji(result.status)
-        # Ensure we render any line breaks in longer detail messages.
-        sanitized_details = result.details.strip.gsub(/\s*\n\s*/, "<br>")
-        lines << "| `#{result.directory}` | #{status_icon} #{result.status} | #{sanitized_details} |"
+      last_directory = T.let("", String)
+      @results.sort_by { |r| [r.directory, r.status] }
+              .group_by { |r| [r.directory, r.status] }
+              .each_value do |results|
+        results.each_with_index do |result, index|
+          sanitized_details = result.details.strip.gsub(/\s*\n\s*/, "<br>")
+          status_icon = status_emoji(result.status)
+
+          dir_cell = result.directory == last_directory ? "" : "`#{result.directory}`"
+          status_cell = index.zero? ? "#{status_icon} #{result.status}" : ""
+
+          lines << "| #{dir_cell} | #{status_cell} | #{sanitized_details} |"
+          last_directory = result.directory
+        end
       end
 
       lines << ""

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -69,7 +69,7 @@ module Dependabot
           status_icon = status_emoji(result.status)
 
           dir_cell = result.directory == last_directory ? "" : "`#{result.directory}`"
-          status_cell = index.zero? ? "#{status_icon} #{result.status}" : ""
+          status_cell = index.zero? ? "#{status_icon} #{result.status.capitalize}" : ""
 
           lines << "| #{dir_cell} | #{status_cell} | #{sanitized_details} |"
           last_directory = result.directory
@@ -99,7 +99,7 @@ module Dependabot
     sig { params(status: String).returns(String) }
     def status_emoji(status)
       case status.downcase
-      when "success" then "✅"
+      when "ok" then "✅"
       when "degraded", "warning" then "⚠️"
       when "failed" then "❌"
       when "skipped" then "⏭️"

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -88,12 +88,10 @@ module Dependabot
       "#{job_type} — #{package_manager}"
     end
 
-    sig { returns(T.nilable(String)) }
+    sig { returns(String) }
     def summary_path
       output_path = Dependabot::Environment.output_path
       File.join(File.dirname(output_path), SUMMARY_FILENAME)
-    rescue StandardError
-      nil
     end
 
     sig { params(status: String).returns(String) }

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -773,11 +773,30 @@ RSpec.describe Dependabot::Service do
   end
 
   describe "#record_workflow_result" do
-    it "delegates to the workflow_summary instance" do
-      service.record_workflow_result(directory: "/app", status: "Success", details: "5 dependencies")
+    context "when workflow_job_summaries experiment is enabled" do
+      before do
+        Dependabot::Experiments.register(:workflow_job_summaries, true)
+      end
 
-      markdown = service.workflow_summary.build_markdown
-      expect(markdown).to include("| `/app` | ✅ Success | 5 dependencies |")
+      it "delegates to the workflow_summary instance" do
+        service.record_workflow_result(directory: "/app", status: "Success", details: "5 dependencies")
+
+        markdown = service.workflow_summary.build_markdown(command: "graph", package_manager: "bundler")
+        expect(markdown).to include("| `/app` | ✅ Success | 5 dependencies |")
+      end
+    end
+
+    context "when workflow_job_summaries experiment is disabled" do
+      before do
+        Dependabot::Experiments.register(:workflow_job_summaries, false)
+      end
+
+      it "does not record results" do
+        service.record_workflow_result(directory: "/app", status: "Success", details: "5 dependencies")
+
+        markdown = service.workflow_summary.build_markdown(command: "graph", package_manager: "bundler")
+        expect(markdown).not_to include("/app")
+      end
     end
   end
 

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -782,7 +782,7 @@ RSpec.describe Dependabot::Service do
         service.record_workflow_result(directory: "/app", status: "ok", details: "5 dependencies")
 
         markdown = service.workflow_summary.build_markdown(command: "graph", package_manager: "bundler")
-        expect(markdown).to include("| `/app` | ✅ Success | 5 dependencies |")
+        expect(markdown).to include("| `/app` | ✅ Ok | 5 dependencies |")
       end
     end
 

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -771,4 +771,24 @@ RSpec.describe Dependabot::Service do
       end
     end
   end
+
+  describe "#record_workflow_result" do
+    it "delegates to the workflow_summary instance" do
+      service.record_workflow_result(directory: "/app", status: "Success", details: "5 dependencies")
+
+      markdown = service.workflow_summary.build_markdown
+      expect(markdown).to include("| `/app` | ✅ Success | 5 dependencies |")
+    end
+  end
+
+  describe "#write_workflow_summary" do
+    before do
+      allow(Dependabot::Environment).to receive(:github_actions?).and_return(false)
+    end
+
+    it "delegates to workflow_summary#write with command and package_manager" do
+      expect(service.workflow_summary).to receive(:write).with(command: "graph", package_manager: "bundler")
+      service.write_workflow_summary(command: "graph", package_manager: "bundler")
+    end
+  end
 end

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -779,7 +779,7 @@ RSpec.describe Dependabot::Service do
       end
 
       it "delegates to the workflow_summary instance" do
-        service.record_workflow_result(directory: "/app", status: "Success", details: "5 dependencies")
+        service.record_workflow_result(directory: "/app", status: "ok", details: "5 dependencies")
 
         markdown = service.workflow_summary.build_markdown(command: "graph", package_manager: "bundler")
         expect(markdown).to include("| `/app` | ✅ Success | 5 dependencies |")
@@ -792,7 +792,7 @@ RSpec.describe Dependabot::Service do
       end
 
       it "does not record results" do
-        service.record_workflow_result(directory: "/app", status: "Success", details: "5 dependencies")
+        service.record_workflow_result(directory: "/app", status: "ok", details: "5 dependencies")
 
         markdown = service.workflow_summary.build_markdown(command: "graph", package_manager: "bundler")
         expect(markdown).not_to include("/app")

--- a/updater/spec/dependabot/update_graph_command_spec.rb
+++ b/updater/spec/dependabot/update_graph_command_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe Dependabot::UpdateGraphCommand do
       mark_job_as_processed: nil,
       record_update_job_error: nil,
       record_update_job_unknown_error: nil,
+      record_workflow_result: nil,
       update_dependency_list: nil,
       increment_metric: nil,
-      wait_for_calls_to_finish: nil
+      wait_for_calls_to_finish: nil,
+      write_workflow_summary: nil
     )
   end
   let(:job_definition) do

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
     it "records a workflow result for the directory" do
       expect(service).to receive(:record_workflow_result).with(
         directory: "/",
-        status: "Success",
+        status: "ok",
         details: "Found 2 dependencies"
       )
 
@@ -805,7 +805,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
     it "records a failed workflow result" do
       expect(service).to receive(:record_workflow_result).with(
         directory: "/",
-        status: "Failed",
+        status: "failed",
         details: "Unable to submit data to the Dependency Snapshot API"
       )
 
@@ -915,12 +915,12 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       it "records a failed workflow result for each directory" do
         expect(service).to receive(:record_workflow_result).with(
           directory: "/",
-          status: "Failed",
+          status: "failed",
           details: a_string_including("Dependabot refused to execute external code")
         )
         expect(service).to receive(:record_workflow_result).with(
           directory: "/subproject",
-          status: "Failed",
+          status: "failed",
           details: a_string_including("Dependabot refused to execute external code")
         )
 

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       Dependabot::Service,
       create_dependency_submission: nil,
       record_update_job_error: nil,
-      record_update_job_warning: nil
+      record_update_job_warning: nil,
+      record_workflow_result: nil
     )
   end
 
@@ -119,6 +120,16 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
         dependency2 = lockfile[:resolved]["pkg:gem/dummy-pkg-b@1.1.0"]
         expect(dependency2[:package_url]).to eql("pkg:gem/dummy-pkg-b@1.1.0")
       end
+
+      update_graph_processor.run
+    end
+
+    it "records a workflow result for the directory" do
+      expect(service).to receive(:record_workflow_result).with(
+        directory: "/",
+        status: "Success",
+        details: "Found 2 dependencies"
+      )
 
       update_graph_processor.run
     end
@@ -790,6 +801,16 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
 
       update_graph_processor.run
     end
+
+    it "records a failed workflow result" do
+      expect(service).to receive(:record_workflow_result).with(
+        directory: "/",
+        status: "Failed",
+        details: "Unable to submit data to the Dependency Snapshot API"
+      )
+
+      update_graph_processor.run
+    end
   end
 
   context "when external code execution is rejected" do
@@ -860,6 +881,12 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
 
         expect(call_count).to eq(2)
       end
+
+      it "does not record workflow results when not in GitHub Actions" do
+        expect(service).not_to receive(:record_workflow_result)
+
+        update_graph_processor.run
+      end
     end
 
     context "when executing in GitHub Actions" do
@@ -881,6 +908,21 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
 
       it "records an error for each directory" do
         expect(service).to receive(:record_update_job_error).twice
+
+        update_graph_processor.run
+      end
+
+      it "records a failed workflow result for each directory" do
+        expect(service).to receive(:record_workflow_result).with(
+          directory: "/",
+          status: "Failed",
+          details: a_string_including("Dependabot refused to execute external code")
+        )
+        expect(service).to receive(:record_workflow_result).with(
+          directory: "/subproject",
+          status: "Failed",
+          details: a_string_including("Dependabot refused to execute external code")
+        )
 
         update_graph_processor.run
       end

--- a/updater/spec/dependabot/workflow_summary_spec.rb
+++ b/updater/spec/dependabot/workflow_summary_spec.rb
@@ -83,8 +83,7 @@ RSpec.describe Dependabot::WorkflowSummary do
 
     before do
       FileUtils.mkdir_p(File.dirname(output_path))
-      allow(Dependabot::Environment).to receive(:github_actions?).and_return(github_actions)
-      allow(Dependabot::Environment).to receive(:output_path).and_return(output_path)
+      allow(Dependabot::Environment).to receive_messages(github_actions?: github_actions, output_path: output_path)
     end
 
     after do

--- a/updater/spec/dependabot/workflow_summary_spec.rb
+++ b/updater/spec/dependabot/workflow_summary_spec.rb
@@ -10,22 +10,22 @@ RSpec.describe Dependabot::WorkflowSummary do
 
   describe "#record_result" do
     it "accumulates results" do
-      summary.record_result(directory: "/src", status: "Success", details: "42 dependencies")
-      summary.record_result(directory: "/lib", status: "Failed", details: "timeout")
+      summary.record_result(directory: "/src", status: "ok", details: "42 dependencies")
+      summary.record_result(directory: "/lib", status: "failed", details: "timeout")
 
       markdown = summary.build_markdown(command: "graph", package_manager: "bundler")
 
-      expect(markdown).to include("| `/src` | ✅ Success | 42 dependencies |")
+      expect(markdown).to include("| `/src` | ✅ Ok | 42 dependencies |")
       expect(markdown).to include("| `/lib` | ❌ Failed | timeout |")
     end
   end
 
   describe "#build_markdown" do
     before do
-      summary.record_result(directory: "/src", status: "Success", details: "42 dependencies")
-      summary.record_result(directory: "/lib", status: "Degraded", details: "error fetching sub-dependencies")
-      summary.record_result(directory: "/tools", status: "Failed", details: "dependency_file_not_resolvable")
-      summary.record_result(directory: "/docs", status: "Skipped", details: "missing manifest files")
+      summary.record_result(directory: "/src", status: "ok", details: "42 dependencies")
+      summary.record_result(directory: "/lib", status: "degraded", details: "error fetching sub-dependencies")
+      summary.record_result(directory: "/tools", status: "failed", details: "dependency_file_not_resolvable")
+      summary.record_result(directory: "/docs", status: "skipped", details: "missing manifest files")
     end
 
     it "uses 'Dependency Graph Snapshot' heading for graph commands" do
@@ -33,7 +33,7 @@ RSpec.describe Dependabot::WorkflowSummary do
 
       expect(markdown).to include("## Dependency Graph Snapshot — go_modules")
       expect(markdown).to include("| Directory | Status | Details |")
-      expect(markdown).to include("| `/src` | ✅ Success | 42 dependencies |")
+      expect(markdown).to include("| `/src` | ✅ Ok | 42 dependencies |")
       expect(markdown).to include("| `/lib` | ⚠️ Degraded | error fetching sub-dependencies |")
       expect(markdown).to include("| `/tools` | ❌ Failed | dependency_file_not_resolvable |")
       expect(markdown).to include("| `/docs` | ⏭️ Skipped | missing manifest files |")
@@ -55,7 +55,7 @@ RSpec.describe Dependabot::WorkflowSummary do
 
     it "replaces newlines in details with br tags to preserve readability" do
       markdown = described_class.new.tap do |s|
-        s.record_result(directory: "/app", status: "Failed", details: "line one\nline two\n  line three")
+        s.record_result(directory: "/app", status: "failed", details: "line one\nline two\n  line three")
       end.build_markdown(command: "graph", package_manager: "bundler")
 
       expect(markdown).to include("| `/app` | ❌ Failed | line one<br>line two<br>line three |")
@@ -63,10 +63,10 @@ RSpec.describe Dependabot::WorkflowSummary do
 
     it "groups multiple results for the same directory and status" do
       grouped_summary = described_class.new
-      grouped_summary.record_result(directory: "/lib", status: "Warning", details: "missing credentials for registry X")
-      grouped_summary.record_result(directory: "/lib", status: "Warning", details: "stale lockfile detected")
-      grouped_summary.record_result(directory: "/lib", status: "Failed", details: "dependency_file_not_resolvable")
-      grouped_summary.record_result(directory: "/src", status: "Success", details: "10 dependencies")
+      grouped_summary.record_result(directory: "/lib", status: "warning", details: "missing credentials for registry X")
+      grouped_summary.record_result(directory: "/lib", status: "warning", details: "stale lockfile detected")
+      grouped_summary.record_result(directory: "/lib", status: "failed", details: "dependency_file_not_resolvable")
+      grouped_summary.record_result(directory: "/src", status: "ok", details: "10 dependencies")
 
       markdown = grouped_summary.build_markdown(command: "graph", package_manager: "go_modules")
 
@@ -74,7 +74,7 @@ RSpec.describe Dependabot::WorkflowSummary do
       expect(markdown).to include("| `/lib` | ❌ Failed | dependency_file_not_resolvable |")
       expect(markdown).to include("|  | ⚠️ Warning | missing credentials for registry X |")
       expect(markdown).to include("|  |  | stale lockfile detected |")
-      expect(markdown).to include("| `/src` | ✅ Success | 10 dependencies |")
+      expect(markdown).to include("| `/src` | ✅ Ok | 10 dependencies |")
     end
   end
 
@@ -95,7 +95,7 @@ RSpec.describe Dependabot::WorkflowSummary do
       let(:github_actions) { true }
 
       it "writes the summary markdown file with the correct heading" do
-        summary.record_result(directory: "/", status: "Success", details: "10 dependencies")
+        summary.record_result(directory: "/", status: "ok", details: "10 dependencies")
 
         summary.write(command: "graph", package_manager: "go_modules")
 
@@ -104,7 +104,7 @@ RSpec.describe Dependabot::WorkflowSummary do
 
         content = File.read(summary_path)
         expect(content).to include("## Dependency Graph Snapshot — go_modules")
-        expect(content).to include("| `/` | ✅ Success | 10 dependencies |")
+        expect(content).to include("| `/` | ✅ Ok | 10 dependencies |")
       end
 
       it "writes an empty file when there are no results" do
@@ -120,7 +120,7 @@ RSpec.describe Dependabot::WorkflowSummary do
       let(:github_actions) { false }
 
       it "does not write a file" do
-        summary.record_result(directory: "/", status: "Success", details: "10 dependencies")
+        summary.record_result(directory: "/", status: "ok", details: "10 dependencies")
 
         summary.write(command: "graph", package_manager: "bundler")
 

--- a/updater/spec/dependabot/workflow_summary_spec.rb
+++ b/updater/spec/dependabot/workflow_summary_spec.rb
@@ -1,0 +1,116 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/workflow_summary"
+require "dependabot/environment"
+
+RSpec.describe Dependabot::WorkflowSummary do
+  subject(:summary) { described_class.new }
+
+  describe "#record_result" do
+    it "accumulates results" do
+      summary.record_result(directory: "/src", status: "Success", details: "42 dependencies")
+      summary.record_result(directory: "/lib", status: "Failed", details: "timeout")
+
+      markdown = summary.build_markdown(command: "graph", package_manager: "bundler")
+
+      expect(markdown).to include("| `/src` | ✅ Success | 42 dependencies |")
+      expect(markdown).to include("| `/lib` | ❌ Failed | timeout |")
+    end
+  end
+
+  describe "#build_markdown" do
+    before do
+      summary.record_result(directory: "/src", status: "Success", details: "42 dependencies")
+      summary.record_result(directory: "/lib", status: "Degraded", details: "error fetching sub-dependencies")
+      summary.record_result(directory: "/tools", status: "Failed", details: "dependency_file_not_resolvable")
+      summary.record_result(directory: "/docs", status: "Skipped", details: "missing manifest files")
+    end
+
+    it "uses 'Dependency Graph Snapshot' heading for graph commands" do
+      markdown = summary.build_markdown(command: "graph", package_manager: "go_modules")
+
+      expect(markdown).to include("## Dependency Graph Snapshot — go_modules")
+      expect(markdown).to include("| Directory | Status | Details |")
+      expect(markdown).to include("| `/src` | ✅ Success | 42 dependencies |")
+      expect(markdown).to include("| `/lib` | ⚠️ Degraded | error fetching sub-dependencies |")
+      expect(markdown).to include("| `/tools` | ❌ Failed | dependency_file_not_resolvable |")
+      expect(markdown).to include("| `/docs` | ⏭️ Skipped | missing manifest files |")
+    end
+
+    it "uses 'Dependency Update' heading for non-graph commands" do
+      markdown = summary.build_markdown(command: "", package_manager: "npm_and_yarn")
+
+      expect(markdown).to include("## Dependency Update — npm_and_yarn")
+    end
+
+    it "handles no recorded results" do
+      empty_summary = described_class.new
+      markdown = empty_summary.build_markdown(command: "graph", package_manager: "bundler")
+
+      expect(markdown).to include("## Dependency Graph Snapshot — bundler")
+      expect(markdown).to include("| Directory | Status | Details |")
+    end
+
+    it "replaces newlines in details with br tags to preserve readability" do
+      markdown = described_class.new.tap { |s|
+        s.record_result(directory: "/app", status: "Failed", details: "line one\nline two\n  line three")
+      }.build_markdown(command: "graph", package_manager: "bundler")
+
+      expect(markdown).to include("| `/app` | ❌ Failed | line one<br>line two<br>line three |")
+    end
+  end
+
+  describe "#write" do
+    let(:output_path) { File.join(Dir.tmpdir, "dependabot-test-#{SecureRandom.hex(4)}", "output.json") }
+
+    before do
+      FileUtils.mkdir_p(File.dirname(output_path))
+      allow(Dependabot::Environment).to receive(:github_actions?).and_return(github_actions)
+      allow(Dependabot::Environment).to receive(:output_path).and_return(output_path)
+    end
+
+    after do
+      FileUtils.rm_rf(File.dirname(output_path))
+    end
+
+    context "when running in GitHub Actions" do
+      let(:github_actions) { true }
+
+      it "writes the summary markdown file with the correct heading" do
+        summary.record_result(directory: "/", status: "Success", details: "10 dependencies")
+
+        summary.write(command: "graph", package_manager: "go_modules")
+
+        summary_path = File.join(File.dirname(output_path), "summary.md")
+        expect(File.exist?(summary_path)).to be true
+
+        content = File.read(summary_path)
+        expect(content).to include("## Dependency Graph Snapshot — go_modules")
+        expect(content).to include("| `/` | ✅ Success | 10 dependencies |")
+      end
+
+      it "writes an empty file when there are no results" do
+        summary.write(command: "graph", package_manager: "bundler")
+
+        summary_path = File.join(File.dirname(output_path), "summary.md")
+        expect(File.exist?(summary_path)).to be true
+        expect(File.read(summary_path)).to eq("")
+      end
+    end
+
+    context "when not running in GitHub Actions" do
+      let(:github_actions) { false }
+
+      it "does not write a file" do
+        summary.record_result(directory: "/", status: "Success", details: "10 dependencies")
+
+        summary.write(command: "graph", package_manager: "bundler")
+
+        summary_path = File.join(File.dirname(output_path), "summary.md")
+        expect(File.exist?(summary_path)).to be false
+      end
+    end
+  end
+end

--- a/updater/spec/dependabot/workflow_summary_spec.rb
+++ b/updater/spec/dependabot/workflow_summary_spec.rb
@@ -54,11 +54,26 @@ RSpec.describe Dependabot::WorkflowSummary do
     end
 
     it "replaces newlines in details with br tags to preserve readability" do
-      markdown = described_class.new.tap { |s|
+      markdown = described_class.new.tap do |s|
         s.record_result(directory: "/app", status: "Failed", details: "line one\nline two\n  line three")
-      }.build_markdown(command: "graph", package_manager: "bundler")
+      end.build_markdown(command: "graph", package_manager: "bundler")
 
       expect(markdown).to include("| `/app` | ❌ Failed | line one<br>line two<br>line three |")
+    end
+
+    it "groups multiple results for the same directory and status" do
+      grouped_summary = described_class.new
+      grouped_summary.record_result(directory: "/lib", status: "Warning", details: "missing credentials for registry X")
+      grouped_summary.record_result(directory: "/lib", status: "Warning", details: "stale lockfile detected")
+      grouped_summary.record_result(directory: "/lib", status: "Failed", details: "dependency_file_not_resolvable")
+      grouped_summary.record_result(directory: "/src", status: "Success", details: "10 dependencies")
+
+      markdown = grouped_summary.build_markdown(command: "graph", package_manager: "go_modules")
+
+      expect(markdown).to include("| `/lib` | ⚠️ Warning | missing credentials for registry X |")
+      expect(markdown).to include("|  |  | stale lockfile detected |")
+      expect(markdown).to include("|  | ❌ Failed | dependency_file_not_resolvable |")
+      expect(markdown).to include("| `/src` | ✅ Success | 10 dependencies |")
     end
   end
 

--- a/updater/spec/dependabot/workflow_summary_spec.rb
+++ b/updater/spec/dependabot/workflow_summary_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe Dependabot::WorkflowSummary do
 
       markdown = grouped_summary.build_markdown(command: "graph", package_manager: "go_modules")
 
-      expect(markdown).to include("| `/lib` | ⚠️ Warning | missing credentials for registry X |")
+      # Sorted by [directory, status]: Failed comes before Warning alphabetically
+      expect(markdown).to include("| `/lib` | ❌ Failed | dependency_file_not_resolvable |")
+      expect(markdown).to include("|  | ⚠️ Warning | missing credentials for registry X |")
       expect(markdown).to include("|  |  | stale lockfile detected |")
-      expect(markdown).to include("|  | ❌ Failed | dependency_file_not_resolvable |")
       expect(markdown).to include("| `/src` | ✅ Success | 10 dependencies |")
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR introduces a `Dependabot::WorkflowSummary` class as an Actions-specific information collector which produces a summary.md file to the container's `output/` directory at the end of each run.

For now, it produces an empty file by default and requires an experiment to be enabled to actually write anything.

Content for the file is collected via the `Dependabot::Service` class by direct call from the job processor for now and only the Update Graph processor makes use of this _for now_, but eventually I would envision extending this to be interoperable with the existing `Dependabot::Service.summary` method to produce this file for all jobs by capturing the information we currently only summarise in logs.

### Anything you want to highlight for special attention from reviewers?

I'm focusing on implementing this for Graph jobs first as they need to radiate status in more places in the UI than dependency update jobs so using the Actions Workflow itself as the user experience for errors, warnings and guidance makes more sense than duplicating a lot of the Dependabot UX.

An important safety note is that this strategy runs using an ensure that will **always overwrite `output/summary.md** even if no messages have been collected or the experimental flag is disabled. This ensures that any malicious attempts to inject content into this file cannot easily escape the container and make it unto the workflow run summary.

### How will you know you've accomplished your goal?

I will be able to enable this experiment on my test repositories and see a job summary appear for graph jobs in various states.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
