### PR TITLE
Fix Maven property update previous version metadata

### DIFF
--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -41,6 +41,7 @@ module Dependabot
           @target_version   = T.let(target_version_details&.fetch(:version), T.nilable(Dependabot::Maven::Version))
           @source_url       = T.let(target_version_details&.fetch(:source_url), T.nilable(String))
           @update_cooldown = update_cooldown
+          @property_value_finder = T.let(nil, T.nilable(Dependabot::Maven::FileParser::PropertyValueFinder))
         end
 
         sig { returns(T::Boolean) }
@@ -79,7 +80,7 @@ module Dependabot
                 name: dep.name,
                 version: updated_version(dep),
                 requirements: updated_requirements(dep),
-                previous_version: dep.version,
+                previous_version: previous_version(dep),
                 previous_requirements: dep.requirements,
                 package_manager: dep.package_manager
               )
@@ -185,6 +186,28 @@ module Dependabot
           T.must(version_string(dep)).gsub("${#{property_name}}", T.must(target_version).to_s)
         end
 
+        sig { params(dep: Dependabot::Dependency).returns(String) }
+        def previous_version(dep)
+          T.must(version_string(dep)).gsub("${#{property_name}}", current_property_value(dep))
+        end
+
+        sig { params(dep: Dependabot::Dependency).returns(String) }
+        def current_property_value(dep)
+          declaring_requirement =
+            dep.requirements
+               .find { |r| r.dig(:metadata, :property_name) == property_name }
+
+          callsite_pom = dependency_files.find { |f| f.name == declaring_requirement&.fetch(:file) }
+          property_value =
+            property_value_finder
+            .property_details(property_name: property_name, callsite_pom: T.must(callsite_pom))
+            &.fetch(:value)
+
+          return property_value if property_value.is_a?(String)
+
+          raise "Property not found: #{property_name}"
+        end
+
         sig { params(dep: Dependabot::Dependency).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
         def updated_requirements(dep)
           @updated_requirements ||= T.let({}, T.nilable(T::Hash[String, T::Array[T::Hash[Symbol, T.untyped]]]))
@@ -195,6 +218,15 @@ module Dependabot
               source_url: source_url,
               properties_to_update: [property_name]
             ).updated_requirements
+        end
+
+        sig { returns(Dependabot::Maven::FileParser::PropertyValueFinder) }
+        def property_value_finder
+          @property_value_finder ||=
+            Dependabot::Maven::FileParser::PropertyValueFinder.new(
+              dependency_files: dependency_files,
+              credentials: credentials
+            )
         end
       end
     end

--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -160,13 +160,9 @@ module Dependabot
 
         sig { params(dep: Dependabot::Dependency).returns(T.nilable(String)) }
         def version_string(dep)
-          declaring_requirement =
-            dep.requirements
-               .find { |r| r.dig(:metadata, :property_name) == property_name }
-
           Maven::FileUpdater::DeclarationFinder.new(
             dependency: dep,
-            declaring_requirement: T.must(declaring_requirement),
+            declaring_requirement: declaring_property_requirement(dep),
             dependency_files: dependency_files
           ).declaration_nodes.first&.at_css("version")&.content
         end
@@ -193,19 +189,36 @@ module Dependabot
 
         sig { params(dep: Dependabot::Dependency).returns(String) }
         def current_property_value(dep)
-          declaring_requirement =
-            dep.requirements
-               .find { |r| r.dig(:metadata, :property_name) == property_name }
+          declaring_requirement = declaring_property_requirement(dep)
+          callsite_pom = dependency_files.find { |f| f.name == declaring_requirement.fetch(:file) }
+          unless callsite_pom
+            raise DependencyFileNotEvaluatable,
+                  "POM not found: #{declaring_requirement.fetch(:file)} for property #{property_name}"
+          end
 
-          callsite_pom = dependency_files.find { |f| f.name == declaring_requirement&.fetch(:file) }
           property_value =
             property_value_finder
-            .property_details(property_name: property_name, callsite_pom: T.must(callsite_pom))
+            .property_details(property_name: property_name, callsite_pom: callsite_pom)
             &.fetch(:value)
 
           return property_value if property_value.is_a?(String)
 
-          raise "Property not found: #{property_name}"
+          raise DependencyFileNotEvaluatable, "Property not found: #{property_name}"
+        end
+
+        sig { params(dep: Dependabot::Dependency).returns(T::Hash[Symbol, T.untyped]) }
+        def declaring_property_requirement(dep)
+          declaring_requirement =
+            dep.requirements.find do |r|
+              next false unless r.dig(:metadata, :property_name) == property_name
+
+              r.dig(:metadata, :property_source) == property_source
+            end
+
+          return declaring_requirement if declaring_requirement
+
+          raise DependencyFileNotEvaluatable,
+                "Requirement not found for property #{property_name} from #{property_source || 'unknown source'}"
         end
 
         sig { params(dep: Dependabot::Dependency).returns(T::Array[T::Hash[Symbol, T.untyped]]) }

--- a/maven/spec/dependabot/maven/update_checker/property_updater_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/property_updater_spec.rb
@@ -202,6 +202,44 @@ RSpec.describe Dependabot::Maven::UpdateChecker::PropertyUpdater do
       )
     end
 
+    context "when parsed dependency versions are stale for a property dependency" do
+      let(:stale_dependencies_using_property) do
+        %w(
+          org.springframework:spring-beans
+          org.springframework:spring-context
+        ).map do |name|
+          Dependabot::Dependency.new(
+            name: name,
+            version: "4.3.11.RELEASE",
+            requirements: [{
+              file: "pom.xml",
+              requirement: "4.3.12.RELEASE",
+              groups: [],
+              source: nil,
+              metadata: {
+                property_name: "springframework.version",
+                property_source: "pom.xml",
+                packaging_type: "jar"
+              }
+            }],
+            package_manager: "maven"
+          )
+        end
+      end
+
+      before do
+        allow(Dependabot::Maven::FileParser)
+          .to receive(:new)
+          .and_return(instance_double(Dependabot::Maven::FileParser, parse: stale_dependencies_using_property))
+      end
+
+      it "uses the current property value as the previous version" do
+        expect(updated_dependencies.map(&:previous_version)).to eq(
+          ["4.3.12.RELEASE", "4.3.12.RELEASE"]
+        )
+      end
+    end
+
     context "when one dependency is missing the target version" do
       before do
         body = fixture("maven_central_metadata", "missing_latest.xml")

--- a/maven/spec/dependabot/maven/update_checker/property_updater_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/property_updater_spec.rb
@@ -238,6 +238,58 @@ RSpec.describe Dependabot::Maven::UpdateChecker::PropertyUpdater do
           ["4.3.12.RELEASE", "4.3.12.RELEASE"]
         )
       end
+
+      context "when the same property name is declared in another POM" do
+        let(:dependency_files) { [pom, other_pom] }
+        let(:other_pom) do
+          Dependabot::DependencyFile.new(
+            name: "other.xml",
+            content: fixture("poms", "property_pom.xml").gsub("4.3.12.RELEASE", "4.3.10.RELEASE")
+          )
+        end
+        let(:stale_dependencies_using_property) do
+          %w(
+            org.springframework:spring-beans
+            org.springframework:spring-context
+          ).map do |name|
+            Dependabot::Dependency.new(
+              name: name,
+              version: "4.3.11.RELEASE",
+              requirements: [
+                {
+                  file: "other.xml",
+                  requirement: "4.3.10.RELEASE",
+                  groups: [],
+                  source: nil,
+                  metadata: {
+                    property_name: "springframework.version",
+                    property_source: "other.xml",
+                    packaging_type: "jar"
+                  }
+                },
+                {
+                  file: "pom.xml",
+                  requirement: "4.3.12.RELEASE",
+                  groups: [],
+                  source: nil,
+                  metadata: {
+                    property_name: "springframework.version",
+                    property_source: "pom.xml",
+                    packaging_type: "jar"
+                  }
+                }
+              ],
+              package_manager: "maven"
+            )
+          end
+        end
+
+        it "uses the property value from the matching property source" do
+          expect(updated_dependencies.map(&:previous_version)).to eq(
+            ["4.3.12.RELEASE", "4.3.12.RELEASE"]
+          )
+        end
+      end
     end
 
     context "when one dependency is missing the target version" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #14934 by ensuring Maven property-based updates report the actual previous property value in PR titles, commit messages, and descriptions.

When multiple Maven dependencies share a version property, Dependabot can construct update metadata from parsed dependency versions that do not reflect the current property declaration. This makes the generated PR text describe an older version than the one actually changed in the manifest.

### Anything you want to highlight for special attention from reviewers?

The fix keeps the existing property-update flow, but uses the current property value from the declaring POM when building previous-version metadata. This keeps PR messaging aligned with the manifest diff while preserving the existing target-version and requirements update behavior.

### How will you know you've accomplished your goal?

The regression coverage models stale parsed dependency versions for a shared Maven property and verifies the update metadata uses the current property value instead.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

Fixes #14934 