### PR TITLE
Gate YARN_NPM_MINIMAL_AGE_GATE on Yarn 4.10+

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -369,13 +369,14 @@ module Dependabot
         end
 
         # Returns an env hash that disables Yarn Berry's npmMinimalAgeGate for security updates.
-        # While `yarn up --no-time-gate` achieves the same effect, that flag was only introduced
-        # in Yarn 4.15.x and would leave users on older Berry releases unprotected. The env var
-        # approach covers all Yarn Berry versions that support the feature and applies uniformly
-        # to every subcommand (install, up, add) without requiring per-command flag changes.
+        # npmMinimalAgeGate was introduced in Yarn 4.10.0. Setting the corresponding
+        # YARN_NPM_MINIMAL_AGE_GATE env var on older Yarn Berry releases (or Yarn classic) raises
+        # "Unrecognized or legacy configuration settings found: npmMinimalAgeGate" and aborts the
+        # install, so we gate on a version check.
         sig { returns(T.nilable(T::Hash[String, String])) }
         def yarn_time_gate_env
           return nil unless security_updates_only?
+          return nil unless Helpers.yarn_berry_supports_minimal_age_gate?
 
           { "YARN_NPM_MINIMAL_AGE_GATE" => "0" }
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -248,6 +248,31 @@ module Dependabot
         yarn_major_version >= 4
       end
 
+      sig { returns(T::Boolean) }
+      def self.yarn_berry_supports_minimal_age_gate?
+        version = Version.new(run_single_yarn_command("--version"))
+        supported = version >= Version.new("4.10.0")
+        if supported
+          Dependabot.logger.info(
+            "Yarn #{version} supports npmMinimalAgeGate. " \
+            "Setting YARN_NPM_MINIMAL_AGE_GATE=0 to bypass the release-age gate for security updates."
+          )
+        else
+          Dependabot.logger.info(
+            "Yarn #{version} does not support npmMinimalAgeGate (requires 4.10.0+). " \
+            "YARN_NPM_MINIMAL_AGE_GATE will not be set."
+          )
+        end
+        supported
+      rescue StandardError => e
+        Dependabot.logger.warn(
+          "Could not determine Yarn version to check npmMinimalAgeGate support: #{e.message}. " \
+          "Assuming unsupported (returning false). YARN_NPM_MINIMAL_AGE_GATE will not be set, " \
+          "so the registry's release-age gate may still block security updates."
+        )
+        false
+      end
+
       sig { returns(T.nilable(String)) }
       def self.setup_yarn_berry
         # Always disable immutable installs so yarn's CI detection doesn't prevent updates.

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
@@ -412,30 +412,64 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
         )
       end
 
-      it "sets YARN_NPM_MINIMAL_AGE_GATE=0 in yarn_time_gate_env" do
-        # Override any npmMinimalAgeGate set in .yarnrc.yml: security fixes must not be
-        # blocked by a release-age gate the user configured for regular updates.
-        expect(updater.send(:yarn_time_gate_env)).to eq({ "YARN_NPM_MINIMAL_AGE_GATE" => "0" })
-      end
-
-      it "passes YARN_NPM_MINIMAL_AGE_GATE=0 to yarn up in run_yarn_berry_top_level_updater" do
-        allow(updater).to receive(:write_temporary_dependency_files)
-        allow(updater).to receive(:pin_berry_versions_if_needed)
-        allow(updater).to receive(:requirements_changed?).and_return(false)
-        allow(File).to receive(:read).and_return("")
-
-        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_yarn_command) do |_cmd, **kwargs|
-          expect(kwargs[:env]).to include("YARN_NPM_MINIMAL_AGE_GATE" => "0")
-          ""
+      context "when Yarn supports npmMinimalAgeGate (>= 4.10.0)" do
+        before do
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:yarn_berry_supports_minimal_age_gate?).and_return(true)
         end
 
-        dep = { name: dependency_name, version: version, requirements: requirements }
-        yarn_lock_file = files.find { |f| f.name == "yarn.lock" }
-        updater.send(
-          :run_yarn_berry_top_level_updater,
-          top_level_dependency_updates: [dep],
-          yarn_lock: yarn_lock_file
-        )
+        it "sets YARN_NPM_MINIMAL_AGE_GATE=0 in yarn_time_gate_env" do
+          expect(updater.send(:yarn_time_gate_env)).to eq({ "YARN_NPM_MINIMAL_AGE_GATE" => "0" })
+        end
+
+        it "passes YARN_NPM_MINIMAL_AGE_GATE=0 to yarn up in run_yarn_berry_top_level_updater" do
+          allow(updater).to receive(:write_temporary_dependency_files)
+          allow(updater).to receive(:pin_berry_versions_if_needed)
+          allow(updater).to receive(:requirements_changed?).and_return(false)
+          allow(File).to receive(:read).and_return("")
+
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_yarn_command) do |_cmd, **kwargs|
+            expect(kwargs[:env]).to include("YARN_NPM_MINIMAL_AGE_GATE" => "0")
+            ""
+          end
+
+          dep = { name: dependency_name, version: version, requirements: requirements }
+          yarn_lock_file = files.find { |f| f.name == "yarn.lock" }
+          updater.send(
+            :run_yarn_berry_top_level_updater,
+            top_level_dependency_updates: [dep],
+            yarn_lock: yarn_lock_file
+          )
+        end
+      end
+
+      context "when Yarn does not support npmMinimalAgeGate (< 4.10.0)" do
+        before do
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:yarn_berry_supports_minimal_age_gate?).and_return(false)
+        end
+
+        it "returns nil from yarn_time_gate_env" do
+          expect(updater.send(:yarn_time_gate_env)).to be_nil
+        end
+
+        it "does not pass YARN_NPM_MINIMAL_AGE_GATE to yarn commands" do
+          allow(updater).to receive(:write_temporary_dependency_files)
+          allow(updater).to receive(:pin_berry_versions_if_needed)
+          allow(updater).to receive(:requirements_changed?).and_return(false)
+          allow(File).to receive(:read).and_return("")
+
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_yarn_command) do |_cmd, **kwargs|
+            expect(kwargs[:env]).to be_nil
+            ""
+          end
+
+          dep = { name: dependency_name, version: version, requirements: requirements }
+          yarn_lock_file = files.find { |f| f.name == "yarn.lock" }
+          updater.send(
+            :run_yarn_berry_top_level_updater,
+            top_level_dependency_updates: [dep],
+            yarn_lock: yarn_lock_file
+          )
+        end
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -917,4 +917,34 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
       end
     end
   end
+
+  describe "::yarn_berry_supports_minimal_age_gate?" do
+    context "when Yarn version is >= 4.10.0" do
+      it "logs version and support decision, returns true" do
+        allow(described_class).to receive(:run_single_yarn_command).with("--version").and_return("4.10.0")
+        expect(Dependabot.logger).to receive(:info)
+          .with(a_string_including("Yarn 4.10.0").and(including("bypass the release-age gate for security updates")))
+        expect(described_class.yarn_berry_supports_minimal_age_gate?).to be(true)
+      end
+    end
+
+    context "when Yarn version is < 4.10.0" do
+      it "logs version and no-support decision, returns false" do
+        allow(described_class).to receive(:run_single_yarn_command).with("--version").and_return("4.9.2")
+        expect(Dependabot.logger).to receive(:info)
+          .with(a_string_including("Yarn 4.9.2").and(including("does not support npmMinimalAgeGate")))
+        expect(described_class.yarn_berry_supports_minimal_age_gate?).to be(false)
+      end
+    end
+
+    context "when the version command raises an error" do
+      it "logs a warning and returns false" do
+        allow(described_class).to receive(:run_single_yarn_command)
+          .with("--version")
+          .and_raise(StandardError, "command failed")
+        expect(Dependabot.logger).to receive(:warn).with(a_string_including("command failed"))
+        expect(described_class.yarn_berry_supports_minimal_age_gate?).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

`npmMinimalAgeGate` was introduced in `Yarn 4.10.0`. Setting `YARN_NPM_MINIMAL_AGE_GATE` on older Yarn Berry releases raises "Unrecognized or legacy configuration settings found: npmMinimalAgeGate" and aborts the install, so we version-gate the env var.

Adds `Helpers.yarn_berry_supports_minimal_age_gate?` and gates yarn_time_gate_env on it in addition to the existing security_updates_only check.

Closes #15194

### How will you know you've accomplished your goal?

1. Tested with the reproducer failing job

Before: https://github.com/mvdicarlo/postybirb/actions/runs/26816179978/job/79058428648#step:3:187

<details>
  <summary>Logs after </summary>
   
  ```
    cli | 2026/06/05 02:48:56 Inserting $LOCAL_GITHUB_ACCESS_TOKEN into credentials
    cli | 2026/06/05 02:48:57 image ghcr.io/dependabot/proxy:latest is already up to date
<omitted due to PR body limits>
{"name":"node","version":"24.16.0","raw_version":"24.16.0"}}}],"type":"record_ecosystem_meta"}
  proxy | 2026/06/05 02:52:51 [391] 200 http://host.docker.internal:49319/update_jobs/cli/record_ecosystem_meta
{"data":{"base-commit-sha":"752f4270b48108a1dec510fe98a65f920c67e876"},"type":"mark_as_processed"}
  proxy | 2026/06/05 02:52:51 [392] PATCH http://host.docker.internal:49319/update_jobs/cli/mark_as_processed
  proxy | 2026/06/05 02:52:51 [392] 200 http://host.docker.internal:49319/update_jobs/cli/mark_as_processed
updater | 2026/06/05 02:52:51 INFO Finished job processing
updater | 2026/06/05 02:52:51 INFO Results:
updater | +------------------------------------------+
updater | |   Changes to Dependabot Pull Requests    |
updater | +---------+--------------------------------+
updater | | updated | uuid ( from 11.1.1 to 14.0.0 ) |
updater | +---------+--------------------------------+
  proxy | 2026/06/05 02:52:58 Skipping sending metrics because api endpoint is empty

  ```
</details>

2. Tested with the [original reproducer ](https://github.com/yeikel/dependabot-reproducer-issue-15137) that displays `YARN_NPM_MINIMAL_AGE_GATE ` expectations
  
```
  proxy | 2026/06/05 03:17:56 [054] 200 http://host.docker.internal:53183/update_jobs/cli/create_pull_request
  proxy | 2026/06/05 03:17:56 [055] POST http://host.docker.internal:53183/update_jobs/cli/record_ecosystem_meta
{"data":[{"ecosystem":{"name":"npm_and_yarn","package_manager":{"name":"yarn","version":"4.14.1","raw_version":"4.14.1"},"language":{"name":"node","version":"24.16.0","raw_version":"24.16.0"}}}],"type":"record_ecosystem_meta"}
  proxy | 2026/06/05 03:17:56 [055] 200 http://host.docker.internal:53183/update_jobs/cli/record_ecosystem_meta
{"data":{"base-commit-sha":"fc0781db91ca81d72b53164c56db8435ca2f7e7b"},"type":"mark_as_processed"}
  proxy | 2026/06/05 03:17:56 [056] PATCH http://host.docker.internal:53183/update_jobs/cli/mark_as_processed
  proxy | 2026/06/05 03:17:56 [056] 200 http://host.docker.internal:53183/update_jobs/cli/mark_as_processed
updater | 2026/06/05 03:17:56 INFO Finished job processing
updater | 2026/06/05 03:17:56 INFO Results:
updater | +---------------------------------------------+
updater | |     Changes to Dependabot Pull Requests     |
updater | +---------+-----------------------------------+
updater | | created | lodash ( from 4.17.15 to 4.18.1 ) |
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
