### PR TITLE
feat(rust_toolchain): add replaces-base/private registry support

### DIFF
--- a/rust_toolchain/lib/dependabot/rust_toolchain/package/package_details_fetcher.rb
+++ b/rust_toolchain/lib/dependabot/rust_toolchain/package/package_details_fetcher.rb
@@ -1,9 +1,11 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "base64"
 require "sorbet-runtime"
 require "uri"
 
+require "dependabot/credential"
 require "dependabot/package/package_details"
 require "dependabot/registry_client"
 require "dependabot/update_checkers/base"
@@ -23,11 +25,13 @@ module Dependabot
 
         sig do
           params(
-            dependency: Dependabot::Dependency
+            dependency: Dependabot::Dependency,
+            credentials: T::Array[Dependabot::Credential]
           ).void
         end
-        def initialize(dependency:)
+        def initialize(dependency:, credentials: [])
           @dependency = dependency
+          @credentials = T.let(credentials, T::Array[Dependabot::Credential])
         end
 
         sig { returns(Dependabot::Package::PackageDetails) }
@@ -55,8 +59,8 @@ module Dependabot
         def fetch_and_parse_manifests
           # Cache bust by appending a timestamp query param so CDN treats each request uniquely
           # This avoids relying on headers that might be ignored by intermediate caches.
-          busted_url = "#{MANIFESTS_URL}?t=#{Time.now.to_i}"
-          response = Dependabot::RegistryClient.get(url: busted_url)
+          busted_url = "#{manifests_url}?t=#{Time.now.to_i}"
+          response = Dependabot::RegistryClient.get(url: busted_url, headers: auth_headers)
           manifests_content = response.body
 
           channels = T.let([], T::Array[Dependabot::RustToolchain::Version])
@@ -90,6 +94,39 @@ module Dependabot
           when /^\d+\.\d+(\.\d+)?$/
             Version.new(channel_part)
           end
+        end
+
+        sig { returns(String) }
+        def manifests_url
+          replaces_base = @credentials.find do |cred|
+            cred["type"] == "rust_registry" && cred.replaces_base?
+          end
+          return MANIFESTS_URL unless replaces_base
+
+          url = replaces_base["url"]
+          return MANIFESTS_URL unless url
+
+          url.chomp("/") + "/manifests.txt"
+        end
+
+        sig { returns(T::Hash[String, String]) }
+        def auth_headers
+          replaces_base = @credentials.find do |cred|
+            cred["type"] == "rust_registry" && cred.replaces_base?
+          end
+          return {} unless replaces_base
+
+          token = replaces_base["token"]
+          return { "Authorization" => "Bearer #{token}" } if token
+
+          username = replaces_base["username"]
+          password = replaces_base["password"]
+          if username && password
+            encoded = Base64.strict_encode64("#{username}:#{password}")
+            return { "Authorization" => "Basic #{encoded}" }
+          end
+
+          {}
         end
 
         sig { returns(Dependabot::Dependency) }

--- a/rust_toolchain/lib/dependabot/rust_toolchain/update_checker/latest_version_finder.rb
+++ b/rust_toolchain/lib/dependabot/rust_toolchain/update_checker/latest_version_finder.rb
@@ -19,7 +19,8 @@ module Dependabot
         sig { override.returns(T.nilable(Dependabot::Package::PackageDetails)) }
         def package_details
           @package_details ||= Dependabot::RustToolchain::Package::PackageDetailsFetcher.new(
-            dependency: dependency
+            dependency: dependency,
+            credentials: credentials
           ).fetch
         end
 

--- a/rust_toolchain/spec/dependabot/rust_toolchain/package/package_details_fetcher_spec.rb
+++ b/rust_toolchain/spec/dependabot/rust_toolchain/package/package_details_fetcher_spec.rb
@@ -1,11 +1,15 @@
 # typed: false
 # frozen_string_literal: true
 
+require "base64"
 require "spec_helper"
+require "dependabot/credential"
 require "dependabot/rust_toolchain/package/package_details_fetcher"
 
 RSpec.describe Dependabot::RustToolchain::Package::PackageDetailsFetcher do
-  subject(:finder) { described_class.new(dependency: dependency) }
+  subject(:finder) { described_class.new(dependency: dependency, credentials: credentials) }
+
+  let(:credentials) { [] }
 
   let(:manifests_url_with_timestamp) { /\A#{Regexp.escape(described_class::MANIFESTS_URL)}(\?t=\d+)?\z/o }
 
@@ -37,7 +41,7 @@ RSpec.describe Dependabot::RustToolchain::Package::PackageDetailsFetcher do
     before do
       # Stub any cache-busted URL variant without assertions inside the hook
       allow(Dependabot::RegistryClient).to receive(:get)
-        .with(url: manifests_url_with_timestamp)
+        .with(url: manifests_url_with_timestamp, headers: {})
         .and_return(instance_double(Excon::Response, body: manifests_response))
     end
 
@@ -111,10 +115,101 @@ RSpec.describe Dependabot::RustToolchain::Package::PackageDetailsFetcher do
 
     it "handles network errors gracefully" do
       allow(Dependabot::RegistryClient).to receive(:get)
-        .with(url: manifests_url_with_timestamp)
+        .with(url: manifests_url_with_timestamp, headers: {})
         .and_raise(Excon::Error::Timeout, "Request timeout")
 
       expect { finder.fetch }.to raise_error(Excon::Error::Timeout)
+    end
+
+    context "with a replaces-base rust_registry credential" do
+      let(:mirror_base_url) { "https://my-mirror.example.com" }
+      let(:mirror_manifests_url) { "#{mirror_base_url}/manifests.txt" }
+      let(:mirror_manifests_url_with_timestamp) { /\A#{Regexp.escape(mirror_manifests_url)}(\?t=\d+)?\z/ }
+      let(:credentials) do
+        [Dependabot::Credential.new({ "type" => "rust_registry", "url" => mirror_base_url, "replaces-base" => true })]
+      end
+
+      before do
+        allow(Dependabot::RegistryClient).to receive(:get)
+          .with(url: mirror_manifests_url_with_timestamp, headers: {})
+          .and_return(instance_double(Excon::Response, body: manifests_response))
+      end
+
+      it "fetches from the mirror URL instead of the default" do
+        finder.fetch
+
+        expect(Dependabot::RegistryClient).to have_received(:get)
+          .with(url: mirror_manifests_url_with_timestamp, headers: {})
+      end
+
+      it "still parses manifests correctly" do
+        package_details = finder.fetch
+
+        expect(package_details.releases.length).to eq(8)
+      end
+    end
+
+    context "with a replaces-base credential with a token" do
+      let(:mirror_base_url) { "https://my-mirror.example.com" }
+      let(:mirror_manifests_url_with_timestamp) do
+        /\A#{Regexp.escape("#{mirror_base_url}/manifests.txt")}(\?t=\d+)?\z/
+      end
+      let(:credentials) do
+        [Dependabot::Credential.new(
+          {
+            "type" => "rust_registry",
+            "url" => mirror_base_url,
+            "replaces-base" => true,
+            "token" => "mytoken"
+          }
+        )]
+      end
+
+      before do
+        allow(Dependabot::RegistryClient).to receive(:get)
+          .with(url: mirror_manifests_url_with_timestamp, headers: { "Authorization" => "Bearer mytoken" })
+          .and_return(instance_double(Excon::Response, body: manifests_response))
+      end
+
+      it "sends a Bearer Authorization header" do
+        finder.fetch
+
+        expect(Dependabot::RegistryClient).to have_received(:get)
+          .with(url: mirror_manifests_url_with_timestamp, headers: { "Authorization" => "Bearer mytoken" })
+      end
+    end
+
+    context "with a replaces-base credential with username and password" do
+      let(:mirror_base_url) { "https://my-mirror.example.com" }
+      let(:mirror_manifests_url_with_timestamp) do
+        /\A#{Regexp.escape("#{mirror_base_url}/manifests.txt")}(\?t=\d+)?\z/
+      end
+      let(:credentials) do
+        [Dependabot::Credential.new(
+          {
+            "type" => "rust_registry",
+            "url" => mirror_base_url,
+            "replaces-base" => true,
+            "username" => "user",
+            "password" => "pass"
+          }
+        )]
+      end
+
+      before do
+        encoded = Base64.strict_encode64("user:pass")
+        allow(Dependabot::RegistryClient).to receive(:get)
+          .with(url: mirror_manifests_url_with_timestamp, headers: { "Authorization" => "Basic #{encoded}" })
+          .and_return(instance_double(Excon::Response, body: manifests_response))
+      end
+
+      it "sends a Basic Authorization header" do
+        encoded = Base64.strict_encode64("user:pass")
+        finder.fetch
+
+        expect(Dependabot::RegistryClient).to have_received(:get)
+          .with(url: mirror_manifests_url_with_timestamp, headers: { "Authorization" => "Basic #{encoded}" })
+      end
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Allow users to redirect `manifests.txt` fetches to an internal mirror by configuring a `rust_registry` credential with `replaces-base: true`. When present, `PackageDetailsFetcher` uses the credential URL as the base and appends `/manifests.txt` instead of hitting `static.rust-lang.org` directly. 

Bearer token and Basic auth (username/password) are also forwarded.

Fixes #15197

### Anything you want to highlight for special attention from reviewers?

`rust-repository` would be a new type of registry and that does not seem to exist today

```yml
version: 2
registries:
  rust-static-mirror:
    type: rust-repository
    url: https://mirrors.ustc.edu.cn/rust-static/
updates:
- package-ecosystem: rust-toolchain
  schedule:
    interval: weekly
  directory: "/rust/toolchain"
  registries: "*" 

```

### How will you know you've accomplished your goal?

It is difficult to test end to end with the current status of things 

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
