### PR TITLE
Detect ICU package error indicating EOL SDK

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -654,5 +654,13 @@ public class MSBuildHelperTests : TestBase
             // expectedError
             new UnknownError(new Exception("Circular dependency detected"), "TEST-JOB-ID"),
         ];
+
+        yield return
+        [
+            // output
+            "Couldn't find a valid ICU package installed on the system. Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support.",
+            // expectedError
+            new UnknownError(new Exception("Couldn't find a valid ICU package installed on the system. Likely EOL SDK."), "TEST-JOB-ID"),
+        ];
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -207,6 +207,7 @@ internal static class SdkProjectDiscovery
                 }
 
                 MSBuildHelper.ThrowOnError(stdOut);
+                MSBuildHelper.ThrowOnError(stdErr);
                 if (exitCode != 0)
                 {
                     // log error, but still try to resolve what we can

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -670,6 +670,7 @@ internal static partial class MSBuildHelper
         ThrowOnUnparseableFile(output);
         ThrowOnMultipleProjectsForPackagesConfig(output);
         ThrowOnCircularDependency(output);
+        ThrowOnInvalidIcuPackage(output);
     }
 
     private static void ThrowOnUnauthenticatedFeed(string stdout)
@@ -818,6 +819,14 @@ internal static partial class MSBuildHelper
         if (pattern.IsMatch(output))
         {
             throw new Exception("Circular dependency detected");
+        }
+    }
+
+    private static void ThrowOnInvalidIcuPackage(string output)
+    {
+        if (output.Contains("Couldn't find a valid ICU package installed on the system."))
+        {
+            throw new Exception("Couldn't find a valid ICU package installed on the system. Likely EOL SDK.");
         }
     }
 


### PR DESCRIPTION
Add a new check to MSBuildHelper.ThrowOnError that detects the string 'Couldn't find a valid ICU package installed on the system.' and throws an exception with the message 'Couldn't find a valid ICU package installed on the system. Likely EOL SDK.'

Also call ThrowOnError on stdErr in SdkProjectDiscovery to catch errors that only appear in stderr output.

### Changes
- **MSBuildHelper.cs**: Added ThrowOnInvalidIcuPackage method and wired it into ThrowOnError
- **SdkProjectDiscovery.cs**: Added MSBuildHelper.ThrowOnError(stdErr) call
- **MSBuildHelperTests.cs**: Added test case for the new ICU error detection