### PR TITLE
Fix Gradle wrapper jar encoding

### DIFF
--- a/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "base64"
 require "shellwords"
 require "pathname"
 

--- a/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 require "shellwords"
+require "pathname"
 
 require "dependabot/gradle/distributions"
 
@@ -39,15 +40,12 @@ module Dependabot
 
         # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
-        # rubocop:disable Metrics/PerceivedComplexity
         sig { params(build_file: Dependabot::DependencyFile).returns(T::Array[Dependabot::DependencyFile]) }
         def update_files(build_file)
           # We only run this updater if it's a distribution dependency
           return [] unless Distributions.distribution_requirements?(dependency.requirements)
 
-          local_files = dependency_files.select do |file|
-            file.directory == build_file.directory && target_file?(file)
-          end
+          local_files = local_wrapper_files(build_file)
 
           # If we don't have any files in the build files don't generate one
           return [] unless local_files.any?
@@ -107,13 +105,47 @@ module Dependabot
         end
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/MethodLength
-        # rubocop:enable Metrics/PerceivedComplexity
 
         private
 
         sig { params(file: Dependabot::DependencyFile).returns(T::Boolean) }
         def target_file?(file)
           @target_files.any? { |r| "/#{file.name}".end_with?(r) }
+        end
+
+        sig { params(build_file: Dependabot::DependencyFile).returns(T::Array[Dependabot::DependencyFile]) }
+        def local_wrapper_files(build_file)
+          wrapper_root = wrapper_root_for(build_file)
+
+          dependency_files.select do |file|
+            file.directory == build_file.directory && target_file_for_wrapper_root?(file, wrapper_root)
+          end
+        end
+
+        sig { params(file: Dependabot::DependencyFile, wrapper_root: String).returns(T::Boolean) }
+        def target_file_for_wrapper_root?(file, wrapper_root)
+          @target_files.any? do |target_file|
+            target_path = target_file.delete_prefix("/")
+            expected_path = wrapper_root.empty? ? target_path : File.join(wrapper_root, target_path)
+            file_path(file) == Pathname.new(expected_path).cleanpath.to_path
+          end
+        end
+
+        sig { params(build_file: Dependabot::DependencyFile).returns(String) }
+        def wrapper_root_for(build_file)
+          path = file_path(build_file)
+          root = if target_file?(build_file)
+                   File.dirname(path, 3)
+                 else
+                   File.dirname(path)
+                 end
+
+          root == "." ? "" : root
+        end
+
+        sig { params(file: Dependabot::DependencyFile).returns(String) }
+        def file_path(file)
+          Pathname.new(file.name).cleanpath.to_path
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
@@ -191,7 +223,11 @@ module Dependabot
         end
         def update_files_content(temp_dir, local_files, updated_files)
           local_files.each do |file|
-            f_content = File.read(File.join(temp_dir, file.directory, file.name))
+            f_content = if file.binary?
+                          File.binread(File.join(temp_dir, file.directory, file.name))
+                        else
+                          File.read(File.join(temp_dir, file.directory, file.name))
+                        end
             tmp_file = file.dup
             tmp_file.content = tmp_file.binary? ? Base64.encode64(f_content) : f_content
             updated_files[T.must(updated_files.index(file))] = tmp_file
@@ -203,7 +239,7 @@ module Dependabot
           files_to_populate.each do |file|
             in_path_name = File.join(temp_dir, file.directory, file.name)
             FileUtils.mkdir_p(File.dirname(in_path_name))
-            File.write(in_path_name, file.content)
+            File.binwrite(in_path_name, file.decoded_content)
           end
         end
 

--- a/gradle/spec/dependabot/gradle/file_updater/wrapper_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/wrapper_updater_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "base64"
 require "dependabot/dependency"
 require "dependabot/gradle/file_updater"
 
@@ -10,10 +11,11 @@ RSpec.describe Dependabot::Gradle::FileUpdater::WrapperUpdater do
 
   let(:updater) do
     described_class.new(
-      dependency_files: [],
+      dependency_files: dependency_files,
       dependency: dependency
     )
   end
+  let(:dependency_files) { [] }
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -65,6 +67,98 @@ RSpec.describe Dependabot::Gradle::FileUpdater::WrapperUpdater do
     it "does not crash and does not include a checksum argument from another wrapper file" do
       expect(command_args).not_to include("--gradle-distribution-sha256-sum")
       expect(command_args).to include("--distribution-type", "bin")
+    end
+  end
+
+  describe "#local_wrapper_files" do
+    subject(:local_wrapper_file_names) do
+      updater.send(:local_wrapper_files, build_file).map(&:name)
+    end
+
+    let(:build_file) do
+      Dependabot::DependencyFile.new(
+        name: "build.gradle",
+        content: "",
+        directory: "/test-project"
+      )
+    end
+    let(:dependency_files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "gradle/wrapper/gradle-wrapper.properties",
+          content: "",
+          directory: "/test-project"
+        ),
+        Dependabot::DependencyFile.new(
+          name: "gradle/wrapper/gradle-wrapper.jar",
+          content: Base64.encode64("root jar"),
+          directory: "/test-project",
+          content_encoding: Dependabot::DependencyFile::ContentEncoding::BASE64
+        ),
+        Dependabot::DependencyFile.new(
+          name: "../buildLogic/gradle/wrapper/gradle-wrapper.jar",
+          content: Base64.encode64("included build jar"),
+          directory: "/test-project",
+          content_encoding: Dependabot::DependencyFile::ContentEncoding::BASE64
+        )
+      ]
+    end
+
+    it "only includes wrapper files from the build root being updated" do
+      expect(local_wrapper_file_names).to contain_exactly(
+        "gradle/wrapper/gradle-wrapper.properties",
+        "gradle/wrapper/gradle-wrapper.jar"
+      )
+    end
+
+    context "when updating an included build" do
+      let(:build_file) do
+        Dependabot::DependencyFile.new(
+          name: "../buildLogic/build.gradle",
+          content: "",
+          directory: "/test-project"
+        )
+      end
+
+      it "only includes wrapper files from the included build root" do
+        expect(local_wrapper_file_names).to contain_exactly("../buildLogic/gradle/wrapper/gradle-wrapper.jar")
+      end
+    end
+  end
+
+  describe "binary wrapper file handling" do
+    let(:raw_jar_content) { "PK\x03\x04binary jar content".b }
+    let(:updated_raw_jar_content) { "PK\x03\x04updated binary jar content".b }
+    let(:jar_file) do
+      Dependabot::DependencyFile.new(
+        name: "gradle/wrapper/gradle-wrapper.jar",
+        content: Base64.encode64(raw_jar_content),
+        content_encoding: Dependabot::DependencyFile::ContentEncoding::BASE64
+      )
+    end
+    let(:dependency_files) { [jar_file] }
+
+    it "writes decoded binary content to the temporary directory" do
+      Dir.mktmpdir do |temp_dir|
+        updater.send(:populate_temp_directory, temp_dir)
+
+        expect(File.binread(File.join(temp_dir, "gradle/wrapper/gradle-wrapper.jar")))
+          .to eq(raw_jar_content)
+      end
+    end
+
+    it "stores updated binary content as base64 encoded dependency file content" do
+      Dir.mktmpdir do |temp_dir|
+        wrapper_path = File.join(temp_dir, "gradle/wrapper/gradle-wrapper.jar")
+        FileUtils.mkdir_p(File.dirname(wrapper_path))
+        File.binwrite(wrapper_path, updated_raw_jar_content)
+
+        updated_files = [jar_file]
+        updater.send(:update_files_content, temp_dir, [jar_file], updated_files)
+
+        expect(updated_files.first.content).to eq(Base64.encode64(updated_raw_jar_content))
+        expect(updated_files.first.decoded_content).to eq(updated_raw_jar_content)
+      end
     end
   end
 end

--- a/gradle/spec/dependabot/gradle/file_updater/wrapper_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/wrapper_updater_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dependabot::Gradle::FileUpdater::WrapperUpdater do
 
     let(:build_file) do
       Dependabot::DependencyFile.new(
-        name: "build.gradle",
+        name: "gradle/wrapper/gradle-wrapper.properties",
         content: "",
         directory: "/test-project"
       )
@@ -100,6 +100,11 @@ RSpec.describe Dependabot::Gradle::FileUpdater::WrapperUpdater do
           content: Base64.encode64("included build jar"),
           directory: "/test-project",
           content_encoding: Dependabot::DependencyFile::ContentEncoding::BASE64
+        ),
+        Dependabot::DependencyFile.new(
+          name: "../buildLogic/gradle/wrapper/gradle-wrapper.properties",
+          content: "",
+          directory: "/test-project"
         )
       ]
     end
@@ -114,14 +119,17 @@ RSpec.describe Dependabot::Gradle::FileUpdater::WrapperUpdater do
     context "when updating an included build" do
       let(:build_file) do
         Dependabot::DependencyFile.new(
-          name: "../buildLogic/build.gradle",
+          name: "../buildLogic/gradle/wrapper/gradle-wrapper.properties",
           content: "",
           directory: "/test-project"
         )
       end
 
       it "only includes wrapper files from the included build root" do
-        expect(local_wrapper_file_names).to contain_exactly("../buildLogic/gradle/wrapper/gradle-wrapper.jar")
+        expect(local_wrapper_file_names).to contain_exactly(
+          "../buildLogic/gradle/wrapper/gradle-wrapper.jar",
+          "../buildLogic/gradle/wrapper/gradle-wrapper.properties"
+        )
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Fix Gradle wrapper updates so Dependabot preserves binary wrapper JAR contents correctly and only updates the wrapper files that belong to the build currently being updated.

This prevents wrapper JARs from being committed as base64 text and avoids touching included-build wrapper JARs when the Dependabot update is scoped to another Gradle build.

Fixes #15062

### Anything you want to highlight for special attention from reviewers?

The wrapper updater now treats `DependencyFile` binary content according to its encoding contract when materializing the temporary Gradle project, and determines the wrapper root from the build file being processed before selecting wrapper files to update.

### How will you know you've accomplished your goal?

The regression coverage exercises both reported failure modes: binary wrapper JAR content is decoded before Gradle runs and re-encoded only for the returned `DependencyFile`, and included-build wrapper files are excluded when updating the root build wrapper.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
