### PR TITLE
fix: allow security related PRs to be tagged

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 require "dependabot/errors"
+require "dependabot/experiments"
 require "dependabot/pull_request_creator/message_builder"
 
 # This class describes a change to the project's Dependencies which has been
@@ -96,7 +97,8 @@ module Dependabot
         pr_message_max_length: pr_message_max_length,
         pr_message_encoding: pr_message_encoding,
         ignore_conditions: job.ignore_conditions,
-        notices: notices
+        notices: notices,
+        vulnerabilities_fixed: vulnerabilities_fixed
       ).message
 
       @pr_message = message
@@ -192,6 +194,42 @@ module Dependabot
     end
 
     private
+
+    # Maps each updated dependency whose update resolves a security advisory to
+    # the advisories it fixes, in the shape MessageBuilder expects:
+    # `{ name => [advisory_hash, ...] }`. A non-empty entry is what flips on the
+    # `[security]` PR-title prefix and the "includes a security fix" body line.
+    #
+    # That signposting machinery has existed since 2018 (PrNamePrefixer /
+    # MessageBuilder) but was never wired up from the updater — MessageBuilder
+    # defaulted `vulnerabilities_fixed: {}`, so security PRs raised by the
+    # updater went unmarked. See dependabot-core#4761.
+    #
+    # Gated behind the `add_security_pr_prefix` experiment (default off): a
+    # public `[security]` PR can disclose that a repo is currently vulnerable
+    # before the fix merges, so consumers opt in rather than getting it by
+    # default. With the flag off this returns `{}` — i.e. today's behaviour.
+    sig { returns(T::Hash[String, T::Array[T::Hash[String, T.untyped]]]) }
+    def vulnerabilities_fixed
+      return {} unless Dependabot::Experiments.enabled?(:add_security_pr_prefix)
+
+      updated_dependencies.each_with_object({}) do |dep, fixed|
+        next unless job.security_fix?(dep)
+
+        advisories =
+          job.security_advisories
+             .select { |adv| adv.fetch("dependency-name", nil)&.casecmp(dep.name)&.zero? }
+             .map do |adv|
+               {
+                 "patched_versions" => Array(adv["patched-versions"]),
+                 "unaffected_versions" => Array(adv["unaffected-versions"]),
+                 "affected_versions" => Array(adv["affected-versions"])
+               }
+             end
+
+        fixed[dep.name] = advisories if advisories.any?
+      end
+    end
 
     # Older PRs will not have a directory key, in that case do not consider directory in the comparison. This will
     # allow rebases to continue working for those, but for multi-directory configs we do compare with the directory.

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -102,7 +102,8 @@ RSpec.describe Dependabot::DependencyChange do
       allow(job).to receive_messages(
         source: github_source,
         credentials: job_credentials,
-        commit_message_options: commit_message_options
+        commit_message_options: commit_message_options,
+        security_fix?: false
       )
       allow(Dependabot::PullRequestCreator::MessageBuilder).to receive(:new).and_return(message_builder_mock)
     end
@@ -119,7 +120,8 @@ RSpec.describe Dependabot::DependencyChange do
           pr_message_encoding: nil,
           pr_message_max_length: 65_535,
           ignore_conditions: [],
-          notices: []
+          notices: [],
+          vulnerabilities_fixed: {}
         )
 
       expect(dependency_change.pr_message.pr_message).to eql("Hello World!")
@@ -147,10 +149,64 @@ RSpec.describe Dependabot::DependencyChange do
             pr_message_encoding: nil,
             pr_message_max_length: 65_535,
             ignore_conditions: [],
-            notices: []
+            notices: [],
+            vulnerabilities_fixed: {}
           )
 
         expect(dependency_change.pr_message&.pr_message).to eql("Hello World!")
+      end
+    end
+
+    context "when an update resolves a security advisory" do
+      let(:security_advisories) do
+        [
+          {
+            "dependency-name" => "business",
+            "affected-versions" => ["< 1.8.0"],
+            "patched-versions" => ["1.8.0"],
+            "unaffected-versions" => []
+          }
+        ]
+      end
+
+      before do
+        allow(job).to receive_messages(
+          security_fix?: true,
+          security_advisories: security_advisories
+        )
+      end
+
+      context "when the add_security_pr_prefix experiment is enabled" do
+        before { Dependabot::Experiments.register(:add_security_pr_prefix, true) }
+        after { Dependabot::Experiments.reset! }
+
+        it "passes the fixed advisories to the MessageBuilder, marking the PR as a security fix" do
+          expect(Dependabot::PullRequestCreator::MessageBuilder)
+            .to receive(:new).with(
+              hash_including(
+                vulnerabilities_fixed: {
+                  "business" => [
+                    {
+                      "patched_versions" => ["1.8.0"],
+                      "unaffected_versions" => [],
+                      "affected_versions" => ["< 1.8.0"]
+                    }
+                  ]
+                }
+              )
+            )
+
+          expect(dependency_change.pr_message.pr_message).to eql("Hello World!")
+        end
+      end
+
+      context "when the experiment is disabled (the default)" do
+        it "leaves vulnerabilities_fixed empty so the PR is not marked" do
+          expect(Dependabot::PullRequestCreator::MessageBuilder)
+            .to receive(:new).with(hash_including(vulnerabilities_fixed: {}))
+
+          expect(dependency_change.pr_message.pr_message).to eql("Hello World!")
+        end
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Adds the `[security]` PR-title prefix for security updates, behind an opt-in `add_security_pr_prefix` experiment (default off).

The prefix logic has existed since 2018, but the updater builds its `MessageBuilder` without passing `vulnerabilities_fixed`, so `security_fix?` was always `false` and security PRs went unmarked. This derives it from the job's advisories and threads it through. Fixes #4761.

### Anything you want to highlight for special attention from reviewers?

Default off on purpose — a public `[security]` PR discloses a repo is vulnerable before the fix merges (the reason #4761 stalled). Flag off → `vulnerabilities_fixed: {}`, identical to today. Adds the title prefix + body line only, not the `security` label (separate `Labeler` path).

It's not '23 any more. AI agents know exactly what packages your using and what's vulnerable. Pretend that raising a PR is going to draw more attention to it is security theater. It's far better maintainers see that PRs need to land as a priority because the bad guys already know where the weak spots are. I would argue this should be on by default given our current situation. We need these security PRs landed in massive quantities. But at a minimum give individual repo maintainers the option to allow these types of high priority PRs to be be highlighted.

### How will you know you've accomplished your goal?

A maintainer has the config option to flag security related PRs.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
