### PR TITLE
Add docstring to InvalidConfigError class

### DIFF
--- a/common/lib/dependabot/config.rb
+++ b/common/lib/dependabot/config.rb
@@ -3,6 +3,7 @@
 
 module Dependabot
   module Config
+    # Error raised when the configuration is invalid.
     class InvalidConfigError < StandardError; end
   end
 end


### PR DESCRIPTION
## Problem
The `InvalidConfigError` class in `Dependabot::Config` was missing a docstring, which reduces code readability and doesn't follow Ruby documentation best practices.

## Solution
Added a concise docstring: `# Error raised when the configuration is invalid.` to clearly describe the purpose of the class.

## Verification
This change is purely documentation and does not alter code behavior or functionality. It can be verified by:
- Reviewing the code change to ensure the docstring is accurate.
- Running existing tests to confirm no regressions.
- Checking that the class remains syntactically valid.