### PR TITLE
Fix workflow summary experiment name

### DIFF
--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -138,7 +138,7 @@ module Dependabot
     # This method writes the information into a collection we can use to generate a summary markdown file in actions
     sig { params(directory: String, status: String, details: String).void }
     def record_workflow_result(directory:, status:, details:)
-      return unless Experiments.enabled?(:workflow_job_summaries)
+      return unless Experiments.enabled?(:workflow_job_summary)
 
       workflow_summary.record_result(directory: directory, status: status, details: details)
     end

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -43,6 +43,7 @@ module Dependabot
       if @results.empty?
         # Ensure we write an empty file even if no summary is required
         File.write(path, "")
+        Dependabot.logger.debug("Workflow summary blank, empty file written to #{path}")
         return
       end
 

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -773,9 +773,9 @@ RSpec.describe Dependabot::Service do
   end
 
   describe "#record_workflow_result" do
-    context "when workflow_job_summaries experiment is enabled" do
+    context "when workflow_job_summary experiment is enabled" do
       before do
-        Dependabot::Experiments.register(:workflow_job_summaries, true)
+        Dependabot::Experiments.register(:workflow_job_summary, true)
       end
 
       it "delegates to the workflow_summary instance" do
@@ -786,9 +786,9 @@ RSpec.describe Dependabot::Service do
       end
     end
 
-    context "when workflow_job_summaries experiment is disabled" do
+    context "when workflow_job_summary experiment is disabled" do
       before do
-        Dependabot::Experiments.register(:workflow_job_summaries, false)
+        Dependabot::Experiments.register(:workflow_job_summary, false)
       end
 
       it "does not record results" do


### PR DESCRIPTION
### What are you trying to accomplish?

The experiment has been configured to be injected as `workflow_job_summary` but the code is expecting the plural form, `workflow_job_summaries`.

The former makes more sense so let's fix on that.

### Anything you want to highlight for special attention from reviewers?

To aid in validation testing, I've added debug logging when we set a blank summary file.

### How will you know you've accomplished your goal?

I will start seeing "Workflow summary written" log lines in my test repositories.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
