### PR TITLE
Revert "Bump library/rust from 1.93.1-bookworm to 1.95.0-bookworm in /cargo"

### DIFF
--- a/cargo/Dockerfile
+++ b/cargo/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.20
-FROM docker.io/library/rust:1.95.0-bookworm AS rust
+FROM docker.io/library/rust:1.93.1-bookworm AS rust
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 


### PR DESCRIPTION
## Summary

Pins the Cargo updater image back from the current Rust/Cargo image line to Rust 1.93.1-bookworm for a controlled diagnostic revert.

We started seeing repeated Cargo sparse-index failures after the Rust/Cargo image updates, where Cargo fails while downloading crates.io index entries with: [8] Weird server reply (Invalid status line).

The suspected regression window includes the Cargo/libcurl stack introduced after 1.93.1. Cargo has had a related upstream issue with that curl stack while updating the crates.io index, which was mitigated upstream by downgrading curl-sys.

## Why

This revert is intended to confirm whether the newer Cargo/libcurl stack is causing the flaky sparse-index failures in Dependabot production jobs. If the errors stop after reverting, we can follow up with Cargo/upstream using the narrower regression range. If they continue, that points investigation back toward crates.io/CDN, Dependabot proxying, or surrounding infrastructure.

## Links

- Reverts the Cargo image line introduced by: https://github.com/dependabot/dependabot-core/pull/14383
- Supersedes current Cargo image bump context: https://github.com/dependabot/dependabot-core/pull/15188
- Related Dependabot issue: https://github.com/dependabot/dependabot-core/issues/14743
- Related upstream Cargo mitigation: https://github.com/rust-lang/cargo/pull/16379
