### PR TITLE
Improve Cargo sparse index failure context

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -23,6 +23,10 @@ module Dependabot
         /mx
 
         LOCKFILE_CHECKSUM_REGEX = /^"checksum .*$/
+        CARGO_CRATES_IO_INDEX_URL_REGEX = %r{https://index\.crates\.io/(?<path>[a-z0-9_+.-]+(?:/[a-z0-9_+.-]+)+)}
+        CARGO_DOWNLOAD_PATH_REGEX = %r{download of (?<path>[a-z0-9_+.-]+(?:/[a-z0-9_+.-]+)+) failed}
+        CARGO_FAILED_PACKAGE_REGEX = /error: failed to get `(?<package>[A-Za-z0-9_-]+)`/
+        CARGO_CURL_ERROR_REGEX = /\[(?<code>\d+)\] (?<message>[^\n]+)/
 
         sig do
           params(
@@ -246,8 +250,45 @@ module Dependabot
               fingerprint: fingerprint,
               time_taken: time_taken,
               process_exit_value: "non-zero"
-            }
+            }.merge(crates_io_sparse_index_error_context(stdout))
           )
+        end
+
+        sig { params(stdout: String).returns(T::Hash[Symbol, T.untyped]) }
+        def crates_io_sparse_index_error_context(stdout)
+          index_url_match = stdout.match(CARGO_CRATES_IO_INDEX_URL_REGEX)
+          return {} unless index_url_match
+          return {} unless stdout.include?("curl failed") || stdout.match?(CARGO_CURL_ERROR_REGEX)
+
+          context = T.let(
+            {
+              cargo_error_type: "crates_io_sparse_index_download",
+              cargo_registry: "crates-io",
+              cargo_index_url_host: "index.crates.io",
+              cargo_index_path: T.must(index_url_match[:path])
+            },
+            T::Hash[Symbol, T.untyped]
+          )
+
+          context[:cargo_download_path] = stdout.match(CARGO_DOWNLOAD_PATH_REGEX)&.[](:path)
+          context[:cargo_failed_package] = stdout.match(CARGO_FAILED_PACKAGE_REGEX)&.[](:package)
+
+          if (curl_error = stdout.match(CARGO_CURL_ERROR_REGEX))
+            context[:cargo_curl_code] = curl_error[:code]
+            context[:cargo_curl_message] = sanitized_cargo_curl_message(T.must(curl_error[:message]))
+          end
+
+          registry_protocol = ENV.fetch("CARGO_REGISTRIES_CRATES_IO_PROTOCOL", nil)
+          context[:cargo_registry_protocol] = registry_protocol if %w(git sparse).include?(registry_protocol)
+
+          context.compact
+        end
+
+        sig { params(message: String).returns(T.nilable(String)) }
+        def sanitized_cargo_curl_message(message)
+          return nil if message.match?(%r{https?://|@})
+
+          message.strip
         end
 
         sig { params(stdout: String).void }

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -91,6 +91,84 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
           end
       end
 
+      context "with a crates.io sparse index transport failure" do
+        let(:cargo_output) do
+          <<~OUTPUT
+            Updating crates.io index
+            error: failed to get `dirs` as a dependency of package `hub v0.1.0 (dependabot_tmp_dir/native/hub)`
+
+            Caused by:
+              download of di/rs/dirs failed
+
+            Caused by:
+              failed to download from `https://index.crates.io/di/rs/dirs`
+
+            Caused by:
+              [8] Weird server reply (Invalid status line)
+          OUTPUT
+        end
+
+        before do
+          allow(Open3).to receive(:capture2e)
+            .and_return([cargo_output, instance_double(Process::Status, success?: false)])
+        end
+
+        it "adds sanitized sparse index context to the helper failure" do
+          expect { updater.updated_lockfile_content }
+            .to raise_error do |error|
+              expect(error).to be_a(Dependabot::SharedHelpers::HelperSubprocessFailed)
+              expect(error.error_context).to include(
+                cargo_error_type: "crates_io_sparse_index_download",
+                cargo_registry: "crates-io",
+                cargo_index_url_host: "index.crates.io",
+                cargo_index_path: "di/rs/dirs",
+                cargo_download_path: "di/rs/dirs",
+                cargo_failed_package: "dirs",
+                cargo_curl_code: "8",
+                cargo_curl_message: "Weird server reply (Invalid status line)"
+              )
+            end
+        end
+      end
+
+      context "with an arbitrary registry transport failure" do
+        let(:cargo_output) do
+          <<~OUTPUT
+            Updating `private-registry` index
+            error: failed to get `private-package` as a dependency of package `hub v0.1.0`
+
+            Caused by:
+              failed to download from `https://user:secret@example.com/private-package`
+
+            Caused by:
+              [8] Weird server reply (Invalid status line)
+          OUTPUT
+        end
+
+        before do
+          allow(Open3).to receive(:capture2e)
+            .and_return([cargo_output, instance_double(Process::Status, success?: false)])
+        end
+
+        it "does not add registry details that could contain credentials" do
+          expect { updater.updated_lockfile_content }
+            .to raise_error do |error|
+              expect(error).to be_a(Dependabot::SharedHelpers::HelperSubprocessFailed)
+              expect(error.error_context.keys).not_to include(
+                :cargo_error_type,
+                :cargo_registry,
+                :cargo_index_url_host,
+                :cargo_index_path,
+                :cargo_download_path,
+                :cargo_failed_package,
+                :cargo_curl_code,
+                :cargo_curl_message
+              )
+              expect(error.error_context.values.join(" ")).not_to include("user:secret", "example.com")
+            end
+        end
+      end
+
       context "when an existing requirement is not sufficient" do
         let(:dependency_version) { "0.1.38" }
         let(:requirements) do


### PR DESCRIPTION
### What are you trying to accomplish?

Improve observability for recurring Cargo sparse-index download failures from crates.io, especially transport errors such as `Weird server reply (Invalid status line)`. The goal is to add enough sanitized structured context to distinguish whether these failures are coming from Cargo/libcurl, crates.io/CDN, Dependabot proxying, or surrounding infrastructure, without adding sensitive registry data to Sentry context.

Related public issues: #14743, #14540

### Anything you want to highlight for special attention from reviewers?

The added context is intentionally narrow: it is only populated for recognized public `index.crates.io` sparse-index download failures. Arbitrary registry URLs, credentials, Cargo config contents, environment values, and raw Cargo output are not copied into the new structured context.

This keeps the existing Cargo subprocess failure flow intact while adding safe fields that should make the recurring failure mode easier to group and investigate.

### How will you know you've accomplished your goal?

The Cargo lockfile updater spec covers both the positive crates.io sparse-index case and a private/arbitrary registry failure case to ensure sensitive registry details are not added to the structured context.

Validation run:

- `bundle exec rspec spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb`
- `bundle exec rubocop lib/dependabot/cargo/file_updater/lockfile_updater.rb spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb`

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
