### PR TITLE
Validate dependency versions in GlobalJsonDiscovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.GlobalJson.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.GlobalJson.cs
@@ -103,5 +103,36 @@ public partial class DiscoveryWorkerTests
                 }
             );
         }
+
+        [Fact]
+        public async Task FiltersDependenciesWithUnparseableVersions()
+        {
+            await TestDiscoveryAsync(
+                packages: [],
+                workspacePath: "",
+                files: [
+                    ("global.json", """
+                        {
+                          "sdk": {
+                            "version": "2.2.104"
+                          },
+                          "msbuild-sdks": {
+                            "Microsoft.Build.Traversal": "not-a-version"
+                          }
+                        }
+                        """),
+                ],
+                expectedResult: new()
+                {
+                    Path = "",
+                    GlobalJson = new()
+                    {
+                        FilePath = "global.json",
+                        ExpectedDependencyCount = 0,
+                    },
+                    ExpectedProjectCount = 0,
+                }
+            );
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/GlobalJsonDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/GlobalJsonDiscovery.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 
+using NuGet.Versioning;
+
 namespace NuGetUpdater.Core.Discover;
 
 internal static class GlobalJsonDiscovery
@@ -16,15 +18,28 @@ internal static class GlobalJsonDiscovery
 
         logger.Info($"  Discovered [{globalJsonFile.RelativePath}] file.");
 
-        var dependencies = BuildFile.GetDependencies(globalJsonFile)
+        var allDependencies = BuildFile.GetDependencies(globalJsonFile)
             .OrderBy(d => d.Name)
             .ToImmutableArray();
+
+        var dependencies = ImmutableArray.CreateBuilder<Dependency>();
+        foreach (var dependency in allDependencies)
+        {
+            if (NuGetVersion.TryParse(dependency.Version, out _))
+            {
+                dependencies.Add(dependency);
+            }
+            else
+            {
+                logger.Warn($"  Dependency '{dependency.Name}' has an unparseable version: '{dependency.Version}' and will be ignored.");
+            }
+        }
 
         return new()
         {
             FilePath = globalJsonFile.RelativePath,
             IsSuccess = !globalJsonFile.FailedToParse,
-            Dependencies = dependencies,
+            Dependencies = dependencies.ToImmutable(),
         };
     }
 }


### PR DESCRIPTION
Filter out dependencies whose versions cannot be parsed as `NuGetVersion` and log a warning for each one, rather than including them in the discovery results.

### Changes
- Added `NuGetVersion.TryParse` validation in `GlobalJsonDiscovery.Discover`  
- Dependencies with unparseable versions are filtered out with a logged warning
- Added test `FiltersDependenciesWithUnparseableVersions`