### PR TITLE
Parse remaining Job collections into typed structs

### DIFF
--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -82,7 +82,7 @@ module Dependabot
         ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
         ErrorAttributes::JOB_ID => job.id,
         ErrorAttributes::DEPENDENCIES => job.dependencies,
-        ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups
+        ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups.map(&:to_h)
       }.compact
       service.record_update_job_unknown_error(error_type: "updater_error", error_details: error_details)
       service.increment_metric(

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -184,14 +184,11 @@ module Dependabot
       if grouped_update?
         # We only want PRs for the same group that have the same versions
         job.existing_group_pull_requests.any? do |pr|
-          next false if pr["dependency-group-name"] != dependency_group&.name
+          next false if pr.dependency_group_name != dependency_group&.name
 
-          directories_in_use = pr["dependencies"].all? { |dep| dep["directory"] }
-          dependencies = pr["dependencies"]
-          # Remove the pr-number key as it's not relevant to the comparison.
-          # To improve this code, use the PullRequest class which already contains this logic.
-          dependencies.each { |dep| dep.delete("pr-number") }
-          Set.new(dependencies) == updated_dependencies_set(should_consider_directory: directories_in_use)
+          dependencies = T.must(pr.dependencies)
+          directories_in_use = dependencies.all?(&:directory)
+          dependencies.to_set(&:to_h) == updated_dependencies_set(should_consider_directory: directories_in_use)
         end
       else
         job.existing_pull_requests.any?(new_pr)

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -36,9 +36,9 @@ module Dependabot
 
       groups = job.dependency_groups.map do |group|
         Dependabot::DependencyGroup.new(
-          name: group["name"],
-          rules: group["rules"],
-          applies_to: group["applies-to"]
+          name: T.must(group.name),
+          rules: group.rules || {},
+          applies_to: group.applies_to
         )
       end
 
@@ -65,14 +65,14 @@ module Dependabot
       return unless job.dependency_groups.any?
 
       unsupported_groups = job.dependency_groups.select do |group|
-        rules = group["rules"] || {}
+        rules = group.rules || {}
         rules.key?("dependency-type") &&
           !PACKAGE_MANAGERS_SUPPORTING_DEPENDENCY_TYPE.include?(job.package_manager)
       end
 
       return unless unsupported_groups.any?
 
-      group_names = unsupported_groups.map { |g| g["name"] }.join(", ")
+      group_names = unsupported_groups.map(&:name).join(", ")
       Dependabot.logger.warn <<~WARN
         The 'dependency-type' option is not supported for the '#{job.package_manager}' package manager.
         It is only supported for: #{PACKAGE_MANAGERS_SUPPORTING_DEPENDENCY_TYPE.join(', ')}.

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "base64"
@@ -136,7 +136,7 @@ module Dependabot
 
           dependencies_in_existing_prs = dependencies_in_existing_prs.filter do |dep|
             # When grouping by name, include deps from all directories; otherwise filter by current directory
-            group_by_name || !dep["directory"] || dep["directory"] == directory
+            group_by_name || !dep.directory || dep.directory == directory
           end
 
           # also add dependencies that might be in the group, as a rebase would add them;
@@ -147,14 +147,12 @@ module Dependabot
 
           add_handled_dependencies(
             current_dependencies.concat(
-              dependencies_in_existing_prs.filter_map do |dep|
-                dep["dependency-name"]
-              end
+              dependencies_in_existing_prs.filter_map(&:name)
             )
           )
         else
           # add the existing dependencies in the group so individual updates don't try to update them
-          add_handled_dependencies(dependencies_in_existing_pr_for_group(group).filter_map { |d| d["dependency-name"] })
+          add_handled_dependencies(dependencies_in_existing_pr_for_group(group).filter_map(&:name))
           # also add dependencies that might be in the group, as a rebase would add them;
           # this avoids individual PR creation that immediately is superseded by a group PR supersede
           add_handled_dependencies(group.dependencies.map(&:name))
@@ -198,15 +196,13 @@ module Dependabot
       allowed_dependencies.reject { |dep| handled_dependencies.include?(dep.name) }
     end
 
-    sig { params(group: Dependabot::DependencyGroup).returns(T::Array[T::Hash[String, T.untyped]]) }
+    sig { params(group: Dependabot::DependencyGroup).returns(T::Array[Job::ExistingGroupPullRequest::Dependency]) }
     def dependencies_in_existing_pr_for_group(group)
       existing = job.existing_group_pull_requests.find do |pr|
-        pr["dependency-group-name"] == group.name
-      end&.fetch("dependencies", []) || []
-
-      existing.filter do |dep|
-        dep["dependency-name"]
+        pr.dependency_group_name == group.name
       end
+
+      (existing&.dependencies || []).select(&:name)
     end
 
     private

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -302,7 +302,7 @@ module Dependabot
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,
-            ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups
+            ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups.map(&:to_h)
           }.compact,
           T::Hash[Symbol, T.untyped]
         )

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -16,6 +16,9 @@ require "dependabot/package/release_cooldown_options"
 require "dependabot/updater/update_type_helper"
 
 require "dependabot/job/allowed_update"
+require "dependabot/job/blocked_version"
+require "dependabot/job/dependency_group_definition"
+require "dependabot/job/existing_group_pull_request"
 require "dependabot/job/ignore_condition"
 require "dependabot/job/security_advisory_entry"
 
@@ -81,7 +84,7 @@ module Dependabot
     sig { returns(T::Array[PullRequest]) }
     attr_reader :existing_pull_requests
 
-    sig { returns(T::Array[T::Hash[String, T.untyped]]) }
+    sig { returns(T::Array[Dependabot::Job::ExistingGroupPullRequest]) }
     attr_reader :existing_group_pull_requests
 
     sig { returns(String) }
@@ -114,7 +117,7 @@ module Dependabot
     sig { returns(T::Boolean) }
     attr_reader :vendor_dependencies
 
-    sig { returns(T::Array[T.untyped]) }
+    sig { returns(T::Array[Dependabot::Job::DependencyGroupDefinition]) }
     attr_reader :dependency_groups
 
     sig { returns(T.nilable(String)) }
@@ -123,11 +126,13 @@ module Dependabot
     sig { returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
     attr_reader :cooldown
 
-    sig { returns(T::Array[T::Hash[String, T.untyped]]) }
+    sig { returns(T::Array[Dependabot::Job::BlockedVersion]) }
     attr_reader :blocked_versions
 
     sig { params(blocked_versions: T::Array[T::Hash[String, T.untyped]]).void }
-    attr_writer :blocked_versions
+    def blocked_versions=(blocked_versions)
+      @blocked_versions = self.class.parse_blocked_versions(blocked_versions)
+    end
 
     sig { returns(Dependabot::Config::UpdateConfig) }
     attr_reader :update_config
@@ -161,14 +166,21 @@ module Dependabot
       new(attrs.merge(id: job_id, repo_contents_path: repo_contents_path))
     end
 
-    sig { params(hash: T::Hash[T.untyped, T.untyped]).returns(T::Hash[T.untyped, T.untyped]) }
+    sig { params(hash: T::Hash[String, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
     def self.standardise_keys(hash)
       hash.transform_keys { |key| key.tr("-", "_").to_sym }
     end
 
+    # Non-hash entries are dropped rather than raising so that malformed
+    # entries are ignored, matching the previous hash-based filtering.
+    sig { params(blocked_versions: T::Array[T::Hash[String, T.untyped]]).returns(T::Array[BlockedVersion]) }
+    def self.parse_blocked_versions(blocked_versions)
+      blocked_versions.grep(Hash).map { |bv| BlockedVersion.from_hash(bv) }
+    end
+
     # NOTE: "attributes" are fetched and injected at run time from
     # dependabot-api using the UpdateJobPrivateSerializer
-    sig { params(attributes: T.untyped).void }
+    sig { params(attributes: T::Hash[Symbol, T.untyped]).void }
     def initialize(attributes) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       @id                             = T.let(attributes.fetch(:id), String)
       @command                        = T.let(attributes.fetch(:command, ""), String)
@@ -178,7 +190,7 @@ module Dependabot
       )
       @commit_message_options = T.let(
         attributes.fetch(:commit_message_options, {}),
-        T.nilable(T::Hash[T.untyped, T.untyped])
+        T.nilable(T::Hash[String, T.untyped])
       )
       @credentials = T.let(
         attributes.fetch(:credentials, []).map do |data|
@@ -186,7 +198,7 @@ module Dependabot
         end,
         T::Array[Dependabot::Credential]
       )
-      @dependencies                   = T.let(attributes.fetch(:dependencies), T.nilable(T::Array[T.untyped]))
+      @dependencies                   = T.let(attributes.fetch(:dependencies), T.nilable(T::Array[String]))
       @exclude_paths                  = T.let(attributes.fetch(:exclude_paths, []), T.nilable(T::Array[String]))
       @existing_pull_requests         = T.let(PullRequest.create_from_job_definition(attributes), T::Array[PullRequest])
       # TODO: Make this hash required
@@ -195,12 +207,14 @@ module Dependabot
       # so let's consider it optional for now. If we get a nil value, let's force it to be
       # an array.
       @existing_group_pull_requests = T.let(
-        attributes.fetch(:existing_group_pull_requests, []) || [],
-        T::Array[T::Hash[String, T.untyped]]
+        (attributes.fetch(:existing_group_pull_requests, []) || []).grep(Hash).map do |pr|
+          ExistingGroupPullRequest.from_hash(pr)
+        end,
+        T::Array[ExistingGroupPullRequest]
       )
       @experiments = T.let(
         attributes.fetch(:experiments, {}),
-        T.nilable(T::Hash[T.untyped, T.untyped])
+        T.nilable(T::Hash[String, T.untyped])
       )
       @ignore_conditions = T.let(
         attributes.fetch(:ignore_conditions).map { |h| Job::IgnoreCondition.from_hash(h) },
@@ -212,7 +226,8 @@ module Dependabot
 
       @requirements_update_strategy   = T.let(
         build_update_strategy(
-          **attributes.slice(:requirements_update_strategy, :lockfile_only)
+          requirements_update_strategy: attributes.fetch(:requirements_update_strategy),
+          lockfile_only: attributes.fetch(:lockfile_only)
         ),
         T.nilable(Dependabot::RequirementsUpdateStrategy)
       )
@@ -231,18 +246,23 @@ module Dependabot
         build_cooldown(attributes.fetch(:cooldown, nil)),
         T.nilable(Dependabot::Package::ReleaseCooldownOptions)
       )
-      @multi_ecosystem_update         = T.let(attributes.fetch(:multi_ecosystem_update, false), T::Boolean)
+      @multi_ecosystem_update = T.let(attributes.fetch(:multi_ecosystem_update, false), T::Boolean)
       # TODO: Make this hash required
       #
       # We will need to do a pass updating the CLI and smoke tests before this is possible,
       # so let's consider it optional for now. If we get a nil value, let's force it to be
       # an array.
-      @dependency_groups              = T.let(attributes.fetch(:dependency_groups, []) || [], T::Array[T.untyped])
+      @dependency_groups = T.let(
+        (attributes.fetch(:dependency_groups, []) || []).grep(Hash).map do |group|
+          DependencyGroupDefinition.from_hash(group)
+        end,
+        T::Array[DependencyGroupDefinition]
+      )
       @dependency_group_to_refresh    = T.let(attributes.fetch(:dependency_group_to_refresh, nil), T.nilable(String))
       @repo_private                   = T.let(attributes.fetch(:repo_private, nil), T.nilable(T::Boolean))
       @blocked_versions               = T.let(
-        attributes.fetch(:blocked_versions, []) || [],
-        T::Array[T::Hash[String, T.untyped]]
+        self.class.parse_blocked_versions(attributes.fetch(:blocked_versions, []) || []),
+        T::Array[BlockedVersion]
       )
 
       @update_config = T.let(calculate_update_config, Dependabot::Config::UpdateConfig)
@@ -502,7 +522,7 @@ module Dependabot
     sig { params(dependency: Dependabot::Dependency).returns(T::Array[String]) }
     def blocked_versions_for(dependency)
       matching_blocked_entries(dependency).filter_map do |bv|
-        req = bv["version-requirement"].strip
+        req = T.must(bv.version_requirement).strip
         req.empty? ? nil : req
       end
     end
@@ -510,10 +530,10 @@ module Dependabot
     sig { params(dependency: Dependabot::Dependency).void }
     def log_blocked_versions_for(dependency)
       entries = matching_blocked_entries(dependency).filter_map do |bv|
-        req = bv["version-requirement"].strip
+        req = T.must(bv.version_requirement).strip
         next if req.empty?
 
-        reason = bv["reason"].is_a?(String) ? bv["reason"].strip : nil
+        reason = bv.reason&.strip
         { version_requirement: req, reason: reason&.empty? ? nil : reason }
       end
       return if entries.empty?
@@ -528,15 +548,15 @@ module Dependabot
 
     sig do
       params(dependency: Dependabot::Dependency)
-        .returns(T::Array[T::Hash[String, T.untyped]])
+        .returns(T::Array[BlockedVersion])
     end
     def matching_blocked_entries(dependency)
       normaliser = name_normaliser
       normalized_dep_name = T.must(normaliser).call(dependency.name)
 
       blocked_versions
-        .select { |bv| bv["dependency-name"].is_a?(String) && bv["version-requirement"].is_a?(String) }
-        .select { |bv| T.must(normaliser).call(bv["dependency-name"]) == normalized_dep_name }
+        .select { |bv| bv.dependency_name && bv.version_requirement }
+        .select { |bv| T.must(normaliser).call(T.must(bv.dependency_name)) == normalized_dep_name }
     end
 
     sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }

--- a/updater/lib/dependabot/job/blocked_version.rb
+++ b/updater/lib/dependabot/job/blocked_version.rb
@@ -1,0 +1,41 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class Job
+    # Parsed representation of a blocked version entry, either from the job
+    # definition or fetched from the service mid-job.
+    #
+    # Replaces the raw T::Hash[String, T.untyped] with a typed struct so
+    # downstream code gets compile-time checked field access instead of
+    # hash key lookups that return T.untyped.
+    class BlockedVersion < T::ImmutableStruct
+      extend T::Sig
+
+      const :dependency_name, T.nilable(String)
+      const :version_requirement, T.nilable(String)
+      const :reason, T.nilable(String)
+
+      # Non-string values are dropped rather than raising so that malformed
+      # entries are ignored, matching the previous hash-based filtering.
+      # T.untyped is unavoidable here: this parses a freshly-deserialised
+      # JSON hash at the wire boundary.
+      # rubocop:disable Sorbet/ForbidTUntyped
+      sig { params(hash: T::Hash[String, T.untyped]).returns(BlockedVersion) }
+      # rubocop:enable Sorbet/ForbidTUntyped
+      def self.from_hash(hash)
+        name = hash["dependency-name"]
+        requirement = hash["version-requirement"]
+        reason = hash["reason"]
+
+        new(
+          dependency_name: name.is_a?(String) ? name : nil,
+          version_requirement: requirement.is_a?(String) ? requirement : nil,
+          reason: reason.is_a?(String) ? reason : nil
+        )
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/job/dependency_group_definition.rb
+++ b/updater/lib/dependabot/job/dependency_group_definition.rb
@@ -1,0 +1,61 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class Job
+    # Parsed representation of a dependency group from the job definition.
+    #
+    # Replaces the raw T::Hash[String, T.untyped] with a typed struct so
+    # downstream code gets compile-time checked field access instead of
+    # hash key lookups that return T.untyped.
+    #
+    # Named DependencyGroupDefinition to avoid colliding with
+    # Dependabot::DependencyGroup, the runtime grouping model this
+    # definition is used to build.
+    class DependencyGroupDefinition < T::ImmutableStruct
+      extend T::Sig
+
+      const :name, T.nilable(String)
+      const :applies_to, T.nilable(String)
+      # Rules are open-ended, ecosystem-agnostic configuration, so their
+      # values cannot be typed more precisely than T.untyped.
+      # rubocop:disable Sorbet/ForbidTUntyped
+      const :rules, T.nilable(T::Hash[String, T.untyped])
+      # rubocop:enable Sorbet/ForbidTUntyped
+
+      # Unexpected value types are coerced to nil rather than raising, so a
+      # malformed entry degrades gracefully instead of crashing the job at
+      # the parse boundary. T.untyped is unavoidable here: this parses a
+      # freshly-deserialised JSON hash at the wire boundary.
+      # rubocop:disable Sorbet/ForbidTUntyped
+      sig { params(hash: T::Hash[String, T.untyped]).returns(DependencyGroupDefinition) }
+      # rubocop:enable Sorbet/ForbidTUntyped
+      def self.from_hash(hash)
+        name = hash["name"]
+        applies_to = hash["applies-to"]
+        rules = hash["rules"]
+
+        new(
+          name: name.is_a?(String) ? name : nil,
+          applies_to: applies_to.is_a?(String) ? applies_to : nil,
+          rules: rules.is_a?(Hash) ? rules : nil
+        )
+      end
+
+      # The wire format of this group definition, used when reporting job
+      # errors back to the service.
+      # rubocop:disable Sorbet/ForbidTUntyped
+      sig { returns(T::Hash[String, T.untyped]) }
+      # rubocop:enable Sorbet/ForbidTUntyped
+      def to_h
+        {
+          "name" => name,
+          "applies-to" => applies_to,
+          "rules" => rules
+        }.compact
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/job/existing_group_pull_request.rb
+++ b/updater/lib/dependabot/job/existing_group_pull_request.rb
@@ -1,0 +1,86 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class Job
+    # Parsed representation of an existing group pull request from the job
+    # definition.
+    #
+    # Replaces the raw T::Hash[String, T.untyped] with a typed struct so
+    # downstream code gets compile-time checked field access instead of
+    # hash key lookups that return T.untyped.
+    class ExistingGroupPullRequest < T::ImmutableStruct
+      extend T::Sig
+
+      # A dependency listed in an existing group pull request.
+      #
+      # Values are kept exactly as received from the job definition (no
+      # directory normalisation) so comparisons against other raw job data
+      # behave the same as the previous hash-based access. Values of an
+      # unexpected type are dropped rather than raising so that malformed
+      # entries are ignored, matching the previous hash-based filtering.
+      class Dependency < T::ImmutableStruct
+        extend T::Sig
+
+        const :name, T.nilable(String)
+        const :version, T.nilable(String)
+        const :directory, T.nilable(String)
+        const :removed, T::Boolean, default: false
+
+        # T.untyped is unavoidable here: this parses a freshly-deserialised
+        # JSON hash at the wire boundary.
+        # rubocop:disable Sorbet/ForbidTUntyped
+        sig { params(hash: T::Hash[String, T.untyped]).returns(Dependency) }
+        # rubocop:enable Sorbet/ForbidTUntyped
+        def self.from_hash(hash)
+          name = hash["dependency-name"]
+          version = hash["dependency-version"]
+          directory = hash["directory"]
+
+          new(
+            name: name.is_a?(String) ? name : nil,
+            version: version.is_a?(String) ? version : nil,
+            directory: directory.is_a?(String) ? directory : nil,
+            removed: hash["dependency-removed"] == true
+          )
+        end
+
+        # The wire format of this dependency, with falsey values omitted.
+        # Matches the shape produced by DependencyChange#updated_dependencies_set
+        # so the two can be compared.
+        sig { returns(T::Hash[String, T.any(String, T::Boolean)]) }
+        def to_h
+          {
+            "dependency-name" => name,
+            "dependency-version" => version,
+            "directory" => directory,
+            "dependency-removed" => removed || nil
+          }.compact
+        end
+      end
+
+      const :dependency_group_name, T.nilable(String)
+      const :pr_number, T.nilable(Integer)
+      const :dependencies, T.nilable(T::Array[Dependency])
+
+      # T.untyped is unavoidable here: this parses a freshly-deserialised
+      # JSON hash at the wire boundary.
+      # rubocop:disable Sorbet/ForbidTUntyped
+      sig { params(hash: T::Hash[String, T.untyped]).returns(ExistingGroupPullRequest) }
+      # rubocop:enable Sorbet/ForbidTUntyped
+      def self.from_hash(hash)
+        group_name = hash["dependency-group-name"]
+        pr_number = hash["pr_number"]
+        dependencies = hash["dependencies"]
+
+        new(
+          dependency_group_name: group_name.is_a?(String) ? group_name : nil,
+          pr_number: pr_number.is_a?(Integer) ? pr_number : nil,
+          dependencies: dependencies.is_a?(Array) ? dependencies.grep(Hash).map { |d| Dependency.from_hash(d) } : nil
+        )
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -177,7 +177,7 @@ module Dependabot
         ErrorAttributes::PACKAGE_MANAGER => job&.package_manager,
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,
-        ErrorAttributes::DEPENDENCY_GROUPS => dependency_group&.name || job&.dependency_groups,
+        ErrorAttributes::DEPENDENCY_GROUPS => dependency_group&.name || job_dependency_groups(job),
         ErrorAttributes::SECURITY_UPDATE => job&.security_updates_only?
       }.compact
       record_update_job_unknown_error(error_type: "unknown_error", error_details: error_details)
@@ -220,6 +220,11 @@ module Dependabot
 
     sig { returns(Dependabot::ApiClient) }
     attr_reader :client
+
+    sig { params(job: T.untyped).returns(T.nilable(T::Array[T::Hash[String, T.untyped]])) }
+    def job_dependency_groups(job)
+      job&.dependency_groups&.map(&:to_h)
+    end
 
     sig { returns(T.nilable(Terminal::Table)) }
     def pull_request_summary

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -131,7 +131,7 @@ module Dependabot
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,
-            ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups
+            ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups.map(&:to_h)
           }.compact
 
           service.capture_exception(error: error, job: job)

--- a/updater/lib/dependabot/update_graph_command.rb
+++ b/updater/lib/dependabot/update_graph_command.rb
@@ -86,7 +86,7 @@ module Dependabot
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,
-            ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups
+            ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups.map(&:to_h)
           }.compact
 
           service.capture_exception(error: error, job: job)

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -208,7 +208,7 @@ module Dependabot
           ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
           ErrorAttributes::JOB_ID => job.id,
           ErrorAttributes::DEPENDENCIES => job.dependencies,
-          ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups
+          ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups.map(&:to_h)
         }.compact
 
         service.increment_metric(

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -559,25 +559,25 @@ module Dependabot
         !find_existing_group_pr(group).nil?
       end
 
-      sig { params(group: Dependabot::DependencyGroup).returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig { params(group: Dependabot::DependencyGroup).returns(T.nilable(Dependabot::Job::ExistingGroupPullRequest)) }
       def find_existing_group_pr(group)
         job.existing_group_pull_requests.find do |pr|
-          next false unless pr["dependency-group-name"] == group.name
+          next false unless pr.dependency_group_name == group.name
 
           existing_pr_covers_job_directories?(pr)
         end
       end
 
-      sig { params(pull_request: T::Hash[String, T.untyped]).returns(T::Boolean) }
+      sig { params(pull_request: Dependabot::Job::ExistingGroupPullRequest).returns(T::Boolean) }
       def existing_pr_covers_job_directories?(pull_request)
-        dependencies = pull_request["dependencies"]
+        dependencies = pull_request.dependencies
 
         # Old PRs without directory info — treat as match (backward compat).
         # Only enforce directory matching when ALL dependencies include a directory,
         # consistent with DependencyChange#matches_existing_pr? and PullRequest#using_directory?.
-        return true if dependencies.nil? || !dependencies.all? { |dep| dep["directory"] }
+        return true if dependencies.nil? || !dependencies.all?(&:directory)
 
-        pr_directories = dependencies.filter_map { |dep| dep["directory"] }
+        pr_directories = dependencies.filter_map(&:directory)
         job_directories = job.source.directories || [job.source.directory || "/"]
         normalized_job_dirs = job_directories.map { |d| Pathname.new(d).cleanpath.to_s }.uniq
         normalized_pr_dirs = pr_directories.map { |d| Pathname.new(d).cleanpath.to_s }.uniq

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/updater/operations/create_group_update_pull_request"
@@ -28,7 +28,7 @@ module Dependabot
 
           if job.security_updates_only?
             return true if job.dependencies && T.must(job.dependencies).count > 1
-            return true if job.dependency_groups.any? { |group| group["applies-to"] == "security-updates" }
+            return true if job.dependency_groups.any? { |group| group.applies_to == "security-updates" }
 
             return false
           end
@@ -87,7 +87,7 @@ module Dependabot
           groups_without_pr = dependency_snapshot.groups.filter_map do |group|
             existing_pr = find_existing_group_pr(group)
             if existing_pr
-              pr_number = existing_pr["pr_number"]
+              pr_number = existing_pr.pr_number
 
               Dependabot.logger.info(
                 "Detected existing pull request ##{pr_number} for the dependency group '#{group.name}'."

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -41,7 +41,7 @@ module Dependabot
 
           if job.security_updates_only?
             return true if T.must(job.dependencies).count > 1
-            return true if job.dependency_groups.any? { |group| group["applies-to"] == "security-updates" }
+            return true if job.dependency_groups.any? { |group| group.applies_to == "security-updates" }
 
             return false
           end
@@ -136,9 +136,9 @@ module Dependabot
               # are not also in the PR of the group being checked, preventing erroneous PR closures
               group_pr_deps = dependency_snapshot.dependencies_in_existing_pr_for_group(group)
               group_pr_deps.each do |dep|
-                dep_dir = dep["directory"] || "/"
+                dep_dir = dep.directory || "/"
                 existing_pr_dependencies[dep_dir] ||= Set.new
-                existing_pr_dependencies[dep_dir].add(dep["dependency-name"])
+                existing_pr_dependencies[dep_dir].add(dep.name)
               end
             end
 

--- a/updater/spec/dependabot/dependency_change_spec.rb
+++ b/updater/spec/dependabot/dependency_change_spec.rb
@@ -431,7 +431,9 @@ RSpec.describe Dependabot::DependencyChange do
         instance_double(
           Dependabot::Job,
           dependencies: updated_dependencies.map(&:name),
-          existing_group_pull_requests: existing_group_pull_requests
+          existing_group_pull_requests: existing_group_pull_requests.map do |pr|
+            Dependabot::Job::ExistingGroupPullRequest.from_hash(pr)
+          end
         )
       end
       let(:existing_group_pull_requests) do
@@ -480,7 +482,9 @@ RSpec.describe Dependabot::DependencyChange do
         instance_double(
           Dependabot::Job,
           dependencies: updated_dependencies.map(&:name),
-          existing_group_pull_requests: existing_group_pull_requests
+          existing_group_pull_requests: existing_group_pull_requests.map do |pr|
+            Dependabot::Job::ExistingGroupPullRequest.from_hash(pr)
+          end
         )
       end
       let(:existing_group_pull_requests) do

--- a/updater/spec/dependabot/dependency_group_engine_spec.rb
+++ b/updater/spec/dependabot/dependency_group_engine_spec.rb
@@ -24,10 +24,13 @@ RSpec.describe Dependabot::DependencyGroupEngine do
   end
   let(:security_updates_only) { false }
   let(:dependencies) { nil }
+  let(:group_definitions) do
+    dependency_groups_config.map { |group| Dependabot::Job::DependencyGroupDefinition.from_hash(group) }
+  end
   let(:job) do
     instance_double(
       Dependabot::Job,
-      dependency_groups: dependency_groups_config,
+      dependency_groups: group_definitions,
       source: source,
       dependencies: dependencies,
       security_updates_only?: security_updates_only
@@ -518,7 +521,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
           let(:job) do
             instance_double(
               Dependabot::Job,
-              dependency_groups: dependency_groups_config,
+              dependency_groups: group_definitions,
               source: source,
               dependencies: nil,
               security_updates_only?: false,
@@ -540,7 +543,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
           let(:job) do
             instance_double(
               Dependabot::Job,
-              dependency_groups: dependency_groups_config,
+              dependency_groups: group_definitions,
               source: source,
               dependencies: nil,
               security_updates_only?: false,
@@ -595,7 +598,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
       let(:job) do
         instance_double(
           Dependabot::Job,
-          dependency_groups: dependency_groups_config,
+          dependency_groups: group_definitions,
           source: source,
           dependencies: nil,
           security_updates_only?: false,
@@ -626,7 +629,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
       let(:job) do
         instance_double(
           Dependabot::Job,
-          dependency_groups: dependency_groups_config,
+          dependency_groups: group_definitions,
           source: source,
           dependencies: nil,
           security_updates_only?: false,
@@ -725,7 +728,7 @@ RSpec.describe Dependabot::DependencyGroupEngine do
     let(:job) do
       instance_double(
         Dependabot::Job,
-        dependency_groups: dependency_groups_config,
+        dependency_groups: group_definitions,
         source: source,
         dependencies: nil,
         security_updates_only?: false,

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Dependabot::DependencySnapshot do
     )
   end
 
+  let(:group_definitions) do
+    dependency_groups.map { |group| Dependabot::Job::DependencyGroupDefinition.from_hash(group) }
+  end
+
   let(:job) do
     instance_double(
       Dependabot::Job,
@@ -48,7 +52,7 @@ RSpec.describe Dependabot::DependencySnapshot do
       credentials: [],
       reject_external_code?: false,
       source: source,
-      dependency_groups: dependency_groups,
+      dependency_groups: group_definitions,
       allowed_update?: true,
       dependency_group_to_refresh: nil,
       dependencies: nil,
@@ -274,7 +278,7 @@ RSpec.describe Dependabot::DependencySnapshot do
           credentials: [],
           reject_external_code?: false,
           source: source,
-          dependency_groups: dependency_groups,
+          dependency_groups: group_definitions,
           allowed_update?: true,
           dependency_group_to_refresh: "monorepo-deps/dummy-pkg-a",
           dependencies: nil,
@@ -309,7 +313,7 @@ RSpec.describe Dependabot::DependencySnapshot do
           credentials: [],
           reject_external_code?: false,
           source: source,
-          dependency_groups: dependency_groups,
+          dependency_groups: group_definitions,
           dependencies: ["dummy-pkg-a"],
           allowed_update?: false,
           dependency_group_to_refresh: nil,
@@ -361,12 +365,14 @@ RSpec.describe Dependabot::DependencySnapshot do
         credentials: [],
         reject_external_code?: false,
         source: source,
-        dependency_groups: dependency_groups,
+        dependency_groups: group_definitions,
         allowed_update?: true,
         dependency_group_to_refresh: nil,
         dependencies: nil,
         experiments: { large_hadron_collider: true },
-        existing_group_pull_requests: existing_group_pull_requests
+        existing_group_pull_requests: existing_group_pull_requests.map do |pr|
+          Dependabot::Job::ExistingGroupPullRequest.from_hash(pr)
+        end
       )
     end
 

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -76,6 +76,20 @@ RSpec.describe Dependabot::Job do
   let(:repo_private) { false }
   let(:cooldown) { nil }
 
+  describe "when wire-format collections contain non-hash entries" do
+    let(:attributes) do
+      super().merge(
+        dependency_groups: [nil, { "name" => "group-a", "rules" => { "patterns" => ["*"] } }],
+        existing_group_pull_requests: ["not-a-hash", { "dependency-group-name" => "group-a" }]
+      )
+    end
+
+    it "ignores the non-hash entries instead of raising" do
+      expect(job.dependency_groups.map(&:name)).to eq(["group-a"])
+      expect(job.existing_group_pull_requests.map(&:dependency_group_name)).to eq(["group-a"])
+    end
+  end
+
   describe "::new_update_job" do
     let(:job_json) { fixture("jobs/job_with_credentials.json") }
 

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -469,7 +469,13 @@ RSpec.describe Dependabot::UpdateFilesCommand do
       perform_job
 
       job_instance = job.send(:job)
-      expect(job_instance.blocked_versions).to eq(blocked_versions)
+      expect(job_instance.blocked_versions).to contain_exactly(
+        an_object_having_attributes(
+          dependency_name: "rails",
+          version_requirement: "= 7.0.0",
+          reason: "vulnerability"
+        )
+      )
     end
 
     context "when the experiment is enabled via the job definition" do
@@ -496,7 +502,13 @@ RSpec.describe Dependabot::UpdateFilesCommand do
         perform_job
 
         job_instance = job.send(:job)
-        expect(job_instance.blocked_versions).to eq(blocked_versions)
+        expect(job_instance.blocked_versions).to contain_exactly(
+          an_object_having_attributes(
+            dependency_name: "rails",
+            version_requirement: "= 7.0.0",
+            reason: "vulnerability"
+          )
+        )
       end
     end
 

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -174,7 +174,9 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
         before do
           allow(job).to receive_messages(
             dependencies: [dependency],
-            dependency_groups: [{ "applies-to" => "security-updates" }]
+            dependency_groups: [
+              Dependabot::Job::DependencyGroupDefinition.from_hash({ "applies-to" => "security-updates" })
+            ]
           )
         end
 
@@ -187,7 +189,9 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
         before do
           allow(job).to receive_messages(
             dependencies: [dependency],
-            dependency_groups: [{ "applies-to" => "version-updates" }]
+            dependency_groups: [
+              Dependabot::Job::DependencyGroupDefinition.from_hash({ "applies-to" => "version-updates" })
+            ]
           )
         end
 
@@ -266,7 +270,7 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
           allow(job).to receive(:existing_group_pull_requests).and_return(
             [
               { "dependency-group-name" => "dummy-group", "pr_number" => 123 }
-            ]
+            ].map { |pr| Dependabot::Job::ExistingGroupPullRequest.from_hash(pr) }
           )
         end
 
@@ -299,7 +303,7 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
                   }
                 ]
               }
-            ],
+            ].map { |pr| Dependabot::Job::ExistingGroupPullRequest.from_hash(pr) },
             source: mock_source
           )
           allow(mock_source).to receive(:directory).and_return("/")
@@ -328,7 +332,7 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
                   }
                 ]
               }
-            ],
+            ].map { |pr| Dependabot::Job::ExistingGroupPullRequest.from_hash(pr) },
             source: mock_source
           )
           allow(mock_source).to receive(:directory).and_return("/")
@@ -352,7 +356,7 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
                   { "dependency-name" => "rollup", "dependency-version" => "2.79.2" }
                 ]
               }
-            ],
+            ].map { |pr| Dependabot::Job::ExistingGroupPullRequest.from_hash(pr) },
             source: mock_source
           )
           allow(mock_source).to receive(:directory).and_return("/")

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
                 }
               ]
             }
-          ]
+          ].map { |pr| Dependabot::Job::ExistingGroupPullRequest.from_hash(pr) }
         )
       end
 
@@ -334,7 +334,7 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
                 }
               ]
             }
-          ]
+          ].map { |pr| Dependabot::Job::ExistingGroupPullRequest.from_hash(pr) }
         )
       end
 
@@ -386,7 +386,7 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
                 { "dependency-name" => "dummy-pkg-d", "dependency-version" => "0.1.0" }
               ]
             }
-          ]
+          ].map { |pr| Dependabot::Job::ExistingGroupPullRequest.from_hash(pr) }
         )
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Continues #14616. `Job#existing_group_pull_requests`, `#dependency_groups`, and `#blocked_versions` were untyped arrays, so every consumer did unchecked key lookups like `pr["dependency-group-name"]`. This parses all three into `T::ImmutableStruct`s at the job boundary (`ExistingGroupPullRequest`, `DependencyGroupDefinition`, `BlockedVersion`) and migrates the ten consumer files to typed field access. It also tightens a few sigs in job.rb (`dependencies`, `initialize`, `standardise_keys`, `experiments`, `commit_message_options`).

### Anything you want to highlight for special attention from reviewers?

The structs keep the old hash semantics on purpose: raw directory strings with no normalisation, lenient parsing that nils out malformed values instead of raising, and a `to_h` that reproduces the wire format for error payloads. `DependencyChange#matches_existing_pr?` no longer mutates job state via `dep.delete("pr-number")` because pr-number is a parsed field now. New files use targeted `rubocop:disable Sorbet/ForbidTUntyped` comments for the wire-boundary `from_hash` sigs rather than growing the grandfathered todo list.

### How will you know you've accomplished your goal?

`srb tc` and `rubocop` pass, and the full updater suite is green (852 examples, 0 failures). Stubs in five spec files now feed structs instead of raw hashes.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
