### PR TITLE
Add a typed Hash subclass for requirement entries

### DIFF
--- a/common/lib/dependabot/dependency.rb
+++ b/common/lib/dependabot/dependency.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/dependency_requirement"
 require "dependabot/version"
 
 module Dependabot
@@ -90,7 +91,7 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_reader :version
 
-    sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+    sig { returns(T::Array[Dependabot::DependencyRequirement]) }
     attr_reader :requirements
 
     sig { returns(String) }
@@ -99,7 +100,7 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_reader :previous_version
 
-    sig { returns(T.nilable(T::Array[T::Hash[Symbol, T.untyped]])) }
+    sig { returns(T.nilable(T::Array[Dependabot::DependencyRequirement])) }
     attr_reader :previous_requirements
 
     sig { returns(T.nilable(String)) }
@@ -124,7 +125,6 @@ module Dependabot
     sig { returns(T.nilable(Time)) }
     attr_accessor :attribution_timestamp
 
-    # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/PerceivedComplexity
     sig do
       params(
@@ -162,12 +162,15 @@ module Dependabot
         T.nilable(String)
       )
       @version = nil if @version == ""
-      @requirements = T.let(requirements.map { |req| symbolize_keys(req) }, T::Array[T::Hash[Symbol, T.untyped]])
+      @requirements = T.let(
+        requirements.map { |req| DependencyRequirement.create(req) },
+        T::Array[Dependabot::DependencyRequirement]
+      )
       @previous_version = previous_version
       @previous_version = nil if @previous_version == ""
       @previous_requirements = T.let(
-        previous_requirements&.map { |req| symbolize_keys(req) },
-        T.nilable(T::Array[T::Hash[Symbol, T.untyped]])
+        previous_requirements&.map { |req| DependencyRequirement.create(req) },
+        T.nilable(T::Array[Dependabot::DependencyRequirement])
       )
       @package_manager = package_manager
       @directory = directory
@@ -181,7 +184,6 @@ module Dependabot
       @metadata = T.let(symbolize_keys(metadata || {}), T::Hash[Symbol, T.untyped])
       check_values
     end
-    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/PerceivedComplexity
 
     sig { returns(T::Boolean) }
@@ -272,7 +274,7 @@ module Dependabot
       end
     end
 
-    sig { params(requirements: T::Array[T::Hash[Symbol, T.untyped]]).returns(T.nilable(String)) }
+    sig { params(requirements: T::Array[Dependabot::DependencyRequirement]).returns(T.nilable(String)) }
     def docker_digest_from_reqs(requirements)
       requirements
         .filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }
@@ -340,9 +342,9 @@ module Dependabot
       self == other
     end
 
-    sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+    sig { returns(T::Array[Dependabot::DependencyRequirement]) }
     def specific_requirements
-      requirements.select { |r| requirement_class.new(r[:requirement]).specific? }
+      requirements.select { |r| requirement_class.new(r.requirement).specific? }
     end
 
     sig { returns(T.class_of(Dependabot::Requirement)) }

--- a/common/lib/dependabot/dependency_requirement.rb
+++ b/common/lib/dependabot/dependency_requirement.rb
@@ -1,0 +1,94 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  # A single requirement entry within Dependency#requirements, e.g.:
+  #
+  #   {
+  #     requirement: ">= 1.0, < 2.0",
+  #     file: "Gemfile",
+  #     groups: [:default],
+  #     source: { type: "rubygems", url: "https://rubygems.org" },
+  #     metadata: { property_name: "rails.version" } # optional
+  #   }
+  #
+  # Subclasses Hash so it is a drop-in replacement at call sites (and in
+  # type annotations) that treat requirement entries as
+  # T::Hash[Symbol, T.untyped], while exposing typed readers for the
+  # well-known keys. New code should prefer the typed readers; hash-style
+  # access remains supported while call sites are migrated gradually.
+  #
+  # Wire compatibility: instances serialise to JSON exactly like the plain
+  # hash they were created from, and compare equal (==/eql?/#hash) to plain
+  # hashes with the same content, so existing comparisons, Array/Set
+  # operations, and API payloads are unaffected.
+  #
+  # Note on Hash methods: in Ruby 3+, #merge, #dup and #compact preserve
+  # this class, while #select, #reject, #except, #transform_values and
+  # #to_h return plain Hash instances. Dependency#initialize re-wraps
+  # whatever it is given, so both styles remain safe.
+  class DependencyRequirement < Hash
+    extend T::Sig
+    extend T::Generic
+
+    # The values of a requirement entry are heterogeneous and
+    # ecosystem-specific, so this bridge class is necessarily untyped at
+    # the Hash level; the typed readers below are the migration path.
+    # rubocop:disable Sorbet/ForbidTUntyped
+    K = type_member { { fixed: Symbol } }
+    V = type_member { { fixed: T.untyped } }
+    Elem = type_member { { fixed: [Symbol, T.untyped] } }
+
+    # Builds a DependencyRequirement from a requirement hash, symbolising
+    # top-level keys. Accepts both plain hashes and existing
+    # DependencyRequirement instances and always returns a new instance.
+    sig { params(hash: T::Hash[T.any(Symbol, String), T.untyped]).returns(DependencyRequirement) }
+    def self.create(hash)
+      requirement = new
+      requirement.replace(hash.keys.to_h { |k| [k.to_sym, hash[k]] })
+      requirement
+    end
+
+    # The version constraint string, e.g. ">= 1.0, < 2.0". Nil when the
+    # dependency is pinned by a lockfile rather than a manifest constraint.
+    sig { returns(T.nilable(String)) }
+    def requirement
+      self[:requirement]
+    end
+
+    # The manifest file this requirement was declared in, e.g. "Gemfile".
+    sig { returns(T.nilable(String)) }
+    def file
+      self[:file]
+    end
+
+    # The dependency groups this requirement belongs to, e.g. ["dev"] or
+    # [:default]. Element types vary by ecosystem (strings or symbols).
+    # Nilable because some requirement entries are constructed with
+    # groups: nil, and the reader must reflect that to stay a drop-in for
+    # the underlying hash access under sorbet-runtime.
+    sig { returns(T.nilable(T::Array[T.untyped])) }
+    def groups
+      self[:groups]
+    end
+
+    # The source details for the dependency, e.g.
+    # { type: "git", url: "https://github.com/..." }. Keys may be symbols
+    # or strings depending on whether the requirement was built by a file
+    # parser or deserialised from a job definition.
+    sig { returns(T.nilable(T::Hash[T.any(Symbol, String), T.untyped])) }
+    def source
+      self[:source]
+    end
+
+    # Optional ecosystem-specific metadata about the requirement, e.g.
+    # { property_name: "rails.version" }.
+    sig { returns(T.nilable(T::Hash[T.any(Symbol, String), T.untyped])) }
+    def metadata
+      self[:metadata]
+    end
+    # rubocop:enable Sorbet/ForbidTUntyped
+  end
+end

--- a/common/spec/dependabot/dependency_requirement_spec.rb
+++ b/common/spec/dependabot/dependency_requirement_spec.rb
@@ -1,0 +1,104 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_requirement"
+
+RSpec.describe Dependabot::DependencyRequirement do
+  let(:requirement_hash) do
+    {
+      requirement: ">= 1.0, < 2.0",
+      file: "Gemfile",
+      groups: [:default],
+      source: { type: "rubygems", url: "https://rubygems.org" },
+      metadata: { property_name: "rails.version" }
+    }
+  end
+
+  describe ".create" do
+    it "symbolises string keys" do
+      requirement = described_class.create(
+        "requirement" => ">= 1.0",
+        "file" => "Gemfile",
+        "groups" => [],
+        "source" => nil
+      )
+
+      expect(requirement).to eq(
+        requirement: ">= 1.0",
+        file: "Gemfile",
+        groups: [],
+        source: nil
+      )
+    end
+
+    it "returns a new instance when given a DependencyRequirement" do
+      original = described_class.create(requirement_hash)
+      copy = described_class.create(original)
+
+      expect(copy).to eq(original)
+      expect(copy).not_to equal(original)
+    end
+  end
+
+  describe "typed readers" do
+    subject(:requirement) { described_class.create(requirement_hash) }
+
+    it "exposes the well-known keys" do
+      expect(requirement.requirement).to eq(">= 1.0, < 2.0")
+      expect(requirement.file).to eq("Gemfile")
+      expect(requirement.groups).to eq([:default])
+      expect(requirement.source).to eq(type: "rubygems", url: "https://rubygems.org")
+      expect(requirement.metadata).to eq(property_name: "rails.version")
+    end
+
+    it "returns nil for absent optional keys" do
+      minimal = described_class.create(requirement: nil, file: "Gemfile", groups: [], source: nil)
+
+      expect(minimal.requirement).to be_nil
+      expect(minimal.source).to be_nil
+      expect(minimal.metadata).to be_nil
+    end
+
+    it "returns nil groups without raising when the entry has groups: nil" do
+      req = described_class.create(requirement: ">= 1.0", file: "Gemfile", groups: nil, source: nil)
+
+      expect(req.groups).to be_nil
+    end
+  end
+
+  describe "hash compatibility" do
+    subject(:requirement) { described_class.create(requirement_hash) }
+
+    it "supports hash-style access" do
+      expect(requirement[:file]).to eq("Gemfile")
+      expect(requirement.fetch(:requirement)).to eq(">= 1.0, < 2.0")
+      expect(requirement.dig(:source, :type)).to eq("rubygems")
+    end
+
+    it "compares equal to a plain hash with the same content" do
+      expect(requirement).to eq(requirement_hash)
+      expect(requirement_hash).to eq(requirement)
+      expect(requirement.eql?(requirement_hash)).to be(true)
+      expect(requirement.hash).to eq(requirement_hash.hash)
+    end
+
+    it "interoperates with plain hashes in Array and Set operations" do
+      expect([requirement] - [requirement_hash]).to be_empty
+      expect([requirement_hash, requirement].uniq.length).to eq(1)
+      expect(Set.new([requirement_hash])).to include(requirement)
+    end
+
+    it "preserves the class through merge" do
+      merged = requirement.merge(requirement: ">= 2.0")
+
+      expect(merged).to be_a(described_class)
+      expect(merged.requirement).to eq(">= 2.0")
+      expect(requirement.requirement).to eq(">= 1.0, < 2.0")
+    end
+
+    it "serialises to JSON like a plain hash" do
+      expect(JSON.parse(requirement.to_json)).to eq(JSON.parse(requirement_hash.to_json))
+    end
+  end
+end

--- a/julia/lib/dependabot/julia/file_parser.rb
+++ b/julia/lib/dependabot/julia/file_parser.rb
@@ -163,8 +163,7 @@ module Dependabot
           if dependencies_map.key?(name)
             # Merge requirements from additional project files
             existing_dep = T.must(dependencies_map[name])
-            existing_requirements = existing_dep.requirements.dup
-            existing_requirements << new_requirement
+            existing_requirements = existing_dep.requirements + [new_requirement]
             dependencies_map[name] = Dependabot::Dependency.new(
               name: name,
               version: nil,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_workspace_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_workspace_updater.rb
@@ -1,17 +1,10 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/npm_and_yarn/helpers"
 require "dependabot/npm_and_yarn/package/registry_finder"
 require "dependabot/npm_and_yarn/registry_parser"
 require "dependabot/shared_helpers"
-
-class DependencyRequirement < T::Struct
-  const :file, String
-  const :requirement, String
-  const :groups, T::Array[String]
-  const :source, T.nilable(T::Hash[Symbol, T.untyped])
-end
 
 module Dependabot
   module NpmAndYarn
@@ -73,13 +66,13 @@ module Dependabot
           params(
             content: String,
             dependency: Dependabot::Dependency,
-            old_requirement: DependencyRequirement,
-            new_requirement: DependencyRequirement
+            old_requirement: Dependabot::DependencyRequirement,
+            new_requirement: Dependabot::DependencyRequirement
           ).returns(String)
         end
         def replace_version_in_content(content:, dependency:, old_requirement:, new_requirement:)
-          old_version = old_requirement.requirement
-          new_version = new_requirement.requirement
+          old_version = T.must(old_requirement.requirement)
+          new_version = T.must(new_requirement.requirement)
 
           pattern = build_replacement_pattern(
             dependency_name: dependency.name,
@@ -104,37 +97,19 @@ module Dependabot
           "\\1#{dependency_name}\\1: \\2#{version}\\2"
         end
 
-        sig { params(dependency: Dependabot::Dependency).returns(T::Array[DependencyRequirement]) }
+        sig { params(dependency: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
         def new_requirements(dependency)
-          dependency.requirements
-                    .select { |r| r[:file] == workspace_file.name }
-                    .map do |r|
-            DependencyRequirement.new(
-              file: r[:file],
-              requirement: r[:requirement],
-              groups: r[:groups],
-              source: r[:source]
-            )
-          end
+          dependency.requirements.select { |r| r.file == workspace_file.name }
         end
 
         sig do
           params(
             dependency: Dependabot::Dependency,
-            new_requirement: DependencyRequirement
-          ).returns(T.nilable(DependencyRequirement))
+            new_requirement: Dependabot::DependencyRequirement
+          ).returns(T.nilable(Dependabot::DependencyRequirement))
         end
         def old_requirement(dependency, new_requirement)
-          matching_req = T.must(dependency.previous_requirements).find { |r| r[:groups] == new_requirement.groups }
-
-          return nil if matching_req.nil?
-
-          DependencyRequirement.new(
-            file: matching_req[:file],
-            requirement: matching_req[:requirement],
-            groups: matching_req[:groups],
-            source: matching_req[:source]
-          )
+          T.must(dependency.previous_requirements).find { |r| r.groups == new_requirement.groups }
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

The requirements array-of-hashes is the single largest source of `T.untyped` in the codebase: 217 annotations of `T::Array[T::Hash[Symbol, T.untyped]]` across every ecosystem. This adds `Dependabot::DependencyRequirement`, a Hash subclass with fixed type members (`K = Symbol`) and typed readers for the well-known keys (`requirement`, `file`, `groups`, `source`, `metadata`). `Dependency#initialize` wraps each entry, so `#requirements` returns typed objects while remaining a static subtype of the existing hash annotations.

### Anything you want to highlight for special attention from reviewers?

A Hash subclass rather than a `T::Struct`, because it has to satisfy both worlds at once: existing sigs, hash access, `merge`, JSON payloads, and `==`/`eql?`/`hash` against plain hashes all keep working. That lets the 217 call sites migrate to the typed readers gradually instead of in one cutover. Only two files needed changes to keep `srb tc` green. One of them, `pnpm_workspace_updater.rb`, defined its own `DependencyRequirement` `T::Struct` at the global namespace; this deletes it in favour of the shared class.

### How will you know you've accomplished your goal?

`srb tc` is clean across the monorepo. The new class has its own spec covering hash compatibility (equality, `merge`, JSON serialisation, Array/Set interop), and the suites that exercise requirements all pass: common (1941 examples), bundler file_parser, file_updater and requirements_updater (267), pnpm workspace updater (18), and the updater requirements flow (156).

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
