### PR TITLE
Generate `.npmrc` from scope property when lockfile inference fails

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -12,6 +12,7 @@ require "dependabot/npm_and_yarn/helpers"
 require "dependabot/npm_and_yarn/package_manager"
 require "dependabot/npm_and_yarn/file_parser"
 require "dependabot/npm_and_yarn/file_parser/lockfile_parser"
+require "dependabot/npm_and_yarn/file_updater/npmrc_builder"
 
 module Dependabot
   module NpmAndYarn
@@ -82,7 +83,7 @@ module Dependabot
       def fetch_files
         fetched_files = T.let([], T::Array[DependencyFile])
         fetched_files << package_json
-        fetched_files << T.must(npmrc) if npmrc
+        fetched_files << T.must(npmrc) if npmrc && !scope_overrides_npmrc?
         fetched_files += npm_files if npm_version
         fetched_files += yarn_files if yarn_version
         fetched_files += pnpm_files if pnpm_version
@@ -137,14 +138,29 @@ module Dependabot
         fetched_lerna_files
       end
 
-      # If every entry in the lockfile uses the same registry, we can infer
-      # that there is a global .npmrc file, so add it here as if it were in the repo.
+      # Generates or infers an .npmrc file for the project.
+      # Priority order:
+      #   1. If credentials have `scope` → generate from credentials (authoritative, overrides everything)
+      #   2. If no `scope` AND `.npmrc` in repo → return nil (committed file handled upstream)
+      #   3. If no `scope` AND no `.npmrc` → try lockfile inference (transitional)
+      #   4. If nothing works → return nil
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/MethodLength
       sig { returns(T.nilable(DependencyFile)) }
       def inferred_npmrc # rubocop:disable Metrics/PerceivedComplexity
         return @inferred_npmrc if defined?(@inferred_npmrc)
+
+        if Dependabot::Experiments.enabled?(:enable_npmrc_credential_generation) && credentials_have_scope?
+          npmrc_from_credentials = generate_npmrc_from_credentials
+          if npmrc_from_credentials
+            Dependabot.logger.info("Generated .npmrc from credential scope configuration (overrides committed .npmrc)")
+            return @inferred_npmrc ||= T.let(npmrc_from_credentials, T.nilable(DependencyFile))
+          end
+        end
+
         return @inferred_npmrc ||= T.let(nil, T.nilable(DependencyFile)) unless npmrc.nil? && package_lock
 
         known_registries = []
@@ -157,9 +173,6 @@ module Dependabot
           begin
             uri = URI.parse(resolved)
           rescue URI::InvalidURIError
-            # Ignoring non-URIs since they're not registries.
-            # This can happen if resolved is `false`, for instance
-            # npm6 bug https://github.com/npm/cli/issues/1138
             next
           end
 
@@ -187,10 +200,42 @@ module Dependabot
           )
         end
 
+        # Lockfile inference failed — fall back to replaces-base credential generation
+        if Dependabot::Experiments.enabled?(:enable_npmrc_credential_generation)
+          npmrc_from_credentials = generate_npmrc_from_credentials
+          if npmrc_from_credentials
+            Dependabot.logger.info("Generated .npmrc from credential replaces-base configuration")
+            return @inferred_npmrc ||= npmrc_from_credentials
+          end
+        end
+
         @inferred_npmrc ||= nil
       end
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/PerceivedComplexity
+
+      sig { returns(T.nilable(DependencyFile)) }
+      def generate_npmrc_from_credentials
+        content = NpmAndYarn::FileUpdater::NpmrcBuilder.npmrc_content_from_credentials(credentials)
+        return unless content
+
+        Dependabot::DependencyFile.new(
+          name: ".npmrc",
+          content: content
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def credentials_have_scope?
+        credentials.any? { |cred| cred["type"] == "npm_registry" && cred.scope }
+      end
+
+      sig { returns(T::Boolean) }
+      def scope_overrides_npmrc?
+        Dependabot::Experiments.enabled?(:enable_npmrc_credential_generation) && credentials_have_scope?
+      end
 
       sig { returns(T.nilable(T.any(Integer, String))) }
       def npm_version

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -136,7 +136,7 @@ module Dependabot
 
         sig { returns(String) }
         def build_npmrc_from_scope_credentials
-          content = T.must(self.class.npmrc_content_from_credentials(credentials))
+          content = T.must(NpmrcBuilder.npmrc_content_from_credentials(credentials))
 
           # Append auth lines for all configured registries
           lines = [content]
@@ -167,7 +167,7 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def build_npmrc_content_from_credential_scopes
-          content = self.class.npmrc_content_from_credentials(credentials)
+          content = NpmrcBuilder.npmrc_content_from_credentials(credentials)
           return unless content
 
           replaces_base_cred = registry_credentials.find(&:replaces_base?)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb
@@ -12,7 +12,7 @@ module Dependabot
       # Build a .npmrc file from the lockfile content, credentials, and any
       # committed .npmrc
       # We should refactor this to use Package::RegistryFinder
-      class NpmrcBuilder
+      class NpmrcBuilder # rubocop:disable Metrics/ClassLength
         extend T::Sig
 
         CENTRAL_REGISTRIES = T.let(
@@ -38,9 +38,50 @@ module Dependabot
           @dependencies = dependencies
         end
 
+        # Generates .npmrc content solely from credential scope/replaces-base properties,
+        # without lockfile inference or auth token lines. Used by FileFetcher as a fallback
+        # when lockfile inference fails.
+        # rubocop:disable Metrics/PerceivedComplexity
+        sig { params(credentials: T::Array[Dependabot::Credential]).returns(T.nilable(String)) }
+        def self.npmrc_content_from_credentials(credentials)
+          registry_creds = credentials.select { |cred| cred.fetch("type") == "npm_registry" }
+          replaces_base_cred = registry_creds.find(&:replaces_base?)
+          scoped_credentials = registry_creds.select { |cred| cred.scope && cred["registry"] }
+          return if replaces_base_cred.nil? && scoped_credentials.empty?
+
+          lines = T.let([], T::Array[String])
+
+          if replaces_base_cred
+            registry = replaces_base_cred.fetch("registry")
+            registry_url = registry.start_with?("http") ? registry : "https://#{registry}"
+            lines << "registry=#{registry_url}"
+          end
+
+          scoped_credentials.each do |cred|
+            registry = cred.fetch("registry")
+            registry_url = registry.start_with?("http") ? registry : "https://#{registry}"
+            T.must(cred.scope).each do |s|
+              lines << "#{Helpers.normalize_npm_scope(s)}:registry=#{registry_url}"
+            end
+          end
+
+          lines.join("\n")
+        end
+        # rubocop:enable Metrics/PerceivedComplexity
+
         # PROXY WORK
+        # rubocop:disable Metrics/PerceivedComplexity
         sig { returns(String) }
         def npmrc_content
+          # When credentials have explicit scope, always generate from credentials
+          # (overrides committed .npmrc and lockfile inference)
+          if credentials_have_scope?
+            Dependabot.logger.info(
+              "Generating .npmrc from credential scope configuration (committed .npmrc ignored)"
+            )
+            return build_npmrc_from_scope_credentials
+          end
+
           initial_content =
             if npmrc_file then complete_npmrc_from_credentials
             elsif yarnrc_file then build_npmrc_from_yarnrc
@@ -60,6 +101,7 @@ module Dependabot
 
           final_content
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
         # PROXY WORK
         # Yarn allows registries to be defined either in an .npmrc or .yarnrc
@@ -87,6 +129,30 @@ module Dependabot
         sig { returns(T::Array[Dependabot::Dependency]) }
         attr_reader :dependencies
 
+        sig { returns(T::Boolean) }
+        def credentials_have_scope?
+          registry_credentials.any?(&:scope)
+        end
+
+        sig { returns(String) }
+        def build_npmrc_from_scope_credentials
+          content = T.must(self.class.npmrc_content_from_credentials(credentials))
+
+          # Append auth lines for all configured registries
+          lines = [content]
+          registry_credentials.each do |cred|
+            token = cred.fetch("token", nil)
+            next unless token
+
+            lines << auth_line(token, cred.fetch("registry"))
+          end
+
+          replaces_base_cred = registry_credentials.find(&:replaces_base?)
+          lines << "always-auth = true" if replaces_base_cred
+
+          lines.reject(&:empty?).join("\n")
+        end
+
         sig { returns(T.nilable(String)) }
         def build_npmrc_content_from_lockfile
           return unless yarn_lock || package_lock || shrinkwrap
@@ -101,19 +167,13 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def build_npmrc_content_from_credential_scopes
-          scoped_credentials = registry_credentials.select { |cred| cred.scope && cred["registry"] }
-          return if scoped_credentials.empty?
+          content = self.class.npmrc_content_from_credentials(credentials)
+          return unless content
 
-          lines = T.let([], T::Array[String])
-          scoped_credentials.each do |cred|
-            registry = cred.fetch("registry")
-            registry_url = registry.start_with?("http") ? registry : "https://#{registry}"
-            T.must(cred.scope).each do |s|
-              lines << "#{Helpers.normalize_npm_scope(s)}:registry=#{registry_url}"
-            end
-          end
+          replaces_base_cred = registry_credentials.find(&:replaces_base?)
+          return content unless replaces_base_cred
 
-          lines.join("\n")
+          "#{content}\nalways-auth = true"
         end
 
         sig { returns(T.nilable(String)) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_finder.rb
@@ -61,7 +61,7 @@ module Dependabot
         def registry
           return @registry if @registry
 
-          @registry = configured_registry || locked_registry || scoped_credential_registry_for_dependency ||
+          @registry = scoped_credential_registry_for_dependency || configured_registry || locked_registry ||
                       first_registry_with_dependency_details
           T.must(@registry)
         end
@@ -226,7 +226,7 @@ module Dependabot
                             .select { |cred| cred["type"] == "npm_registry" && cred["registry"] }
                             .tap do |arr|
                               arr.each do |c|
-                                c["registry"] = prepare_registry_url(c["registry"])
+                                c["registry"] = prepare_registry_url(c["registry"])&.delete_suffix("/")
                                 c["token"] ||= nil
                               end
                             end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2570,6 +2570,270 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         .to eq("registry=https://myRegistry/api/npm/npm")
     end
   end
+
+  context "with a committed .npmrc, but credentials have scope (scope overrides committed file)" do
+    let(:credentials) do
+      [Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      ), Dependabot::Credential.new(
+        {
+          "type" => "npm_registry",
+          "registry" => "npm.pkg.github.com",
+          "token" => "my_token",
+          "scope" => "@my-company"
+        }
+      )]
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_npmrc_credential_generation, true)
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, url + "?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_js_npm_with_config.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "package_json_content.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "package_lock_content.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, ".npmrc?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "npmrc_content.json"),
+          headers: json_header
+        )
+    end
+
+    it "uses generated .npmrc from credentials instead of committed file" do
+      npmrc_file = file_fetcher_instance.files.find { |f| f.name == ".npmrc" }
+      expect(npmrc_file).not_to be_nil
+      expect(npmrc_file.content).to eq("@my-company:registry=https://npm.pkg.github.com")
+    end
+
+    it "does not include the committed .npmrc as a separate file" do
+      npmrc_files = file_fetcher_instance.files.select { |f| f.name == ".npmrc" }
+      expect(npmrc_files.count).to eq(1)
+    end
+  end
+
+  context "with no .npmrc, lockfile inference fails, but credentials have scope" do
+    let(:credentials) do
+      [Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      ), Dependabot::Credential.new(
+        {
+          "type" => "npm_registry",
+          "registry" => "npm.pkg.github.com",
+          "token" => "my_token",
+          "scope" => "@my-company"
+        }
+      )]
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_npmrc_credential_generation, true)
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, File.join(url, "package.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package-lock.json"),
+          headers: json_header
+        )
+    end
+
+    it "generates an npmrc from credential scopes" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .to include(".npmrc")
+      expect(file_fetcher_instance.files.find { |f| f.name == ".npmrc" }.content)
+        .to eq("@my-company:registry=https://npm.pkg.github.com")
+    end
+  end
+
+  context "with no .npmrc, lockfile inference fails, but credentials have replaces-base" do
+    let(:credentials) do
+      [Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      ), Dependabot::Credential.new(
+        {
+          "type" => "npm_registry",
+          "registry" => "private.registry.com",
+          "token" => "my_token",
+          "replaces-base" => true
+        }
+      )]
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_npmrc_credential_generation, true)
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, File.join(url, "package.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package-lock.json"),
+          headers: json_header
+        )
+    end
+
+    it "generates an npmrc with the global registry" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .to include(".npmrc")
+      expect(file_fetcher_instance.files.find { |f| f.name == ".npmrc" }.content)
+        .to eq("registry=https://private.registry.com")
+    end
+  end
+
+  context "with no .npmrc, lockfile inference fails, and credentials have both scope and replaces-base" do
+    let(:credentials) do
+      [Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      ), Dependabot::Credential.new(
+        {
+          "type" => "npm_registry",
+          "registry" => "private.registry.com",
+          "token" => "base_token",
+          "replaces-base" => true
+        }
+      ), Dependabot::Credential.new(
+        {
+          "type" => "npm_registry",
+          "registry" => "npm.pkg.github.com",
+          "token" => "scope_token",
+          "scope" => "@my-org"
+        }
+      )]
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_npmrc_credential_generation, true)
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, File.join(url, "package.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package-lock.json"),
+          headers: json_header
+        )
+    end
+
+    it "generates an npmrc with global and scoped registries" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .to include(".npmrc")
+      expect(file_fetcher_instance.files.find { |f| f.name == ".npmrc" }.content)
+        .to eq("registry=https://private.registry.com\n@my-org:registry=https://npm.pkg.github.com")
+    end
+  end
+
+  context "with no .npmrc, lockfile inference fails, and no credential scope/replaces-base" do
+    let(:credentials) do
+      [Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      ), Dependabot::Credential.new(
+        {
+          "type" => "npm_registry",
+          "registry" => "npm.pkg.github.com",
+          "token" => "my_token"
+        }
+      )]
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_npmrc_credential_generation, true)
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, File.join(url, "package.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package-lock.json"),
+          headers: json_header
+        )
+    end
+
+    it "does not generate an npmrc" do
+      expect(file_fetcher_instance.files.map(&:name))
+        .not_to include(".npmrc")
+    end
+  end
 end
 
 def fixture_to_response(dir, file)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npmrc_builder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npmrc_builder_spec.rb
@@ -1247,7 +1247,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
         end
       end
 
-      context "when credentials have an explicit scope and lockfile inference fails" do
+      context "when credentials have an explicit scope (no lockfile, no .npmrc)" do
         let(:dependency_files) { project_dependency_files("generic/simple") }
 
         let(:credentials) do
@@ -1304,6 +1304,145 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmrcBuilder do
               @org1:registry=https://npm.pkg.github.com
               @org2:registry=https://npm.pkg.github.com
               //npm.pkg.github.com/:_authToken=my_token
+            NPMRC
+        end
+      end
+
+      context "when credentials have replaces-base and no lockfile" do
+        let(:dependency_files) { project_dependency_files("generic/simple") }
+
+        let(:credentials) do
+          [Dependabot::Credential.new(
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }
+          ), Dependabot::Credential.new(
+            {
+              "type" => "npm_registry",
+              "registry" => "private.registry.com",
+              "token" => "my_token",
+              "replaces-base" => true
+            }
+          )]
+        end
+
+        it "generates a global registry line with always-auth" do
+          expect(npmrc_content)
+            .to eq(<<~NPMRC.chomp)
+              registry=https://private.registry.com
+              always-auth = true
+              //private.registry.com/:_authToken=my_token
+            NPMRC
+        end
+      end
+
+      context "when credentials have both replaces-base and scope" do
+        let(:dependency_files) { project_dependency_files("generic/simple") }
+
+        let(:credentials) do
+          [Dependabot::Credential.new(
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }
+          ), Dependabot::Credential.new(
+            {
+              "type" => "npm_registry",
+              "registry" => "private.registry.com",
+              "token" => "base_token",
+              "replaces-base" => true
+            }
+          ), Dependabot::Credential.new(
+            {
+              "type" => "npm_registry",
+              "registry" => "npm.pkg.github.com",
+              "token" => "scope_token",
+              "scope" => "@my-org"
+            }
+          )]
+        end
+
+        it "generates global registry, scoped registry, and auth lines" do
+          expect(npmrc_content)
+            .to eq(<<~NPMRC.chomp)
+              registry=https://private.registry.com
+              @my-org:registry=https://npm.pkg.github.com
+              //private.registry.com/:_authToken=base_token
+              //npm.pkg.github.com/:_authToken=scope_token
+              always-auth = true
+            NPMRC
+        end
+      end
+
+      context "when credentials have scope and a committed .npmrc exists (scope overrides)" do
+        let(:dependency_files) { project_dependency_files("generic/npmrc_auth_token") }
+
+        let(:credentials) do
+          [Dependabot::Credential.new(
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }
+          ), Dependabot::Credential.new(
+            {
+              "type" => "npm_registry",
+              "registry" => "npm.pkg.github.com",
+              "token" => "my_token",
+              "scope" => "@my-company"
+            }
+          )]
+        end
+
+        it "generates from credentials, ignoring the committed .npmrc" do
+          expect(npmrc_content)
+            .to eq(<<~NPMRC.chomp)
+              @my-company:registry=https://npm.pkg.github.com
+              //npm.pkg.github.com/:_authToken=my_token
+            NPMRC
+        end
+      end
+
+      context "when credentials have only replaces-base (no scope)" do
+        let(:dependency_files) { project_dependency_files("generic/simple") }
+
+        let(:credentials) do
+          [Dependabot::Credential.new(
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }
+          ), Dependabot::Credential.new(
+            {
+              "type" => "npm_registry",
+              "registry" => "private.registry.com",
+              "token" => "my_token",
+              "replaces-base" => true
+            }
+          ), Dependabot::Credential.new(
+            {
+              "type" => "npm_registry",
+              "registry" => "registry.npmjs.org",
+              "token" => "public_token"
+            }
+          )]
+        end
+
+        it "generates global registry with always-auth and all auth lines" do
+          expect(npmrc_content)
+            .to eq(<<~NPMRC.chomp)
+              registry=https://private.registry.com
+              always-auth = true
+              //private.registry.com/:_authToken=my_token
+              //registry.npmjs.org/:_authToken=public_token
             NPMRC
         end
       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package/registry_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package/registry_finder_spec.rb
@@ -593,7 +593,7 @@ RSpec.describe Dependabot::NpmAndYarn::Package::RegistryFinder do
       it { is_expected.to eq("npm.pkg.github.com") }
     end
 
-    context "with a scoped dependency where rc file takes priority over credential scope" do
+    context "with a scoped dependency where credential scope takes priority over rc file" do
       let(:dependency_name) { "@my-company/some_dep" }
       let(:npmrc_file) do
         Dependabot::DependencyFile.new(
@@ -612,10 +612,10 @@ RSpec.describe Dependabot::NpmAndYarn::Package::RegistryFinder do
         )]
       end
 
-      it { is_expected.to eq("npmrc-registry.example.com") }
+      it { is_expected.to eq("npm.pkg.github.com") }
     end
 
-    context "with a scoped dependency where lockfile source takes priority over credential scope" do
+    context "with a scoped dependency where credential scope takes priority over lockfile source" do
       let(:dependency_name) { "@my-company/some_dep" }
       let(:source) do
         { type: "registry", url: "https://locked-registry.example.com" }
@@ -631,7 +631,7 @@ RSpec.describe Dependabot::NpmAndYarn::Package::RegistryFinder do
         )]
       end
 
-      it { is_expected.to eq("locked-registry.example.com") }
+      it { is_expected.to eq("npm.pkg.github.com") }
     end
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?
Generate `.npmrc` from credential `scope`/`replaces-base` properties as the **authoritative** source when present — overriding any committed `.npmrc` and lockfile inference.
<!-- Provide both a what and a _why_ for the change. -->
Currently, when users don't check in a `.npmrc` file, Dependabot tries to infer registry configuration from lockfile `resolved` URLs — which is brittle and a top source of customer escalations. This change adds a reliable fallback: if credentials have explicit `scope` or `replaces-base` configuration, we generate the `.npmrc` content directly from them.

**Priority order:** credential-based generation (`scope`) > `.npmrc` in repo > lockfile inference > credential-based generation (`replaces-base` only) > nil
<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
- **NpmrcBuilder** (`npmrc_content`): Now checks `credentials_have_scope?` **first** — when any credential has `scope`, generates `.npmrc` from credentials via `build_npmrc_from_scope_credentials` (ignoring committed `.npmrc` and lockfile inference entirely). The existing `build_npmrc_content_from_credential_scopes` remains as a fallback for `replaces-base`-only credentials when lockfile inference fails.
- **FileFetcher** (`fetch_files`): Skips the committed `.npmrc` when `scope_overrides_npmrc?` (feature-flagged) — prevents duplicate/conflicting `.npmrc` files.
- **FileFetcher** (`inferred_npmrc`): Checks scope credentials **first** (before the guard clause and lockfile inference). When scope is present, generates immediately. The `replaces-base`-only fallback still triggers after lockfile inference fails.
- **RegistryFinder** (`registry`): `scoped_credential_registry_for_dependency` is now **first** in the resolution chain (before `configured_registry` and `locked_registry`) — scope is authoritative for registry resolution too. Also fixed trailing-slash normalization in `known_registries` to prevent auth token lookup mismatches.
- **Feature flag**: All new behavior gated behind `enable_npmrc_credential_generation` — when disabled, existing behavior is fully preserved.
- **DependencyFilesBuilder**: No changes needed — it already passes `dependency_files` and `credentials` to NpmrcBuilder, which handles all paths.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- All 69 NpmrcBuilder spec tests pass (including tests for scope overriding committed `.npmrc`, multiple scopes, `replaces-base` + scope combined)
- All 6 FileFetcher credential-related spec tests pass covering: scope overrides committed `.npmrc`, scope without `.npmrc`, `replaces-base` fallback, combined, and no-fallback
- All 61 RegistryFinder spec tests pass (scope takes priority over `.npmrc` and lockfile source)
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
