### PR TITLE
fix(uv): limit requirements discovery to uv workspace members

### DIFF
--- a/uv/lib/dependabot/uv/file_fetcher.rb
+++ b/uv/lib/dependabot/uv/file_fetcher.rb
@@ -320,6 +320,9 @@ module Dependabot
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def fetch_requirement_files_from_dirs
+        workspace_paths = workspace_fetcher.workspace_member_paths
+        return workspace_paths.uniq.flat_map { |path| fetch_requirement_files_from_path(path) } unless workspace_paths.empty?
+
         repo_contents
           .select { |f| T.unsafe(f).type == "dir" }
           .flat_map { |dir| req_files_for_dir(dir) }

--- a/uv/lib/dependabot/uv/file_fetcher.rb
+++ b/uv/lib/dependabot/uv/file_fetcher.rb
@@ -321,7 +321,9 @@ module Dependabot
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def fetch_requirement_files_from_dirs
         workspace_paths = workspace_fetcher.workspace_member_paths
-        return workspace_paths.uniq.flat_map { |path| fetch_requirement_files_from_path(path) } unless workspace_paths.empty?
+        unless workspace_paths.empty?
+          return workspace_paths.uniq.flat_map { |path| fetch_requirement_files_from_path(path) }
+        end
 
         repo_contents
           .select { |f| T.unsafe(f).type == "dir" }

--- a/uv/lib/dependabot/uv/file_fetcher/workspace_fetcher.rb
+++ b/uv/lib/dependabot/uv/file_fetcher/workspace_fetcher.rb
@@ -40,6 +40,16 @@ module Dependabot
           end
         end
 
+        sig { returns(T::Array[String]) }
+        def workspace_member_paths
+          return [] unless @pyproject
+
+          members = parsed_pyproject.dig("tool", "uv", "workspace", "members")
+          return [] unless members.is_a?(Array)
+
+          members.grep(String).flat_map { |pattern| expand_workspace_pattern(pattern) }
+        end
+
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         def version_source_files
           return [] unless @pyproject
@@ -244,16 +254,6 @@ module Dependabot
         def path_within_repo?(path)
           cleaned = clean_path(path)
           !cleaned.start_with?("../", "/")
-        end
-
-        sig { returns(T::Array[String]) }
-        def workspace_member_paths
-          return [] unless @pyproject
-
-          members = parsed_pyproject.dig("tool", "uv", "workspace", "members")
-          return [] unless members.is_a?(Array)
-
-          members.grep(String).flat_map { |pattern| expand_workspace_pattern(pattern) }
         end
 
         sig { params(pattern: String).returns(T::Array[String]) }

--- a/uv/spec/dependabot/uv/file_fetcher_spec.rb
+++ b/uv/spec/dependabot/uv/file_fetcher_spec.rb
@@ -1117,6 +1117,44 @@ RSpec.describe Dependabot::Uv::FileFetcher do
         workspace_file = file_fetcher_instance.files.find { |f| f.name == "packages/my-package/pyproject.toml" }
         expect(workspace_file&.support_file?).to be(true)
       end
+
+      context "when a non-workspace top-level requirements file exists" do
+        before do
+          stub_request(:get, url + "?ref=sha")
+            .with(headers: { "Authorization" => "token token" })
+            .to_return(
+              status: 200,
+              body: [
+                { name: "pyproject.toml", path: "pyproject.toml", type: "file", size: 100 },
+                { name: "packages", path: "packages", type: "dir", size: 0 },
+                { name: "academy", path: "academy", type: "dir", size: 0 }
+              ].to_json,
+              headers: { "content-type" => "application/json" }
+            )
+
+          stub_request(:get, url + "academy?ref=sha")
+            .with(headers: { "Authorization" => "token token" })
+            .to_return(
+              status: 200,
+              body: [
+                { name: "requirements.txt", path: "academy/requirements.txt", type: "file", size: 16 }
+              ].to_json,
+              headers: { "content-type" => "application/json" }
+            )
+
+          stub_request(:get, url + "academy/requirements.txt?ref=sha")
+            .with(headers: { "Authorization" => "token token" })
+            .to_return(
+              status: 200,
+              body: fixture("github", "requirements_content.json"),
+              headers: { "content-type" => "application/json" }
+            )
+        end
+
+        it "does not fetch requirements files from non-workspace directories" do
+          expect(file_fetcher_instance.files.map(&:name)).not_to include("academy/requirements.txt")
+        end
+      end
     end
 
     context "with hatch version source path" do


### PR DESCRIPTION
### What are you trying to accomplish?

Issue reproduced in sample repository:
https://github.com/thavaahariharangit/uv-monorepo-fr-13582

The root uv.lock file does not include Django:
https://github.com/thavaahariharangit/uv-monorepo-fr-13582/blob/main/uv.lock

However, Dependabot still runs a security update for Django in the root uv job:
https://github.com/thavaahariharangit/uv-monorepo-fr-13582/actions/runs/27270642433

Fix:
- restrict uv requirement file scanning to declared workspace members when `[tool.uv.workspace]` is present
- avoid sweeping non-workspace top-level directories for `requirements.txt` / `*.in`
- expose workspace member paths from workspace fetcher for reuse in file fetcher
- add regression coverage to ensure non-workspace academy/requirements.txt is not fetched in a workspace repo


### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

- Reproduction check: in a uv workspace repo, a non-workspace top-level requirements file (for example `academy/requirements.txt`) is no longer fetched or considered by the uv updater flow.
- Functional check: requirement-file discovery is limited to declared workspace members whenever tool.uv.workspace.members exists, and only falls back to top-level scanning when no workspace is defined.
- Automated proof: uv file fetcher specs pass, including the new regression case that asserts non-workspace requirement files are excluded.
- Run used for validation: `/workspaces/dependabot-core/bin/test uv spec/dependabot/uv/file_fetcher_spec.rb` with 57 examples and 0 failures.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
