### PR TITLE
Improve handling of Python failures when insecure-external-code-execution: deny is set, Tidier summary output

### DIFF
--- a/common/lib/dependabot/file_parsers/base.rb
+++ b/common/lib/dependabot/file_parsers/base.rb
@@ -28,6 +28,11 @@ module Dependabot
       sig { returns(T::Hash[Symbol, T.untyped]) }
       attr_reader :options
 
+      sig { returns(T::Boolean) }
+      def reject_external_code?
+        @reject_external_code
+      end
+
       sig do
         params(
           dependency_files: T::Array[Dependabot::DependencyFile],

--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -65,8 +65,8 @@ module Dependabot
       sig { override.void }
       def prepare!
         if poetry_project_without_lockfile?
-          # Generating an ephemeral lockfile requires executing poetry lock, strictly this violates our policy
-          # on refusing to run Python tooling without external code execution so let's fail fast
+          # Generating an ephemeral lockfile requires executing `poetry lock`. Strictly speaking, that violates our
+          # policy of refusing to run Python tooling when external code execution is disallowed, so fail fast.
           raise Dependabot::UnexpectedExternalCode if file_parser.reject_external_code?
 
           Dependabot.logger.info("No poetry.lock found, generating ephemeral lockfile for dependency graphing")

--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -65,6 +65,10 @@ module Dependabot
       sig { override.void }
       def prepare!
         if poetry_project_without_lockfile?
+          # Generating an ephemeral lockfile requires executing poetry lock, strictly this violates our policy
+          # on refusing to run Python tooling without external code execution so let's fail fast
+          raise Dependabot::UnexpectedExternalCode if file_parser.reject_external_code?
+
           Dependabot.logger.info("No poetry.lock found, generating ephemeral lockfile for dependency graphing")
           generate_ephemeral_lockfile!
           emit_missing_lockfile_warning! if @ephemeral_lockfile_generated

--- a/python/spec/dependabot/python/dependency_grapher_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher_spec.rb
@@ -467,6 +467,25 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
           expect(grapher.relevant_dependency_file).to eql(pyproject_toml)
         end
       end
+
+      context "when reject_external_code is true" do
+        let(:parser) do
+          Dependabot::FileParsers.for_package_manager("pip").new(
+            dependency_files: dependency_files,
+            source: nil,
+            credentials: [],
+            reject_external_code: true
+          )
+        end
+
+        it "raises UnexpectedExternalCode without attempting lockfile generation" do
+          expect(Dependabot::Python::DependencyGrapher::LockfileGenerator)
+            .not_to receive(:new)
+
+          expect { grapher.resolved_dependencies }
+            .to raise_error(Dependabot::UnexpectedExternalCode)
+        end
+      end
     end
 
     context "when poetry.lock is corrupt" do

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -122,9 +122,12 @@ module Dependabot
       # We should record this failure and allow other directories in the job to continue, as they may
       # not be misconfigured.
       Dependabot.logger.info("Skipping directory #{directory} — #{UNEXPECTED_EXTERNAL_CODE_MESSAGE}")
-      service.record_update_job_error(
-        error_type: "unexpected_external_code",
-        error_details: { message: "Cannot process directory #{directory} without external code execution" }
+
+      # Emit a warning rather than an error since this is a misconfiguration the user needs to fix.
+      service.record_update_job_warning(
+        warn_type: "unexpected_external_code",
+        warn_title: "Refusing to execute external code",
+        warn_description: "Cannot process directory #{directory} without external code execution"
       )
 
       return unless Dependabot::Environment.github_actions?

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -60,20 +60,15 @@ module Dependabot
       lines << "| Directory | Status | Details |"
       lines << "|-----------|--------|---------|"
 
-      last_directory = T.let("", String)
       @results.sort_by { |r| [r.directory, r.status] }
               .group_by { |r| [r.directory, r.status] }
               .each_value do |results|
-        results.each_with_index do |result, index|
-          sanitized_details = result.details.strip.gsub(/\s*\n\s*/, "<br>")
-          status_icon = status_emoji(result.status)
+        first = T.must(results.first)
+        status_icon = status_emoji(first.status)
+        combined_details = results.map { |r| r.details.strip.gsub(/\s*\n\s*/, "<br>") }
+                                  .join("<br><br>")
 
-          dir_cell = result.directory == last_directory ? "" : "`#{result.directory}`"
-          status_cell = index.zero? ? "#{status_icon} #{result.status.capitalize}" : ""
-
-          lines << "| #{dir_cell} | #{status_cell} | #{sanitized_details} |"
-          last_directory = result.directory
-        end
+        lines << "| `#{first.directory}` | #{status_icon} #{first.status.capitalize} | #{combined_details} |"
       end
 
       lines << ""

--- a/updater/lib/dependabot/workflow_summary.rb
+++ b/updater/lib/dependabot/workflow_summary.rb
@@ -60,9 +60,9 @@ module Dependabot
       lines << "| Directory | Status | Details |"
       lines << "|-----------|--------|---------|"
 
-      @results.sort_by { |r| [r.directory, r.status] }
-              .group_by { |r| [r.directory, r.status] }
-              .each_value do |results|
+      @results.group_by { |r| [r.directory, r.status] }
+              .sort_by { |key, _| key }
+              .each do |_, results|
         first = T.must(results.first)
         status_icon = status_emoji(first.status)
         combined_details = results.map { |r| r.details.strip.gsub(/\s*\n\s*/, "<br>") }

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -855,13 +855,15 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       end
 
       it "records an error for each directory" do
-        expect(service).to receive(:record_update_job_error).with(
-          error_type: "unexpected_external_code",
-          error_details: { message: "Cannot process directory / without external code execution" }
+        expect(service).to receive(:record_update_job_warning).with(
+          warn_type: "unexpected_external_code",
+          warn_title: "Refusing to execute external code",
+          warn_description: "Cannot process directory / without external code execution"
         )
-        expect(service).to receive(:record_update_job_error).with(
-          error_type: "unexpected_external_code",
-          error_details: { message: "Cannot process directory /subproject without external code execution" }
+        expect(service).to receive(:record_update_job_warning).with(
+          warn_type: "unexpected_external_code",
+          warn_title: "Refusing to execute external code",
+          warn_description: "Cannot process directory /subproject without external code execution"
         )
 
         update_graph_processor.run
@@ -875,7 +877,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
 
       it "does not halt processing of remaining directories" do
         call_count = 0
-        allow(service).to receive(:record_update_job_error) { call_count += 1 }
+        allow(service).to receive(:record_update_job_warning) { call_count += 1 }
 
         update_graph_processor.run
 
@@ -907,7 +909,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       end
 
       it "records an error for each directory" do
-        expect(service).to receive(:record_update_job_error).twice
+        expect(service).to receive(:record_update_job_warning).twice
 
         update_graph_processor.run
       end

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -854,7 +854,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
         allow(Dependabot::Environment).to receive(:github_actions?).and_return(false)
       end
 
-      it "records an error for each directory" do
+      it "records a warning for each directory" do
         expect(service).to receive(:record_update_job_warning).with(
           warn_type: "unexpected_external_code",
           warn_title: "Refusing to execute external code",
@@ -908,7 +908,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
         update_graph_processor.run
       end
 
-      it "records an error for each directory" do
+      it "records a warning for each directory" do
         expect(service).to receive(:record_update_job_warning).twice
 
         update_graph_processor.run

--- a/updater/spec/dependabot/workflow_summary_spec.rb
+++ b/updater/spec/dependabot/workflow_summary_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Dependabot::WorkflowSummary do
       expect(markdown).to include("| `/app` | ❌ Failed | line one<br>line two<br>line three |")
     end
 
-    it "groups multiple results for the same directory and status" do
+    it "groups multiple results for the same directory and status into one row" do
       grouped_summary = described_class.new
       grouped_summary.record_result(directory: "/lib", status: "warning", details: "missing credentials for registry X")
       grouped_summary.record_result(directory: "/lib", status: "warning", details: "stale lockfile detected")
@@ -72,8 +72,9 @@ RSpec.describe Dependabot::WorkflowSummary do
 
       # Sorted by [directory, status]: Failed comes before Warning alphabetically
       expect(markdown).to include("| `/lib` | ❌ Failed | dependency_file_not_resolvable |")
-      expect(markdown).to include("|  | ⚠️ Warning | missing credentials for registry X |")
-      expect(markdown).to include("|  |  | stale lockfile detected |")
+      expect(markdown).to include(
+        "| `/lib` | ⚠️ Warning | missing credentials for registry X<br><br>stale lockfile detected |"
+      )
       expect(markdown).to include("| `/src` | ✅ Ok | 10 dependencies |")
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR follows up on:
- #15223 

We still want Dependabot jobs that end with job errors to show an overall failure status and avoid rendering the summary - this ensures unhandled errors cannot 'leak' anything into our summary output - but this means we need to be consistent about treating anything that isn't a true job-halting error as a warning instead.

This PR changes the grapher's handling of `Dependabot:: UnexpectedExternalCode` - currently only raised by Python - to a warning as it means the repository is misconfigured and the user needs to fix the issue, not that the job has actually failed.

This ensures that the summary will render the guideance on what went wrong and how to fix it as intended.

#### Other improvements

- Python graphing now fast fails if it is about to generate an ephemeral lockfile for Poetry when external code execution is disallowed rather than generate the file and then refuse to parse it
- In the event a directory has more than one message, these are now grouped into one row instead of showing the detail from each message on separate rows, e.g.

<img width="1497" height="317" alt="Screenshot 2026-06-09 at 13 37 18" src="https://github.com/user-attachments/assets/162794cf-67ea-4687-a30c-d7dd9187dc3b" />


### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

My test repository with a broken Python configuration will now show a summary instead of a hard job failure.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
