### PR TITLE
fix(maven): handle `.target` updates in file updater

### DIFF
--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -20,8 +20,8 @@ module Dependabot
         updated_files = T.let(dependency_files.dup, T::Array[Dependabot::DependencyFile])
 
         # Loop through each of the changed requirements, applying changes to
-        # all pom and extensions files for that change. Note that the logic
-        # is different here to other package managers because Maven has property
+        # all Maven dependency files for that change. Note that the logic is
+        # different here to other package managers because Maven has property
         # inheritance across files
         dependencies.each do |dependency|
           updated_files = update_files_for_dependency(

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -30,7 +30,7 @@ module Dependabot
           )
         end
 
-        updated_files.select! { |f| f.name.end_with?(".xml") }
+        updated_files.select! { |f| f.name.end_with?(".xml", ".target") }
         updated_files.reject! { |f| dependency_files.include?(f) }
 
         raise "No files changed!" if updated_files.none?

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -117,8 +117,10 @@ RSpec.describe Dependabot::Maven::FileUpdater do
 
       it "returns the updated .target file" do
         expect(updated_files.map(&:name)).to include("releng/myproject.target")
-        expect(updated_files.find { |f| f.name == "releng/myproject.target" }&.content)
-          .to include("<version>2.22.0</version>")
+        updated_target_file = updated_files.find { |f| f.name == "releng/myproject.target" }
+
+        expect(updated_target_file&.content).to include("<version>2.22.0</version>")
+        expect(updated_target_file&.content).not_to include("<version>2.11.0</version>")
       end
     end
 

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -87,6 +87,41 @@ RSpec.describe Dependabot::Maven::FileUpdater do
 
     its(:length) { is_expected.to eq(1) }
 
+    context "when updating a dependency declared in a .target file" do
+      let(:target_body) { fixture("target-files", "example.target") }
+      let(:target_file) do
+        Dependabot::DependencyFile.new(content: target_body, name: "releng/myproject.target")
+      end
+      let(:dependency_files) { [pom, target_file] }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "commons-io:commons-io",
+          version: "2.22.0",
+          requirements: [{
+            file: "releng/myproject.target",
+            requirement: "2.22.0",
+            groups: [],
+            source: nil,
+            metadata: { packaging_type: "jar" }
+          }],
+          previous_requirements: [{
+            file: "releng/myproject.target",
+            requirement: "2.11.0",
+            groups: [],
+            source: nil,
+            metadata: { packaging_type: "jar" }
+          }],
+          package_manager: "maven"
+        )
+      end
+
+      it "returns the updated .target file" do
+        expect(updated_files.map(&:name)).to include("releng/myproject.target")
+        expect(updated_files.find { |f| f.name == "releng/myproject.target" }&.content)
+          .to include("<version>2.22.0</version>")
+      end
+    end
+
     describe "the updated pom file" do
       subject(:updated_pom_file) do
         updated_files.find { |f| f.name == "pom.xml" }


### PR DESCRIPTION
### What are you trying to accomplish?

Motivation:
The Maven updater was identifying valid version bumps from Eclipse target definitions, but then failed with No files changed because those updates were not being treated as publishable updated files. This created false negatives during update runs and blocked PR creation for real dependency updates.

Changes:
The updater logic was adjusted so Maven updates include target definition outputs alongside XML-based updates, and a regression test was added to cover the target-file update path. This ensures dependency updates discovered in target-platform metadata are surfaced as real file updates.

Approach:
I traced the runtime failure from the update flow to the file collection step, aligned updater behavior with parser capabilities, and validated the fix with focused specs plus linting. The fix was kept minimal and behavior-focused to resolve the failure mode without broad refactoring.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Issue reproduced in repo: https://github.com/b2ihealthcare/snow-owl
Job Id: 1399557390

Before Fix:
```
2026-06-05T12:08:09.1586477Z 2026/06/05 12:08:09 ERROR <job_1399557390> No files changed!
2026-06-05T12:08:09.1588393Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/maven/lib/dependabot/maven/file_updater.rb:36:in 'Dependabot::Maven::FileUpdater#updated_dependency_files'
2026-06-05T12:08:09.1590438Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:919:in 'UnboundMethod#bind_call'
2026-06-05T12:08:09.1592913Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:919:in 'block in Dependabot::Maven::FileUpdater#create_validator_method_medium0'
2026-06-05T12:08:09.1594902Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:155:in 'Dependabot::DependencyChangeBuilder#generate_dependency_files'
2026-06-05T12:08:09.1596797Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:919:in 'UnboundMethod#bind_call'
2026-06-05T12:08:09.1598347Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:919:in 'block in Dependabot::DependencyChangeBuilder#create_validator_method_medium0'
2026-06-05T12:08:09.1599807Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:74:in 'Dependabot::DependencyChangeBuilder#run'
2026-06-05T12:08:09.1601061Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:59:in 'UnboundMethod#bind_call'
2026-06-05T12:08:09.1602592Z updater | 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation_2_7.rb:59:in 'block in Dependabot::DependencyChangeBuilder#create_validator_method_fast0'
2026-06-05T12:08:09.1604253Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/lib/dependabot/dependency_change_builder.rb:44:in 'Dependabot::DependencyChangeBuilder.create_from'
2026-06-05T12:08:09.1605525Z updater | 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:191:in 'UnboundMethod#bind_call'
2026-06-05T12:08:09.1607272Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:191:in 'T::Private::Methods::CallValidation.validate_call_skip_block_type'
2026-06-05T12:08:09.1608991Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/vendor/ruby/3.4.0/gems/sorbet-runtime-0.6.13208/lib/types/private/methods/call_validation.rb:133:in 'block in Dependabot::DependencyChangeBuilder.create_validator_slow_skip_block_type'
2026-06-05T12:08:09.1610573Z 2026/06/05 12:08:09 ERROR <job_1399557390> /home/dependabot/dependabot-updater/lib/dependabot/updater/operations/update_all_versions.rb:176:in 
```

```
2026-06-05T12:10:27.2407167Z Dependabot encountered '87' error(s) during execution, please check the logs for more details.
2026-06-05T12:10:27.2407939Z +------------------------------------------------------------------------------------------------------+
2026-06-05T12:10:27.2408506Z |                                    Dependencies failed to update                                     |
2026-06-05T12:10:27.2409031Z +----------------------------------------------------------------------+---------------+---------------+
2026-06-05T12:10:27.2409549Z | Dependency                                                           | Error Type    | Error Details |
2026-06-05T12:10:27.2410528Z +----------------------------------------------------------------------+---------------+---------------+
2026-06-05T12:10:27.2411094Z | net.bytebuddy:byte-buddy-agent                                       | unknown_error | null          |
2026-06-05T12:10:27.2411652Z | net.bytebuddy:byte-buddy                                             | unknown_error | null          |
2026-06-05T12:10:27.2412177Z | org.eclipse.jetty:jetty-io                                           | unknown_error | null          |
2026-06-05T12:10:27.2412788Z | org.eclipse.jetty.websocket:jetty-websocket-core-server              | unknown_error | null          |
2026-06-05T12:10:27.2413450Z | jakarta.websocket:jakarta.websocket-api                              | unknown_error | null          |
2026-06-05T12:10:27.2414076Z | org.eclipse.jetty.ee10.osgi:jetty-ee10-osgi-boot                     | unknown_error | null          |
2026-06-05T12:10:27.2414668Z | com.bucket4j:bucket4j_jdk17-core                                     | unknown_error | null          |
2026-06-05T12:10:27.2415222Z | org.codehaus.woodstox:stax2-api                                      | unknown_error | null          |
```

After fix:
```
updater | +--------------------------------------------------------------------------------------------------------------------------+
updater | |                                           Changes to Dependabot Pull Requests                                            |
updater | +---------+----------------------------------------------------------------------------------------------------------------+
updater | | created | net.bytebuddy:byte-buddy-agent ( from 1.18.5 to 1.18.10 ), net.bytebuddy:byte-buddy ( from 1.18.5 to 1.18.10 ) |
updater | | created | org.slf4j:slf4j-api ( from 2.0.17 to 2.0.18 )                                                                  |
updater | | created | org.slf4j:jcl-over-slf4j ( from 2.0.17 to 2.0.18 )                                                             |
updater | | created | org.slf4j:jul-to-slf4j ( from 2.0.17 to 2.0.18 )                                                               |
updater | | created | ch.qos.logback:logback-classic ( from 1.5.32 to 1.5.34 )                                                       |
updater | | created | ch.qos.logback:logback-core ( from 1.5.32 to 1.5.34 )                                                          |
updater | | created | com.fasterxml.jackson.core:jackson-annotations ( from 2.21 to 2.22 )                                           |
updater | | created | com.fasterxml.jackson.core:jackson-core ( from 2.21.1 to 2.22.0 )                                              |
updater | | created | com.fasterxml.jackson.core:jackson-databind ( from 2.21.1 to 2.22.0 )                                          |
updater | | created | com.fasterxml.jackson.dataformat:jackson-dataformat-cbor ( from 2.21.1 to 2.22.0 )                             |
updater | | created | com.fasterxml.jackson.dataformat:jackson-dataformat-csv ( from 2.21.1 to 2.22.0 )                              |
updater | | created | com.fasterxml.jackson.dataformat:jackson-dataformat-smile ( from 2.21.1 to 2.22.0 )                            |
updater | | created | com.fasterxml.jackson.dataformat:jackson-dataformat-xml ( from 2.21.1 to 2.22.0 )                              |
updater | | created | com.fasterxml.jackson.dataformat:jackson-dataformat-yaml ( from 2.21.1 to 2.22.0 )                             |
updater | | created | org.yaml:snakeyaml ( from 2.5 to 2.6 )                                                                         |
updater | | created | com.fasterxml.jackson.datatype:jackson-datatype-guava ( from 2.21.1 to 2.22.0 )                                |
updater | | created | com.fasterxml.jackson.datatype:jackson-datatype-jsr310 ( from 2.21.1 to 2.22.0 )                               |
updater | | created | com.fasterxml.jackson.module:jackson-module-afterburner ( from 2.21.1 to 2.22.0 )                              |
updater | | created | org.codehaus.woodstox:stax2-api ( from 4.2.2 to 4.3.0 )                                                        |
updater | | created | com.fasterxml.woodstox:woodstox-core ( from 7.1.1 to 7.2.1 )                                                   |
updater | | created | io.netty:netty-buffer ( from 4.1.132.Final to 4.2.15.Final )   
```


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
