### PR TITLE
Type updated_requirements as DependencyRequirement across all ecosystems

### DIFF
--- a/bazel/lib/dependabot/bazel/update_checker.rb
+++ b/bazel/lib/dependabot/bazel/update_checker.rb
@@ -34,14 +34,16 @@ module Dependabot
         nil
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         return dependency.requirements unless latest_version
 
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          latest_version: latest_version.to_s
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            latest_version: latest_version.to_s
+          ).updated_requirements
+        )
       end
 
       sig { returns(T.class_of(Dependabot::Bazel::Version)) }

--- a/bun/lib/dependabot/bun/update_checker.rb
+++ b/bun/lib/dependabot/bun/update_checker.rb
@@ -51,7 +51,7 @@ module Dependabot
       )
         @latest_version = T.let(nil, T.nilable(T.any(String, Gem::Version)))
         @latest_resolvable_version = T.let(nil, T.nilable(T.any(String, Dependabot::Version)))
-        @updated_requirements = T.let(nil, T.nilable(T::Array[T::Hash[Symbol, T.untyped]]))
+        @updated_requirements = T.let(nil, T.nilable(T::Array[Dependabot::DependencyRequirement]))
         @vulnerability_audit = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
         @vulnerable_versions = T.let(nil, T.nilable(T::Array[T.any(String, Gem::Version)]))
 
@@ -161,7 +161,7 @@ module Dependabot
         T.unsafe(version_resolver.latest_resolvable_previous_version(updated_version))
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         resolvable_version =
           if preferred_resolvable_version.is_a?(version_class)
@@ -176,12 +176,14 @@ module Dependabot
           end
 
         @updated_requirements ||=
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            updated_source: updated_source,
-            latest_resolvable_version: resolvable_version,
-            update_strategy: T.must(requirements_update_strategy)
-          ).updated_requirements
+          wrap_requirements(
+            RequirementsUpdater.new(
+              requirements: dependency.requirements,
+              updated_source: updated_source,
+              latest_resolvable_version: resolvable_version,
+              update_strategy: T.must(requirements_update_strategy)
+            ).updated_requirements
+          )
       end
 
       sig { returns(T::Boolean) }

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -75,18 +75,20 @@ module Dependabot
         end
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         latest_version_for_req_updater = latest_version_details&.fetch(:version)&.to_s
         latest_resolvable_version_for_req_updater = preferred_resolvable_version_details&.fetch(:version)&.to_s
 
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          update_strategy: T.must(requirements_update_strategy),
-          updated_source: updated_source,
-          latest_version: latest_version_for_req_updater,
-          latest_resolvable_version: latest_resolvable_version_for_req_updater
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            update_strategy: T.must(requirements_update_strategy),
+            updated_source: updated_source,
+            latest_version: latest_version_for_req_updater,
+            latest_resolvable_version: latest_resolvable_version_for_req_updater
+          ).updated_requirements
+        )
       end
 
       sig { returns(T::Boolean) }

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -88,14 +88,16 @@ module Dependabot
         )
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          updated_source: updated_source,
-          target_version: target_version,
-          update_strategy: requirements_update_strategy
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            updated_source: updated_source,
+            target_version: target_version,
+            update_strategy: requirements_update_strategy
+          ).updated_requirements
+        )
       end
 
       sig { override.returns(T::Boolean) }

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -182,7 +182,7 @@ module Dependabot
         dependency.version
       end
 
-      sig { overridable.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { overridable.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         raise NotImplementedError
       end
@@ -225,6 +225,16 @@ module Dependabot
       end
 
       private
+
+      # Wraps an array of raw requirement hashes (e.g. the output of an
+      # ecosystem RequirementsUpdater) into typed DependencyRequirement
+      # objects, so updated_requirements overrides can satisfy the typed
+      # return contract. Idempotent: DependencyRequirement is itself a Hash,
+      # so already-wrapped entries are handled too.
+      sig { params(requirements: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Array[Dependabot::DependencyRequirement]) }
+      def wrap_requirements(requirements)
+        requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) }
+      end
 
       sig { returns(T::Array[Dependabot::SecurityAdvisory]) }
       def active_advisories

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -229,11 +229,15 @@ module Dependabot
       # Wraps an array of raw requirement hashes (e.g. the output of an
       # ecosystem RequirementsUpdater) into typed DependencyRequirement
       # objects, so updated_requirements overrides can satisfy the typed
-      # return contract. Idempotent: DependencyRequirement is itself a Hash,
-      # so already-wrapped entries are handled too.
+      # return contract. Entries that are already DependencyRequirement
+      # instances are returned as-is; plain hashes are wrapped. Re-wrapping
+      # would produce a value-equal copy, so skipping it avoids needless
+      # allocations.
       sig { params(requirements: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Array[Dependabot::DependencyRequirement]) }
       def wrap_requirements(requirements)
-        requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) }
+        requirements.map do |requirement|
+          requirement.is_a?(Dependabot::DependencyRequirement) ? requirement : Dependabot::DependencyRequirement.create(requirement)
+        end
       end
 
       sig { returns(T::Array[Dependabot::SecurityAdvisory]) }

--- a/composer/lib/dependabot/composer/update_checker.rb
+++ b/composer/lib/dependabot/composer/update_checker.rb
@@ -75,13 +75,15 @@ module Dependabot
         )
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          latest_resolvable_version: preferred_resolvable_version&.to_s,
-          update_strategy: T.must(requirements_update_strategy)
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            latest_resolvable_version: preferred_resolvable_version&.to_s,
+            update_strategy: T.must(requirements_update_strategy)
+          ).updated_requirements
+        )
       end
 
       sig { returns(T::Boolean) }

--- a/conda/lib/dependabot/conda/update_checker.rb
+++ b/conda/lib/dependabot/conda/update_checker.rb
@@ -94,13 +94,15 @@ module Dependabot
         @lowest_resolvable_security_fix_version
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          update_strategy: requirements_update_strategy,
-          latest_resolvable_version: preferred_resolvable_version&.to_s
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            update_strategy: requirements_update_strategy,
+            latest_resolvable_version: preferred_resolvable_version&.to_s
+          ).updated_requirements
+        )
       end
 
       sig { override.returns(Dependabot::RequirementsUpdateStrategy) }

--- a/deno/lib/dependabot/deno/update_checker.rb
+++ b/deno/lib/dependabot/deno/update_checker.rb
@@ -28,13 +28,14 @@ module Dependabot
         dependency.version
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         return dependency.requirements unless latest_version
 
-        dependency.requirements.map do |req|
+        updated = dependency.requirements.map do |req|
           req.merge(requirement: updated_constraint(req[:requirement]))
         end
+        wrap_requirements(updated)
       end
 
       private

--- a/devcontainers/lib/dependabot/devcontainers/update_checker.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker.rb
@@ -31,9 +31,9 @@ module Dependabot
         raise NotImplementedError
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        dependency.requirements.map do |requirement|
+        updated_reqs = dependency.requirements.map do |requirement|
           required_version = T.cast(version_class.new(requirement[:requirement]), Dependabot::Devcontainers::Version)
           updated_requirement = remove_precision_changes(
             T.cast(release_versions, T::Array[Dependabot::Devcontainers::Version]),
@@ -46,6 +46,7 @@ module Dependabot
             source: requirement[:source]
           }
         end
+        wrap_requirements(updated_reqs)
       end
 
       private

--- a/devcontainers/lib/dependabot/devcontainers/update_checker.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker.rb
@@ -41,7 +41,7 @@ module Dependabot
           ).last
           {
             file: requirement[:file],
-            requirement: updated_requirement,
+            requirement: updated_requirement&.to_s,
             groups: requirement[:groups],
             source: requirement[:source]
           }

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -130,9 +130,9 @@ module Dependabot
         dependency.version
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        dependency.requirements.map do |req|
+        updated = dependency.requirements.map do |req|
           updated_source = req.fetch(:source).dup
 
           tag = req[:source][:tag]
@@ -148,6 +148,7 @@ module Dependabot
 
           req.merge(source: updated_source)
         end
+        wrap_requirements(updated)
       end
 
       private

--- a/dotnet_sdk/lib/dependabot/dotnet_sdk/update_checker.rb
+++ b/dotnet_sdk/lib/dependabot/dotnet_sdk/update_checker.rb
@@ -40,9 +40,9 @@ module Dependabot
         raise NotImplementedError
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        dependency.requirements.map do |requirement|
+        updated_reqs = dependency.requirements.map do |requirement|
           {
             file: requirement[:file],
             requirement: preferred_resolvable_version,
@@ -50,6 +50,7 @@ module Dependabot
             source: requirement[:source]
           }
         end
+        wrap_requirements(updated_reqs)
       end
 
       private

--- a/dotnet_sdk/lib/dependabot/dotnet_sdk/update_checker.rb
+++ b/dotnet_sdk/lib/dependabot/dotnet_sdk/update_checker.rb
@@ -45,7 +45,7 @@ module Dependabot
         updated_reqs = dependency.requirements.map do |requirement|
           {
             file: requirement[:file],
-            requirement: preferred_resolvable_version,
+            requirement: preferred_resolvable_version&.to_s,
             groups: requirement[:groups],
             source: requirement[:source]
           }

--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -37,12 +37,14 @@ module Dependabot
         nil
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.nilable(String)]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          latest_resolvable_version: latest_resolvable_version
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            latest_resolvable_version: latest_resolvable_version
+          ).updated_requirements
+        )
       end
 
       # Overwrite the base class to allow multi-dependency update PRs for

--- a/git_submodules/lib/dependabot/git_submodules/update_checker.rb
+++ b/git_submodules/lib/dependabot/git_submodules/update_checker.rb
@@ -37,7 +37,7 @@ module Dependabot
         latest_version
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         # Submodule requirements are the URL and branch to use for the
         # submodule. We never want to update either.

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -52,9 +52,9 @@ module Dependabot
         )
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        dependency.requirements.map do |req|
+        updated_reqs = dependency.requirements.map do |req|
           source = req[:source]
           updated = updated_ref(source)
           next req unless updated
@@ -72,6 +72,7 @@ module Dependabot
           new_source = source.merge(ref: updated)
           req.merge(source: new_source)
         end
+        wrap_requirements(updated_reqs)
       end
 
       private

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -47,11 +47,12 @@ module Dependabot
         nil
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        dependency.requirements.map do |req|
+        updated = dependency.requirements.map do |req|
           req.merge(requirement: latest_version)
         end
+        wrap_requirements(updated)
       end
 
       private

--- a/go_modules/lib/dependabot/go_modules/update_checker.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker.rb
@@ -50,7 +50,7 @@ module Dependabot
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         updated = dependency.requirements.map do |req|
-          req.merge(requirement: latest_version)
+          req.merge(requirement: latest_version&.to_s)
         end
         wrap_requirements(updated)
       end

--- a/gradle/lib/dependabot/gradle/update_checker.rb
+++ b/gradle/lib/dependabot/gradle/update_checker.rb
@@ -62,18 +62,20 @@ module Dependabot
         nil
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         property_names =
           declarations_using_a_property
           .map { |req| req.dig(:metadata, :property_name) }
 
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          latest_version: preferred_resolvable_version&.to_s,
-          source_url: preferred_version_details&.fetch(:source_url),
-          properties_to_update: property_names
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            latest_version: preferred_resolvable_version&.to_s,
+            source_url: preferred_version_details&.fetch(:source_url),
+            properties_to_update: property_names
+          ).updated_requirements
+        )
       end
 
       sig { override.returns(T::Boolean) }

--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -36,17 +36,18 @@ module Dependabot
         dependency.version
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         return dependency.requirements unless latest_version
 
-        dependency.requirements.map do |req|
+        updated_reqs = dependency.requirements.map do |req|
           updated_metadata = req.fetch(:metadata).dup
           updated_req = req.dup
           updated_req[:requirement] = latest_version.to_s if updated_metadata.key?(:type)
 
           updated_req
         end
+        wrap_requirements(updated_reqs)
       end
 
       private

--- a/hex/lib/dependabot/hex/update_checker.rb
+++ b/hex/lib/dependabot/hex/update_checker.rb
@@ -57,13 +57,15 @@ module Dependabot
           end
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          updated_source: updated_source,
-          latest_resolvable_version: latest_resolvable_version&.to_s
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            updated_source: updated_source,
+            latest_resolvable_version: latest_resolvable_version&.to_s
+          ).updated_requirements
+        )
       end
 
       private

--- a/julia/lib/dependabot/julia/update_checker.rb
+++ b/julia/lib/dependabot/julia/update_checker.rb
@@ -91,13 +91,15 @@ module Dependabot
         Dependabot::Julia::Version.new(latest_version.to_s)
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        Dependabot::Julia::RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          target_version: latest_resolvable_version&.to_s,
-          update_strategy: requirements_update_strategy&.to_s&.to_sym
-        ).updated_requirements
+        wrap_requirements(
+          Dependabot::Julia::RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            target_version: latest_resolvable_version&.to_s,
+            update_strategy: requirements_update_strategy&.to_s&.to_sym
+          ).updated_requirements
+        )
       end
 
       private

--- a/maven/lib/dependabot/maven/update_checker.rb
+++ b/maven/lib/dependabot/maven/update_checker.rb
@@ -90,18 +90,20 @@ module Dependabot
         nil
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         property_names =
           declarations_using_a_property
           .map { |req| req.dig(:metadata, :property_name) }
 
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          latest_version: preferred_resolvable_version&.to_s,
-          source_url: preferred_version_details&.fetch(:source_url),
-          properties_to_update: property_names
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            latest_version: preferred_resolvable_version&.to_s,
+            source_url: preferred_version_details&.fetch(:source_url),
+            properties_to_update: property_names
+          ).updated_requirements
+        )
       end
 
       sig { override.returns(T::Boolean) }

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -36,12 +36,12 @@ module Dependabot
         latest_version
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         if ref_pinned_to_version_tag?
-          updated_requirements_for_tag
+          wrap_requirements(updated_requirements_for_tag)
         elsif ref_is_versioned_branch?
-          updated_requirements_for_versioned_branch
+          wrap_requirements(updated_requirements_for_versioned_branch)
         else
           dependency.requirements
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -51,7 +51,7 @@ module Dependabot
       )
         @latest_version = T.let(nil, T.nilable(T.any(String, Gem::Version)))
         @latest_resolvable_version = T.let(nil, T.nilable(T.any(String, Dependabot::Version)))
-        @updated_requirements = T.let(nil, T.nilable(T::Array[T::Hash[Symbol, T.untyped]]))
+        @updated_requirements = T.let(nil, T.nilable(T::Array[Dependabot::DependencyRequirement]))
         @vulnerability_audit = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
         @vulnerable_versions = T.let(nil, T.nilable(T::Array[T.any(String, Gem::Version)]))
 
@@ -162,7 +162,7 @@ module Dependabot
         T.unsafe(version_resolver.latest_resolvable_previous_version(updated_version))
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         resolvable_version =
           if preferred_resolvable_version.is_a?(version_class)
@@ -177,12 +177,14 @@ module Dependabot
           end
 
         @updated_requirements ||=
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            updated_source: updated_source,
-            latest_resolvable_version: resolvable_version,
-            update_strategy: T.must(requirements_update_strategy)
-          ).updated_requirements
+          wrap_requirements(
+            RequirementsUpdater.new(
+              requirements: dependency.requirements,
+              updated_source: updated_source,
+              latest_resolvable_version: resolvable_version,
+              update_strategy: T.must(requirements_update_strategy)
+            ).updated_requirements
+          )
       end
 
       sig { returns(T::Boolean) }

--- a/opentofu/lib/dependabot/opentofu/update_checker.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker.rb
@@ -46,13 +46,15 @@ module Dependabot
         nil
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          latest_version: latest_version&.to_s,
-          tag_for_latest_version: tag_for_latest_version
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            latest_version: latest_version&.to_s,
+            tag_for_latest_version: tag_for_latest_version
+          ).updated_requirements
+        )
       end
 
       sig { returns(T::Boolean) }

--- a/pre_commit/lib/dependabot/pre_commit/update_checker.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker.rb
@@ -45,11 +45,11 @@ module Dependabot
         dependency.version
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        return additional_dependency_updated_requirements if additional_dependency?
+        return wrap_requirements(additional_dependency_updated_requirements) if additional_dependency?
 
-        dependency.requirements.map do |req|
+        updated_reqs = dependency.requirements.map do |req|
           source = T.cast(req[:source], T.nilable(T::Hash[Symbol, T.untyped]))
           updated = updated_ref(source)
           next req unless updated
@@ -68,6 +68,7 @@ module Dependabot
           new_metadata = updated_comment_version_metadata(req, updated)
           req.merge(source: new_source, metadata: new_metadata)
         end
+        wrap_requirements(updated_reqs)
       end
 
       private

--- a/pub/lib/dependabot/pub/update_checker.rb
+++ b/pub/lib/dependabot/pub/update_checker.rb
@@ -71,7 +71,7 @@ module Dependabot
         version_unless_ignored(entry)
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         # Requirements that need to be changed, if obtain:
         # latest_resolvable_version or lowest_security_fix_version

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -93,16 +93,18 @@ module Dependabot
         )
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        return updated_git_requirements if git_dependency?
+        return wrap_requirements(updated_git_requirements) if git_dependency?
 
-        RequirementsUpdater.new(
-          requirements: requirements,
-          latest_resolvable_version: preferred_resolvable_version&.to_s,
-          update_strategy: requirements_update_strategy,
-          has_lockfile: !(pipfile_lock || poetry_lock).nil?
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: requirements,
+            latest_resolvable_version: preferred_resolvable_version&.to_s,
+            update_strategy: requirements_update_strategy,
+            has_lockfile: !(pipfile_lock || poetry_lock).nil?
+          ).updated_requirements
+        )
       end
 
       sig { override.returns(T::Boolean) }

--- a/rust_toolchain/lib/dependabot/rust_toolchain/update_checker.rb
+++ b/rust_toolchain/lib/dependabot/rust_toolchain/update_checker.rb
@@ -29,9 +29,9 @@ module Dependabot
         raise NotImplementedError
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        dependency.requirements.map do |requirement|
+        updated_reqs = dependency.requirements.map do |requirement|
           {
             file: requirement[:file],
             requirement: latest_version,
@@ -39,6 +39,7 @@ module Dependabot
             source: requirement[:source]
           }
         end
+        wrap_requirements(updated_reqs)
       end
 
       private

--- a/rust_toolchain/lib/dependabot/rust_toolchain/update_checker.rb
+++ b/rust_toolchain/lib/dependabot/rust_toolchain/update_checker.rb
@@ -34,7 +34,7 @@ module Dependabot
         updated_reqs = dependency.requirements.map do |requirement|
           {
             file: requirement[:file],
-            requirement: latest_version,
+            requirement: latest_version&.to_s,
             groups: requirement[:groups],
             source: requirement[:source]
           }

--- a/rust_toolchain/spec/dependabot/rust_toolchain/update_checker_spec.rb
+++ b/rust_toolchain/spec/dependabot/rust_toolchain/update_checker_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Dependabot::RustToolchain::UpdateChecker do
         [
           {
             file: "rust-toolchain.toml",
-            requirement: latest_version,
+            requirement: latest_version.to_s,
             groups: [],
             source: nil
           }
@@ -187,13 +187,13 @@ RSpec.describe Dependabot::RustToolchain::UpdateChecker do
           [
             {
               file: "rust-toolchain.toml",
-              requirement: latest_version,
+              requirement: latest_version.to_s,
               groups: [],
               source: nil
             },
             {
               file: "other-file.toml",
-              requirement: latest_version,
+              requirement: latest_version.to_s,
               groups: ["dev"],
               source: { type: "git" }
             }

--- a/sbt/lib/dependabot/sbt/update_checker.rb
+++ b/sbt/lib/dependabot/sbt/update_checker.rb
@@ -47,18 +47,20 @@ module Dependabot
         nil
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         property_names =
           declarations_using_a_property
           .filter_map { |req| req.dig(:metadata, :property_name) }
 
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          latest_version: preferred_resolvable_version&.to_s,
-          source_url: preferred_version_details&.fetch(:source_url),
-          properties_to_update: property_names
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            latest_version: preferred_resolvable_version&.to_s,
+            source_url: preferred_version_details&.fetch(:source_url),
+            properties_to_update: property_names
+          ).updated_requirements
+        )
       end
 
       sig { override.returns(T::Boolean) }

--- a/silent/lib/dependabot/silent/update_checker.rb
+++ b/silent/lib/dependabot/silent/update_checker.rb
@@ -63,11 +63,12 @@ module SilentPackageManager
       latest_version
     end
 
-    sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+    sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
     def updated_requirements
-      dependency.requirements.map do |req|
+      updated = dependency.requirements.map do |req|
         req.merge(requirement: preferred_resolvable_version)
       end
+      wrap_requirements(updated)
     end
 
     private

--- a/silent/lib/dependabot/silent/update_checker.rb
+++ b/silent/lib/dependabot/silent/update_checker.rb
@@ -66,7 +66,7 @@ module SilentPackageManager
     sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
     def updated_requirements
       updated = dependency.requirements.map do |req|
-        req.merge(requirement: preferred_resolvable_version)
+        req.merge(requirement: preferred_resolvable_version&.to_s)
       end
       wrap_requirements(updated)
     end

--- a/swift/lib/dependabot/swift/update_checker.rb
+++ b/swift/lib/dependabot/swift/update_checker.rb
@@ -50,18 +50,20 @@ module Dependabot
         )
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        return updated_xcode_requirements if xcode_spm_mode?
+        return wrap_requirements(updated_xcode_requirements) if xcode_spm_mode?
 
         # If no target version is available, return old requirements unchanged
         target = preferred_resolvable_version
-        return old_requirements unless target
+        return wrap_requirements(old_requirements) unless target
 
-        RequirementsUpdater.new(
-          requirements: old_requirements,
-          target_version: target
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: old_requirements,
+            target_version: target
+          ).updated_requirements
+        )
       end
 
       private

--- a/terraform/lib/dependabot/terraform/update_checker.rb
+++ b/terraform/lib/dependabot/terraform/update_checker.rb
@@ -45,13 +45,15 @@ module Dependabot
         nil
       end
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        RequirementsUpdater.new(
-          requirements: dependency.requirements,
-          latest_version: latest_version&.to_s,
-          tag_for_latest_version: tag_for_latest_version
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            latest_version: latest_version&.to_s,
+            tag_for_latest_version: tag_for_latest_version
+          ).updated_requirements
+        )
       end
 
       sig { returns(T::Boolean) }

--- a/uv/lib/dependabot/uv/update_checker.rb
+++ b/uv/lib/dependabot/uv/update_checker.rb
@@ -31,14 +31,16 @@ module Dependabot
       require_relative "update_checker/latest_version_finder"
       require_relative "update_checker/lock_file_resolver"
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        RequirementsUpdater.new(
-          requirements: requirements,
-          latest_resolvable_version: preferred_resolvable_version&.to_s,
-          update_strategy: requirements_update_strategy,
-          has_lockfile: requirements_text_file?
-        ).updated_requirements
+        wrap_requirements(
+          RequirementsUpdater.new(
+            requirements: requirements,
+            latest_resolvable_version: preferred_resolvable_version&.to_s,
+            update_strategy: requirements_update_strategy,
+            has_lockfile: requirements_text_file?
+          ).updated_requirements
+        )
       end
 
       private

--- a/vcpkg/lib/dependabot/vcpkg/update_checker.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker.rb
@@ -30,11 +30,11 @@ module Dependabot
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_resolvable_version_with_no_unlock = latest_version
 
-      sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         return dependency.requirements unless latest_version
 
-        dependency.requirements.filter_map do |requirement|
+        updated = dependency.requirements.filter_map do |requirement|
           source = T.cast(requirement[:source], T.nilable(T::Hash[Symbol, T.untyped]))
           requirement_constraint = requirement[:requirement]
 
@@ -50,6 +50,7 @@ module Dependabot
             requirement
           end
         end
+        wrap_requirements(updated)
       end
 
       private


### PR DESCRIPTION
### What are you trying to accomplish?

Follow-up to #15263. `Dependency#requirements` returns typed `DependencyRequirement` now, but `updated_requirements` (base + every override) still returned `T::Array[T::Hash[Symbol, T.untyped]]`, so callers couldn't use the typed readers. This retypes the base and all 32 overrides to `T::Array[Dependabot::DependencyRequirement]`.

### Anything you want to highlight for special attention from reviewers?

It has to land in one commit. `sorbet-runtime` treats `T::Array` override element types as invariant, so the base and every override must move together. A new private `wrap_requirements` helper wraps the raw hashes from `RequirementsUpdater`/`map`/`merge`; overrides already returning `dependency.requirements` are untouched. (`Hash#merge` statically returns a plain `Hash`, so merge bodies need wrapping too.)

### How will you know you've accomplished your goal?

`srb tc` and `rubocop` pass. Host-runnable ecosystem specs are green; the rest need native helpers and run in the CI matrix.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
