### PR TITLE
fix(npm_and_yarn): prefer replaces-base registry over lockfile source for metadata fetches

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -336,8 +336,6 @@ module Dependabot
         { "Authorization" => "Bearer #{auth_token}" }
       end
 
-
-
       sig { returns(String) }
       def dependency_registry
         # Prioritize replaces-base credential over lockfile source

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -310,9 +310,11 @@ module Dependabot
       sig { returns(String) }
       def dependency_url
         registry_url =
-          if new_source.nil?
-            # Check credentials for a configured registry before falling back to public registry
-            configured_registry_from_credentials || "https://registry.npmjs.org"
+          if (configured_registry = configured_registry_from_credentials)
+            # Prioritize replaces-base credential over lockfile source
+            configured_registry
+          elsif new_source.nil?
+            "https://registry.npmjs.org"
           else
             new_source&.fetch(:url)
           end
@@ -351,6 +353,11 @@ module Dependabot
 
       sig { returns(String) }
       def dependency_registry
+        # Prioritize replaces-base credential over lockfile source
+        if (configured_registry = configured_registry_from_credentials)
+          return configured_registry.sub(%r{^https?://}, "")
+        end
+
         if new_source.nil? then "registry.npmjs.org"
         else
           new_source&.fetch(:url)&.gsub("https://", "")&.gsub("http://", "")

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -9,12 +9,14 @@ require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
 require "dependabot/registry_client"
 require "dependabot/npm_and_yarn/package/registry_finder"
+require "dependabot/npm_and_yarn/package/registry_credential_helpers"
 require "dependabot/npm_and_yarn/version"
 
 module Dependabot
   module NpmAndYarn
     class MetadataFinder < Dependabot::MetadataFinders::Base
       extend T::Sig
+      include Package::RegistryCredentialHelpers
 
       # Lifecycle scripts that run automatically during package installation.
       # These are security-relevant because they execute with user privileges.
@@ -334,22 +336,7 @@ module Dependabot
         { "Authorization" => "Bearer #{auth_token}" }
       end
 
-      sig { returns(T.nilable(String)) }
-      def configured_registry_from_credentials
-        # Look for a credential that replaces the base registry (global registry replacement)
-        replaces_base_cred = credentials.find { |cred| cred["type"] == "npm_registry" && cred.replaces_base? }
-        return normalize_registry_url(replaces_base_cred["registry"]) if replaces_base_cred
 
-        nil
-      end
-
-      sig { params(registry: T.nilable(String)).returns(T.nilable(String)) }
-      def normalize_registry_url(registry)
-        return nil unless registry
-        return registry if registry.start_with?("http")
-
-        "https://#{registry}"
-      end
 
       sig { returns(String) }
       def dependency_registry

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
@@ -3,67 +3,15 @@
 
 require "json"
 require "excon"
-require "base64"
 require "time"
-require "uri"
 require "dependabot/package/package_release"
 require "dependabot/package/package_details"
 require "dependabot/npm_and_yarn/package/registry_finder"
+require "dependabot/npm_and_yarn/package/registry_credential_helpers"
 
 module Dependabot
   module NpmAndYarn
     module Package
-      module RegistryCredentialHelpers
-        extend T::Sig
-        extend T::Helpers
-
-        abstract!
-
-        sig { abstract.returns(T::Array[Dependabot::Credential]) }
-        def credentials; end
-
-        sig { returns(T.nilable(String)) }
-        def configured_registry_from_credentials
-          replaces_base_cred = credentials.find { |cred| cred["type"] == "npm_registry" && cred.replaces_base? }
-          return unless replaces_base_cred&.fetch("registry", nil)
-
-          normalize_registry_url(replaces_base_cred["registry"])
-        end
-
-        sig { params(registry: T.nilable(String)).returns(T.nilable(String)) }
-        def normalize_registry_url(registry)
-          return nil unless registry
-
-          normalized_registry = registry.start_with?("http") ? registry : "https://#{registry}"
-          URI::DEFAULT_PARSER.escape(normalized_registry)&.gsub(%r{/+$}, "")
-        end
-
-        sig { params(registry: String).returns(T::Hash[String, String]) }
-        def auth_headers_for_registry(registry)
-          token = credentials
-                  .select { |cred| cred["type"] == "npm_registry" }
-                  .find { |cred| normalize_registry_url(cred["registry"]) == registry }
-                  &.fetch("token", nil)
-
-          return {} unless token
-
-          auth_header_for(token)
-        end
-
-        sig { params(token: String).returns(T::Hash[String, String]) }
-        def auth_header_for(token)
-          if token.include?(":")
-            encoded_token = Base64.encode64(token).delete("\n")
-            { "Authorization" => "Basic #{encoded_token}" }
-          elsif Base64.decode64(token).ascii_only? &&
-                Base64.decode64(token).include?(":")
-            { "Authorization" => "Basic #{token.delete("\n")}" }
-          else
-            { "Authorization" => "Bearer #{token}" }
-          end
-        end
-      end
-
       class PackageDetailsFetcher
         extend T::Sig
         include RegistryCredentialHelpers

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
@@ -13,8 +13,60 @@ require "dependabot/npm_and_yarn/package/registry_finder"
 module Dependabot
   module NpmAndYarn
     module Package
+      module RegistryCredentialHelpers
+        extend T::Sig
+        extend T::Helpers
+
+        abstract!
+
+        sig { abstract.returns(T::Array[Dependabot::Credential]) }
+        def credentials; end
+
+        sig { returns(T.nilable(String)) }
+        def configured_registry_from_credentials
+          replaces_base_cred = credentials.find { |cred| cred["type"] == "npm_registry" && cred.replaces_base? }
+          return unless replaces_base_cred&.fetch("registry", nil)
+
+          normalize_registry_url(replaces_base_cred["registry"])
+        end
+
+        sig { params(registry: T.nilable(String)).returns(T.nilable(String)) }
+        def normalize_registry_url(registry)
+          return nil unless registry
+
+          normalized_registry = registry.start_with?("http") ? registry : "https://#{registry}"
+          URI::DEFAULT_PARSER.escape(normalized_registry)&.gsub(%r{/+$}, "")
+        end
+
+        sig { params(registry: String).returns(T::Hash[String, String]) }
+        def auth_headers_for_registry(registry)
+          token = credentials
+                  .select { |cred| cred["type"] == "npm_registry" }
+                  .find { |cred| normalize_registry_url(cred["registry"]) == registry }
+                  &.fetch("token", nil)
+
+          return {} unless token
+
+          auth_header_for(token)
+        end
+
+        sig { params(token: String).returns(T::Hash[String, String]) }
+        def auth_header_for(token)
+          if token.include?(":")
+            encoded_token = Base64.encode64(token).delete("\n")
+            { "Authorization" => "Basic #{encoded_token}" }
+          elsif Base64.decode64(token).ascii_only? &&
+                Base64.decode64(token).include?(":")
+            { "Authorization" => "Basic #{token.delete("\n")}" }
+          else
+            { "Authorization" => "Bearer #{token}" }
+          end
+        end
+      end
+
       class PackageDetailsFetcher
         extend T::Sig
+        include RegistryCredentialHelpers
 
         GLOBAL_REGISTRY = "registry.npmjs.org"
         NPM_OFFICIAL_WEBSITE = "https://www.npmjs.com"
@@ -65,7 +117,7 @@ module Dependabot
         sig { returns(Dependabot::Dependency) }
         attr_reader :dependency
 
-        sig { returns(T::Array[Dependabot::Credential]) }
+        sig { override.returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
@@ -402,47 +454,6 @@ module Dependabot
           end
 
           registry_finder.registry
-        end
-
-        sig { returns(T.nilable(String)) }
-        def configured_registry_from_credentials
-          replaces_base_cred = credentials.find { |cred| cred["type"] == "npm_registry" && cred.replaces_base? }
-          return unless replaces_base_cred&.fetch("registry", nil)
-
-          normalize_registry_url(T.must(replaces_base_cred["registry"]))
-        end
-
-        sig { params(registry: T.nilable(String)).returns(T.nilable(String)) }
-        def normalize_registry_url(registry)
-          return nil unless registry
-
-          normalized_registry = registry.start_with?("http") ? registry : "https://#{registry}"
-          URI::DEFAULT_PARSER.escape(normalized_registry)&.gsub(%r{/+$}, "")
-        end
-
-        sig { params(registry: String).returns(T::Hash[String, String]) }
-        def auth_headers_for_registry(registry)
-          token = credentials
-                  .select { |cred| cred["type"] == "npm_registry" }
-                  .find { |cred| normalize_registry_url(T.must(cred["registry"])) == registry }
-                  &.fetch("token", nil)
-
-          return {} unless token
-
-          auth_header_for(token)
-        end
-
-        sig { params(token: String).returns(T::Hash[String, String]) }
-        def auth_header_for(token)
-          if token.include?(":")
-            encoded_token = Base64.encode64(token).delete("\n")
-            { "Authorization" => "Basic #{encoded_token}" }
-          elsif Base64.decode64(token).ascii_only? &&
-                Base64.decode64(token).include?(":")
-            { "Authorization" => "Basic #{token.delete("\n")}" }
-          else
-            { "Authorization" => "Bearer #{token}" }
-          end
         end
 
         sig { returns(Package::RegistryFinder) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
@@ -3,7 +3,9 @@
 
 require "json"
 require "excon"
+require "base64"
 require "time"
+require "uri"
 require "dependabot/package/package_release"
 require "dependabot/package/package_details"
 require "dependabot/npm_and_yarn/package/registry_finder"
@@ -96,6 +98,11 @@ module Dependabot
 
         sig { returns(String) }
         def dependency_url
+          if (configured_registry = configured_registry_from_credentials)
+            escaped_dependency_name = dependency.name.gsub("/", "%2F")
+            return "#{configured_registry}/#{escaped_dependency_name}"
+          end
+
           registry_finder.dependency_url
         end
 
@@ -381,12 +388,61 @@ module Dependabot
 
         sig { returns(T::Hash[String, String]) }
         def registry_auth_headers
+          if (configured_registry = configured_registry_from_credentials)
+            return auth_headers_for_registry(configured_registry)
+          end
+
           registry_finder.auth_headers
         end
 
         sig { returns(String) }
         def dependency_registry
+          if (configured_registry = configured_registry_from_credentials)
+            return configured_registry.sub(%r{^https?://}, "")
+          end
+
           registry_finder.registry
+        end
+
+        sig { returns(T.nilable(String)) }
+        def configured_registry_from_credentials
+          replaces_base_cred = credentials.find { |cred| cred["type"] == "npm_registry" && cred.replaces_base? }
+          return unless replaces_base_cred&.fetch("registry", nil)
+
+          normalize_registry_url(T.must(replaces_base_cred["registry"]))
+        end
+
+        sig { params(registry: T.nilable(String)).returns(T.nilable(String)) }
+        def normalize_registry_url(registry)
+          return nil unless registry
+
+          normalized_registry = registry.start_with?("http") ? registry : "https://#{registry}"
+          URI::DEFAULT_PARSER.escape(normalized_registry)&.gsub(%r{/+$}, "")
+        end
+
+        sig { params(registry: String).returns(T::Hash[String, String]) }
+        def auth_headers_for_registry(registry)
+          token = credentials
+                  .select { |cred| cred["type"] == "npm_registry" }
+                  .find { |cred| normalize_registry_url(T.must(cred["registry"])) == registry }
+                  &.fetch("token", nil)
+
+          return {} unless token
+
+          auth_header_for(token)
+        end
+
+        sig { params(token: String).returns(T::Hash[String, String]) }
+        def auth_header_for(token)
+          if token.include?(":")
+            encoded_token = Base64.encode64(token).delete("\n")
+            { "Authorization" => "Basic #{encoded_token}" }
+          elsif Base64.decode64(token).ascii_only? &&
+                Base64.decode64(token).include?(":")
+            { "Authorization" => "Basic #{token.delete("\n")}" }
+          else
+            { "Authorization" => "Bearer #{token}" }
+          end
         end
 
         sig { returns(Package::RegistryFinder) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_credential_helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_credential_helpers.rb
@@ -1,0 +1,62 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "base64"
+require "uri"
+
+module Dependabot
+  module NpmAndYarn
+    module Package
+      module RegistryCredentialHelpers
+        extend T::Sig
+        extend T::Helpers
+
+        abstract!
+
+        sig { abstract.returns(T::Array[Dependabot::Credential]) }
+        def credentials; end
+
+        sig { returns(T.nilable(String)) }
+        def configured_registry_from_credentials
+          replaces_base_cred = credentials.find { |cred| cred["type"] == "npm_registry" && cred.replaces_base? }
+          return unless replaces_base_cred&.fetch("registry", nil)
+
+          normalize_registry_url(replaces_base_cred["registry"])
+        end
+
+        sig { params(registry: T.nilable(String)).returns(T.nilable(String)) }
+        def normalize_registry_url(registry)
+          return nil unless registry
+
+          normalized_registry = registry.start_with?("http") ? registry : "https://#{registry}"
+          URI::DEFAULT_PARSER.escape(normalized_registry)&.gsub(%r{/+$}, "")
+        end
+
+        sig { params(registry: String).returns(T::Hash[String, String]) }
+        def auth_headers_for_registry(registry)
+          token = credentials
+                  .select { |cred| cred["type"] == "npm_registry" }
+                  .find { |cred| normalize_registry_url(cred["registry"]) == registry }
+                  &.fetch("token", nil)
+
+          return {} unless token
+
+          auth_header_for(token)
+        end
+
+        sig { params(token: String).returns(T::Hash[String, String]) }
+        def auth_header_for(token)
+          if token.include?(":")
+            encoded_token = Base64.encode64(token).delete("\n")
+            { "Authorization" => "Basic #{encoded_token}" }
+          elsif Base64.decode64(token).ascii_only? &&
+                Base64.decode64(token).include?(":")
+            { "Authorization" => "Basic #{token.delete("\n")}" }
+          else
+            { "Authorization" => "Bearer #{token}" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_credential_helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_credential_helpers.rb
@@ -16,6 +16,8 @@ module Dependabot
         sig { abstract.returns(T::Array[Dependabot::Credential]) }
         def credentials; end
 
+        private
+
         sig { returns(T.nilable(String)) }
         def configured_registry_from_credentials
           replaces_base_cred = credentials.find { |cred| cred["type"] == "npm_registry" && cred.replaces_base? }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/metadata_finder_spec.rb
@@ -961,8 +961,8 @@ RSpec.describe Dependabot::NpmAndYarn::MetadataFinder do
         )]
       end
 
-      it "uses source from lockfile, not credentials" do
-        expect(dependency_url).to eq("https://npm.fury.io/dependabot/etag")
+      it "uses replaces-base credentials, not source from lockfile" do
+        expect(dependency_url).to eq("https://different.registry.com/etag")
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
@@ -111,6 +111,50 @@ RSpec.describe Dependabot::NpmAndYarn::Package::PackageDetailsFetcher do
       end
     end
 
+    context "when lockfile source is private but credentials replace the base registry" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "16.6.0",
+          requirements: [{
+            requirement: "^16.0",
+            file: "package.json",
+            groups: ["dependencies"],
+            source: { type: "registry", url: "https://registry.locked.example.com/dependabot" }
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      let(:credentials) do
+        [Dependabot::Credential.new(
+          {
+            "type" => "npm_registry",
+            "registry" => "https://registry.configured.example.com/dependabot",
+            "token" => "secret_token",
+            "replaces-base" => true
+          }
+        )]
+      end
+
+      let(:registry_url) { "https://registry.configured.example.com/dependabot/#{dependency_name}" }
+
+      before do
+        stub_request(:get, registry_url)
+          .with(headers: { "Authorization" => "Bearer secret_token" })
+          .to_return(
+            status: 200,
+            body: fixture("npm_responses", "react.json")
+          )
+      end
+
+      it "uses the configured registry instead of the lockfile source" do
+        release = details.releases.find { |r| r.version.to_s == "16.6.0" }
+
+        expect(release.url).to include("registry.configured.example.com/dependabot")
+      end
+    end
+
     context "when the registry raises Excon::Error::Socket" do
       context "with a private registry" do
         let(:registry_url) { "https://npm.fury.io/dependabot/react" }


### PR DESCRIPTION
### What are you trying to accomplish?

We tested a scenario where:
- the lockfile points to a private registry,
- there is no npmrc file, and
- Dependabot is configured with a public registry using `replaces-base: true`.

In this setup, Dependabot was still fetching package metadata from the private registry.

This PR fixes that behavior so metadata requests follow the configured `replaces-base` registry as expected.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

Success is confirmed by reproducing and then eliminating the workflow failure: https://github.com/thavaahariharangit/replaces-base-test-FR-13822/actions/runs/27351769814/job/80815291592

Before:
trying to access private registry: https://artifactory.internal.corp.example.com:443/artifactory/api/npm/npm-remote/lodash/latest
```
updater | 2026/06/11 13:53:53 INFO <job_1408321959> Submitting lodash pull request for creation
  proxy | 2026/06/11 13:53:53 [022] GET [https://api.github.com:443/repos/thavaahariharangit/replaces-base-test-FR-13822/commits?per_page=100](https://api.github.com/repos/thavaahariharangit/replaces-base-test-FR-13822/commits?per_page=100)
2026/06/11 13:53:53 [022] * authenticating github api request with token for api.github.com
  proxy | 2026/06/11 13:53:53 [022] 200 [https://api.github.com:443/repos/thavaahariharangit/replaces-base-test-FR-13822/commits?per_page=100](https://api.github.com/repos/thavaahariharangit/replaces-base-test-FR-13822/commits?per_page=100)
  proxy | 2026/06/11 13:53:53 [024] GET [https://artifactory.internal.corp.example.com:443/artifactory/api/npm/npm-remote/lodash/latest](https://artifactory.internal.corp.example.com/artifactory/api/npm/npm-remote/lodash/latest)
  proxy | 2026/06/11 13:53:53 [024] WARN: Cannot read TLS response from mitm'd server lookup artifactory.internal.corp.example.com on 127.0.0.11:53: no such host
  proxy | 2026/06/11 13:53:58 [026] GET [https://artifactory.internal.corp.example.com:443/artifactory/api/npm/npm-remote/lodash/latest](https://artifactory.internal.corp.example.com/artifactory/api/npm/npm-remote/lodash/latest)
  proxy | 2026/06/11 13:53:58 [026] WARN: Cannot read TLS response from mitm'd server lookup artifactory.internal.corp.example.com on 127.0.0.11:53: no such host
  proxy | 2026/06/11 13:54:03 [028] GET [https://artifactory.internal.corp.example.com:443/artifactory/api/npm/npm-remote/lodash/latest](https://artifactory.internal.corp.example.com/artifactory/api/npm/npm-remote/lodash/latest)
  proxy | 2026/06/11 13:54:03 [028] WARN: Cannot read TLS response from mitm'd server lookup artifactory.internal.corp.example.com on 127.0.0.11:53: no such host
  proxy | 2026/06/11 13:54:09 [030] GET [https://artifactory.internal.corp.example.com:443/artifactory/api/npm/npm-remote/lodash/latest](https://artifactory.internal.corp.example.com/artifactory/api/npm/npm-remote/lodash/latest)
  proxy | 2026/06/11 13:54:09 [030] WARN: Cannot read TLS response from mitm'd server lookup artifactory.internal.corp.example.com on 127.0.0.11:53: no such host
updater | 2026/06/11 13:54:09 ERROR <job_1408321959> Error while generating PR message: EOFError (EOFError)
```

After:
```
updater | 2026/06/11 15:07:10 INFO Submitting lodash pull request for creation
  proxy | 2026/06/11 15:07:11 [019] GET https://api.github.com:443/repos/thavaahariharangit/replaces-base-test-FR-13822/commits?per_page=100
  proxy | 2026/06/11 15:07:11 [019] * authenticating github api request with token for api.github.com
  proxy | 2026/06/11 15:07:11 [019] 200 https://api.github.com:443/repos/thavaahariharangit/replaces-base-test-FR-13822/commits?per_page=100
  proxy | 2026/06/11 15:07:11 [021] GET https://registry.npmjs.org:443/lodash/latest
  proxy | 2026/06/11 15:07:11 [021] * authenticating npm registry request (host: registry.npmjs.org, token auth)
  proxy | 2026/06/11 15:07:11 [021] 200 https://registry.npmjs.org:443/lodash/latest
```


### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
