### PR TITLE
Add JobCommand enum and Command property to NuGet Job model

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
@@ -1,8 +1,10 @@
 using System.Collections.Immutable;
+using System.Text.Json;
 
 using NuGet.Versioning;
 
 using NuGetUpdater.Core.Analyze;
+using NuGetUpdater.Core.Run;
 using NuGetUpdater.Core.Run.ApiModel;
 using NuGetUpdater.Core.Test.Utilities;
 
@@ -416,6 +418,75 @@ public class JobTests
             "/src/client/ios/ui"
         }.ToImmutableArray();
         AssertEx.Equal(expectedDirectories, actualDirectories);
+    }
+
+    [Theory]
+    [InlineData("update", JobCommand.Update)]
+    [InlineData("recreate", JobCommand.Recreate)]
+    [InlineData("graph", JobCommand.Graph)]
+    [InlineData("", JobCommand.None)]
+    public void CommandDeserialization_KnownValues(string commandValue, JobCommand expectedCommand)
+    {
+        var json = $$"""
+            {
+              "job": {
+                "package-manager": "nuget",
+                "command": "{{commandValue}}",
+                "source": {
+                  "provider": "github",
+                  "repo": "test/repo",
+                  "directory": "/"
+                }
+              }
+            }
+            """;
+        var jobFile = RunWorker.Deserialize(json);
+        Assert.Equal(expectedCommand, jobFile.Job.Command);
+    }
+
+    [Fact]
+    public void CommandDeserialization_MissingField_DefaultsToNone()
+    {
+        var json = """
+            {
+              "job": {
+                "package-manager": "nuget",
+                "source": {
+                  "provider": "github",
+                  "repo": "test/repo",
+                  "directory": "/"
+                }
+              }
+            }
+            """;
+        var jobFile = RunWorker.Deserialize(json);
+        Assert.Equal(JobCommand.None, jobFile.Job.Command);
+    }
+
+    [Fact]
+    public void CommandDeserialization_UnknownValue_DefaultsToNoneAndLogsWarning()
+    {
+        var json = """
+            {
+              "job": {
+                "package-manager": "nuget",
+                "command": "unknown_value",
+                "source": {
+                  "provider": "github",
+                  "repo": "test/repo",
+                  "directory": "/"
+                }
+              }
+            }
+            """;
+
+        var logger = new StringLogger();
+        var options = new JsonSerializerOptions(RunWorker.SerializerOptions);
+        // replace the default converter with one using our test logger
+        options.Converters.Insert(0, new JobCommandConverter(logger));
+        var jobFile = JsonSerializer.Deserialize<JobFile>(json, options)!;
+        Assert.Equal(JobCommand.None, jobFile.Job.Command);
+        Assert.Contains(logger.Messages, m => m.Contains("Unknown job command value") && m.Contains("unknown_value"));
     }
 
     private static Job CreateJob(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
@@ -464,6 +464,49 @@ public class JobTests
     }
 
     [Fact]
+    public void CommandDeserialization_NullValue_DefaultsToNone()
+    {
+        var json = """
+            {
+              "job": {
+                "package-manager": "nuget",
+                "command": null,
+                "source": {
+                  "provider": "github",
+                  "repo": "test/repo",
+                  "directory": "/"
+                }
+              }
+            }
+            """;
+        var jobFile = RunWorker.Deserialize(json);
+        Assert.Equal(JobCommand.None, jobFile.Job.Command);
+    }
+
+    [Fact]
+    public void CommandDeserialization_NonStringToken_DefaultsToNoneAndLogsWarning()
+    {
+        var json = """
+            {
+              "job": {
+                "package-manager": "nuget",
+                "command": 42,
+                "source": {
+                  "provider": "github",
+                  "repo": "test/repo",
+                  "directory": "/"
+                }
+              }
+            }
+            """;
+
+        var logger = new StringLogger();
+        var jobFile = RunWorker.Deserialize(json, logger);
+        Assert.Equal(JobCommand.None, jobFile.Job.Command);
+        Assert.Contains(logger.Messages, m => m.Contains("Unexpected JSON token type"));
+    }
+
+    [Fact]
     public void CommandDeserialization_UnknownValue_DefaultsToNoneAndLogsWarning()
     {
         var json = """

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/CloneWorker.cs
@@ -34,7 +34,7 @@ public class CloneWorker
         JobErrorBase? parseError = null;
         try
         {
-            jobFile = RunWorker.Deserialize(jobFileContent);
+            jobFile = RunWorker.Deserialize(jobFileContent, _logger);
             if (jobFile is null)
             {
                 parseError = new UnknownError(new Exception("Job file could not be deserialized"), _jobId);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Graph/GraphWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Graph/GraphWorker.cs
@@ -28,7 +28,7 @@ public class GraphWorker : IGraphWorker
     {
         // Deserialize the job file
         var jobFileContent = await File.ReadAllTextAsync(jobFilePath.FullName);
-        var jobWrapper = RunWorker.Deserialize(jobFileContent);
+        var jobWrapper = RunWorker.Deserialize(jobFileContent, _logger);
         var job = jobWrapper.Job;
 
         // Use the case-insensitive repo contents path if provided, otherwise use the original

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -14,6 +14,9 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 public sealed record Job
 {
     public string PackageManager { get; init; } = "nuget";
+
+    public JobCommand Command { get; init; } = JobCommand.None;
+
     public ImmutableArray<AllowedUpdate> AllowedUpdates { get; init; } = [new AllowedUpdate()];
 
     [JsonConverter(typeof(NullAsBoolConverter))]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommand.cs
@@ -1,0 +1,9 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public enum JobCommand
+{
+    None,
+    Update,
+    Recreate,
+    Graph,
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommandConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommandConverter.cs
@@ -19,6 +19,13 @@ public class JobCommandConverter : JsonConverter<JobCommand>
             return JobCommand.None;
         }
 
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            _logger.Warn($"Unexpected JSON token type for job command: {reader.TokenType}; defaulting to None.");
+            reader.Skip();
+            return JobCommand.None;
+        }
+
         var value = reader.GetString();
         return value switch
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommandConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommandConverter.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public class JobCommandConverter : JsonConverter<JobCommand>
+{
+    private readonly ILogger _logger;
+
+    public JobCommandConverter(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    public override JobCommand Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return JobCommand.None;
+        }
+
+        var value = reader.GetString();
+        return value switch
+        {
+            "" => JobCommand.None,
+            "update" => JobCommand.Update,
+            "recreate" => JobCommand.Recreate,
+            "graph" => JobCommand.Graph,
+            _ => LogAndDefault(value),
+        };
+    }
+
+    private JobCommand LogAndDefault(string? value)
+    {
+        _logger.Warn($"Unknown job command value: \"{value}\"; defaulting to None.");
+        return JobCommand.None;
+    }
+
+    public override void Write(Utf8JsonWriter writer, JobCommand value, JsonSerializerOptions options)
+    {
+        var str = value switch
+        {
+            JobCommand.Update => "update",
+            JobCommand.Recreate => "recreate",
+            JobCommand.Graph => "graph",
+            _ => "",
+        };
+        writer.WriteStringValue(str);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -28,7 +28,7 @@ public class RunWorker
     {
         PropertyNamingPolicy = JsonNamingPolicy.KebabCaseLower,
         WriteIndented = true,
-        Converters = { new JsonStringEnumConverter(), new PullRequestConverter(), new RequirementConverter(), new VersionConverter() },
+        Converters = { new JobCommandConverter(new ConsoleLogger()), new JsonStringEnumConverter(), new PullRequestConverter(), new RequirementConverter(), new VersionConverter() },
     };
 
     public RunWorker(string jobId, IApiHandler apiHandler, IDiscoveryWorker discoverWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updateWorker, ILogger logger)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -28,7 +28,7 @@ public class RunWorker
     {
         PropertyNamingPolicy = JsonNamingPolicy.KebabCaseLower,
         WriteIndented = true,
-        Converters = { new JobCommandConverter(new ConsoleLogger()), new JsonStringEnumConverter(), new PullRequestConverter(), new RequirementConverter(), new VersionConverter() },
+        Converters = { new JsonStringEnumConverter(), new PullRequestConverter(), new RequirementConverter(), new VersionConverter() },
     };
 
     public RunWorker(string jobId, IApiHandler apiHandler, IDiscoveryWorker discoverWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updateWorker, ILogger logger)
@@ -44,7 +44,7 @@ public class RunWorker
     public async Task<int> RunAsync(FileInfo jobFilePath, DirectoryInfo repoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha)
     {
         var jobFileContent = await File.ReadAllTextAsync(jobFilePath.FullName);
-        var jobWrapper = Deserialize(jobFileContent);
+        var jobWrapper = Deserialize(jobFileContent, _logger);
         var experimentsManager = ExperimentsManager.GetExperimentsManager(jobWrapper.Job.Experiments);
         var result = await RunAsync(jobWrapper.Job, repoContentsPath, caseInsensitiveRepoContentsPath, baseCommitSha, experimentsManager);
         return result;
@@ -367,9 +367,12 @@ public class RunWorker
         return updatedDependencyList;
     }
 
-    public static JobFile Deserialize(string json)
+    public static JobFile Deserialize(string json) => Deserialize(json, new ConsoleLogger());
+
+    public static JobFile Deserialize(string json, ILogger logger)
     {
-        var jobFile = JsonSerializer.Deserialize<JobFile>(json, SerializerOptions);
+        var options = GetDeserializerOptions(logger);
+        var jobFile = JsonSerializer.Deserialize<JobFile>(json, options);
         if (jobFile is null)
         {
             throw new InvalidOperationException("Unable to deserialize job wrapper.");
@@ -381,6 +384,13 @@ public class RunWorker
         }
 
         return jobFile;
+    }
+
+    internal static JsonSerializerOptions GetDeserializerOptions(ILogger logger)
+    {
+        var options = new JsonSerializerOptions(SerializerOptions);
+        options.Converters.Insert(0, new JobCommandConverter(logger));
+        return options;
     }
 
     internal static string AddInsecureConnectionsAttribute(string nugetConfigContents)


### PR DESCRIPTION
## Summary

Adds a `JobCommand` enum (`None`, `Update`, `Recreate`, `Graph`) and a `Command` property to the NuGet `Job` model, with a custom `JobCommandConverter` that deserializes the job JSON `command` field.

## Details

- **Empty strings**, **null**, and **missing fields** map to `JobCommand.None`
- **Unknown values** log a warning via `ILogger` and default to `None`
- The converter is registered in `RunWorker.SerializerOptions` (before `JsonStringEnumConverter` to ensure precedence)
- The NuGet update handlers already close PRs when discovery finds no matching dependencies, so no behavioral handler changes were needed

## Tests

- Deserialization of known values (update, recreate, graph, empty string)
- Missing field defaults to None
- Unknown value defaults to None and logs a warning (verified via StringLogger)