### PR TITLE
Type create_dependency_file with keyword arguments

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1884
+# Offense count: 1882
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -318,9 +318,7 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/experiments.rb"
     - "common/lib/dependabot/file_fetchers/base.rb"
     - "common/lib/dependabot/file_parsers/base.rb"
-    - "common/lib/dependabot/file_updaters/artifact_updater.rb"
     - "common/lib/dependabot/file_updaters/base.rb"
-    - "common/lib/dependabot/file_updaters/vendor_updater.rb"
     - "common/lib/dependabot/git_commit_checker.rb"
     - "common/lib/dependabot/git_metadata_fetcher.rb"
     - "common/lib/dependabot/metadata_finders/base/changelog_finder.rb"

--- a/common/lib/dependabot/file_updaters/artifact_updater.rb
+++ b/common/lib/dependabot/file_updaters/artifact_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/common/lib/dependabot/file_updaters/artifact_updater.rb
+++ b/common/lib/dependabot/file_updaters/artifact_updater.rb
@@ -120,25 +120,46 @@ module Dependabot
 
       sig do
         overridable
-          .params(parameters: T::Hash[Symbol, T.untyped])
+          .params(
+            name: String,
+            content: T.nilable(String),
+            directory: String,
+            type: String,
+            support_file: T::Boolean,
+            vendored_file: T::Boolean,
+            symlink_target: T.nilable(String),
+            content_encoding: String,
+            deleted: T::Boolean,
+            operation: String,
+            mode: T.nilable(String)
+          )
           .returns(Dependabot::DependencyFile)
       end
-      def create_dependency_file(parameters)
+      def create_dependency_file(
+        name:,
+        content: nil,
+        directory: "/",
+        type: "file",
+        support_file: false,
+        vendored_file: false,
+        symlink_target: nil,
+        content_encoding: Dependabot::DependencyFile::ContentEncoding::UTF_8,
+        deleted: false,
+        operation: Dependabot::DependencyFile::Operation::UPDATE,
+        mode: nil
+      )
         Dependabot::DependencyFile.new(
-          name: parameters.fetch(:name),
-          content: parameters[:content],
-          directory: parameters.fetch(:directory, "/"),
-          type: parameters.fetch(:type, "file"),
-          support_file: parameters.fetch(:support_file, false),
-          vendored_file: parameters.fetch(:vendored_file, false),
-          symlink_target: parameters[:symlink_target],
-          content_encoding: parameters.fetch(
-            :content_encoding,
-            Dependabot::DependencyFile::ContentEncoding::UTF_8
-          ),
-          deleted: parameters.fetch(:deleted, false),
-          operation: parameters.fetch(:operation, Dependabot::DependencyFile::Operation::UPDATE),
-          mode: parameters[:mode]
+          name: name,
+          content: content,
+          directory: directory,
+          type: type,
+          support_file: support_file,
+          vendored_file: vendored_file,
+          symlink_target: symlink_target,
+          content_encoding: content_encoding,
+          deleted: deleted,
+          operation: operation,
+          mode: mode
         )
       end
     end

--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -31,27 +31,51 @@ module Dependabot
 
       private
 
+      # VendorUpdater always flags files as vendored, so it accepts but ignores
+      # the vendored_file argument. The parameter must stay to keep the override
+      # signature compatible with ArtifactUpdater#create_dependency_file.
       sig do
         override
-          .params(parameters: T::Hash[Symbol, T.untyped])
+          .params(
+            name: String,
+            content: T.nilable(String),
+            directory: String,
+            type: String,
+            support_file: T::Boolean,
+            vendored_file: T::Boolean,
+            symlink_target: T.nilable(String),
+            content_encoding: String,
+            deleted: T::Boolean,
+            operation: String,
+            mode: T.nilable(String)
+          )
           .returns(Dependabot::DependencyFile)
       end
-      def create_dependency_file(parameters)
-        Dependabot::DependencyFile.new(
-          name: parameters.fetch(:name),
-          content: parameters[:content],
-          directory: parameters.fetch(:directory, "/"),
-          type: parameters.fetch(:type, "file"),
-          support_file: parameters.fetch(:support_file, false),
+      def create_dependency_file(
+        name:,
+        content: nil,
+        directory: "/",
+        type: "file",
+        support_file: false,
+        vendored_file: false, # rubocop:disable Lint/UnusedMethodArgument
+        symlink_target: nil,
+        content_encoding: Dependabot::DependencyFile::ContentEncoding::UTF_8,
+        deleted: false,
+        operation: Dependabot::DependencyFile::Operation::UPDATE,
+        mode: nil
+      )
+        super(
+          name: name,
+          content: content,
+          directory: directory,
+          type: type,
+          support_file: support_file,
           vendored_file: true,
-          symlink_target: parameters[:symlink_target],
-          content_encoding: parameters.fetch(
-            :content_encoding,
-            Dependabot::DependencyFile::ContentEncoding::UTF_8
-          ),
-          deleted: parameters.fetch(:deleted, false),
-          operation: parameters.fetch(:operation, Dependabot::DependencyFile::Operation::UPDATE),
-          mode: parameters[:mode]
+          symlink_target: symlink_target,
+          content_encoding: content_encoding,
+          deleted: deleted,
+          operation: operation,
+          mode: mode
         )
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Continue the `Sorbet/ForbidTUntyped` burndown. `ArtifactUpdater#create_dependency_file` and its `VendorUpdater` override took a single `T::Hash[Symbol, T.untyped]` and pulled values out by key. This replaces that hash with typed keyword arguments and drops both files from the todo exclude list (381 to 379 files).

The only caller already used keyword syntax, so it needs no change.

### Anything you want to highlight for special attention from reviewers?

Stacked on #15278; review and merge that first.

`VendorUpdater` always vendors, so its override forwards `vendored_file: true` to `super` and ignores the argument it receives. The argument has to stay for the override signature to match the base, so I added a scoped `Lint/UnusedMethodArgument` disable with a comment explaining why.

### How will you know you've accomplished your goal?

`srb tc` passes, `rubocop` reports no offenses on both files, and the artifact and vendor updater specs (38 examples) pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
