### PR TITLE
Remove T.untyped from three updater files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1882
+# Offense count: 1879
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -582,7 +582,6 @@ Sorbet/ForbidTUntyped:
     - "updater/lib/dependabot/api_client.rb"
     - "updater/lib/dependabot/dependency_attribution.rb"
     - "updater/lib/dependabot/dependency_change.rb"
-    - "updater/lib/dependabot/dependency_snapshot.rb"
     - "updater/lib/dependabot/environment.rb"
     - "updater/lib/dependabot/file_fetcher_command.rb"
     - "updater/lib/dependabot/job.rb"
@@ -600,8 +599,6 @@ Sorbet/ForbidTUntyped:
     - "updater/lib/dependabot/updater/error_handler.rb"
     - "updater/lib/dependabot/updater/errors.rb"
     - "updater/lib/dependabot/updater/group_dependency_selector.rb"
-    - "updater/lib/dependabot/updater/group_update_creation.rb"
-    - "updater/lib/dependabot/updater/operations/update_all_versions.rb"
     - "updater/lib/dependabot/updater/pattern_specificity_calculator.rb"
     - "updater/lib/dependabot/updater/update_type_helper.rb"
     - "updater/lib/github_api/dependency_submission.rb"

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -476,7 +476,7 @@ module Dependabot
         }
       end
 
-      sig { params(group: T.untyped, version: Gem::Version, latest_version: Gem::Version).returns(T::Boolean) }
+      sig { params(group: Dependabot::DependencyGroup, version: Gem::Version, latest_version: Gem::Version).returns(T::Boolean) }
       def cargo_update_type_allowed?(group, version, latest_version)
         return true unless Dependabot::Cargo::Version.respond_to?(:update_type)
 

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -192,7 +192,13 @@ module Dependabot
 
           create_pull_request(dependency_change)
         end
-        sig { params(dependency_name: String, latest_version: String, latest_version_obj: T.untyped).void }
+        sig do
+          params(
+            dependency_name: String,
+            latest_version: String,
+            latest_version_obj: T.nilable(T.any(String, Gem::Version))
+          ).void
+        end
         def log_existing_pr_for_latest_version(dependency_name, latest_version, latest_version_obj)
           existing_pr = job.existing_pull_requests.find do |pr|
             pr.contains_dependency?(dependency_name, latest_version, T.must(job.source.directory))
@@ -250,7 +256,7 @@ module Dependabot
           job.log_ignore_conditions_for(dependency)
         end
 
-        sig { params(error: StandardError, dependency: Dependabot::Dependency).returns(T.untyped) }
+        sig { params(error: StandardError, dependency: Dependabot::Dependency).void }
         def process_dependency_error(error, dependency)
           if error.class.to_s.include?("RegistryError")
             ex = Dependabot::DependencyFileNotResolvable.new(error.message)


### PR DESCRIPTION
### What are you trying to accomplish?

Continue the `Sorbet/ForbidTUntyped` burndown, this time in `updater/`. Removes three files from the todo exclude list (379 to 376):

- `updater/dependency_snapshot.rb` was already `typed: strong` with no `T.untyped`; it was a stale entry, so this just drops the line.
- `updater/group_update_creation.rb`: `cargo_update_type_allowed?` took `group: T.untyped`. Every other method in the file types it as `Dependabot::DependencyGroup`, so this matches them. Removing it makes the file eligible for `typed: strong`, so the sigil is bumped too.
- `updater/operations/update_all_versions.rb`: `latest_version_obj` is now `T.nilable(T.any(String, Gem::Version))` (the type its caller passes), and `process_dependency_error` returns `void` (its body calls a `void` method and the one caller discards the result).

### Anything you want to highlight for special attention from reviewers?

These are type annotations only, with no change to runtime behaviour, so `srb tc` is the main check.

### How will you know you've accomplished your goal?

`srb tc` passes, the three `spoom srb bump` checks stay clean, `rubocop` reports no offenses, and the updater specs pass in CI.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
