### PR TITLE
Set default max branch name length to 100 characters

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -197,7 +197,7 @@ module Dependabot
       milestone: nil,
       branch_name_separator: "/",
       branch_name_prefix: "dependabot",
-      branch_name_max_length: nil,
+      branch_name_max_length: 100,
       label_language: false,
       automerge_candidate: false,
       github_redirection_service: DEFAULT_GITHUB_REDIRECTION_SERVICE,

--- a/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
@@ -1,6 +1,7 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "digest"
 require "sorbet-runtime"
 
 module Dependabot
@@ -70,9 +71,10 @@ module Dependabot
           sanitized_name = sanitized_name.gsub("/", separator)
 
           # Shorten the ref in case users refs have length limits
-          if max_length && (sanitized_name.length > T.must(max_length))
-            sha = T.must(Digest::SHA1.hexdigest(sanitized_name)[0, T.must(max_length)])
-            sanitized_name[[T.must(max_length) - sha.size, 0].max..] = sha
+          branch_name_max_length = max_length
+          if branch_name_max_length && (sanitized_name.length > branch_name_max_length)
+            sha = T.must(Digest::SHA1.hexdigest(sanitized_name)[0, branch_name_max_length])
+            sanitized_name[[branch_name_max_length - sha.size, 0].max..] = sha
           end
 
           sanitized_name

--- a/common/spec/dependabot/pull_request_creator_spec.rb
+++ b/common/spec/dependabot/pull_request_creator_spec.rb
@@ -226,6 +226,63 @@ RSpec.describe Dependabot::PullRequestCreator do
       end
     end
 
+    context "with a dependency name that would generate a branch longer than 100 characters" do
+      let(:source) { Dependabot::Source.new(provider: "github", repo: "gc/bp", branch: "main") }
+      let(:dummy_creator) { instance_double(described_class::Github) }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "this.is.an.extremely.long.package.name.that.will.definitely.exceed.the.maximum.length.limit",
+          version: "1.5.0",
+          previous_version: "1.4.0",
+          package_manager: "bundler",
+          requirements:
+            [{ file: "Gemfile", requirement: "~> 1.5.0", groups: [], source: nil }],
+          previous_requirements:
+            [{ file: "Gemfile", requirement: "~> 1.4.0", groups: [], source: nil }]
+        )
+      end
+
+      it "shortens the branch name to 100 characters by default" do
+        expect(described_class::Github)
+          .to receive(:new) do |**kwargs|
+            expect(kwargs[:branch_name].length).to eq(100)
+            dummy_creator
+          end
+        expect(dummy_creator).to receive(:create)
+        creator.create
+      end
+
+      context "when branch_name_max_length is explicitly set to nil" do
+        subject(:creator) do
+          described_class.new(
+            source: source,
+            base_commit: base_commit,
+            dependencies: dependencies,
+            files: files,
+            credentials: credentials,
+            custom_labels: custom_labels,
+            reviewers: reviewers,
+            assignees: assignees,
+            milestone: milestone,
+            author_details: author_details,
+            signature_key: signature_key,
+            provider_metadata: provider_metadata,
+            branch_name_max_length: nil
+          )
+        end
+
+        it "does not shorten the branch name" do
+          expect(described_class::Github)
+            .to receive(:new) do |**kwargs|
+              expect(kwargs[:branch_name].length).to be > 100
+              dummy_creator
+            end
+          expect(dummy_creator).to receive(:create)
+          creator.create
+        end
+      end
+    end
+
     context "with a GitLab source" do
       let(:source) { Dependabot::Source.new(provider: "gitlab", repo: "gc/bp", branch: "main") }
       let(:dummy_creator) { instance_double(described_class::Gitlab) }


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #12854

This sets the default `branch_name_max_length` in `Dependabot::PullRequestCreator` to 100. This activates the existing SHA1-tail shortening in `BranchNamer::Base#sanitize_branch_name` for single-dependency branch names that would otherwise exceed filesystem path limits, such as the NuGet NU5123 path-too-long failures reported on Windows.

Supersedes #12913.

### Anything you want to highlight for special attention from reviewers?

The shortening algorithm itself is unchanged. Branch names under 100 characters are unaffected, while over-100-character names are deterministically shortened using the full SHA1 entropy, so refreshes remain stable with no realistic collision risk.

Existing PR de-duplication in the updater keys on dependency name, version, and directory rather than branch name, and `PullRequestUpdater` uses the live `head.ref`. Already-open PRs with long branch names should therefore continue to refresh correctly. Group and multi-dependency strategies already digest their branch names; this change addresses single-dependency branches with long fully-qualified names.

### How will you know you've accomplished your goal?

New specs in `pull_request_creator_spec.rb` cover both the default-on cap at 100 characters and the explicit `branch_name_max_length: nil` opt-out for backwards compatibility. Existing parameterized `BranchNamer` shortening specs continue to exercise the unchanged shortening behavior.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.