### PR TITLE
Type DependencyFile#to_h and Notice#to_hash serialization hashes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1879
+# Offense count: 1877
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -312,7 +312,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/command_helpers.rb"
     - "common/lib/dependabot/config/file.rb"
     - "common/lib/dependabot/dependency.rb"
-    - "common/lib/dependabot/dependency_file.rb"
     - "common/lib/dependabot/dependency_group.rb"
     - "common/lib/dependabot/errors.rb"
     - "common/lib/dependabot/experiments.rb"
@@ -323,7 +322,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/git_metadata_fetcher.rb"
     - "common/lib/dependabot/metadata_finders/base/changelog_finder.rb"
     - "common/lib/dependabot/metadata_finders/base/release_finder.rb"
-    - "common/lib/dependabot/notices.rb"
     - "common/lib/dependabot/package/package_latest_version_finder.rb"
     - "common/lib/dependabot/package/package_release.rb"
     - "common/lib/dependabot/pull_request_creator.rb"

--- a/common/lib/dependabot/dependency_file.rb
+++ b/common/lib/dependabot/dependency_file.rb
@@ -123,7 +123,7 @@ module Dependabot
       raise "Only symlinked files must specify a target!" if symlink_target
     end
 
-    sig { returns(T::Hash[String, T.untyped]) }
+    sig { returns(T::Hash[String, T.nilable(T.any(String, T::Boolean))]) }
     def to_h
       details = {
         "name" => name,

--- a/common/lib/dependabot/notices.rb
+++ b/common/lib/dependabot/notices.rb
@@ -59,7 +59,7 @@ module Dependabot
 
     # Converts the Notice object to a hash.
     # @return [Hash] The hash representation of the notice.
-    sig { returns(T::Hash[Symbol, T.untyped]) }
+    sig { returns(T::Hash[Symbol, T.any(String, T::Boolean)]) }
     def to_hash
       {
         mode: @mode,


### PR DESCRIPTION
### What are you trying to accomplish?

Continue the `Sorbet/ForbidTUntyped` burndown in `common/`. Two serialization methods returned `T::Hash[..., T.untyped]` when their values are actually a small, known set of types. Typing them precisely removes the `T.untyped` and clears both files from the todo (376 to 374).

- `DependencyFile#to_h` returns `T::Hash[String, T.nilable(T.any(String, T::Boolean))]` (name, content, directory, etc. are strings, booleans, or nil).
- `Notice#to_hash` returns `T::Hash[Symbol, T.any(String, T::Boolean)]` (five strings and two booleans).

### Anything you want to highlight for special attention from reviewers?

Narrowing a widely-called method like `DependencyFile#to_h` could ripple, but `srb tc` is clean across the repo, so no caller relied on the values being untyped. These are annotation-only changes with no runtime effect.

### How will you know you've accomplished your goal?

`srb tc` passes, the three `spoom srb bump` checks stay clean, `rubocop` reports no offenses, and the `notices` and `dependency_file` specs (46 examples) pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
