### PR TITLE
Type parse_dep_string return in bundler and npm_and_yarn

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1877
+# Offense count: 1875
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -284,7 +284,6 @@ Sorbet/ForbidTUntyped:
     - "bundler/lib/dependabot/bundler/metadata_finder.rb"
     - "bundler/lib/dependabot/bundler/native_helpers.rb"
     - "bundler/lib/dependabot/bundler/package/package_details_fetcher.rb"
-    - "bundler/lib/dependabot/bundler/requirement.rb"
     - "bundler/lib/dependabot/bundler/update_checker.rb"
     - "bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb"
     - "bundler/lib/dependabot/bundler/update_checker/force_updater.rb"
@@ -480,7 +479,6 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/requirement.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/library_detector.rb"

--- a/bundler/lib/dependabot/bundler/requirement.rb
+++ b/bundler/lib/dependabot/bundler/requirement.rb
@@ -26,7 +26,7 @@ module Dependabot
         [new(requirement_string)]
       end
 
-      sig { params(dep_string: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { params(dep_string: String).returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
       def self.parse_dep_string(dep_string)
         stripped = dep_string.strip
         return nil if stripped.empty?

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/requirement.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/requirement.rb
@@ -68,7 +68,7 @@ module Dependabot
         end
       end
 
-      sig { params(dep_string: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { params(dep_string: String).returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
       def self.parse_dep_string(dep_string)
         stripped = dep_string.strip
         return nil if stripped.empty?


### PR DESCRIPTION
### What are you trying to accomplish?

Continue the `Sorbet/ForbidTUntyped` burndown in two high-traffic ecosystems. `Bundler::Requirement.parse_dep_string` and `NpmAndYarn::Requirement.parse_dep_string` both returned `T.nilable(T::Hash[Symbol, T.untyped])`, but every value in the returned hash (`name`, `normalised_name`, `version`, `requirement`, `extras`) is a `String` or `nil`. Typing the return as `T.nilable(T::Hash[Symbol, T.nilable(String)])` removes the `T.untyped` and clears both files from the todo (374 to 372).

### Anything you want to highlight for special attention from reviewers?

Stacked on #15283; review and merge that first.

`parse_dep_string` is the shared interface that `pre_commit/file_parser.rb` calls per language. `pre_commit` reaches it through an untyped lambda table, so narrowing the return type does not ripple there. `srb tc` is clean across the repo. The `cargo` and `pub` Requirement classes have the same method and pattern; I left them for a follow-up to keep this scoped to the high-traffic ecosystems.

### How will you know you've accomplished your goal?

`srb tc` passes, the three `spoom srb bump` checks stay clean, `rubocop` reports no offenses, and the bundler and npm_and_yarn requirement specs (94 examples) pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
