### PR TITLE
Type registry_parser, git_pin_replacer, and drop stale pnpm entry

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1875
+# Offense count: 1873
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -277,7 +277,6 @@ Sorbet/ForbidTUntyped:
     - "bundler/lib/dependabot/bundler/file_parser.rb"
     - "bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb"
     - "bundler/lib/dependabot/bundler/file_parser/gemspec_declaration_finder.rb"
-    - "bundler/lib/dependabot/bundler/file_updater/git_pin_replacer.rb"
     - "bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb"
     - "bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb"
     - "bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb"
@@ -470,7 +469,6 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_workspace_updater.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb"
@@ -478,7 +476,6 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_finder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/library_detector.rb"

--- a/bundler/lib/dependabot/bundler/file_updater/git_pin_replacer.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/git_pin_replacer.rb
@@ -52,7 +52,7 @@ module Dependabot
             @new_pin = T.let(new_pin, String)
           end
 
-          sig { params(node: Parser::AST::Node).returns(T.untyped) }
+          sig { params(node: Parser::AST::Node).void }
           def on_send(node)
             return unless declares_targeted_gem?(node)
             return unless node.children.last.type == :hash

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_parser.rb
@@ -16,7 +16,7 @@ module Dependabot
         @credentials = credentials
       end
 
-      sig { params(name: String).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(name: String).returns(T::Hash[Symbol, T.nilable(String)]) }
       def registry_source_for(name)
         url =
           if resolved_url.include?("/~/")


### PR DESCRIPTION
### What are you trying to accomplish?

Continue the `Sorbet/ForbidTUntyped` burndown across bundler and npm_and_yarn. Clears three files from the todo (372 to 369):

- `NpmAndYarn::RegistryParser#registry_source_for` returns `{ type:, url: }` where both values are strings or nil, so the return type is now `T::Hash[Symbol, T.nilable(String)]`.
- `Bundler::FileUpdater::GitPinReplacer::Rewriter#on_send` is a `Parser::TreeRewriter` callback that edits source through the rewriter and ignores its return, so it is now `void`.
- `npm_and_yarn/file_updater/pnpm_workspace_updater.rb` was already `typed: strong` with no `T.untyped`; it was a stale todo entry, so this just drops the line.

### Anything you want to highlight for special attention from reviewers?

Stacked on #15284 (and #15283); review and merge those first.

The `on_send` change is the one to sanity-check: `TreeRewriter` drives edits via `replace(...)` on the rewriter, not via the callback return, so `void` matches reality. The git_pin_replacer spec confirms it.

### How will you know you've accomplished your goal?

`srb tc` passes, the three `spoom srb bump` checks stay clean, `rubocop` reports no offenses, and the git_pin_replacer (6) and registry_parser (9) specs pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
