### PR TITLE
Type parse_dep_string return in cargo and pub

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1870
+# Offense count: 1868
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -297,7 +297,6 @@ Sorbet/ForbidTUntyped:
     - "cargo/lib/dependabot/cargo/file_updater/workspace_manifest_updater.rb"
     - "cargo/lib/dependabot/cargo/metadata_finder.rb"
     - "cargo/lib/dependabot/cargo/package/package_details_fetcher.rb"
-    - "cargo/lib/dependabot/cargo/requirement.rb"
     - "cargo/lib/dependabot/cargo/update_checker.rb"
     - "cargo/lib/dependabot/cargo/update_checker/file_preparer.rb"
     - "cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb"
@@ -509,7 +508,6 @@ Sorbet/ForbidTUntyped:
     - "pub/lib/dependabot/pub/helpers.rb"
     - "pub/lib/dependabot/pub/metadata_finder.rb"
     - "pub/lib/dependabot/pub/package/package_details_fetcher.rb"
-    - "pub/lib/dependabot/pub/requirement.rb"
     - "pub/lib/dependabot/pub/update_checker.rb"
     - "pub/lib/dependabot/pub/update_checker/latest_version_finder.rb"
     - "python/lib/dependabot/python/dependency_grapher.rb"

--- a/cargo/lib/dependabot/cargo/requirement.rb
+++ b/cargo/lib/dependabot/cargo/requirement.rb
@@ -50,7 +50,7 @@ module Dependabot
 
       # Parses a pre-commit Rust additional_dependency string.
       # Formats: "package_name:version", "cli:package_name:version"
-      sig { params(dep_string: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { params(dep_string: String).returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
       def self.parse_dep_string(dep_string)
         stripped = dep_string.strip
         return nil if stripped.empty?

--- a/pub/lib/dependabot/pub/requirement.rb
+++ b/pub/lib/dependabot/pub/requirement.rb
@@ -53,7 +53,7 @@ module Dependabot
 
       # Parses a pre-commit Dart additional_dependency string.
       # Formats: "package_name:version" or "package_name:^version"
-      sig { params(dep_string: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { params(dep_string: String).returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
       def self.parse_dep_string(dep_string)
         stripped = dep_string.strip
         return nil if stripped.empty?


### PR DESCRIPTION
### What are you trying to accomplish?

Finish typing the `parse_dep_string` interface that #15284 (bundler, npm) and #15287 (python) started. `Cargo::Requirement.parse_dep_string` and `Pub::Requirement.parse_dep_string` return the same `{ name, normalised_name, version, requirement, extras }` shape, where every value is a string or nil, so both now return `T.nilable(T::Hash[Symbol, T.nilable(String)])`. Clears the last two files in this interface from the todo (367 to 365).

### Anything you want to highlight for special attention from reviewers?

Stacked on #15287 (and the rest of the stack); review and merge those first.

This completes the shared `pre_commit` parser interface: bundler, npm, python, cargo, and pub now all return the typed hash. `pre_commit` reaches them through an untyped lambda table, so there is no ripple.

### How will you know you've accomplished your goal?

`srb tc` passes, the three `spoom srb bump` checks stay clean, `rubocop` reports no offenses, and the cargo (36) and pub (28) requirement specs pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
