### PR TITLE
set temporary token for cargo auth that the proxy will then replace

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -88,7 +88,7 @@ module Dependabot
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         attr_reader :dependency_files
 
-        sig { returns(T::Array[T.untyped]) }
+        sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
 
         # Currently, there will only be a single updated dependency
@@ -217,10 +217,7 @@ module Dependabot
         def run_cargo_command(command, fingerprint:)
           start = Time.now
           command = SharedHelpers.escape_command(command)
-          Helpers.bypass_cargo_credential_providers
-          # Pass through any cargo registry configuration via environment variables
-          # (e.g. CARGO_REGISTRIES_CRATES_IO_PROTOCOL, CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS).
-          env = ENV.select { |key, _value| key.match(/^CARGO_REGISTR(Y|IES)_/) }
+          env = Helpers.cargo_command_env(dependency_files, credentials)
           stdout, process = Open3.capture2e(env, command)
           time_taken = Time.now - start
 

--- a/cargo/lib/dependabot/cargo/helpers.rb
+++ b/cargo/lib/dependabot/cargo/helpers.rb
@@ -1,26 +1,14 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "uri"
 require "toml-rb"
+require "dependabot/experiments"
 
 module Dependabot
   module Cargo
     module Helpers
       extend T::Sig
-
-      # Disable Cargo's *global* credential providers so that Cargo does not attempt to look up registry tokens
-      # on its own. The dependabot proxy (https://github.com/dependabot/proxy/) handles all registry authentication
-      # transparently by intercepting HTTP requests and injecting the appropriate credentials.
-      #
-      # Note: this only affects the global/default credential provider. Per-registry `credential-provider` settings
-      # in .cargo/config.toml override this env var, so those are stripped separately by `sanitize_cargo_config`.
-      #
-      # Uses ||= so developers can override by setting CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token in their
-      # shell (along with the appropriate CARGO_REGISTRIES_{NAME}_TOKEN vars) for local development without the proxy.
-      sig { void }
-      def self.bypass_cargo_credential_providers
-        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] ||= ""
-      end
 
       # Strip per-registry `credential-provider` settings from .cargo/config.toml.
       #
@@ -55,6 +43,98 @@ module Dependabot
           ".cargo/config.toml",
           "Failed to parse Cargo config file: #{e.message}"
         )
+      end
+
+      # Parses cargo config content and returns the names of custom registries
+      # whose index URL matches a credential host or url.
+      sig { params(config_content: String, credentials: T::Array[Dependabot::Credential]).returns(T::Array[String]) }
+      def self.custom_registry_names(config_content, credentials)
+        parsed = TomlRB.parse(config_content)
+        registries = parsed["registries"]
+        return [] unless registries.is_a?(Hash)
+
+        credential_hosts = credentials.filter_map { |cred| cred["host"] }.to_set
+        credential_urls = credentials.filter_map { |cred| cred["url"]&.delete_suffix("/") }.to_set
+
+        registries.select do |_name, config|
+          config.is_a?(Hash) && registry_index_matches?(config, credential_hosts, credential_urls)
+        end.keys
+      rescue TomlRB::Error, URI::InvalidURIError => e
+        Dependabot.logger.warn("Failed to parse cargo config for registry names: #{e.message}")
+        []
+      end
+
+      sig do
+        params(
+          config: T::Hash[String, String],
+          credential_hosts: T::Set[String],
+          credential_urls: T::Set[String]
+        ).returns(T::Boolean)
+      end
+      def self.registry_index_matches?(config, credential_hosts, credential_urls)
+        index = config["index"]
+        return false unless index.is_a?(String)
+
+        # Index URLs may have a scheme prefix like "sparse+" before the actual URL
+        url = index.sub(/^[a-z]+\+/, "")
+        host = URI.parse(url).host
+
+        (host && credential_hosts.include?(host)) ||
+          credential_urls.include?(url.delete_suffix("/"))
+      end
+
+      # Builds a hash of environment variables for Cargo registry token auth.
+      # Returns env vars like CARGO_REGISTRIES_<NAME>_TOKEN=garbage_token for each
+      # matched registry, plus CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token.
+      sig do
+        params(config_content: String, credentials: T::Array[Dependabot::Credential])
+          .returns(T::Hash[String, String])
+      end
+      def self.registry_token_env(config_content, credentials)
+        registry_names = custom_registry_names(config_content, credentials)
+        return {} if registry_names.empty?
+
+        registry_names.each_with_object({}) do |name, hash|
+          key = "CARGO_REGISTRIES_#{name.upcase.tr('-', '_')}_TOKEN"
+          hash[key] = "garbage_token"
+        end
+      end
+
+      # Convenience method: extracts .cargo/config.toml from dependency files and
+      # builds registry token env vars. Returns an empty hash if no config file exists.
+      sig do
+        params(
+          dependency_files: T::Array[Dependabot::DependencyFile],
+          credentials: T::Array[Dependabot::Credential]
+        ).returns(T::Hash[String, String])
+      end
+      def self.registry_token_env_from_files(dependency_files, credentials)
+        config_file = dependency_files.find { |f| f.name == ".cargo/config.toml" }
+        return {} unless config_file
+
+        registry_token_env(T.must(config_file.content), credentials)
+      end
+
+      # Builds the complete environment variable hash for running cargo commands:
+      # 1. Sets CARGO_REGISTRIES_<NAME>_TOKEN for each matched custom registry
+      # 2. Merges real CARGO_REGISTR(Y|IES)_* vars from the process environment
+      # 3. Sets CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token
+      sig do
+        params(
+          dependency_files: T::Array[Dependabot::DependencyFile],
+          credentials: T::Array[Dependabot::Credential]
+        ).returns(T::Hash[String, String])
+      end
+      def self.cargo_command_env(dependency_files, credentials)
+        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] ||= ""
+        return {} unless ENV.fetch("DEPENDABOT", nil) == "true"
+        return {} unless Dependabot::Experiments.enabled?(:cargo_set_registry_token_auth)
+
+        env = registry_token_env_from_files(dependency_files, credentials)
+        Dependabot.logger.info("Setting registry token env vars: #{env.keys.join(', ')}") unless env.empty?
+        env.merge!(ENV.select { |key, _value| key.match(/^CARGO_REGISTR(Y|IES)_/) })
+        env["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] = "cargo:token"
+        env
       end
     end
   end

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -187,10 +187,7 @@ module Dependabot
         def run_cargo_command(command, fingerprint: nil)
           start = Time.now
           command = SharedHelpers.escape_command(command)
-          Helpers.bypass_cargo_credential_providers
-          # Pass through any cargo registry configuration via environment variables
-          # (e.g. CARGO_REGISTRIES_CRATES_IO_PROTOCOL, CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS).
-          env = ENV.select { |key, _value| key.match(/^CARGO_REGISTR(Y|IES)_/) }
+          env = Helpers.cargo_command_env(original_dependency_files, credentials)
 
           stdout, process = Open3.capture2e(env, command)
           time_taken = Time.now - start

--- a/cargo/spec/dependabot/cargo/helpers_spec.rb
+++ b/cargo/spec/dependabot/cargo/helpers_spec.rb
@@ -5,36 +5,6 @@ require "spec_helper"
 require "dependabot/cargo/helpers"
 
 RSpec.describe Dependabot::Cargo::Helpers do
-  describe ".bypass_cargo_credential_providers" do
-    after do
-      ENV.delete("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")
-    end
-
-    context "when CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS is not set" do
-      before do
-        ENV.delete("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")
-      end
-
-      it "sets it to an empty string to disable credential providers" do
-        described_class.bypass_cargo_credential_providers
-
-        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")).to eq("")
-      end
-    end
-
-    context "when CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS is already set" do
-      before do
-        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] = "cargo:token"
-      end
-
-      it "does not overwrite the existing value" do
-        described_class.bypass_cargo_credential_providers
-
-        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")).to eq("cargo:token")
-      end
-    end
-  end
-
   describe ".sanitize_cargo_config" do
     context "when config has no credential-provider settings" do
       let(:config_content) do
@@ -156,6 +126,264 @@ RSpec.describe Dependabot::Cargo::Helpers do
       it "raises DependencyFileNotParseable" do
         expect { described_class.sanitize_cargo_config(config_content) }
           .to raise_error(Dependabot::DependencyFileNotParseable, /Failed to parse Cargo config file/)
+      end
+    end
+  end
+
+  describe ".custom_registry_names" do
+    it "returns empty array when no registries are defined" do
+      config_content = <<~TOML
+        [net]
+        git-fetch-with-cli = true
+      TOML
+      expect(described_class.custom_registry_names(config_content, [])).to eq([])
+    end
+
+    it "returns a single registry name when credential host matches" do
+      config_content = <<~TOML
+        [registries.my-registry]
+        index = "sparse+https://example.com/index/"
+      TOML
+      creds = [Dependabot::Credential.new({ "host" => "example.com" })]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq(["my-registry"])
+    end
+
+    it "returns only registries whose index host matches a credential host" do
+      config_content = <<~TOML
+        [registries.first-registry]
+        index = "sparse+https://first.example.com/index/"
+
+        [registries.second-registry]
+        index = "sparse+https://second.example.com/index/"
+      TOML
+      creds = [Dependabot::Credential.new({ "host" => "first.example.com" })]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq(["first-registry"])
+    end
+
+    it "returns multiple registries when multiple credential hosts match" do
+      config_content = <<~TOML
+        [registries.first-registry]
+        index = "sparse+https://first.example.com/index/"
+
+        [registries.second-registry]
+        index = "sparse+https://second.example.com/index/"
+      TOML
+      creds = [
+        Dependabot::Credential.new({ "host" => "first.example.com" }),
+        Dependabot::Credential.new({ "host" => "second.example.com" })
+      ]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq(%w(first-registry second-registry))
+    end
+
+    it "ignores non-registry sections" do
+      config_content = <<~TOML
+        [registry]
+        default = "my-registry"
+
+        [registries.my-registry]
+        index = "sparse+https://example.com/index/"
+
+        [net]
+        git-fetch-with-cli = true
+      TOML
+      creds = [Dependabot::Credential.new({ "host" => "example.com" })]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq(["my-registry"])
+    end
+
+    it "handles leading whitespace on registry lines" do
+      config_content = "  [registries.spaced-registry]\n  index = \"https://example.com\"\n"
+      creds = [Dependabot::Credential.new({ "host" => "example.com" })]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq(["spaced-registry"])
+    end
+
+    it "returns empty array for empty content" do
+      expect(described_class.custom_registry_names("", [])).to eq([])
+    end
+
+    it "returns empty array when no credential hosts match" do
+      config_content = <<~TOML
+        [registries.my-registry]
+        index = "sparse+https://example.com/index/"
+      TOML
+      creds = [Dependabot::Credential.new({ "host" => "other.com" })]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq([])
+    end
+
+    it "matches a registry when credential url matches the index URL" do
+      config_content = <<~TOML
+        [registries.my-registry]
+        index = "sparse+https://example.com/index/"
+      TOML
+      creds = [Dependabot::Credential.new({ "url" => "https://example.com/index/" })]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq(["my-registry"])
+    end
+
+    it "matches a registry when credential url matches ignoring trailing slashes" do
+      config_content = <<~TOML
+        [registries.my-registry]
+        index = "sparse+https://example.com/index"
+      TOML
+      creds = [Dependabot::Credential.new({ "url" => "https://example.com/index/" })]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq(["my-registry"])
+    end
+
+    it "does not match when credential url differs from index URL" do
+      config_content = <<~TOML
+        [registries.my-registry]
+        index = "sparse+https://example.com/index/"
+      TOML
+      creds = [Dependabot::Credential.new({ "url" => "https://other.com/index/" })]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq([])
+    end
+
+    it "matches when either host or url credential matches" do
+      config_content = <<~TOML
+        [registries.host-registry]
+        index = "sparse+https://host.example.com/index/"
+
+        [registries.url-registry]
+        index = "sparse+https://url.example.com/path/"
+      TOML
+      creds = [
+        Dependabot::Credential.new({ "host" => "host.example.com" }),
+        Dependabot::Credential.new({ "url" => "https://url.example.com/path/" })
+      ]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq(%w(host-registry url-registry))
+    end
+
+    it "returns empty array for malformed TOML" do
+      expect(described_class.custom_registry_names("not valid toml {{{{", [])).to eq([])
+    end
+
+    it "returns empty array for invalid URI in index" do
+      config_content = <<~TOML
+        [registries.bad]
+        index = "sparse+ht tp://bad url"
+      TOML
+      creds = [Dependabot::Credential.new({ "host" => "bad" })]
+      expect(described_class.custom_registry_names(config_content, creds)).to eq([])
+    end
+  end
+
+  describe ".registry_token_env" do
+    let(:config_content) do
+      <<~TOML
+        [registries.my-private-registry]
+        index = "sparse+https://private.example.com/index/"
+
+        [registries.another-registry]
+        index = "sparse+https://another.example.com/index/"
+      TOML
+    end
+
+    let(:creds) do
+      [
+        { "host" => "private.example.com" },
+        { "host" => "another.example.com" }
+      ]
+    end
+
+    it "returns token env vars for matched registries" do
+      env = described_class.registry_token_env(config_content, creds)
+      expect(env).to eq(
+        "CARGO_REGISTRIES_MY_PRIVATE_REGISTRY_TOKEN" => "garbage_token",
+        "CARGO_REGISTRIES_ANOTHER_REGISTRY_TOKEN" => "garbage_token"
+      )
+    end
+
+    it "returns empty hash when no registries match" do
+      env = described_class.registry_token_env(config_content, [])
+      expect(env).to eq({})
+    end
+
+    it "returns empty hash for empty config" do
+      env = described_class.registry_token_env("", creds)
+      expect(env).to eq({})
+    end
+  end
+
+  describe ".cargo_command_env" do
+    let(:config_content) do
+      <<~TOML
+        [registries.my-registry]
+        index = "sparse+https://private.example.com/index/"
+      TOML
+    end
+    let(:creds) { [Dependabot::Credential.new({ "host" => "private.example.com" })] }
+    let(:dependency_files) do
+      [
+        Dependabot::DependencyFile.new(name: ".cargo/config.toml", content: config_content)
+      ]
+    end
+
+    before do
+      ENV["DEPENDABOT"] = "true"
+      Dependabot::Experiments.register(:cargo_set_registry_token_auth, true)
+    end
+
+    after do
+      ENV.delete("DEPENDABOT")
+      ENV.delete("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")
+      Dependabot::Experiments.reset!
+    end
+
+    it "includes token env vars for matched registries" do
+      env = described_class.cargo_command_env(dependency_files, creds)
+      expect(env["CARGO_REGISTRIES_MY_REGISTRY_TOKEN"]).to eq("garbage_token")
+    end
+
+    it "always sets CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS" do
+      env = described_class.cargo_command_env(dependency_files, creds)
+      expect(env["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"]).to eq("cargo:token")
+    end
+
+    it "passes through real CARGO_REGISTRIES_* env vars" do
+      allow(ENV).to receive(:select).and_return({ "CARGO_REGISTRIES_CRATES_IO_PROTOCOL" => "sparse" })
+      env = described_class.cargo_command_env(dependency_files, creds)
+      expect(env["CARGO_REGISTRIES_CRATES_IO_PROTOCOL"]).to eq("sparse")
+    end
+
+    it "real env vars override token env vars with same key" do
+      allow(ENV).to receive(:select).and_return(
+        { "CARGO_REGISTRIES_MY_REGISTRY_TOKEN" => "real_token" }
+      )
+      env = described_class.cargo_command_env(dependency_files, creds)
+      expect(env["CARGO_REGISTRIES_MY_REGISTRY_TOKEN"]).to eq("real_token")
+    end
+
+    it "sets CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS even without config file" do
+      empty_files = [Dependabot::DependencyFile.new(name: "Cargo.toml", content: "")]
+      env = described_class.cargo_command_env(empty_files, creds)
+      expect(env["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"]).to eq("cargo:token")
+    end
+
+    context "when DEPENDABOT env var is not set" do
+      before { ENV.delete("DEPENDABOT") }
+
+      it "returns empty hash" do
+        env = described_class.cargo_command_env(dependency_files, creds)
+        expect(env).to eq({})
+      end
+
+      it "sets CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS in ENV via ||=" do
+        ENV.delete("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS")
+        described_class.cargo_command_env(dependency_files, creds)
+        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS", nil)).to eq("")
+      end
+    end
+
+    context "when cargo_set_registry_token_auth experiment is disabled" do
+      before { Dependabot::Experiments.register(:cargo_set_registry_token_auth, false) }
+
+      it "returns empty hash" do
+        env = described_class.cargo_command_env(dependency_files, creds)
+        expect(env).to eq({})
+      end
+
+      it "does not overwrite existing CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS" do
+        ENV["CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS"] = "existing"
+        described_class.cargo_command_env(dependency_files, creds)
+        expect(ENV.fetch("CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS", nil)).to eq("existing")
       end
     end
   end


### PR DESCRIPTION
Fixes #14172

Goes along with https://github.com/dependabot/cli/pull/631

When custom Cargo feeds are used the proxy auto-updates the request headers appropriately, but the Cargo tooling isn't aware of this and complains with the error:

```
... authenticated registries require a credential-provider to be configured.
```

Previous PRs #14340 and #14359 have made progress on this but custom private registries still can't authenticate appropriately.

This PR addresses that by:
1. Scanning the `.cargo/config.toml` file for custom registries
2. Matches those against known credential objects
3. Builds an environment variable hash where a custom token of `garbage_token` is set for those registries
4. Sets `CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS=cargo:token` to force Cargo tooling to use these environment variables
5. Calls the cargo tooling with these environment variables
6. The proxy will then replace the `Authorization` header with the real token

This new behavior has been placed behind the `$DEPENDABOT` environment variable (only set in an official run) and the feature flag `cargo_set_registry_token_auth` which has yet to be created on the internal side.

Manually verified locally with the dependabot CLI and setting the experiment flag in the job file.

Future work:
- add the new experiment flag internally