### PR TITLE
Type Prism AST node parameters in bundler finders

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1868
+# Offense count: 1859
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -269,13 +269,7 @@ Sorbet/ForbidTUntyped:
     - "bun/lib/dependabot/bun/update_checker/version_resolver.rb"
     - "bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb"
     - "bun/lib/dependabot/bun/version_selector.rb"
-    - "bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb"
-    - "bundler/lib/dependabot/bundler/file_fetcher/gemspec_finder.rb"
-    - "bundler/lib/dependabot/bundler/file_fetcher/included_path_finder.rb"
-    - "bundler/lib/dependabot/bundler/file_fetcher/path_gemspec_finder.rb"
     - "bundler/lib/dependabot/bundler/file_parser.rb"
-    - "bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb"
-    - "bundler/lib/dependabot/bundler/file_parser/gemspec_declaration_finder.rb"
     - "bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb"
     - "bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb"
     - "bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb"

--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -113,7 +113,7 @@ module Dependabot
         []
       end
 
-      sig { returns(T::Array[String]) }
+      sig { returns(T::Array[Pathname]) }
       def gemspec_directories
         gemfiles = ([gemfile] + child_gemfiles).compact
         directories =
@@ -121,7 +121,7 @@ module Dependabot
             GemspecFinder.new(gemfile: file).gemspec_directories
           end.uniq
 
-        directories.empty? ? ["."] : directories
+        directories.empty? ? [Pathname.new(".")] : directories
       end
 
       sig { returns(T.nilable(DependencyFile)) }

--- a/bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/child_gemfile_finder.rb
@@ -33,17 +33,18 @@ module Dependabot
         sig { returns(T.nilable(Dependabot::DependencyFile)) }
         attr_reader :gemfile
 
-        sig { params(node: T.untyped).returns(T::Array[String]) }
+        sig { params(node: T.nilable(Prism::Node)).returns(T::Array[String]) }
         def find_child_gemfile_paths(node)
           return [] if node.nil?
 
           if declares_eval_gemfile?(node)
-            path_node = node.arguments&.arguments&.first
+            call_node = T.cast(node, Prism::CallNode)
+            path_node = call_node.arguments&.arguments&.first
             unless path_node.is_a?(Prism::StringNode)
               path = gemfile&.path
               msg = "Dependabot only supports uninterpolated string arguments " \
                     "to eval_gemfile. Got " \
-                    "`#{path_node.slice}`"
+                    "`#{path_node&.slice}`"
               raise Dependabot::DependencyFileNotParseable.new(T.must(path), msg)
             end
 

--- a/bundler/lib/dependabot/bundler/file_fetcher/gemspec_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/gemspec_finder.rb
@@ -20,7 +20,7 @@ module Dependabot
           @gemfile = gemfile
         end
 
-        sig { returns(T::Array[String]) }
+        sig { returns(T::Array[Pathname]) }
         def gemspec_directories
           result = Prism.parse(T.must(gemfile).content)
           raise Dependabot::DependencyFileNotParseable, T.must(gemfile).path if result.failure?
@@ -33,7 +33,7 @@ module Dependabot
         sig { returns(T.nilable(Dependabot::DependencyFile)) }
         attr_reader :gemfile
 
-        sig { params(node: T.nilable(Prism::Node)).returns(T::Array[T.untyped]) }
+        sig { params(node: T.nilable(Prism::Node)).returns(T::Array[Pathname]) }
         def find_gemspec_paths(node)
           return [] if node.nil?
 

--- a/bundler/lib/dependabot/bundler/file_fetcher/included_path_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/included_path_finder.rb
@@ -33,12 +33,13 @@ module Dependabot
         sig { returns(Dependabot::DependencyFile) }
         attr_reader :file
 
-        sig { params(node: T.untyped).returns(T::Array[String]) }
+        sig { params(node: T.nilable(Prism::Node)).returns(T::Array[String]) }
         def find_require_relative_paths(node)
           return [] if node.nil?
 
           if declares_require_relative?(node)
-            relative_arg = node.arguments&.arguments&.first
+            call_node = T.cast(node, Prism::CallNode)
+            relative_arg = call_node.arguments&.arguments&.first
             return [] unless relative_arg.is_a?(Prism::StringNode)
 
             path = relative_arg.unescaped
@@ -52,12 +53,13 @@ module Dependabot
           end
         end
 
-        sig { params(node: T.untyped).returns(T::Array[String]) }
+        sig { params(node: T.nilable(Prism::Node)).returns(T::Array[String]) }
         def find_eval_paths(node)
           return [] if node.nil?
 
           if declares_eval?(node)
-            eval_arg = node.arguments&.arguments&.first
+            call_node = T.cast(node, Prism::CallNode)
+            eval_arg = call_node.arguments&.arguments&.first
 
             if eval_arg.is_a?(Prism::Node)
               file_read_node = find_file_read_node(eval_arg)

--- a/bundler/lib/dependabot/bundler/file_fetcher/path_gemspec_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher/path_gemspec_finder.rb
@@ -20,7 +20,7 @@ module Dependabot
           @gemfile = gemfile
         end
 
-        sig { returns(T::Array[String]) }
+        sig { returns(T::Array[Pathname]) }
         def path_gemspec_paths
           result = Prism.parse(gemfile&.content)
           raise Dependabot::DependencyFileNotParseable, T.must(gemfile).path if result.failure?
@@ -33,7 +33,7 @@ module Dependabot
         sig { returns(T.nilable(Dependabot::DependencyFile)) }
         attr_reader :gemfile
 
-        sig { params(node: T.untyped).returns(T::Array[T.untyped]) }
+        sig { params(node: T.nilable(Prism::Node)).returns(T::Array[Pathname]) }
         def find_path_gemspec_paths(node)
           return [] unless node.is_a?(Prism::Node)
 

--- a/bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb
@@ -77,7 +77,7 @@ module Dependabot
 
         sig do
           params(
-            node: T.untyped,
+            node: T.nilable(Prism::Node),
             dependency: T::Hash[String, String]
           )
             .returns(T.nilable(Prism::Node))
@@ -95,7 +95,7 @@ module Dependabot
 
         sig do
           params(
-            node: T.untyped,
+            node: T.nilable(Prism::Node),
             dependency: T::Hash[String, String]
           )
             .returns(T::Boolean)

--- a/bundler/lib/dependabot/bundler/file_parser/gemspec_declaration_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/gemspec_declaration_finder.rb
@@ -46,7 +46,7 @@ module Dependabot
           @declaration_nodes[dependency]
         end
 
-        sig { params(node: T.untyped, dependency: T::Hash[String, String]).returns(T.nilable(Prism::Node)) }
+        sig { params(node: T.nilable(Prism::Node), dependency: T::Hash[String, String]).returns(T.nilable(Prism::Node)) }
         def deep_search_for_gem(node, dependency)
           return unless node.is_a?(Prism::Node)
           return T.cast(node, Prism::CallNode) if declares_targeted_gem?(node, dependency)
@@ -58,7 +58,7 @@ module Dependabot
           declaration_node
         end
 
-        sig { params(node: T.untyped, dependency: T::Hash[String, String]).returns(T::Boolean) }
+        sig { params(node: T.nilable(Prism::Node), dependency: T::Hash[String, String]).returns(T::Boolean) }
         def declares_targeted_gem?(node, dependency)
           return false unless node.is_a?(Prism::CallNode)
 


### PR DESCRIPTION
### What are you trying to accomplish?

Continue the `Sorbet/ForbidTUntyped` burndown in bundler by typing the Gemfile/gemspec AST finders. Six files walked the Prism AST with `node: T.untyped` parameters; this types them as `T.nilable(Prism::Node)` and clears all six from the todo (357 to 351).

- `child_gemfile_finder`, `included_path_finder`: type the recursive `node` params; narrow to `Prism::CallNode` (via `T.cast`, matching the existing pattern in `gemspec_declaration_finder`) before reading call arguments.
- `gemfile_declaration_finder`, `gemspec_declaration_finder`: type the `node` params (the `is_a?` guards already narrow internally).
- `gemspec_finder`, `path_gemspec_finder`: type the `find_*` returns. Their `clean_path` helpers return `Pathname`, and the finder specs assert `Pathname` results, so the public `gemspec_directories`/`path_gemspec_paths` were mis-annotated as `T::Array[String]`. Corrected them (and the matching `FileFetcher#gemspec_directories`) to `T::Array[Pathname]`. `repo_contents` and `File.join` already accept `Pathname`, so consumers are unaffected.

### Anything you want to highlight for special attention from reviewers?

The `T::Array[String]` to `T::Array[Pathname]` correction is the part worth a look: it fixes annotations that disagreed with both `clean_path` and the existing specs (which assert `Pathname`). No runtime behaviour changes; the values were already `Pathname` at runtime. One latent nil was also made explicit (`path_node&.slice` in `child_gemfile_finder`, matching the sibling finder).

### How will you know you've accomplished your goal?

`srb tc` passes, the three `spoom srb bump` checks stay clean, `rubocop` reports no offenses, and the bundler finder specs plus `file_fetcher_spec` (81 examples) pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
