### PR TITLE
Introduce typed GitTagDetails for GitCommitChecker local-tag shape

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1859
+# Offense count: 1850
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -14,6 +14,7 @@ require "dependabot/source"
 require "dependabot/dependency"
 require "dependabot/credential"
 require "dependabot/git_metadata_fetcher"
+require "dependabot/git_tag_details"
 module Dependabot
   # rubocop:disable Metrics/ClassLength
   class GitCommitChecker
@@ -159,31 +160,31 @@ module Dependabot
       local_repo_git_metadata_fetcher.head_commit_for_ref(name)
     end
 
-    sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    sig { returns(T.nilable(Dependabot::GitTagDetails)) }
     def local_ref_for_latest_version_matching_existing_precision
       allowed_refs = local_tag_for_pinned_sha ? allowed_version_tags : allowed_version_refs
 
       max_local_tag_for_current_precision(allowed_refs)
     end
 
-    sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    sig { returns(T.nilable(Dependabot::GitTagDetails)) }
     def local_ref_for_latest_version_lower_precision
       allowed_refs = local_tag_for_pinned_sha ? allowed_version_tags : allowed_version_refs
 
       max_local_tag_for_lower_precision(allowed_refs)
     end
 
-    sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    sig { returns(T.nilable(Dependabot::GitTagDetails)) }
     def local_tag_for_latest_version
       max_local_tag(allowed_version_tags)
     end
 
-    sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+    sig { returns(T::Array[Dependabot::GitTagDetails]) }
     def local_tags_for_allowed_versions_matching_existing_precision
       select_matching_existing_precision(allowed_version_tags).filter_map { |t| to_local_tag(t) }
     end
 
-    sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+    sig { returns(T::Array[Dependabot::GitTagDetails]) }
     def local_tags_for_allowed_versions
       allowed_version_tags.filter_map { |t| to_local_tag(t) }
     end
@@ -272,7 +273,7 @@ module Dependabot
       local_tags_matching_sha(commit_sha).map(&:name)
     end
 
-    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T.nilable(Dependabot::GitTagDetails)) }
     def max_local_tag(tags)
       max_version_tag = tags.max_by { |t| version_from_tag(t) }
 
@@ -295,12 +296,12 @@ module Dependabot
     sig { returns(T::Array[String]) }
     attr_reader :ignored_versions
 
-    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T.nilable(Dependabot::GitTagDetails)) }
     def max_local_tag_for_current_precision(tags)
       max_local_tag(select_matching_existing_precision(tags))
     end
 
-    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T.nilable(Dependabot::GitTagDetails)) }
     def max_local_tag_for_lower_precision(tags)
       max_local_tag(select_lower_precision(tags))
     end
@@ -553,17 +554,17 @@ module Dependabot
       prefix.length > 1 ? prefix.gsub(/v$/i, "") : prefix.gsub(/^v$/i, "")
     end
 
-    sig { params(tag: T.nilable(Dependabot::GitRef)).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    sig { params(tag: T.nilable(Dependabot::GitRef)).returns(T.nilable(Dependabot::GitTagDetails)) }
     def to_local_tag(tag)
       return unless tag
 
       version = version_from_tag(tag)
-      {
+      GitTagDetails.new(
         tag: tag.name,
         version: version,
         commit_sha: tag.commit_sha,
         tag_sha: tag.ref_sha
-      }
+      )
     end
 
     sig { returns(T.nilable(String)) }

--- a/common/lib/dependabot/git_tag_details.rb
+++ b/common/lib/dependabot/git_tag_details.rb
@@ -1,0 +1,78 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  # A git tag (or ref) resolved to a version, as produced by GitCommitChecker's
+  # local_tag_for_* / local_ref_for_* methods, e.g.:
+  #
+  #   {
+  #     tag: "v1.2.0",
+  #     version: Dependabot::Version.new("1.2.0"),
+  #     commit_sha: "a1b2c3...",
+  #     tag_sha: "d4e5f6..." # nil for lightweight tags
+  #   }
+  #
+  # Distinct from Dependabot::GitTagWithDetail, which carries a tag name and
+  # release date for cooldown handling.
+  #
+  # Subclasses Hash so it is a drop-in replacement at the many call sites that
+  # read entries with [:key] / fetch and treat them as
+  # T::Hash[Symbol, T.untyped], while exposing typed readers for the well-known
+  # keys. Instances compare equal (Hash#==) to plain hashes with the same
+  # content, so existing comparisons and API payloads are unaffected.
+  class GitTagDetails < Hash
+    extend T::Sig
+    extend T::Generic
+
+    # The values are heterogeneous (strings and a version object), so this
+    # bridge class is necessarily untyped at the Hash level; the typed readers
+    # below are the migration path.
+    # rubocop:disable Sorbet/ForbidTUntyped
+    K = type_member { { fixed: Symbol } }
+    V = type_member { { fixed: T.untyped } }
+    Elem = type_member { { fixed: [Symbol, T.untyped] } }
+    # rubocop:enable Sorbet/ForbidTUntyped
+
+    sig do
+      params(
+        tag: String,
+        version: T.nilable(Gem::Version),
+        commit_sha: T.nilable(String),
+        tag_sha: T.nilable(String)
+      ).void
+    end
+    def initialize(tag:, version: nil, commit_sha: nil, tag_sha: nil)
+      super()
+      self[:tag] = tag
+      self[:version] = version
+      self[:commit_sha] = commit_sha
+      self[:tag_sha] = tag_sha
+    end
+
+    # The tag or ref name, e.g. "v1.2.0".
+    sig { returns(String) }
+    def tag
+      self[:tag]
+    end
+
+    # The version parsed from the tag name.
+    sig { returns(T.nilable(Gem::Version)) }
+    def version
+      self[:version]
+    end
+
+    # The SHA of the commit the tag points at.
+    sig { returns(T.nilable(String)) }
+    def commit_sha
+      self[:commit_sha]
+    end
+
+    # The SHA of the tag object itself (nil for lightweight tags).
+    sig { returns(T.nilable(String)) }
+    def tag_sha
+      self[:tag_sha]
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Continue the `Sorbet/ForbidTUntyped` burndown by typing the most widespread remaining untyped shape: the git tag/ref hash that `GitCommitChecker` produces (`{ tag:, version:, commit_sha:, tag_sha: }`). Nine of its `local_tag_for_*` / `local_ref_for_*` / `max_local_tag` / `to_local_tag` methods returned `T::Hash[Symbol, T.untyped]`.

This adds a typed `Dependabot::GitTagDetails` and uses it as the return type of those methods (offense count 1859 to 1850).

### Anything you want to highlight for special attention from reviewers?

Stacked on #15299; review and merge that first.

`GitTagDetails` subclasses `Hash` (the same pattern as `DependencyRequirement`), so it is a drop-in for the ~78 call sites that read these results with `.fetch(:commit_sha)` / `[:version]` and treat them as `T::Hash[Symbol, T.untyped]`. No consumers change, and `Hash#==` keeps existing comparisons working. It is deliberately distinct from `GitTagWithDetail` (tag + release_date, for cooldown); this one carries the version and SHAs used in version resolution.

`GitCommitChecker` keeps three unrelated `T.untyped` (Octokit release objects and the git source-details hash), so it stays on the todo list for now.

### How will you know you've accomplished your goal?

`srb tc` passes (confirming all consumers accept `GitTagDetails` as a `T::Hash[Symbol, T.untyped]`), `rubocop` is clean, and the `git_commit_checker` (129) and a representative consumer, `github_actions` update_checker (89), specs pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
