### PR TITLE
Type requirements parameters as DependencyRequirement in gradle and cargo

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1850
+# Offense count: 1847
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -287,7 +287,6 @@ Sorbet/ForbidTUntyped:
     - "cargo/lib/dependabot/cargo/file_fetcher.rb"
     - "cargo/lib/dependabot/cargo/file_parser.rb"
     - "cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb"
-    - "cargo/lib/dependabot/cargo/file_updater/workspace_manifest_updater.rb"
     - "cargo/lib/dependabot/cargo/metadata_finder.rb"
     - "cargo/lib/dependabot/cargo/package/package_details_fetcher.rb"
     - "cargo/lib/dependabot/cargo/update_checker.rb"
@@ -381,10 +380,8 @@ Sorbet/ForbidTUntyped:
     - "go_modules/lib/dependabot/go_modules/version.rb"
     - "gradle/lib/dependabot/gradle/distributions.rb"
     - "gradle/lib/dependabot/gradle/file_parser.rb"
-    - "gradle/lib/dependabot/gradle/file_parser/distributions_finder.rb"
     - "gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb"
     - "gradle/lib/dependabot/gradle/file_updater.rb"
-    - "gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb"
     - "gradle/lib/dependabot/gradle/package/distributions_fetcher.rb"
     - "gradle/lib/dependabot/gradle/package/package_details_fetcher.rb"
     - "gradle/lib/dependabot/gradle/package/release_date_extractor.rb"

--- a/cargo/lib/dependabot/cargo/file_updater/workspace_manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/workspace_manifest_updater.rb
@@ -64,7 +64,7 @@ module Dependabot
           updated_content
         end
 
-        sig { params(requirements: T.nilable(T::Array[T::Hash[Symbol, T.untyped]])).returns(T.nilable(String)) }
+        sig { params(requirements: T.nilable(T::Array[Dependabot::DependencyRequirement])).returns(T.nilable(String)) }
         def find_workspace_requirement(requirements)
           requirements&.find { |r| r[:groups]&.include?("workspace.dependencies") }
                       &.fetch(:requirement)

--- a/gradle/lib/dependabot/gradle/file_parser/distributions_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/distributions_finder.rb
@@ -26,30 +26,34 @@ module Dependabot
           version = match.fetch("version")
 
           requirements = T.let(
-            [{
-              requirement: version,
-              file: properties_file.name,
-              source: {
-                type: Distributions::DISTRIBUTION_DEPENDENCY_TYPE,
-                url: distribution_url,
-                property: "distributionUrl"
-              },
-              groups: []
-            }],
-            T::Array[T::Hash[Symbol, T.untyped]]
+            [DependencyRequirement.create(
+              {
+                requirement: version,
+                file: properties_file.name,
+                source: {
+                  type: Distributions::DISTRIBUTION_DEPENDENCY_TYPE,
+                  url: distribution_url,
+                  property: "distributionUrl"
+                },
+                groups: []
+              }
+            )],
+            T::Array[Dependabot::DependencyRequirement]
           )
 
           if checksum
-            requirements << {
-              requirement: checksum,
-              file: properties_file.name,
-              source: {
-                type: Distributions::DISTRIBUTION_DEPENDENCY_TYPE,
-                url: "#{distribution_url}.sha256",
-                property: "distributionSha256Sum"
-              },
-              groups: []
-            }
+            requirements << DependencyRequirement.create(
+              {
+                requirement: checksum,
+                file: properties_file.name,
+                source: {
+                  type: Distributions::DISTRIBUTION_DEPENDENCY_TYPE,
+                  url: "#{distribution_url}.sha256",
+                  property: "distributionSha256Sum"
+                },
+                groups: []
+              }
+            )
           end
 
           Dependency.new(

--- a/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
@@ -150,7 +150,12 @@ module Dependabot
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
-        sig { params(requirements: T::Array[T::Hash[Symbol, T.untyped]], network_timeout: T.nilable(String)).returns(T::Array[String]) }
+        sig do
+          params(
+            requirements: T::Array[Dependabot::DependencyRequirement],
+            network_timeout: T.nilable(String)
+          ).returns(T::Array[String])
+        end
         def command_args(requirements, network_timeout)
           version = T.let(requirements[0]&.[](:requirement), String)
           checksum = T.let(requirements[1]&.[](:requirement), T.nilable(String)) if requirements.size > 1


### PR DESCRIPTION
### What are you trying to accomplish?

Continue the `Sorbet/ForbidTUntyped` burndown by using the existing `Dependabot::DependencyRequirement` type (introduced in #15272) for requirements parameters that were still typed as the raw `T::Array[T::Hash[Symbol, T.untyped]]`. Clears three files from the todo (1850 to 1847 offenses):

- `cargo` `WorkspaceManifestUpdater#find_workspace_requirement` — called only with `dep.requirements` / `dep.previous_requirements`, which are already `DependencyRequirement[]`.
- `gradle` `WrapperUpdater#command_args` — called with `dependency.requirements.select { ... }`, also `DependencyRequirement[]`.
- `gradle` `DistributionsFinder` — builds requirement entries; now builds them with `DependencyRequirement.create(...)` (the entries are wrapped into `DependencyRequirement` by `Dependency#initialize` anyway, so this is behaviour-preserving).

### Anything you want to highlight for special attention from reviewers?

Stacked on #15300 (and #15299); review and merge those first.

I deliberately left `Gradle::Distributions.distribution_requirements?` alone: it is also called from the gradle `RequirementsUpdater` with raw hash requirements, and typing it would cascade into the `RequirementsUpdater` class hierarchy (an abstract method shared across all ecosystems). That is a separate, larger change.

### How will you know you've accomplished your goal?

`srb tc` passes (confirming every caller already passes `DependencyRequirement`), `rubocop` is clean, and the gradle `distributions_finder` (17) and cargo `file_updater` edge-case (4) specs pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
