### PR TITLE
Type go_modules requirement parsing and version comparison

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1847
+# Offense count: 1842
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -374,10 +374,7 @@ Sorbet/ForbidTUntyped:
     - "go_modules/lib/dependabot/go_modules/file_updater/go_mod_updater.rb"
     - "go_modules/lib/dependabot/go_modules/package/package_details_fetcher.rb"
     - "go_modules/lib/dependabot/go_modules/replace_stubber.rb"
-    - "go_modules/lib/dependabot/go_modules/requirement.rb"
-    - "go_modules/lib/dependabot/go_modules/requirement_parser.rb"
     - "go_modules/lib/dependabot/go_modules/update_checker.rb"
-    - "go_modules/lib/dependabot/go_modules/version.rb"
     - "gradle/lib/dependabot/gradle/distributions.rb"
     - "gradle/lib/dependabot/gradle/file_parser.rb"
     - "gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb"

--- a/go_modules/lib/dependabot/go_modules/requirement.rb
+++ b/go_modules/lib/dependabot/go_modules/requirement.rb
@@ -30,7 +30,7 @@ module Dependabot
 
       # Use GoModules::Version rather than Gem::Version to ensure that
       # pre-release versions aren't transformed.
-      sig { params(obj: T.untyped).returns([String, Gem::Version]) }
+      sig { params(obj: T.any(Gem::Version, String)).returns([String, Gem::Version]) }
       def self.parse(obj)
         return ["=", Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
 

--- a/go_modules/lib/dependabot/go_modules/requirement_parser.rb
+++ b/go_modules/lib/dependabot/go_modules/requirement_parser.rb
@@ -19,7 +19,7 @@ module Dependabot
       GO_DEP_WITHOUT_VERSION =
         /\A\s*(?<name>#{MODULE_PATH})\s*\z/x
 
-      sig { params(dependency_string: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { params(dependency_string: String).returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
       def self.parse(dependency_string)
         match = dependency_string.strip.match(GO_DEP_WITH_VERSION)
         return nil unless match

--- a/go_modules/lib/dependabot/go_modules/version.rb
+++ b/go_modules/lib/dependabot/go_modules/version.rb
@@ -71,15 +71,15 @@ module Dependabot
       # see https://github.com/golang/mod/blob/fa1ba4269bda724bb9f01ec381fbbaf031e45833/semver/semver.go#L333
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
-      sig { params(left: T.untyped, right: T.untyped).returns(Integer) }
+      sig { params(left: String, right: String).returns(Integer) }
       def compare_prerelease(left, right)
         return 0 if left == right
         return 1 if left == ""
         return -1 if right == ""
 
         while left != "" && right != ""
-          left = left[1..-1] if left.start_with?(".", "-")
-          right = right[1..-1] if right.start_with?(".", "-")
+          left = T.must(left[1..-1]) if left.start_with?(".", "-")
+          right = T.must(right[1..-1]) if right.start_with?(".", "-")
 
           dx, left = next_ident(left)
           dy, right = next_ident(right)
@@ -108,17 +108,17 @@ module Dependabot
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/PerceivedComplexity
 
-      sig { params(data: String).returns(T.untyped) }
+      sig { params(data: String).returns([String, String]) }
       def next_ident(data)
         i = 0
         i += 1 while i < data.length && data[i] != "."
-        [data[0..i], data[i..-1]]
+        [T.must(data[0..i]), T.must(data[i..-1])]
       end
 
-      sig { params(data: T.untyped).returns(T::Boolean) }
+      sig { params(data: String).returns(T::Boolean) }
       def num?(data)
         i = 0
-        i += 1 while i < data.length && data[i] >= "0" && data[i] <= "9"
+        i += 1 while i < data.length && T.must(data[i]) >= "0" && T.must(data[i]) <= "9"
         i == data.length
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Part of the Sorbet `ForbidTUntyped` burndown. This types the go_modules requirement parser, requirement class, and version comparison, which clears three files from the `.rubocop_todo.yml` allowlist (offense count 1847 → 1842).

- `RequirementParser.parse` returns `T.nilable(T::Hash[Symbol, T.nilable(String)])` (all captures are strings or nil).
- `Requirement.parse`'s `obj` becomes `T.any(Gem::Version, String)`, matching the cargo and python siblings.
- `Version#compare_prerelease`, `#next_ident`, and `#num?` are typed as the string walkers they already are.

### Anything you want to highlight for special attention from reviewers?

The version helpers index and slice strings inside loops whose bounds already guarantee the character is present, so the typed versions use `T.must` on those `[]` lookups rather than reshaping the algorithm.

### How will you know you've accomplished your goal?

`srb tc`, the three `spoom srb bump --dry` ratchet checks, and RuboCop all pass. The 129 go_modules version and requirement specs still pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
