### PR TITLE
Enable six zero-offense Sorbet guardrail cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,6 +102,18 @@ Sorbet/ForbidTUnsafe:
   Enabled: true
 Sorbet/ForbidTUntyped:
   Enabled: true
+Sorbet/ForbidIncludeConstLiteral:
+  Enabled: true
+Sorbet/ForbidSuperclassConstLiteral:
+  Enabled: true
+Sorbet/HasSigil:
+  Enabled: true
+Sorbet/Refinement:
+  Enabled: true
+Sorbet/SingleLineRbiClassModuleDefinitions:
+  Enabled: true
+Sorbet/VoidCheckedTests:
+  Enabled: true
 Sorbet/TrueSigil:
   Enabled: true
   Exclude:


### PR DESCRIPTION
### What are you trying to accomplish?

With rubocop-sorbet 0.12.0 in use, several Sorbet cops sit at zero offences but aren't switched on. This enables six of them as guardrails so the current state can't regress:

- `Sorbet/Refinement` and `Sorbet/VoidCheckedTests` — both were pending, so this also clears the pending-cop warning
- `Sorbet/HasSigil`
- `Sorbet/SingleLineRbiClassModuleDefinitions`
- `Sorbet/ForbidSuperclassConstLiteral`
- `Sorbet/ForbidIncludeConstLiteral`

### Anything you want to highlight for special attention from reviewers?

All six report zero offences today, so there's no code change — only `.rubocop.yml`.

### How will you know you've accomplished your goal?

`bundle exec rubocop --only` the six cops inspects 1668 files with no offences, and no Sorbet cops remain pending.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
