### PR TITLE
Replace to_hash with to_h and enable ImplicitConversionMethod

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,6 +108,8 @@ Sorbet/ForbidSuperclassConstLiteral:
   Enabled: true
 Sorbet/HasSigil:
   Enabled: true
+Sorbet/ImplicitConversionMethod:
+  Enabled: true
 Sorbet/Refinement:
   Enabled: true
 Sorbet/SingleLineRbiClassModuleDefinitions:

--- a/common/lib/dependabot/notices.rb
+++ b/common/lib/dependabot/notices.rb
@@ -60,7 +60,7 @@ module Dependabot
     # Converts the Notice object to a hash.
     # @return [Hash] The hash representation of the notice.
     sig { returns(T::Hash[Symbol, T.any(String, T::Boolean)]) }
-    def to_hash
+    def to_h
       {
         mode: @mode,
         type: @type,

--- a/common/spec/dependabot/notices_spec.rb
+++ b/common/spec/dependabot/notices_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Dependabot::Notice do
         let(:raw_version) { Dependabot::Version.new("2.0.1") }
 
         it "returns a deprecation notice using detected_version" do
-          expect(deprecation_notice.to_hash)
+          expect(deprecation_notice.to_h)
             .to eq(
               {
                 mode: "WARN",
@@ -150,7 +150,7 @@ RSpec.describe Dependabot::Notice do
         let(:raw_version) { nil }
 
         it "returns a deprecation notice using detected_version" do
-          expect(deprecation_notice.to_hash)
+          expect(deprecation_notice.to_h)
             .to eq(
               {
                 mode: "WARN",

--- a/updater/lib/dependabot/job/allowed_update.rb
+++ b/updater/lib/dependabot/job/allowed_update.rb
@@ -27,18 +27,6 @@ module Dependabot
           update_types: hash.fetch("update-types", []) || []
         )
       end
-
-      # Temporary bridge: returns the original hash format for code that
-      # still expects hash access. Remove once all callers are migrated.
-      sig { returns(T::Hash[String, T.untyped]) }
-      def to_hash
-        h = T.let({}, T::Hash[String, T.untyped])
-        h["dependency-name"] = dependency_name if dependency_name
-        h["dependency-type"] = dependency_type
-        h["update-type"] = update_type
-        h["update-types"] = update_types unless update_types.empty?
-        h
-      end
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

`Sorbet/ImplicitConversionMethod` flags `to_hash` because Ruby calls it implicitly (splats, `Hash()`), which Sorbet can't model. Two classes defined it:

- `Dependabot::Notice#to_hash` is renamed to `to_h`; its only callers were two specs, updated here.
- `Dependabot::Job::AllowedUpdate#to_hash` is removed — it was a temporary hash-access bridge with no remaining callers.

The cop is then enabled.

### Anything you want to highlight for special attention from reviewers?

`AllowedUpdate#to_hash` was dead code — its own comment said to remove it once callers had migrated, and a repo-wide search finds none — so it's deleted rather than renamed.

### How will you know you've accomplished your goal?

`srb tc` passes, `Sorbet/ImplicitConversionMethod` reports zero offences, and the `notices` spec passes.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
