### PR TITLE
Enforce method signatures via Sorbet/EnforceSignatures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,6 +96,13 @@ Sorbet/BlockMethodDefinition:
   Enabled: true
   Exclude:
     - "**/spec/**/*"
+Sorbet/EnforceSignatures:
+  Enabled: true
+  Exclude:
+    - "**/spec/**/*"
+    - "bin/**/*"
+    - "bundler/helpers/**/*"
+    - "rakelib/support/test/**/*"
 Sorbet/ForbidTAnyWithNil:
   Enabled: true
 Sorbet/ForbidTUnsafe:


### PR DESCRIPTION
### What are you trying to accomplish?

Enables `Sorbet/EnforceSignatures` so every method in the typed codebase must carry a `sig`. It's configured to skip the areas Sorbet already ignores: specs, `bin/`, `bundler/helpers/`, and `rakelib/support/test/`.

### Anything you want to highlight for special attention from reviewers?

No grandfathering was needed. Outside the excluded areas there are zero unsigned methods, because `# typed: strict` and `strong` files already require signatures. So this locks in full signature coverage rather than seeding a burndown list.

### How will you know you've accomplished your goal?

`bundle exec rubocop --only Sorbet/EnforceSignatures` inspects 1668 files with no offences.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
