### PR TITLE
Bump bundled Deno to 2.8.3 for lockfile v5 support

### DIFF
--- a/deno/Dockerfile
+++ b/deno/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.20
 FROM ghcr.io/dependabot/dependabot-updater-core
 
-ARG DENO_VERSION=2.1.0
+ARG DENO_VERSION=2.8.3
 
 USER root
 

--- a/deno/README.md
+++ b/deno/README.md
@@ -47,6 +47,14 @@ Deno support for [`dependabot-core`][core-repo].
 - `deno.lock` regeneration when the manifest changes
 - Cooldown for direct dependencies
 
+### Runtime
+
+The updater image bundles a single Deno binary (`DENO_VERSION` in `deno/Dockerfile`).
+It is kept current so it can read the latest `deno.lock` format; older lockfiles are
+still read and are upgraded in place to the bundled Deno's format on regeneration.
+Bumping `DENO_VERSION` may change the emitted `deno.lock` version — the
+`lockfile_updater` specs pin the expected version so such bumps are intentional.
+
 ### Not yet supported (planned)
 
 - HTTPS imports (`https://deno.land/x/...`)

--- a/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
+++ b/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
@@ -52,10 +52,6 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
     end
 
     it "upgrades a legacy v4 lockfile to the bundled Deno's format" do
-      # The image ships a current Deno (see deno/Dockerfile). Reading a legacy
-      # v4 lockfile is still supported, but Deno rewrites it in its own (newer)
-      # lockfile version on `deno install`. Pin that expectation so a future
-      # Deno bump that changes the emitted version is a conscious change.
       content = updater.updated_lockfile_content
       lock = JSON.parse(content)
       expect(lock["version"]).to eq("5")
@@ -63,10 +59,6 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
   end
 
   context "with a v5 lockfile" do
-    # Regression test for the launch-blocking bug where the bundled Deno (2.1.0)
-    # could not read lockfile v5 (emitted by Deno 2.3.0+), failing with
-    # "Unsupported lockfile version '5'". Proves the image round-trips a v5
-    # lockfile and emits a valid, updated v5 lockfile.
     let(:files) { project_dependency_files("deno/with_lockfile_v5") }
 
     it "reads and updates the v5 lockfile" do

--- a/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
+++ b/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
@@ -51,10 +51,35 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
       expect(lock.fetch("jsr")).not_to have_key("@std/path@1.0.0")
     end
 
-    it "preserves the v4 lockfile format" do
+    it "upgrades a legacy v4 lockfile to the bundled Deno's format" do
+      # The image ships a current Deno (see deno/Dockerfile). Reading a legacy
+      # v4 lockfile is still supported, but Deno rewrites it in its own (newer)
+      # lockfile version on `deno install`. Pin that expectation so a future
+      # Deno bump that changes the emitted version is a conscious change.
       content = updater.updated_lockfile_content
       lock = JSON.parse(content)
-      expect(lock["version"]).to eq("4")
+      expect(lock["version"]).to eq("5")
+    end
+  end
+
+  context "with a v5 lockfile" do
+    # Regression test for the launch-blocking bug where the bundled Deno (2.1.0)
+    # could not read lockfile v5 (emitted by Deno 2.3.0+), failing with
+    # "Unsupported lockfile version '5'". Proves the image round-trips a v5
+    # lockfile and emits a valid, updated v5 lockfile.
+    let(:files) { project_dependency_files("deno/with_lockfile_v5") }
+
+    it "reads and updates the v5 lockfile" do
+      content = updater.updated_lockfile_content
+      lock = JSON.parse(content)
+
+      expect(lock["version"]).to eq("5")
+
+      path_keys = lock.fetch("jsr").keys.grep(%r{^@std/path@})
+      expect(path_keys.length).to eq(1)
+      resolved = Gem::Version.new(path_keys.first.split("@").last)
+      expect(resolved).to be >= Gem::Version.new("1.1.4")
+      expect(resolved).to be < Gem::Version.new("2.0.0")
     end
   end
 

--- a/deno/spec/fixtures/projects/deno/with_lockfile_v5/deno.json
+++ b/deno/spec/fixtures/projects/deno/with_lockfile_v5/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@std/path": "jsr:@std/path@^1.0.0"
+  }
+}

--- a/deno/spec/fixtures/projects/deno/with_lockfile_v5/deno.lock
+++ b/deno/spec/fixtures/projects/deno/with_lockfile_v5/deno.lock
@@ -1,0 +1,23 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@1": "1.1.5"
+  },
+  "jsr": {
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/path@1"
+    ]
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

The Deno updater image pinned **Deno 2.1.0**, which only understands lockfile **v4**. Deno **2.3.0+** (shipped May 2025) emits lockfile **v5**, so any repo on a current Deno fails `deno.lock` regeneration with:

```
Failed reading lockfile at 'dependabot_tmp_dir/deno.lock'
Caused by:
    Unsupported lockfile version '5'. Try upgrading Deno or recreating the lockfile
```

This is actively blocking real users since the Deno beta/GA launch.

This PR bumps `DENO_VERSION` to **2.8.3**, which reads both **v4** and **v5** lockfiles. Legacy v4 lockfiles remain readable and are upgraded in place to v5 on `deno install` (Deno's own behaviour).

| Lockfile timeline | Version | Status before | Status after |
| --- | --- | --- | --- |
| Deno 2.0.0 – 2.2.x | v4 | OK | OK (upgraded to v5 on regen) |
| Deno 2.3.0+ | v5 | **Fails** | OK |

Refs: dependabot/dependabot-core#2417

### Anything you want to highlight for special attention from reviewers?

- I verified empirically against a real Deno 2.8.3 binary that (a) it reads a v5 lockfile that 2.1.0 could not, and (b) it upgrades an existing v4 lockfile to v5 on `deno install`. The previously-passing "preserves the v4 lockfile format" spec was therefore changed to assert the in-place upgrade to v5, and a dedicated **v5 round-trip regression test** (new `with_lockfile_v5` fixture) was added to lock the fix in.
- A single pinned binary means a future lockfile v6 would re-introduce this class of problem. Keeping `DENO_VERSION` as a build `ARG` and pinning the emitted version in the specs makes the next bump a small, conscious change. Multi-version selection was considered but is out of scope here.

### How will you know you've accomplished your goal?

- New regression test `with a v5 lockfile → reads and updates the v5 lockfile` exercises the exact path that previously failed.
- Full Deno suite green against Deno 2.8.3:

```
$ cd deno && bundle exec rspec
86 examples, 0 failures
```

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
