### PR TITLE
Add Deno workspace support

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1842
+# Offense count: 1843
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -350,6 +350,7 @@ Sorbet/ForbidTUntyped:
     - "deno/lib/dependabot/deno/file_fetcher.rb"
     - "deno/lib/dependabot/deno/file_parser.rb"
     - "deno/lib/dependabot/deno/file_updater/manifest_updater.rb"
+    - "deno/lib/dependabot/deno/helpers.rb"
     - "devcontainers/lib/dependabot/devcontainers/file_fetcher.rb"
     - "devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb"
     - "devcontainers/lib/dependabot/devcontainers/file_updater.rb"

--- a/deno/Dockerfile
+++ b/deno/Dockerfile
@@ -7,6 +7,14 @@ USER root
 
 RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh -s v${DENO_VERSION}
 
+# All registry traffic is intercepted by Dependabot's MITM proxy, which presents a
+# certificate signed by its own CA (injected into the system bundle at runtime).
+# Deno 2.8+ honors NODE_EXTRA_CA_CERTS at the root certificate store level — so it's
+# applied to fetch(), jsr/npm downloads, and node compat — letting `deno install`
+# trust the proxy. Missing/invalid files only warn, so local runs are unaffected.
+# Mirrors npm_and_yarn / bun.
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 USER dependabot
 
 COPY --chown=dependabot:dependabot --parents deno common $DEPENDABOT_HOME/

--- a/deno/README.md
+++ b/deno/README.md
@@ -45,6 +45,8 @@ Deno support for [`dependabot-core`][core-repo].
 - `deno.json` and `deno.jsonc` import maps
 - `jsr:` and `npm:` specifiers (scoped, unscoped, versionless, sub-path)
 - `deno.lock` regeneration when the manifest changes
+- Workspaces — member `deno.json`/`deno.jsonc` manifests are discovered via the root
+  `workspace` field, including glob patterns (`./packages/*`) and `!` negations
 - Cooldown for direct dependencies
 
 ### Runtime
@@ -60,7 +62,7 @@ Bumping `DENO_VERSION` may change the emitted `deno.lock` version — the
 - HTTPS imports (`https://deno.land/x/...`)
 - `scopes` field overrides
 - `vendor/` directory regeneration
-- Workspaces (nested `deno.json`)
+- `package.json`-only workspace members (handled by the `npm_and_yarn` ecosystem)
 - `links` field (local package overrides)
 - `DENO_AUTH_TOKENS` / private registries
 - Frozen-lockfile UX (we pass `--frozen=false` and may overwrite a frozen lockfile)

--- a/deno/lib/dependabot/deno/file_fetcher.rb
+++ b/deno/lib/dependabot/deno/file_fetcher.rb
@@ -87,7 +87,13 @@ module Dependabot
         includes, excludes = members.partition { |m| !m.start_with?("!") }
         excluded = excludes.flat_map { |m| expand_member(m.delete_prefix("!")) }
 
-        includes.flat_map { |m| expand_member(m) }.uniq.reject { |dir| excluded.include?(dir) }
+        includes
+          .flat_map { |m| expand_member(m) }
+          .uniq
+          .reject { |dir| excluded.include?(dir) }
+          # Member paths come from manifest content; never fetch from an absolute
+          # path or one that traverses out of the repo via "..".
+          .select { |dir| Helpers.safe_relative_path?(dir) }
       end
 
       sig { returns(T::Array[String]) }

--- a/deno/lib/dependabot/deno/file_fetcher.rb
+++ b/deno/lib/dependabot/deno/file_fetcher.rb
@@ -1,8 +1,9 @@
-# typed: strong
+# typed: strict
 # frozen_string_literal: true
 
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
+require "dependabot/deno/helpers"
 
 module Dependabot
   module Deno
@@ -25,8 +26,9 @@ module Dependabot
       def fetch_files
         fetched_files = []
         fetched_files << manifest_file
+        fetched_files.concat(workspace_member_files)
         fetched_files << lockfile if lockfile
-        fetched_files
+        fetched_files.uniq(&:name)
       end
 
       sig { override.returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -55,6 +57,94 @@ module Dependabot
           fetch_file_if_present("deno.lock"),
           T.nilable(DependencyFile)
         )
+      end
+
+      # Fetches the deno.json/deno.jsonc of every workspace member declared in the
+      # root manifest's "workspace" field. Members with neither file (e.g.
+      # package.json-only members) are skipped.
+      sig { returns(T::Array[DependencyFile]) }
+      def workspace_member_files
+        @workspace_member_files ||= T.let(
+          workspace_member_dirs.filter_map { |dir| fetch_member_manifest(dir) },
+          T.nilable(T::Array[DependencyFile])
+        )
+      end
+
+      sig { params(dir: String).returns(T.nilable(DependencyFile)) }
+      def fetch_member_manifest(dir)
+        MANIFEST_FILENAMES.filter_map { |f| fetch_file_if_present(File.join(dir, f)) }.first
+      end
+
+      # Resolves the "workspace" field into a concrete list of member directory
+      # paths (relative to the repo directory), expanding glob patterns and
+      # applying "!" negations. Supports both the array form (["./a", "./b"]) and
+      # the legacy object form ({ "members": [...] }).
+      sig { returns(T::Array[String]) }
+      def workspace_member_dirs
+        members = workspace_members
+        return [] if members.empty?
+
+        includes, excludes = members.partition { |m| !m.start_with?("!") }
+        excluded = excludes.flat_map { |m| expand_member(m.delete_prefix("!")) }
+
+        includes.flat_map { |m| expand_member(m) }.uniq.reject { |dir| excluded.include?(dir) }
+      end
+
+      sig { returns(T::Array[String]) }
+      def workspace_members
+        workspace = Helpers.parse_json_or_jsonc(manifest_file.content).fetch("workspace", nil)
+
+        case workspace
+        when Array then workspace.map(&:to_s)
+        when Hash then Array(workspace["members"]).map(&:to_s)
+        else []
+        end
+      end
+
+      # Expands a single member entry to directory paths. Plain paths are
+      # normalised; glob entries (containing "*") are matched against the repo
+      # tree, honouring Deno's literal depth semantics (each "/*" = one level).
+      sig { params(member: String).returns(T::Array[String]) }
+      def expand_member(member)
+        normalised = normalise_member_path(member)
+        return [normalised] unless normalised.include?("*")
+
+        expand_glob(normalised)
+      end
+
+      sig { params(member: String).returns(String) }
+      def normalise_member_path(member)
+        member.delete_prefix("./").delete_suffix("/")
+      end
+
+      # Expands a glob like "packages/*" or "examples/*/*" by walking the repo one
+      # directory level per "*" segment. Only directories are kept.
+      sig { params(pattern: String).returns(T::Array[String]) }
+      def expand_glob(pattern)
+        segments = pattern.split("/")
+        dirs = T.let([""], T::Array[String])
+
+        segments.each do |segment|
+          dirs = dirs.flat_map do |base|
+            if segment == "*"
+              child_directories(base)
+            else
+              child = base.empty? ? segment : File.join(base, segment)
+              [child]
+            end
+          end
+        end
+
+        dirs.reject(&:empty?)
+      end
+
+      sig { params(dir: String).returns(T::Array[String]) }
+      def child_directories(dir)
+        contents = repo_contents(dir: dir.empty? ? "." : dir, raise_errors: false)
+        contents.select { |entry| entry.type == "dir" }
+                .map { |entry| dir.empty? ? entry.name : File.join(dir, entry.name) }
+      rescue Dependabot::DependencyFileNotFound, Dependabot::DirectoryNotFound
+        []
       end
     end
   end

--- a/deno/lib/dependabot/deno/file_parser.rb
+++ b/deno/lib/dependabot/deno/file_parser.rb
@@ -5,6 +5,7 @@ require "json"
 require "dependabot/dependency"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
+require "dependabot/deno/helpers"
 require "dependabot/deno/version"
 
 module Dependabot
@@ -20,17 +21,6 @@ module Dependabot
       JSR_SPECIFIER = %r{\Ajsr:(?<name>@[^@/]+/[^@/]+)(?:@(?<constraint>[^/]+))?(?:/[^\s]*)?\z}
       NPM_SPECIFIER = %r{\Anpm:(?<name>(?:@[^/]+/)?[^@/]+)(?:@(?<constraint>[^/]+))?(?:/[^\s]*)?\z}
 
-      # Matches either a JSON string literal (with escapes), a line comment, a
-      # block comment, or a trailing comma. The alternation lets gsub preserve
-      # strings while stripping the JSONC-only constructs, so e.g. "//" inside a
-      # URL value is not mistaken for the start of a comment.
-      JSONC_TOKEN = %r{
-        ("(?:\\.|[^"\\])*")    # JSON string literal
-        | //[^\n]*             # line comment
-        | /\*.*?\*/            # block comment
-        | ,(?=\s*[\}\]])       # trailing comma
-      }mx
-
       sig { override.returns(T::Array[Dependabot::Dependency]) }
       def parse
         # Multiple import aliases can reference the same underlying package
@@ -43,22 +33,24 @@ module Dependabot
         # can update them all.
         deps_by_key = {}
 
-        imports.each do |_alias_name, specifier|
-          dep = parse_specifier(specifier.to_s)
-          next unless dep
+        manifest_files.each do |file|
+          imports_for(file).each do |_alias_name, specifier|
+            dep = parse_specifier(specifier.to_s, file)
+            next unless dep
 
-          key = [dep.name, T.must(dep.requirements.first)[:source][:type]]
-          existing = deps_by_key[key]
-          deps_by_key[key] = if existing
-                               Dependabot::Dependency.new(
-                                 name: existing.name,
-                                 version: existing.version,
-                                 requirements: (existing.requirements + dep.requirements).uniq,
-                                 package_manager: existing.package_manager
-                               )
-                             else
-                               dep
-                             end
+            key = [dep.name, T.must(dep.requirements.first)[:source][:type]]
+            existing = deps_by_key[key]
+            deps_by_key[key] = if existing
+                                 Dependabot::Dependency.new(
+                                   name: existing.name,
+                                   version: existing.version,
+                                   requirements: (existing.requirements + dep.requirements).uniq,
+                                   package_manager: existing.package_manager
+                                 )
+                               else
+                                 dep
+                               end
+          end
         end
 
         deps_by_key.values.sort_by(&:name)
@@ -68,51 +60,55 @@ module Dependabot
 
       sig { override.void }
       def check_required_files
-        return if manifest_file
+        return if manifest_files.any?
 
         raise "No deno.json or deno.jsonc found!"
       end
 
-      sig { returns(T::Hash[String, T.untyped]) }
-      def imports
-        parsed_manifest.fetch("imports", {})
-      end
-
-      sig { returns(T::Hash[String, T.untyped]) }
-      def parsed_manifest
-        @parsed_manifest ||= T.let(
-          parse_json_or_jsonc(T.must(manifest_file).content),
-          T.nilable(T::Hash[String, T.untyped])
+      # The root manifest plus every workspace member manifest. Members are
+      # fetched relative to the root (e.g. "packages/foo/deno.json"), so match
+      # on basename rather than the full path.
+      sig { returns(T::Array[DependencyFile]) }
+      def manifest_files
+        @manifest_files ||= T.let(
+          dependency_files.select { |f| MANIFEST_FILENAMES.include?(File.basename(f.name)) },
+          T.nilable(T::Array[DependencyFile])
         )
       end
 
-      sig { returns(T.nilable(DependencyFile)) }
-      def manifest_file
-        @manifest_file ||= T.let(
-          MANIFEST_FILENAMES.filter_map { |f| get_original_file(f) }.first,
-          T.nilable(DependencyFile)
-        )
+      sig { params(file: DependencyFile).returns(T::Hash[String, T.untyped]) }
+      def imports_for(file)
+        Helpers.parse_json_or_jsonc(file.content).fetch("imports", {})
       end
 
-      sig { params(specifier: String).returns(T.nilable(Dependabot::Dependency)) }
-      def parse_specifier(specifier)
+      sig { params(specifier: String, file: DependencyFile).returns(T.nilable(Dependabot::Dependency)) }
+      def parse_specifier(specifier, file)
         if (match = JSR_SPECIFIER.match(specifier))
           build_dependency(
             name: T.must(match[:name]),
             constraint: match[:constraint],
-            source_type: "jsr"
+            source_type: "jsr",
+            file: file
           )
         elsif (match = NPM_SPECIFIER.match(specifier))
           build_dependency(
             name: T.must(match[:name]),
             constraint: match[:constraint],
-            source_type: "npm"
+            source_type: "npm",
+            file: file
           )
         end
       end
 
-      sig { params(name: String, constraint: T.nilable(String), source_type: String).returns(Dependabot::Dependency) }
-      def build_dependency(name:, constraint:, source_type:)
+      sig do
+        params(
+          name: String,
+          constraint: T.nilable(String),
+          source_type: String,
+          file: DependencyFile
+        ).returns(Dependabot::Dependency)
+      end
+      def build_dependency(name:, constraint:, source_type:, file:)
         version = constraint ? extract_version(constraint) : nil
 
         Dependabot::Dependency.new(
@@ -120,7 +116,7 @@ module Dependabot
           version: version,
           requirements: [{
             requirement: constraint,
-            file: T.must(manifest_file).name,
+            file: file.name,
             groups: ["imports"],
             source: { type: source_type }
           }],
@@ -134,15 +130,6 @@ module Dependabot
         return version_str if Deno::Version.correct?(version_str)
 
         nil
-      end
-
-      sig { params(content: T.nilable(String)).returns(T::Hash[String, T.untyped]) }
-      def parse_json_or_jsonc(content)
-        return {} unless content
-
-        cleaned = content.gsub(JSONC_TOKEN) { ::Regexp.last_match(1) || "" }
-
-        JSON.parse(cleaned)
       end
     end
   end

--- a/deno/lib/dependabot/deno/file_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater.rb
@@ -19,7 +19,7 @@ module Dependabot
         updated_files = []
 
         dependency_files.each do |file|
-          next unless MANIFEST_FILENAMES.include?(file.name)
+          next unless MANIFEST_FILENAMES.include?(File.basename(file.name))
 
           new_content = update_manifest_content(file)
           next if new_content == file.content
@@ -41,7 +41,7 @@ module Dependabot
 
       sig { override.void }
       def check_required_files
-        return if dependency_files.any? { |f| MANIFEST_FILENAMES.include?(f.name) }
+        return if dependency_files.any? { |f| MANIFEST_FILENAMES.include?(File.basename(f.name)) }
 
         raise "No deno.json or deno.jsonc found!"
       end

--- a/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
@@ -1,6 +1,7 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "fileutils"
 require "json"
 require "sorbet-runtime"
 
@@ -89,20 +90,26 @@ module Dependabot
 
         sig { params(dir: String).void }
         def write_temporary_files(dir)
-          File.write(File.join(dir, manifest.name), updated_manifest_content)
+          manifest_files.each do |file|
+            path = File.join(dir, file.name)
+            FileUtils.mkdir_p(File.dirname(path))
+            File.write(path, updated_manifest_content(file))
+          end
           File.write(File.join(dir, LOCKFILE_FILENAME), T.must(lockfile.content))
         end
 
-        sig { returns(String) }
-        def updated_manifest_content
-          ManifestUpdater.new(dependencies: dependencies, manifest: manifest).updated_manifest_content
+        sig { params(file: Dependabot::DependencyFile).returns(String) }
+        def updated_manifest_content(file)
+          ManifestUpdater.new(dependencies: dependencies, manifest: file).updated_manifest_content
         end
 
-        sig { returns(Dependabot::DependencyFile) }
-        def manifest
-          @manifest ||= T.let(
-            T.must(dependency_files.find { |f| FileUpdater::MANIFEST_FILENAMES.include?(f.name) }),
-            T.nilable(Dependabot::DependencyFile)
+        # The root manifest plus every workspace member manifest. Members are
+        # fetched relative to the root, so match on basename rather than path.
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        def manifest_files
+          @manifest_files ||= T.let(
+            dependency_files.select { |f| FileUpdater::MANIFEST_FILENAMES.include?(File.basename(f.name)) },
+            T.nilable(T::Array[Dependabot::DependencyFile])
           )
         end
 

--- a/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/lockfile_updater.rb
@@ -91,6 +91,15 @@ module Dependabot
         sig { params(dir: String).void }
         def write_temporary_files(dir)
           manifest_files.each do |file|
+            # Defence in depth: manifest names ultimately derive from workspace
+            # member paths in repo content. Refuse to write through an absolute
+            # name or one containing ".." so lockfile regeneration can't become a
+            # write primitive outside the temporary directory.
+            unless Helpers.safe_relative_path?(file.name)
+              raise Dependabot::DependencyFileNotResolvable,
+                    "Unsafe manifest path: #{file.name}"
+            end
+
             path = File.join(dir, file.name)
             FileUtils.mkdir_p(File.dirname(path))
             File.write(path, updated_manifest_content(file))

--- a/deno/lib/dependabot/deno/helpers.rb
+++ b/deno/lib/dependabot/deno/helpers.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "pathname"
 require "sorbet-runtime"
 
 require "dependabot/shared_helpers"
@@ -31,7 +32,25 @@ module Dependabot
 
         cleaned = content.gsub(JSONC_TOKEN) { ::Regexp.last_match(1) || "" }
 
-        JSON.parse(cleaned)
+        parsed = JSON.parse(cleaned)
+        # A deno.json(c) must be a JSON object. Guard here so a malformed manifest
+        # (e.g. a top-level array) surfaces as a clear parse error rather than an
+        # opaque sorbet-runtime type error at the call site.
+        raise JSON::ParserError, "Expected a JSON object, got #{parsed.class}" unless parsed.is_a?(Hash)
+
+        parsed
+      end
+
+      # True when `path` is a repo-relative path with no traversal. Workspace
+      # member paths are derived from manifest content, so absolute paths
+      # ("/etc") or ".." segments must never be used as fetch/write targets —
+      # File.join would otherwise escape the repo checkout or temp directory.
+      sig { params(path: String).returns(T::Boolean) }
+      def self.safe_relative_path?(path)
+        return false if path.empty?
+        return false if Pathname.new(path).absolute?
+
+        Pathname.new(path).each_filename.none?("..")
       end
 
       # Wraps `deno <args>` via Dependabot's standard subprocess helper, so

--- a/deno/lib/dependabot/deno/helpers.rb
+++ b/deno/lib/dependabot/deno/helpers.rb
@@ -1,6 +1,7 @@
-# typed: strong
+# typed: strict
 # frozen_string_literal: true
 
+require "json"
 require "sorbet-runtime"
 
 require "dependabot/shared_helpers"
@@ -9,6 +10,29 @@ module Dependabot
   module Deno
     module Helpers
       extend T::Sig
+
+      # Matches either a JSON string literal (with escapes), a line comment, a
+      # block comment, or a trailing comma. The alternation lets gsub preserve
+      # strings while stripping the JSONC-only constructs, so e.g. "//" inside a
+      # URL value is not mistaken for the start of a comment.
+      JSONC_TOKEN = T.let(
+        %r{
+          ("(?:\\.|[^"\\])*")    # JSON string literal
+          | //[^\n]*             # line comment
+          | /\*.*?\*/            # block comment
+          | ,(?=\s*[\}\]])       # trailing comma
+        }mx,
+        Regexp
+      )
+
+      sig { params(content: T.nilable(String)).returns(T::Hash[String, T.untyped]) }
+      def self.parse_json_or_jsonc(content)
+        return {} unless content
+
+        cleaned = content.gsub(JSONC_TOKEN) { ::Regexp.last_match(1) || "" }
+
+        JSON.parse(cleaned)
+      end
 
       # Wraps `deno <args>` via Dependabot's standard subprocess helper, so
       # failures surface as Dependabot::SharedHelpers::HelperSubprocessFailed

--- a/deno/spec/dependabot/deno/file_fetcher_spec.rb
+++ b/deno/spec/dependabot/deno/file_fetcher_spec.rb
@@ -50,4 +50,34 @@ RSpec.describe Dependabot::Deno::FileFetcher do
       expect(described_class.required_files_message).to include("deno.json")
     end
   end
+
+  describe "#files" do
+    context "with a workspace using a glob member pattern" do
+      let(:repo_contents_path) { build_tmp_repo("deno/workspace") }
+      let(:file_fetcher_instance) do
+        described_class.new(
+          source: source,
+          credentials: credentials,
+          repo_contents_path: repo_contents_path
+        )
+      end
+
+      before do
+        allow(file_fetcher_instance).to receive(:clone_repo_contents).and_return(repo_contents_path)
+      end
+
+      after do
+        FileUtils.rm_rf(repo_contents_path)
+      end
+
+      it "fetches the root manifest, every member manifest, and the lockfile" do
+        expect(file_fetcher_instance.files.map(&:name)).to contain_exactly(
+          "deno.json",
+          "packages/alpha/deno.json",
+          "packages/beta/deno.json",
+          "deno.lock"
+        )
+      end
+    end
+  end
 end

--- a/deno/spec/dependabot/deno/file_fetcher_spec.rb
+++ b/deno/spec/dependabot/deno/file_fetcher_spec.rb
@@ -79,5 +79,32 @@ RSpec.describe Dependabot::Deno::FileFetcher do
         )
       end
     end
+
+    context "with unsafe workspace member entries" do
+      let(:repo_contents_path) { build_tmp_repo("deno/workspace_unsafe") }
+      let(:file_fetcher_instance) do
+        described_class.new(
+          source: source,
+          credentials: credentials,
+          repo_contents_path: repo_contents_path
+        )
+      end
+
+      before do
+        allow(file_fetcher_instance).to receive(:clone_repo_contents).and_return(repo_contents_path)
+      end
+
+      after do
+        FileUtils.rm_rf(repo_contents_path)
+      end
+
+      it "skips absolute and traversal member paths" do
+        # Members "../escape" and "/etc" must not be fetched.
+        expect(file_fetcher_instance.files.map(&:name)).to contain_exactly(
+          "deno.json",
+          "packages/alpha/deno.json"
+        )
+      end
+    end
   end
 end

--- a/deno/spec/dependabot/deno/file_parser_spec.rb
+++ b/deno/spec/dependabot/deno/file_parser_spec.rb
@@ -63,6 +63,27 @@ RSpec.describe Dependabot::Deno::FileParser do
     end
   end
 
+  context "with a workspace" do
+    let(:files) do
+      project_dependency_files("deno/workspace")
+    end
+
+    it "parses dependencies from the root and member manifests" do
+      deps = parser.parse
+      expect(deps.map(&:name)).to contain_exactly("@std/assert", "@std/path", "chalk")
+    end
+
+    it "attributes each dependency to its declaring manifest" do
+      deps = parser.parse
+
+      expect(deps.find { |d| d.name == "@std/path" }.requirements.first[:file]).to eq("deno.json")
+      expect(deps.find { |d| d.name == "@std/assert" }.requirements.first[:file])
+        .to eq("packages/alpha/deno.json")
+      expect(deps.find { |d| d.name == "chalk" }.requirements.first[:file])
+        .to eq("packages/beta/deno.json")
+    end
+  end
+
   context "with scoped npm packages" do
     let(:files) do
       project_dependency_files("deno/scoped_npm")

--- a/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
+++ b/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
@@ -213,6 +213,21 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
     end
   end
 
+  context "when a manifest has an unsafe path" do
+    let(:files) do
+      [
+        Dependabot::DependencyFile.new(name: "../evil/deno.json", content: "{}", directory: "/"),
+        Dependabot::DependencyFile.new(name: "deno.lock", content: "{}", directory: "/")
+      ]
+    end
+
+    it "raises DependencyFileNotResolvable instead of writing outside the temp dir" do
+      expect do
+        updater.updated_lockfile_content
+      end.to raise_error(Dependabot::DependencyFileNotResolvable, /Unsafe manifest path/)
+    end
+  end
+
   context "when deno install does not change the lockfile" do
     before do
       # Stub run_deno_command to leave the lockfile untouched in the tmpdir.

--- a/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
+++ b/deno/spec/dependabot/deno/file_updater/lockfile_updater_spec.rb
@@ -177,6 +177,42 @@ RSpec.describe Dependabot::Deno::FileUpdater::LockfileUpdater do
     end
   end
 
+  context "with a workspace (member dependency bump)" do
+    let(:files) { project_dependency_files("deno/workspace") }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "@std/assert",
+        version: "1.0.19",
+        previous_version: "1.0.19",
+        requirements: [{
+          requirement: "^1.0.10",
+          file: "packages/alpha/deno.json",
+          groups: ["imports"],
+          source: { type: "jsr" }
+        }],
+        previous_requirements: [{
+          requirement: "^1.0.0",
+          file: "packages/alpha/deno.json",
+          groups: ["imports"],
+          source: { type: "jsr" }
+        }],
+        package_manager: "deno"
+      )
+    end
+
+    it "regenerates the root lockfile from the bumped member manifest" do
+      content = updater.updated_lockfile_content
+      lock = JSON.parse(content)
+
+      expect(lock["version"]).to eq("5")
+      expect(lock.fetch("specifiers")).to have_key("jsr:@std/assert@^1.0.10")
+
+      # Other members' dependencies remain resolvable in the shared lockfile.
+      expect(lock.fetch("jsr").keys).to include(match(%r{^@std/path@}))
+      expect(lock.fetch("npm").keys).to include(match(/^chalk@/))
+    end
+  end
+
   context "when deno install does not change the lockfile" do
     before do
       # Stub run_deno_command to leave the lockfile untouched in the tmpdir.

--- a/deno/spec/dependabot/deno/helpers_spec.rb
+++ b/deno/spec/dependabot/deno/helpers_spec.rb
@@ -6,6 +6,51 @@ require "dependabot/deno/helpers"
 require "dependabot/shared_helpers"
 
 RSpec.describe Dependabot::Deno::Helpers do
+  describe ".parse_json_or_jsonc" do
+    it "returns an empty hash for nil content" do
+      expect(described_class.parse_json_or_jsonc(nil)).to eq({})
+    end
+
+    it "parses JSON with comments and trailing commas" do
+      content = <<~JSONC
+        {
+          // a line comment
+          /* a block comment */
+          "imports": {
+            "@std/path": "jsr:@std/path@^1.0.0",
+          },
+        }
+      JSONC
+      expect(described_class.parse_json_or_jsonc(content))
+        .to eq("imports" => { "@std/path" => "jsr:@std/path@^1.0.0" })
+    end
+
+    it "raises a clear error when the top-level value is not an object" do
+      expect do
+        described_class.parse_json_or_jsonc("[1, 2, 3]")
+      end.to raise_error(JSON::ParserError, /Expected a JSON object/)
+    end
+  end
+
+  describe ".safe_relative_path?" do
+    it "accepts repo-relative paths" do
+      expect(described_class.safe_relative_path?("packages/alpha")).to be(true)
+    end
+
+    it "rejects empty paths" do
+      expect(described_class.safe_relative_path?("")).to be(false)
+    end
+
+    it "rejects absolute paths" do
+      expect(described_class.safe_relative_path?("/etc")).to be(false)
+    end
+
+    it "rejects paths containing traversal segments" do
+      expect(described_class.safe_relative_path?("packages/../../etc")).to be(false)
+      expect(described_class.safe_relative_path?("../outside")).to be(false)
+    end
+  end
+
   describe ".run_deno_command" do
     let(:dir) { "/tmp/some-dir" }
 

--- a/deno/spec/fixtures/projects/deno/workspace/deno.json
+++ b/deno/spec/fixtures/projects/deno/workspace/deno.json
@@ -1,0 +1,6 @@
+{
+  "workspace": ["./packages/*"],
+  "imports": {
+    "@std/path": "jsr:@std/path@^1.0.0"
+  }
+}

--- a/deno/spec/fixtures/projects/deno/workspace/deno.lock
+++ b/deno/spec/fixtures/projects/deno/workspace/deno.lock
@@ -1,0 +1,49 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@1": "1.1.5",
+    "npm:chalk@^5.3.0": "5.6.2"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    }
+  },
+  "npm": {
+    "chalk@5.6.2": {
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/path@1"
+    ],
+    "members": {
+      "packages/alpha": {
+        "dependencies": [
+          "jsr:@std/assert@1"
+        ]
+      },
+      "packages/beta": {
+        "dependencies": [
+          "npm:chalk@^5.3.0"
+        ]
+      }
+    }
+  }
+}

--- a/deno/spec/fixtures/projects/deno/workspace/packages/alpha/deno.json
+++ b/deno/spec/fixtures/projects/deno/workspace/packages/alpha/deno.json
@@ -1,0 +1,8 @@
+{
+  "name": "@example/alpha",
+  "version": "0.1.0",
+  "exports": "./mod.ts",
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.0"
+  }
+}

--- a/deno/spec/fixtures/projects/deno/workspace/packages/beta/deno.json
+++ b/deno/spec/fixtures/projects/deno/workspace/packages/beta/deno.json
@@ -1,0 +1,8 @@
+{
+  "name": "@example/beta",
+  "version": "0.1.0",
+  "exports": "./mod.ts",
+  "imports": {
+    "chalk": "npm:chalk@^5.3.0"
+  }
+}

--- a/deno/spec/fixtures/projects/deno/workspace_unsafe/deno.json
+++ b/deno/spec/fixtures/projects/deno/workspace_unsafe/deno.json
@@ -1,0 +1,6 @@
+{
+  "workspace": ["./packages/alpha", "../escape", "/etc"],
+  "imports": {
+    "@std/path": "jsr:@std/path@^1.0.0"
+  }
+}

--- a/deno/spec/fixtures/projects/deno/workspace_unsafe/packages/alpha/deno.json
+++ b/deno/spec/fixtures/projects/deno/workspace_unsafe/packages/alpha/deno.json
@@ -1,0 +1,8 @@
+{
+  "name": "@example/alpha",
+  "version": "0.1.0",
+  "exports": "./mod.ts",
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.0"
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Add **Deno workspace** support. Previously the Deno ecosystem only fetched, parsed, and updated the **root** `deno.json`/`deno.jsonc`. A monorepo that declares members via the root `workspace` field kept most of its dependencies in **member** manifests that Dependabot never saw — users had to manually enumerate every member directory in `dependabot.yml` as a workaround.

This PR makes Dependabot discover and update dependencies declared in workspace member manifests:

- **file_fetcher** — reads the root `workspace` field (array form `["./a", "./b"]` or the legacy object form `{ "members": [...] }`), expands **glob patterns** (`./packages/*`, `./examples/*/*`) and `!` negations against the repo tree, and fetches each member `deno.json`/`deno.jsonc`. Members with neither file (e.g. `package.json`-only members) are skipped.
- **file_parser** — parses `imports` from every member manifest, attributing each requirement to its declaring file.
- **file_updater** — matches manifests by basename so member files are updated.
- **lockfile_updater** — reconstructs the workspace tree in the temp dir (root + members at their relative paths) before `deno install`, so the single root `deno.lock` resolves all members.
- Extracts the JSONC parser into `Deno::Helpers` (shared by the fetcher and parser).

Scope: `deno.json`/`deno.jsonc` members only. `package.json`-only members remain the `npm_and_yarn` ecosystem's domain; `importMap`, `scopes`, and `vendor` are unchanged.

### Anything you want to highlight for special attention from reviewers?

- **Glob expansion** walks the repo one directory level per `*` segment, matching Deno's literal depth semantics (`path/*` = exactly one level). It uses `repo_contents(raise_errors: false)` so missing directories yield no members rather than aborting the job.
- `file_fetcher.rb` and `helpers.rb` moved from `# typed: strong` to `# typed: strict` because they now handle parsed-JSON / `repo_contents` values that are inherently `T.untyped`; `helpers.rb` is added to the existing `Sorbet/ForbidTUntyped` exclude list alongside the other Deno files.
- The new `workspace` fixture's `deno.lock` is lockfile **v5**, so this builds on the Deno 2.8.3 bump from #15319.

### How will you know you've accomplished your goal?

New fixture `deno/spec/fixtures/projects/deno/workspace/` (root with a `./packages/*` glob, two members declaring `jsr:` and `npm:` deps, real v5 lockfile) plus specs:

- fetcher: discovers the root manifest, both glob-matched member manifests, and the lockfile;
- parser: attributes member deps to their member files;
- lockfile_updater: a member-dependency bump regenerates the shared root lockfile while keeping other members resolvable.

```
$ cd deno && bundle exec rspec
90 examples, 0 failures
```

`bundle exec srb tc` and `rubocop` are clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
