### PR TITLE
fix(npm_and_yarn): strip trailing slash from registry URL in Corepack env vars

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -27,6 +27,15 @@ module Dependabot
       # Default npm registry - no need to set env vars for this
       DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org"
 
+      # Canonicalise a registry URL: ensure an https:// scheme and strip any
+      # trailing slashes. Used wherever a registry URL is written into an env var
+      # so there is a single source of truth for URL normalisation.
+      sig { params(url: String).returns(String) }
+      def self.normalize_registry_url(url)
+        url = "https://#{url}" unless url.start_with?("http://", "https://")
+        url.sub(%r{/+\z}, "")
+      end
+
       sig do
         params(
           registry_config_files: T::Hash[Symbol, T.nilable(Dependabot::DependencyFile)],
@@ -44,15 +53,9 @@ module Dependabot
 
         env_variables = {}
 
-        if registry_info[:registry] # Prevent the https from being stripped in the process
-          registry = registry_info[:registry]
-          registry = "https://#{T.must(registry)}" unless T.must(registry).start_with?("http://", "https://")
-          # Corepack appends "/<package>" directly to this value, so a trailing slash
-          # produces a double-slash URL (e.g. ".../registry//@scope/pkg") that causes
-          # request failures on any registry that does not normalise double slashes.
-          registry = T.must(registry).sub(%r{/+\z}, "")
+        if (raw_registry = registry_info[:registry])
+          registry = RegistryHelper.normalize_registry_url(raw_registry)
 
-          # Set both in the env_variables hash
           unless registry == DEFAULT_NPM_REGISTRY
             env_variables[COREPACK_NPM_REGISTRY_ENV] = registry # For Corepack
             env_variables[NPM_CONFIG_REGISTRY_ENV] = registry # For npm

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -47,6 +47,10 @@ module Dependabot
         if registry_info[:registry] # Prevent the https from being stripped in the process
           registry = registry_info[:registry]
           registry = "https://#{T.must(registry)}" unless T.must(registry).start_with?("http://", "https://")
+          # Corepack appends "/<package>" directly to this value, so a trailing slash
+          # produces a double-slash URL (e.g. ".../registry//@scope/pkg") that causes
+          # request failures on any registry that does not normalise double slashes.
+          registry = T.must(registry).sub(%r{/+\z}, "")
 
           # Set both in the env_variables hash
           unless registry == DEFAULT_NPM_REGISTRY

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -32,8 +32,9 @@ module Dependabot
       # so there is a single source of truth for URL normalisation.
       sig { params(url: String).returns(String) }
       def self.normalize_registry_url(url)
-        url = "https://#{url}" unless url.start_with?("http://", "https://")
-        url.sub(%r{/+\z}, "")
+        normalized = url.start_with?("http://", "https://") ? url.dup : "https://#{url}"
+        normalized.delete_suffix!("/") while normalized.end_with?("/")
+        normalized
       end
 
       sig do

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -935,8 +935,7 @@ module Dependabot
           registry_url = replaces_base_cred&.[]("registry")
           return nil unless registry_url
 
-          registry_url = "https://#{registry_url}" unless registry_url.start_with?("http")
-          registry_url = registry_url.sub(%r{/+\z}, "")
+          registry_url = Dependabot::NpmAndYarn::RegistryHelper.normalize_registry_url(registry_url)
 
           { "npm_config_registry" => registry_url }
         end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -936,6 +936,7 @@ module Dependabot
           return nil unless registry_url
 
           registry_url = "https://#{registry_url}" unless registry_url.start_with?("http")
+          registry_url = registry_url.sub(%r{/+\z}, "")
 
           { "npm_config_registry" => registry_url }
         end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -117,6 +117,31 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
       end
     end
 
+    context "when credentials are provided with a trailing slash in the registry URL" do
+      let(:registry_config_files) { {} }
+      let(:credentials) do
+        [
+          {
+            "type" => "npm_registry",
+            "registry" => "artifactory.example.com/npm/",
+            "token" => "my-token",
+            "replaces-base" => true
+          }
+        ]
+      end
+
+      it "strips the trailing slash from the registry URL" do
+        helper = described_class.new(registry_config_files, credentials)
+        env_variables = helper.find_corepack_env_variables
+        expect(env_variables).to eq(
+          "COREPACK_NPM_REGISTRY" => "https://artifactory.example.com/npm",
+          "npm_config_registry" => "https://artifactory.example.com/npm",
+          "COREPACK_NPM_TOKEN" => "my-token",
+          "registry" => "https://artifactory.example.com/npm"
+        )
+      end
+    end
+
     context "when npmrc has registry but no token" do
       let(:registry_config_files) { { npmrc: npmrc_without_token_file } }
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -76,6 +76,28 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
     Dependabot::DependencyFile.new(name: "yarnrc.yml", content: "")
   end
 
+  describe ".normalize_registry_url" do
+    it "adds https scheme when missing" do
+      expect(described_class.normalize_registry_url("my-registry.com/npm")).to eq("https://my-registry.com/npm")
+    end
+
+    it "preserves an existing https scheme" do
+      expect(described_class.normalize_registry_url("https://my-registry.com/npm")).to eq("https://my-registry.com/npm")
+    end
+
+    it "strips a single trailing slash" do
+      expect(described_class.normalize_registry_url("https://my-registry.com/npm/")).to eq("https://my-registry.com/npm")
+    end
+
+    it "strips multiple trailing slashes" do
+      expect(described_class.normalize_registry_url("https://my-registry.com/npm///")).to eq("https://my-registry.com/npm")
+    end
+
+    it "preserves a path component while stripping the trailing slash" do
+      expect(described_class.normalize_registry_url("https://host.example.com/npm/")).to eq("https://host.example.com/npm")
+    end
+  end
+
   describe "#find_corepack_env_variables" do
     context "when npmrc is provided" do
       let(:registry_config_files) { { npmrc: npmrc_file } }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -80,14 +80,14 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
     context "when npmrc is provided" do
       let(:registry_config_files) { { npmrc: npmrc_file } }
 
-      it "returns registry from npmrc" do
+      it "returns registry from npmrc with trailing slash stripped" do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://custom-registry.com/",
-          "npm_config_registry" => "https://custom-registry.com/",
+          "COREPACK_NPM_REGISTRY" => "https://custom-registry.com",
+          "npm_config_registry" => "https://custom-registry.com",
           "COREPACK_NPM_TOKEN" => "custom-token",
-          "registry" => "https://custom-registry.com/"
+          "registry" => "https://custom-registry.com"
         )
       end
     end
@@ -120,13 +120,13 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
     context "when npmrc has registry but no token" do
       let(:registry_config_files) { { npmrc: npmrc_without_token_file } }
 
-      it "returns only the registry from npmrc" do
+      it "returns only the registry from npmrc with trailing slash stripped" do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://custom-registry.com/",
-          "npm_config_registry" => "https://custom-registry.com/",
-          "registry" => "https://custom-registry.com/"
+          "COREPACK_NPM_REGISTRY" => "https://custom-registry.com",
+          "npm_config_registry" => "https://custom-registry.com",
+          "registry" => "https://custom-registry.com"
         )
       end
     end
@@ -134,14 +134,14 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
     context "when yarnrc is provided" do
       let(:registry_config_files) { { yarnrc: yarnrc_file } }
 
-      it "returns registry from yarnrc" do
+      it "returns registry from yarnrc with trailing slash stripped" do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://yarn-registry.com/",
-          "npm_config_registry" => "https://yarn-registry.com/",
+          "COREPACK_NPM_REGISTRY" => "https://yarn-registry.com",
+          "npm_config_registry" => "https://yarn-registry.com",
           "COREPACK_NPM_TOKEN" => "your-auth-token-here",
-          "registry" => "https://yarn-registry.com/"
+          "registry" => "https://yarn-registry.com"
         )
       end
     end
@@ -149,13 +149,13 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
     context "when yarnrc has registry but no token" do
       let(:registry_config_files) { { yarnrc: yarnrc_without_token_file } }
 
-      it "returns only the registry from yarnrc" do
+      it "returns only the registry from yarnrc with trailing slash stripped" do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://yarn-registry.com/",
-          "npm_config_registry" => "https://yarn-registry.com/",
-          "registry" => "https://yarn-registry.com/"
+          "COREPACK_NPM_REGISTRY" => "https://yarn-registry.com",
+          "npm_config_registry" => "https://yarn-registry.com",
+          "registry" => "https://yarn-registry.com"
         )
       end
     end
@@ -163,14 +163,14 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
     context "when yarnrc.yml is provided" do
       let(:registry_config_files) { { yarnrc_yml: yarnrc_yml_file } }
 
-      it "returns registry from yarnrc.yml" do
+      it "returns registry from yarnrc.yml with trailing slash stripped" do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://yarnrc-yml-registry.com/",
-          "npm_config_registry" => "https://yarnrc-yml-registry.com/",
+          "COREPACK_NPM_REGISTRY" => "https://yarnrc-yml-registry.com",
+          "npm_config_registry" => "https://yarnrc-yml-registry.com",
           "COREPACK_NPM_TOKEN" => "yarnrc-yml-token",
-          "registry" => "https://yarnrc-yml-registry.com/"
+          "registry" => "https://yarnrc-yml-registry.com"
         )
       end
     end
@@ -178,13 +178,13 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
     context "when yarnrc.yml has registry but no token" do
       let(:registry_config_files) { { yarnrc_yml: yarnrc_yml_without_token_file } }
 
-      it "returns only the registry from yarnrc.yml" do
+      it "returns only the registry from yarnrc.yml with trailing slash stripped" do
         helper = described_class.new(registry_config_files, [])
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
-          "COREPACK_NPM_REGISTRY" => "https://yarnrc-yml-registry.com/",
-          "npm_config_registry" => "https://yarnrc-yml-registry.com/",
-          "registry" => "https://yarnrc-yml-registry.com/"
+          "COREPACK_NPM_REGISTRY" => "https://yarnrc-yml-registry.com",
+          "npm_config_registry" => "https://yarnrc-yml-registry.com",
+          "registry" => "https://yarnrc-yml-registry.com"
         )
       end
     end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/version_resolver_spec.rb
@@ -2326,7 +2326,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VersionResolver do
           .with(
             anything, # The actual command
             hash_including(
-              env: hash_including("npm_config_registry" => "https://artifactory.example.com/artifactory/api/npm/npm/")
+              env: hash_including("npm_config_registry" => "https://artifactory.example.com/artifactory/api/npm/npm")
             )
           )
       end


### PR DESCRIPTION
## Summary

Corepack appends `/<package>` directly to `COREPACK_NPM_REGISTRY`, so a registry URL ending with `/` produces a double-slash path (e.g. `.../registry//@scope/pkg`) that causes request failures on any registry that does not normalise double slashes in URL paths.

- Strip trailing slashes in `RegistryHelper#find_corepack_env_variables` — covers URLs sourced from `.npmrc`, `.yarnrc`, `.yarnrc.yml`, and `replaces-base` credentials
- Same strip in `VersionResolver#corepack_registry_override_env` — proactive consistency fix for the credential-only code path
- Update `registry_helper_spec.rb` expectations to reflect that trailing slashes in source config are normalised before being written into env vars

## Root cause

`COREPACK_NPM_REGISTRY` is constructed from the raw registry string (e.g. from `.npmrc`). Tools like npm commonly write registry URLs with a trailing slash. Corepack does not normalise the base URL before appending the package path, resulting in `//` in the constructed request URL.

## Test plan

- [ ] Existing `registry_helper_spec.rb` tests pass with updated expectations (fixtures retain trailing slash in source; expected output has no trailing slash)
- [ ] Manually confirm Corepack package manager install succeeds against a private registry configured with a trailing slash in `.npmrc`