### PR TITLE
Fix helm checksum and install arch specific oras

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -26,7 +26,7 @@ ARG HELM_VERSION=3.17.2
 # curl -sL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | sha256sum
 ARG HELM_AMD64_CHECKSUM=90c28792a1eb5fb0b50028e39ebf826531ebfcf73f599050dbd79bab2f277241
 # curl -sL https://get.helm.sh/helm-v${HELM_VERSION}-linux-arm64.tar.gz | sha256sum
-ARG HELM_ARM64_CHECKSUM=0b13ec8580dd5498b5a2d7cb34146e098049f59500a266db1bb98f59649eb90a
+ARG HELM_ARM64_CHECKSUM=d78d76ec7625a94991e887ac049d93f44bd70e4876200b945f813c9e1ed1df7c
 
 ENV PATH=/opt/bin:$PATH
 RUN cd /tmp \
@@ -43,7 +43,7 @@ RUN cd /tmp \
 
 
 RUN cd /tmp \
-  && curl -LO https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz \
+  && curl -LO https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${TARGETARCH}.tar.gz \
   && mkdir -p oras-install/ \
   && tar -zxf oras_${ORAS_VERSION}_*.tar.gz -C oras-install/ \
   && mv oras-install/oras /opt/bin/oras \


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

Fixes incorrect checksum for arm64 tar and fixes hardcoded amd64 installation of oras. First fix should unblock build failures, second should ensure correct architecture is used for tool install.

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

I have been building images with this fix for a while and it works fine, CI should validate it.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
