### PR TITLE
NuGet: Filter ImportedFiles by .gitignore in discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -1952,6 +1952,57 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
     }
 
     [Fact]
+    public async Task ImportedFilesInGitIgnoreAreNotReported()
+    {
+        await TestDiscoveryAsync(
+            packages: [MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0")],
+            workspacePath: "src",
+            files: [
+                ("src/project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <Import Project="ignored.props" />
+                      <Import Project="not-ignored.props" />
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("src/ignored.props", """
+                    <Project>
+                    </Project>
+                    """),
+                ("src/not-ignored.props", """
+                    <Project>
+                    </Project>
+                    """),
+                (".gitignore", """
+                    src/ignored.props
+                    """),
+            ],
+            expectedResult: new()
+            {
+                Path = "src",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies = [
+                            new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = ["not-ignored.props"],
+                        AdditionalFiles = [],
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
     public void MergeProjectDiscovery()
     {
         // project discovery is frequently merged with prior results (e.g., `packages.config` followed by `<PackageReference>`)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/GitIgnoreParserTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/GitIgnoreParserTests.cs
@@ -10,7 +10,7 @@ public class GitIgnoreParserTests
     [MemberData(nameof(BasicPatternMatchingData))]
     public void BasicPatternMatching(string gitignoreContent, string testPath, bool expectedIgnored)
     {
-        var parser = CreateParserFromContent(gitignoreContent, pathPrefix: "");
+        var parser = CreateParserFromContent(gitignoreContent, pathPrefix: "", isCaseInsensitive: false);
         Assert.Equal(expectedIgnored, parser.IsIgnored(testPath));
     }
 
@@ -58,13 +58,19 @@ public class GitIgnoreParserTests
 
         // blank lines are ignored
         yield return ["\n\n*.log\n\n", "debug.log", true];
+
+        // backslash escapes special characters
+        yield return ["file\\*.txt", "file*.txt", true];
+        yield return ["file\\*.txt", "fileA.txt", false];
+        yield return ["hello\\#world", "hello#world", true];
+        yield return ["space\\ file.txt", "space file.txt", true];
     }
 
     [Theory]
     [MemberData(nameof(NegationPatternData))]
     public void NegationPatterns(string gitignoreContent, string testPath, bool expectedIgnored)
     {
-        var parser = CreateParserFromContent(gitignoreContent, pathPrefix: "");
+        var parser = CreateParserFromContent(gitignoreContent, pathPrefix: "", isCaseInsensitive: false);
         Assert.Equal(expectedIgnored, parser.IsIgnored(testPath));
     }
 
@@ -94,7 +100,7 @@ public class GitIgnoreParserTests
         tempDir.WriteFile("src/kept.txt", "");
         tempDir.WriteFile("lib/sub-ignored.txt", "");
 
-        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath);
+        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath, isCaseInsensitive: false);
 
         // root .gitignore applies everywhere (unrooted pattern)
         Assert.True(parser.IsIgnored("root-ignored.txt"));
@@ -123,7 +129,7 @@ public class GitIgnoreParserTests
         tempDir.WriteFile("src/generated/output.cs", "");
         tempDir.WriteFile("docs/notes.tmp", "");
 
-        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath);
+        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath, isCaseInsensitive: false);
 
         // root pattern *.tmp applies at any depth
         Assert.True(parser.IsIgnored("docs/notes.tmp"));
@@ -147,7 +153,7 @@ public class GitIgnoreParserTests
         tempDir.WriteFile("lib/obj/debug.dll", "");
         tempDir.WriteFile("lib/obj/release.dll", "");
 
-        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath);
+        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath, isCaseInsensitive: false);
 
         Assert.True(parser.IsIgnored("lib/obj/debug.dll"));
         Assert.False(parser.IsIgnored("lib/obj/release.dll"));
@@ -158,7 +164,7 @@ public class GitIgnoreParserTests
     [Fact]
     public void CharacterClassPatterns()
     {
-        var parser = CreateParserFromContent("[Bb]uild/", pathPrefix: "");
+        var parser = CreateParserFromContent("[Bb]uild/", pathPrefix: "", isCaseInsensitive: false);
         Assert.True(parser.IsIgnored("Build/output.dll"));
         Assert.True(parser.IsIgnored("build/output.dll"));
         Assert.False(parser.IsIgnored("rebuild/output.dll"));
@@ -168,7 +174,7 @@ public class GitIgnoreParserTests
     public void PatternWithLeadingSlashIsRooted()
     {
         // leading slash means pattern is rooted relative to gitignore location
-        var parser = CreateParserFromContent("/build\n/dist", pathPrefix: "");
+        var parser = CreateParserFromContent("/build\n/dist", pathPrefix: "", isCaseInsensitive: false);
         Assert.True(parser.IsIgnored("build"));
         Assert.True(parser.IsIgnored("build/output.dll"));
         Assert.True(parser.IsIgnored("dist"));
@@ -176,12 +182,66 @@ public class GitIgnoreParserTests
         Assert.False(parser.IsIgnored("src/dist"));
     }
 
-    private static GitIgnoreParser CreateParserFromContent(string content, string pathPrefix)
+    private static GitIgnoreParser CreateParserFromContent(string content, string pathPrefix, bool isCaseInsensitive)
     {
         // Use a temp directory with just the gitignore content at the root
         using var tempDir = new TempGitIgnoreDirectory();
         tempDir.WriteFile(".gitignore", content);
-        return GitIgnoreParser.FromRepoRoot(tempDir.RootPath);
+        return GitIgnoreParser.FromRepoRoot(tempDir.RootPath, isCaseInsensitive);
+    }
+
+    [Theory]
+    [MemberData(nameof(CaseInsensitiveData))]
+    public void CaseInsensitiveMatching(string gitignoreContent, string testPath, bool expectedIgnored)
+    {
+        var parser = CreateParserFromContent(gitignoreContent, pathPrefix: "", isCaseInsensitive: true);
+        Assert.Equal(expectedIgnored, parser.IsIgnored(testPath));
+    }
+
+    public static IEnumerable<object[]> CaseInsensitiveData()
+    {
+        // case-insensitive: pattern matches regardless of case
+        yield return ["debug.log", "DEBUG.LOG", true];
+        yield return ["debug.log", "Debug.Log", true];
+        yield return ["*.LOG", "file.log", true];
+        yield return ["Build/", "build/output.dll", true];
+        yield return ["Build/", "BUILD/output.dll", true];
+        yield return ["src/file.txt", "SRC/File.TXT", true];
+    }
+
+    [Theory]
+    [MemberData(nameof(CaseSensitiveData))]
+    public void CaseSensitiveMatching(string gitignoreContent, string testPath, bool expectedIgnored)
+    {
+        var parser = CreateParserFromContent(gitignoreContent, pathPrefix: "", isCaseInsensitive: false);
+        Assert.Equal(expectedIgnored, parser.IsIgnored(testPath));
+    }
+
+    public static IEnumerable<object[]> CaseSensitiveData()
+    {
+        // case-sensitive: pattern must match exact case
+        yield return ["debug.log", "DEBUG.LOG", false];
+        yield return ["debug.log", "debug.log", true];
+        yield return ["*.LOG", "file.log", false];
+        yield return ["*.LOG", "file.LOG", true];
+        yield return ["Build/", "build/output.dll", false];
+        yield return ["Build/", "Build/output.dll", true];
+    }
+
+    [Fact]
+    public void CaseInsensitiveWithSubdirectoryGitIgnore()
+    {
+        using var tempDir = new TempGitIgnoreDirectory();
+        tempDir.WriteFile(".gitignore", "Ignored.Props");
+        tempDir.WriteFile("src/ignored.props", "");
+        tempDir.WriteFile("src/Other.props", "");
+
+        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath, isCaseInsensitive: true);
+
+        // case-insensitive: "Ignored.Props" matches "ignored.props"
+        Assert.True(parser.IsIgnored("src/ignored.props"));
+        Assert.True(parser.IsIgnored("src/IGNORED.PROPS"));
+        Assert.False(parser.IsIgnored("src/Other.props"));
     }
 
     /// <summary>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/GitIgnoreParserTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/GitIgnoreParserTests.cs
@@ -1,0 +1,212 @@
+using NuGetUpdater.Core.Utilities;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Utilities;
+
+public class GitIgnoreParserTests
+{
+    [Theory]
+    [MemberData(nameof(BasicPatternMatchingData))]
+    public void BasicPatternMatching(string gitignoreContent, string testPath, bool expectedIgnored)
+    {
+        var parser = CreateParserFromContent(gitignoreContent, pathPrefix: "");
+        Assert.Equal(expectedIgnored, parser.IsIgnored(testPath));
+    }
+
+    public static IEnumerable<object[]> BasicPatternMatchingData()
+    {
+        // exact file name match
+        yield return ["file.txt", "file.txt", true];
+        yield return ["file.txt", "other.txt", false];
+
+        // unrooted pattern matches at any depth
+        yield return ["*.log", "debug.log", true];
+        yield return ["*.log", "src/debug.log", true];
+        yield return ["*.log", "src/deep/nested/debug.log", true];
+        yield return ["*.log", "debug.txt", false];
+
+        // pattern containing a slash is anchored relative to .gitignore location (per git spec)
+        yield return ["src/file.txt", "src/file.txt", true];
+        yield return ["src/file.txt", "other/src/file.txt", false];
+
+        // wildcard in middle of pattern
+        yield return ["doc/*.txt", "doc/readme.txt", true];
+        yield return ["doc/*.txt", "doc/sub/readme.txt", false];
+
+        // double star matches across directories
+        yield return ["**/logs", "logs", true];
+        yield return ["**/logs", "src/logs", true];
+        yield return ["**/logs", "src/deep/logs", true];
+
+        // double star in middle
+        yield return ["src/**/file.txt", "src/file.txt", true];
+        yield return ["src/**/file.txt", "src/a/file.txt", true];
+        yield return ["src/**/file.txt", "src/a/b/file.txt", true];
+
+        // question mark matches single char
+        yield return ["file?.txt", "file1.txt", true];
+        yield return ["file?.txt", "fileAB.txt", false];
+
+        // directory-only pattern (trailing slash)
+        yield return ["build/", "build/output.dll", true];
+        yield return ["build/", "src/build/output.dll", true];
+
+        // comment lines are ignored
+        yield return ["# this is a comment\n*.log", "debug.log", true];
+        yield return ["# this is a comment\n*.log", "# this is a comment", false];
+
+        // blank lines are ignored
+        yield return ["\n\n*.log\n\n", "debug.log", true];
+    }
+
+    [Theory]
+    [MemberData(nameof(NegationPatternData))]
+    public void NegationPatterns(string gitignoreContent, string testPath, bool expectedIgnored)
+    {
+        var parser = CreateParserFromContent(gitignoreContent, pathPrefix: "");
+        Assert.Equal(expectedIgnored, parser.IsIgnored(testPath));
+    }
+
+    public static IEnumerable<object[]> NegationPatternData()
+    {
+        // negation re-includes a previously excluded file
+        yield return ["*.log\n!important.log", "debug.log", true];
+        yield return ["*.log\n!important.log", "important.log", false];
+
+        // negation only applies if previously matched
+        yield return ["!random.txt", "random.txt", false];
+
+        // order matters: last matching rule wins
+        yield return ["*.log\n!important.log\n*.log", "important.log", true];
+    }
+
+    [Fact]
+    public void GitIgnoreInSubdirectory_OnlyAffectsFilesUnderThatDirectory()
+    {
+        using var tempDir = new TempGitIgnoreDirectory();
+        tempDir.WriteFile(".gitignore", "root-ignored.txt");
+        tempDir.WriteFile("src/.gitignore", "sub-ignored.txt");
+        // create the actual files so directory enumeration works
+        tempDir.WriteFile("root-ignored.txt", "");
+        tempDir.WriteFile("other.txt", "");
+        tempDir.WriteFile("src/sub-ignored.txt", "");
+        tempDir.WriteFile("src/kept.txt", "");
+        tempDir.WriteFile("lib/sub-ignored.txt", "");
+
+        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath);
+
+        // root .gitignore applies everywhere (unrooted pattern)
+        Assert.True(parser.IsIgnored("root-ignored.txt"));
+        Assert.True(parser.IsIgnored("src/root-ignored.txt"));
+
+        // src/.gitignore applies under src/
+        Assert.True(parser.IsIgnored("src/sub-ignored.txt"));
+
+        // src/.gitignore should NOT affect lib/ (pattern is prefixed with src/)
+        Assert.False(parser.IsIgnored("lib/sub-ignored.txt"));
+
+        // non-ignored files remain accessible
+        Assert.False(parser.IsIgnored("other.txt"));
+        Assert.False(parser.IsIgnored("src/kept.txt"));
+    }
+
+    [Fact]
+    public void MultipleGitIgnoreFilesAtDifferentLevels()
+    {
+        using var tempDir = new TempGitIgnoreDirectory();
+        tempDir.WriteFile(".gitignore", "*.tmp");
+        tempDir.WriteFile("src/.gitignore", "generated/");
+        tempDir.WriteFile("src/app/.gitignore", "local.config");
+        // create dirs so enumeration works
+        tempDir.WriteFile("src/app/local.config", "");
+        tempDir.WriteFile("src/generated/output.cs", "");
+        tempDir.WriteFile("docs/notes.tmp", "");
+
+        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath);
+
+        // root pattern *.tmp applies at any depth
+        Assert.True(parser.IsIgnored("docs/notes.tmp"));
+        Assert.True(parser.IsIgnored("src/app/cache.tmp"));
+
+        // src/.gitignore: "generated/" directory pattern
+        Assert.True(parser.IsIgnored("src/generated/output.cs"));
+        Assert.False(parser.IsIgnored("docs/generated/output.cs"));
+
+        // src/app/.gitignore: "local.config" unrooted
+        Assert.True(parser.IsIgnored("src/app/local.config"));
+        Assert.False(parser.IsIgnored("src/local.config"));
+    }
+
+    [Fact]
+    public void RootedPatternInSubdirectoryGitIgnore()
+    {
+        using var tempDir = new TempGitIgnoreDirectory();
+        // A rooted pattern (contains /) in a subdirectory .gitignore
+        tempDir.WriteFile("lib/.gitignore", "obj/debug.dll");
+        tempDir.WriteFile("lib/obj/debug.dll", "");
+        tempDir.WriteFile("lib/obj/release.dll", "");
+
+        var parser = GitIgnoreParser.FromRepoRoot(tempDir.RootPath);
+
+        Assert.True(parser.IsIgnored("lib/obj/debug.dll"));
+        Assert.False(parser.IsIgnored("lib/obj/release.dll"));
+        // should not match in other directories
+        Assert.False(parser.IsIgnored("src/obj/debug.dll"));
+    }
+
+    [Fact]
+    public void CharacterClassPatterns()
+    {
+        var parser = CreateParserFromContent("[Bb]uild/", pathPrefix: "");
+        Assert.True(parser.IsIgnored("Build/output.dll"));
+        Assert.True(parser.IsIgnored("build/output.dll"));
+        Assert.False(parser.IsIgnored("rebuild/output.dll"));
+    }
+
+    [Fact]
+    public void PatternWithLeadingSlashIsRooted()
+    {
+        // leading slash means pattern is rooted relative to gitignore location
+        var parser = CreateParserFromContent("/build\n/dist", pathPrefix: "");
+        Assert.True(parser.IsIgnored("build"));
+        Assert.True(parser.IsIgnored("build/output.dll"));
+        Assert.True(parser.IsIgnored("dist"));
+        Assert.False(parser.IsIgnored("src/build"));
+        Assert.False(parser.IsIgnored("src/dist"));
+    }
+
+    private static GitIgnoreParser CreateParserFromContent(string content, string pathPrefix)
+    {
+        // Use a temp directory with just the gitignore content at the root
+        using var tempDir = new TempGitIgnoreDirectory();
+        tempDir.WriteFile(".gitignore", content);
+        return GitIgnoreParser.FromRepoRoot(tempDir.RootPath);
+    }
+
+    /// <summary>
+    /// Helper to create a temporary directory structure for testing GitIgnoreParser.
+    /// </summary>
+    private sealed class TempGitIgnoreDirectory : IDisposable
+    {
+        public string RootPath { get; }
+
+        public TempGitIgnoreDirectory()
+        {
+            RootPath = Path.Combine(Path.GetTempPath(), $"gitignore-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(RootPath);
+        }
+
+        public void WriteFile(string relativePath, string content)
+        {
+            var fullPath = Path.Combine(RootPath, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            File.WriteAllText(fullPath, content);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(RootPath, true); } catch { }
+        }
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -140,7 +140,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         }
 
         // filter out imported files that are in .gitignore
-        projectResults = FilterImportedFilesByGitIgnore(projectResults, repoRootPath, initialWorkspacePath);
+        projectResults = FilterImportedFilesByGitIgnore(projectResults, repoRootPath, initialWorkspacePath, _experimentsManager.UseCaseInsensitiveFilesystem);
 
         // if any projectResults are not successful, return a failed result
         if (projectResults.Any(p => p.IsSuccess == false))
@@ -570,9 +570,10 @@ public partial class DiscoveryWorker : IDiscoveryWorker
     internal static ImmutableArray<ProjectDiscoveryResult> FilterImportedFilesByGitIgnore(
         ImmutableArray<ProjectDiscoveryResult> projectResults,
         string repoRootPath,
-        string workspacePath)
+        string workspacePath,
+        bool isCaseInsensitive)
     {
-        var gitIgnoreParser = GitIgnoreParser.FromRepoRoot(repoRootPath);
+        var gitIgnoreParser = GitIgnoreParser.FromRepoRoot(repoRootPath, isCaseInsensitive);
         var results = new List<ProjectDiscoveryResult>();
         foreach (var project in projectResults)
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -139,6 +139,9 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             }
         }
 
+        // filter out imported files that are in .gitignore
+        projectResults = FilterImportedFilesByGitIgnore(projectResults, repoRootPath, initialWorkspacePath);
+
         // if any projectResults are not successful, return a failed result
         if (projectResults.Any(p => p.IsSuccess == false))
         {
@@ -562,6 +565,31 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         }
 
         return [.. filtered];
+    }
+
+    internal static ImmutableArray<ProjectDiscoveryResult> FilterImportedFilesByGitIgnore(
+        ImmutableArray<ProjectDiscoveryResult> projectResults,
+        string repoRootPath,
+        string workspacePath)
+    {
+        var gitIgnoreParser = GitIgnoreParser.FromRepoRoot(repoRootPath);
+        var results = new List<ProjectDiscoveryResult>();
+        foreach (var project in projectResults)
+        {
+            var projectDirectory = Path.GetDirectoryName(Path.Combine(workspacePath, project.FilePath))?.NormalizePathToUnix() ?? workspacePath;
+            var filteredImports = project.ImportedFiles
+                .Where(importedFile =>
+                {
+                    // Resolve the imported file path relative to the repo root
+                    var fullRelativePath = PathHelper.JoinPath(projectDirectory, importedFile).NormalizePathToUnix().NormalizeUnixPathParts();
+                    return !gitIgnoreParser.IsIgnored(fullRelativePath);
+                })
+                .ToImmutableArray();
+
+            results.Add(project with { ImportedFiles = filteredImports });
+        }
+
+        return [.. results];
     }
 
     private static ImmutableDictionary<string, ImmutableArray<string>> MergeDependencyGraphs(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/ExperimentsManager.cs
@@ -9,6 +9,7 @@ public record ExperimentsManager
 {
     public bool GenerateSimplePrBody { get; init; } = false;
     public bool FindRootDirectory { get; init; } = false;
+    public bool UseCaseInsensitiveFilesystem { get; init; } = false;
 
     public Dictionary<string, object> ToDictionary()
     {
@@ -16,6 +17,7 @@ public record ExperimentsManager
         {
             ["nuget_generate_simple_pr_body"] = GenerateSimplePrBody,
             ["nuget_find_root_directory"] = FindRootDirectory,
+            ["use_case_insensitive_filesystem"] = UseCaseInsensitiveFilesystem,
         };
     }
 
@@ -25,6 +27,7 @@ public record ExperimentsManager
         {
             GenerateSimplePrBody = IsEnabled(experiments, "nuget_generate_simple_pr_body"),
             FindRootDirectory = IsEnabled(experiments, "nuget_find_root_directory"),
+            UseCaseInsensitiveFilesystem = IsEnabled(experiments, "use_case_insensitive_filesystem"),
         };
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/GitIgnoreParser.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/GitIgnoreParser.cs
@@ -13,12 +13,14 @@ internal class GitIgnoreParser
     }
 
     /// <summary>
-    /// Collects all .gitignore files from the repo root up to and including the directory containing the file being tested.
+    /// Collects all .gitignore files from the entire repo directory tree and builds a parser that can evaluate ignore rules.
     /// </summary>
-    public static GitIgnoreParser FromRepoRoot(string repoRootPath)
+    /// <param name="repoRootPath">The absolute path to the repository root.</param>
+    /// <param name="isCaseInsensitive">Whether the filesystem is case-insensitive (e.g., Windows/macOS).</param>
+    public static GitIgnoreParser FromRepoRoot(string repoRootPath, bool isCaseInsensitive)
     {
         var rules = new List<GitIgnoreRule>();
-        CollectRulesFromDirectory(repoRootPath, repoRootPath, rules);
+        CollectRulesFromDirectory(repoRootPath, repoRootPath, rules, isCaseInsensitive);
         return new GitIgnoreParser([.. rules]);
     }
 
@@ -42,7 +44,7 @@ internal class GitIgnoreParser
         return ignored;
     }
 
-    private static void CollectRulesFromDirectory(string repoRootPath, string currentDirectory, List<GitIgnoreRule> rules)
+    private static void CollectRulesFromDirectory(string repoRootPath, string currentDirectory, List<GitIgnoreRule> rules, bool isCaseInsensitive)
     {
         var gitignorePath = Path.Combine(currentDirectory, ".gitignore");
         if (File.Exists(gitignorePath))
@@ -50,12 +52,18 @@ internal class GitIgnoreParser
             var content = File.ReadAllText(gitignorePath);
             var directoryRelativeToRoot = Path.GetRelativePath(repoRootPath, currentDirectory).NormalizePathToUnix();
             var prefix = directoryRelativeToRoot == "." ? "" : directoryRelativeToRoot + "/";
-            var parsed = ParseRules(content, prefix);
+            var parsed = ParseRules(content, prefix, isCaseInsensitive);
             rules.AddRange(parsed);
         }
 
         // Recurse into subdirectories
-        foreach (var subDir in Directory.EnumerateDirectories(currentDirectory))
+        var enumOptions = new EnumerationOptions
+        {
+            IgnoreInaccessible = true,
+            RecurseSubdirectories = false,
+            AttributesToSkip = FileAttributes.ReparsePoint,
+        };
+        foreach (var subDir in Directory.EnumerateDirectories(currentDirectory, "*", enumOptions))
         {
             var dirName = Path.GetFileName(subDir);
             if (dirName == ".git")
@@ -63,11 +71,11 @@ internal class GitIgnoreParser
                 continue;
             }
 
-            CollectRulesFromDirectory(repoRootPath, subDir, rules);
+            CollectRulesFromDirectory(repoRootPath, subDir, rules, isCaseInsensitive);
         }
     }
 
-    internal static ImmutableArray<GitIgnoreRule> ParseRules(string content, string pathPrefix)
+    internal static ImmutableArray<GitIgnoreRule> ParseRules(string content, string pathPrefix, bool isCaseInsensitive)
     {
         var rules = new List<GitIgnoreRule>();
         foreach (var rawLine in content.Split('\n'))
@@ -87,7 +95,7 @@ internal class GitIgnoreParser
                 line = line[1..];
             }
 
-            // remove trailing spaces (unless escaped)
+            // remove trailing spaces
             line = line.TrimEnd();
 
             if (string.IsNullOrEmpty(line))
@@ -113,7 +121,7 @@ internal class GitIgnoreParser
             // Otherwise it matches at any depth within the .gitignore's directory scope.
             bool isRooted = hasLeadingSlash || line.Contains('/');
 
-            var regex = ConvertPatternToRegex(line, isRooted, directoryOnly, pathPrefix);
+            var regex = ConvertPatternToRegex(line, isRooted, directoryOnly, pathPrefix, isCaseInsensitive);
 
             rules.Add(new GitIgnoreRule(regex, isNegation, directoryOnly));
         }
@@ -121,7 +129,7 @@ internal class GitIgnoreParser
         return [.. rules];
     }
 
-    private static Regex ConvertPatternToRegex(string pattern, bool isRooted, bool directoryOnly, string pathPrefix)
+    private static Regex ConvertPatternToRegex(string pattern, bool isRooted, bool directoryOnly, string pathPrefix, bool isCaseInsensitive)
     {
         // Convert gitignore glob pattern to regex
         var regexPattern = "^";
@@ -152,6 +160,15 @@ internal class GitIgnoreParser
             char c = pattern[i];
             switch (c)
             {
+                case '\\':
+                    // backslash escapes the next character in gitignore
+                    if (i + 1 < pattern.Length)
+                    {
+                        i++;
+                        regexPattern += Regex.Escape(pattern[i].ToString());
+                    }
+
+                    break;
                 case '*':
                     if (i + 1 < pattern.Length && pattern[i + 1] == '*')
                     {
@@ -177,17 +194,6 @@ internal class GitIgnoreParser
                 case '?':
                     regexPattern += "[^/]";
                     break;
-                case '.':
-                case '(':
-                case ')':
-                case '+':
-                case '|':
-                case '^':
-                case '$':
-                case '{':
-                case '}':
-                    regexPattern += "\\" + c;
-                    break;
                 case '[':
                     // character class - pass through to regex
                     var end = pattern.IndexOf(']', i);
@@ -203,7 +209,7 @@ internal class GitIgnoreParser
 
                     break;
                 default:
-                    regexPattern += c;
+                    regexPattern += Regex.Escape(c.ToString());
                     break;
             }
         }
@@ -218,7 +224,13 @@ internal class GitIgnoreParser
             regexPattern += "/.*$";
         }
 
-        return new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        var options = RegexOptions.Compiled;
+        if (isCaseInsensitive)
+        {
+            options |= RegexOptions.IgnoreCase;
+        }
+
+        return new Regex(regexPattern, options);
     }
 
     internal record GitIgnoreRule(Regex Pattern, bool IsNegation, bool DirectoryOnly)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/GitIgnoreParser.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/GitIgnoreParser.cs
@@ -1,0 +1,231 @@
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace NuGetUpdater.Core.Utilities;
+
+internal class GitIgnoreParser
+{
+    private readonly ImmutableArray<GitIgnoreRule> _rules;
+
+    private GitIgnoreParser(ImmutableArray<GitIgnoreRule> rules)
+    {
+        _rules = rules;
+    }
+
+    /// <summary>
+    /// Collects all .gitignore files from the repo root up to and including the directory containing the file being tested.
+    /// </summary>
+    public static GitIgnoreParser FromRepoRoot(string repoRootPath)
+    {
+        var rules = new List<GitIgnoreRule>();
+        CollectRulesFromDirectory(repoRootPath, repoRootPath, rules);
+        return new GitIgnoreParser([.. rules]);
+    }
+
+    /// <summary>
+    /// Determines if a path (relative to the repo root, using unix-style separators) is ignored by any .gitignore rule.
+    /// </summary>
+    public bool IsIgnored(string relativePath)
+    {
+        relativePath = relativePath.NormalizePathToUnix().TrimStart('/');
+
+        // Process rules in order; later rules can override earlier ones (negation patterns)
+        bool ignored = false;
+        foreach (var rule in _rules)
+        {
+            if (rule.IsMatch(relativePath))
+            {
+                ignored = !rule.IsNegation;
+            }
+        }
+
+        return ignored;
+    }
+
+    private static void CollectRulesFromDirectory(string repoRootPath, string currentDirectory, List<GitIgnoreRule> rules)
+    {
+        var gitignorePath = Path.Combine(currentDirectory, ".gitignore");
+        if (File.Exists(gitignorePath))
+        {
+            var content = File.ReadAllText(gitignorePath);
+            var directoryRelativeToRoot = Path.GetRelativePath(repoRootPath, currentDirectory).NormalizePathToUnix();
+            var prefix = directoryRelativeToRoot == "." ? "" : directoryRelativeToRoot + "/";
+            var parsed = ParseRules(content, prefix);
+            rules.AddRange(parsed);
+        }
+
+        // Recurse into subdirectories
+        foreach (var subDir in Directory.EnumerateDirectories(currentDirectory))
+        {
+            var dirName = Path.GetFileName(subDir);
+            if (dirName == ".git")
+            {
+                continue;
+            }
+
+            CollectRulesFromDirectory(repoRootPath, subDir, rules);
+        }
+    }
+
+    internal static ImmutableArray<GitIgnoreRule> ParseRules(string content, string pathPrefix)
+    {
+        var rules = new List<GitIgnoreRule>();
+        foreach (var rawLine in content.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r').TrimEnd();
+
+            // skip empty lines and comments
+            if (string.IsNullOrWhiteSpace(line) || line.StartsWith('#'))
+            {
+                continue;
+            }
+
+            bool isNegation = false;
+            if (line.StartsWith('!'))
+            {
+                isNegation = true;
+                line = line[1..];
+            }
+
+            // remove trailing spaces (unless escaped)
+            line = line.TrimEnd();
+
+            if (string.IsNullOrEmpty(line))
+            {
+                continue;
+            }
+
+            bool directoryOnly = line.EndsWith('/');
+            if (directoryOnly)
+            {
+                line = line.TrimEnd('/');
+            }
+
+            // A leading slash means "rooted at the .gitignore location"
+            bool hasLeadingSlash = line.StartsWith('/');
+            if (hasLeadingSlash)
+            {
+                line = line[1..];
+            }
+
+            // If the pattern contains a slash (not at the end) or has a leading slash,
+            // it's relative to the .gitignore location.
+            // Otherwise it matches at any depth within the .gitignore's directory scope.
+            bool isRooted = hasLeadingSlash || line.Contains('/');
+
+            var regex = ConvertPatternToRegex(line, isRooted, directoryOnly, pathPrefix);
+
+            rules.Add(new GitIgnoreRule(regex, isNegation, directoryOnly));
+        }
+
+        return [.. rules];
+    }
+
+    private static Regex ConvertPatternToRegex(string pattern, bool isRooted, bool directoryOnly, string pathPrefix)
+    {
+        // Convert gitignore glob pattern to regex
+        var regexPattern = "^";
+
+        if (isRooted)
+        {
+            // Rooted patterns are anchored at the .gitignore directory
+            if (!string.IsNullOrEmpty(pathPrefix))
+            {
+                regexPattern += Regex.Escape(pathPrefix);
+            }
+        }
+        else
+        {
+            // Unrooted patterns match at any depth within the .gitignore directory scope
+            if (!string.IsNullOrEmpty(pathPrefix))
+            {
+                regexPattern += Regex.Escape(pathPrefix) + "(.*/)?";
+            }
+            else
+            {
+                regexPattern += "(.*/)?";
+            }
+        }
+
+        for (int i = 0; i < pattern.Length; i++)
+        {
+            char c = pattern[i];
+            switch (c)
+            {
+                case '*':
+                    if (i + 1 < pattern.Length && pattern[i + 1] == '*')
+                    {
+                        // ** matches everything including /
+                        if (i + 2 < pattern.Length && pattern[i + 2] == '/')
+                        {
+                            regexPattern += "(.*/)?";
+                            i += 2;
+                        }
+                        else
+                        {
+                            regexPattern += ".*";
+                            i++;
+                        }
+                    }
+                    else
+                    {
+                        // * matches everything except /
+                        regexPattern += "[^/]*";
+                    }
+
+                    break;
+                case '?':
+                    regexPattern += "[^/]";
+                    break;
+                case '.':
+                case '(':
+                case ')':
+                case '+':
+                case '|':
+                case '^':
+                case '$':
+                case '{':
+                case '}':
+                    regexPattern += "\\" + c;
+                    break;
+                case '[':
+                    // character class - pass through to regex
+                    var end = pattern.IndexOf(']', i);
+                    if (end > i)
+                    {
+                        regexPattern += pattern[i..(end + 1)];
+                        i = end;
+                    }
+                    else
+                    {
+                        regexPattern += "\\[";
+                    }
+
+                    break;
+                default:
+                    regexPattern += c;
+                    break;
+            }
+        }
+
+        if (!directoryOnly)
+        {
+            // Pattern can match a file directly or a directory prefix
+            regexPattern += "(/.*)?$";
+        }
+        else
+        {
+            regexPattern += "/.*$";
+        }
+
+        return new Regex(regexPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    }
+
+    internal record GitIgnoreRule(Regex Pattern, bool IsNegation, bool DirectoryOnly)
+    {
+        public bool IsMatch(string path)
+        {
+            return Pattern.IsMatch(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

NuGet dependency discovery should not report any files that are in a \.gitignore\ file. This PR filters the \ImportedFiles\ property of \ProjectDiscoveryResult\ to remove any file matched by a relevant \.gitignore\ file.

## Changes

- **\GitIgnoreParser.cs\** — New utility that recursively collects \.gitignore\ files from the repo root and evaluates gitignore patterns (globs, negation, directory-only rules, rooted vs unrooted, subdirectory scoping).
- **\DiscoveryWorker.cs\** — Added \FilterImportedFilesByGitIgnore\ step after submodule filtering to remove ignored files from each project's \ImportedFiles\.
- **\GitIgnoreParserTests.cs\** — 32 unit tests covering pattern matching, negation, subdirectory scoping, multi-level \.gitignore\ files, and edge cases.
- **\DiscoveryWorkerTests.cs\** — Integration test verifying end-to-end filtering in discovery.