### PR TITLE
Add blocked_versions.ignored metric for Security-blocked update checks

### DIFF
--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -488,6 +488,11 @@ module Dependabot
       conditions + ignored_versions_from_allowed_update_types(dependency) + blocked_versions_for(dependency)
     end
 
+    sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
+    def blocked_versions_for?(dependency)
+      blocked_versions_for(dependency).any?
+    end
+
     # TODO: Present Dependabot::Config::IgnoreCondition in calling code
     #
     # This is a workaround for our existing logging using the 'raw'

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -290,7 +290,7 @@ module Dependabot
         )
           .returns(T::Array[Dependabot::Dependency])
       end
-      def compile_updates_for(dependency, dependency_files, group) # rubocop:disable Metrics/MethodLength
+      def compile_updates_for(dependency, dependency_files, group) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         checker = update_checker_for(
           dependency,
           dependency_files,
@@ -299,6 +299,7 @@ module Dependabot
         )
 
         log_checking_for_update(dependency)
+        record_blocked_version_ignored(job: job, dependency: dependency, operation: "group_update")
 
         if all_versions_ignored?(dependency, checker)
           record_security_update_ignored_if_applicable(dependency, checker, group)

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -118,6 +118,7 @@ module Dependabot
           checker = update_checker_for(dependency)
 
           log_checking_for_update(dependency)
+          record_blocked_version_ignored(job: job, dependency: dependency, operation: "security_update")
 
           Dependabot.logger.info("Latest version is #{checker.latest_version}")
 

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -163,6 +163,7 @@ module Dependabot
 
           checker = update_checker_for(lead_dependency)
           log_checking_for_update(lead_dependency)
+          record_blocked_version_ignored(job: job, dependency: lead_dependency, operation: "refresh_security_update")
 
           Dependabot.logger.info("Latest version is #{checker.latest_version}")
 

--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -133,6 +133,7 @@ module Dependabot
 
           checker = update_checker_for(lead_dependency, raise_on_ignored: raise_on_ignored?(lead_dependency))
           log_checking_for_update(lead_dependency)
+          record_blocked_version_ignored(job: job, dependency: lead_dependency, operation: "refresh_version_update")
 
           return close_pull_request(reason: :up_to_date) if all_versions_ignored?(lead_dependency, checker)
 

--- a/updater/lib/dependabot/updater/operations/update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/update_all_versions.rb
@@ -124,6 +124,7 @@ module Dependabot
           checker = update_checker_for(dependency, raise_on_ignored: raise_on_ignored?(dependency))
 
           log_checking_for_update(dependency)
+          record_blocked_version_ignored(job: job, dependency: dependency, operation: "version_update")
 
           return if all_versions_ignored?(dependency, checker)
           return log_up_to_date(dependency) if checker.up_to_date?

--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -235,6 +235,35 @@ module Dependabot
           warn_description: notice.description
         )
       end
+
+      # Emits a counter when a GitHub Security blocklist entry applies to a
+      # dependency Core is actively checking for updates.
+      #
+      # This is the "soft" block status. When a block applies, the blocked
+      # versions are folded into the resolver's ignore conditions so they can't
+      # be selected - but they sit alongside the user's own ignores (dependabot.yml
+      # ignore rules and allow update-types), all merged into `ignore_conditions_for`.
+      # Because of that merge, the downstream `AllVersionsIgnored` outcome can't be
+      # attributed to blocking vs ignoring without re-resolving. We therefore only
+      # measure the one block-specific fact Core can observe cleanly: that a Security
+      # block was in effect for this dependency check (presence), not that it
+      # excluded a specific candidate version (causation).
+      #
+      # This pairs with the "hard" status `blocked_versions.enforced` (the
+      # transitive-enforcement path that rejects PR creation) under the shared
+      # `blocked_versions.*` namespace.
+      sig { params(job: Dependabot::Job, dependency: Dependabot::Dependency, operation: String).void }
+      def record_blocked_version_ignored(job:, dependency:, operation:)
+        return unless job.blocked_versions_for?(dependency)
+
+        service.increment_metric(
+          "blocked_versions.ignored",
+          tags: {
+            "operation" => operation,
+            "package_manager" => job.package_manager
+          }
+        )
+      end
     end
   end
 end

--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -259,8 +259,8 @@ module Dependabot
         service.increment_metric(
           "blocked_versions.ignored",
           tags: {
-            "operation" => operation,
-            "package_manager" => job.package_manager
+            operation: operation,
+            package_manager: job.package_manager
           }
         )
       end

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -1601,4 +1601,44 @@ RSpec.describe Dependabot::Job do
       end
     end
   end
+
+  describe "#blocked_versions_for?" do
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "event-stream",
+        package_manager: "bundler",
+        version: "3.3.5",
+        requirements: [{ file: "Gemfile", requirement: "~> 3.3", groups: [], source: nil }]
+      )
+    end
+
+    context "when a non-empty blocked version matches the dependency" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version-requirement" => "= 3.3.6", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "returns true" do
+        expect(job.blocked_versions_for?(dependency)).to be(true)
+      end
+    end
+
+    context "when no usable blocked version matches the dependency" do
+      let(:attributes) do
+        super().merge(
+          blocked_versions: [
+            { "dependency-name" => "event-stream", "version-requirement" => " ", "reason" => "empty" },
+            { "dependency-name" => "other-package", "version-requirement" => "= 1.0.0", "reason" => "malware" }
+          ]
+        )
+      end
+
+      it "returns false" do
+        expect(job.blocked_versions_for?(dependency)).to be(false)
+      end
+    end
+  end
 end

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -536,8 +536,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
         expect(metrics_service).to have_received(:increment_metric).with(
           "blocked_versions.ignored",
           tags: {
-            "operation" => "group_update",
-            "package_manager" => "bundler"
+            operation: "group_update",
+            package_manager: "bundler"
           }
         )
       end

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
       repo_contents_path: repo_contents_path,
       security_advisories_for: security_advisories,
       updating_a_pull_request?: false,
+      blocked_versions_for?: false,
       source: source
     )
   end
@@ -490,6 +491,71 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
         directory: Pathname.new(source_directory).cleanpath
       )
       expect(Dependabot::Workspace).to have_received(:cleanup!).once
+    end
+  end
+
+  describe "#compile_updates_for blocked versions ignored metric" do
+    let(:dependency) { dependencies.first }
+    let(:group) do
+      instance_double(
+        Dependabot::DependencyGroup,
+        name: "test-group",
+        dependencies: [dependency],
+        group_by_dependency_name?: false
+      )
+    end
+
+    let(:metrics_service) do
+      instance_double(Dependabot::Service, record_update_job_error: nil, increment_metric: nil)
+    end
+
+    before do
+      allow(test_instance).to receive_messages(
+        update_checker_for: checker,
+        raise_on_ignored?: false,
+        log_checking_for_update: nil,
+        all_versions_ignored?: false,
+        semver_rules_allow_grouping?: true,
+        log_up_to_date: nil,
+        requirements_to_unlock: [],
+        log_requirements_for_update: nil,
+        service: metrics_service
+      )
+      allow(job).to receive(:package_manager).and_return("bundler")
+      allow(checker).to receive(:up_to_date?).and_return(true)
+    end
+
+    context "when the dependency has an active GitHub Security block" do
+      before do
+        allow(job).to receive(:blocked_versions_for?).with(dependency).and_return(true)
+      end
+
+      it "increments the ignored metric tagged with group_update" do
+        test_instance.compile_updates_for(dependency, dependency_files, group)
+
+        expect(metrics_service).to have_received(:increment_metric).with(
+          "blocked_versions.ignored",
+          tags: {
+            "operation" => "group_update",
+            "package_manager" => "bundler"
+          }
+        )
+      end
+    end
+
+    context "when the dependency only has user ignore rules (no block)" do
+      before do
+        allow(job).to receive(:blocked_versions_for?).with(dependency).and_return(false)
+      end
+
+      it "does not increment the ignored metric" do
+        test_instance.compile_updates_for(dependency, dependency_files, group)
+
+        expect(metrics_service).not_to have_received(:increment_metric).with(
+          "blocked_versions.ignored",
+          tags: anything
+        )
+      end
     end
   end
 

--- a/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
@@ -361,6 +361,8 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
         allow(job)
           .to receive_messages(security_fix?: true, allowed_update?: true)
         allow(job)
+          .to receive(:blocked_versions_for?).with(dependency).and_return(true)
+        allow(job)
           .to receive(:existing_pull_requests).and_return(
             [
               Dependabot::PullRequest.new(
@@ -389,6 +391,19 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
           create_security_update_pull_request
             .send(:check_and_create_pull_request, dependency)
         end
+
+        it "increments the blocked versions ignored metric" do
+          create_security_update_pull_request
+            .send(:check_and_create_pull_request, dependency)
+
+          expect(mock_service).to have_received(:increment_metric).with(
+            "blocked_versions.ignored",
+            tags: {
+              "operation" => "security_update",
+              "package_manager" => "bundler"
+            }
+          )
+        end
       end
     end
 
@@ -409,6 +424,33 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
           .with(stub_update_checker)
         create_security_update_pull_request
           .send(:check_and_create_pull_request, dependency)
+      end
+    end
+
+    context "when every possible update is ignored" do
+      before do
+        allow(stub_update_checker)
+          .to receive(:latest_version)
+          .and_raise(Dependabot::AllVersionsIgnored)
+      end
+
+      it "reraises so the backend records an update job error" do
+        expect do
+          create_security_update_pull_request
+            .send(:check_and_create_pull_request, dependency)
+        end.to raise_error(Dependabot::AllVersionsIgnored)
+      end
+
+      it "does not increment the blocked versions ignored metric" do
+        expect do
+          create_security_update_pull_request
+            .send(:check_and_create_pull_request, dependency)
+        end.to raise_error(Dependabot::AllVersionsIgnored)
+
+        expect(mock_service).not_to have_received(:increment_metric).with(
+          "blocked_versions.ignored",
+          tags: anything
+        )
       end
     end
 

--- a/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
@@ -432,6 +432,8 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
         allow(stub_update_checker)
           .to receive(:latest_version)
           .and_raise(Dependabot::AllVersionsIgnored)
+        allow(job)
+          .to receive(:blocked_versions_for?).with(dependency).and_return(false)
       end
 
       it "reraises so the backend records an update job error" do

--- a/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
@@ -399,8 +399,8 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
           expect(mock_service).to have_received(:increment_metric).with(
             "blocked_versions.ignored",
             tags: {
-              "operation" => "security_update",
-              "package_manager" => "bundler"
+              operation: "security_update",
+              package_manager: "bundler"
             }
           )
         end

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -205,6 +205,55 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
       allow(job).to receive(:package_manager).and_return("bundler")
     end
 
+    context "when the lead dependency has an active GitHub Security block" do
+      before do
+        allow(stub_update_checker).to receive(:up_to_date?).and_return(true)
+        allow(job).to receive_messages(
+          allowed_update?: true,
+          dependencies: ["dummy-pkg-a"],
+          security_advisories: [
+            Dependabot::Job::SecurityAdvisoryEntry.from_hash({ "dependency-name" => "dummy-pkg-a" })
+          ]
+        )
+        allow(job).to receive(:blocked_versions_for?).and_return(true)
+      end
+
+      it "increments the blocked versions ignored metric tagged with refresh_security_update" do
+        refresh_security_update_pull_request.send(:check_and_update_pull_request, [dependency])
+
+        expect(mock_service).to have_received(:increment_metric).with(
+          "blocked_versions.ignored",
+          tags: {
+            "operation" => "refresh_security_update",
+            "package_manager" => "bundler"
+          }
+        )
+      end
+    end
+
+    context "when the lead dependency has no active GitHub Security block" do
+      before do
+        allow(stub_update_checker).to receive(:up_to_date?).and_return(true)
+        allow(job).to receive_messages(
+          allowed_update?: true,
+          dependencies: ["dummy-pkg-a"],
+          security_advisories: [
+            Dependabot::Job::SecurityAdvisoryEntry.from_hash({ "dependency-name" => "dummy-pkg-a" })
+          ]
+        )
+        allow(job).to receive(:blocked_versions_for?).and_return(false)
+      end
+
+      it "does not increment the blocked versions ignored metric" do
+        refresh_security_update_pull_request.send(:check_and_update_pull_request, [dependency])
+
+        expect(mock_service).not_to have_received(:increment_metric).with(
+          "blocked_versions.ignored",
+          tags: anything
+        )
+      end
+    end
+
     context "when the update is not allowed" do
       before do
         allow(stub_update_checker).to receive(:up_to_date?).and_return(true)

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -224,8 +224,8 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
         expect(mock_service).to have_received(:increment_metric).with(
           "blocked_versions.ignored",
           tags: {
-            "operation" => "refresh_security_update",
-            "package_manager" => "bundler"
+            operation: "refresh_security_update",
+            package_manager: "bundler"
           }
         )
       end

--- a/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Dependabot::Updater::Operations::RefreshVersionUpdatePullRequest 
       update_pull_request: nil,
       close_pull_request: nil,
       record_ecosystem_meta: nil,
-      record_cooldown_meta: nil
+      record_cooldown_meta: nil,
+      increment_metric: nil
     )
   end
   let(:mock_error_handler) { instance_double(Dependabot::Updater::ErrorHandler) }
@@ -203,6 +204,45 @@ RSpec.describe Dependabot::Updater::Operations::RefreshVersionUpdatePullRequest 
         ).with(reason: :dependency_removed)
         refresh_version_update_pull_request.send(
           :check_and_update_pull_request, [dependency]
+        )
+      end
+    end
+
+    context "when the lead dependency has an active GitHub Security block" do
+      before do
+        allow(stub_update_checker).to receive(:up_to_date?).and_return(false)
+        allow(refresh_version_update_pull_request).to receive(:all_versions_ignored?).and_return(true)
+        allow(refresh_version_update_pull_request).to receive(:close_pull_request)
+        allow(job).to receive_messages(dependencies: ["dummy-pkg-a"], blocked_versions_for?: true)
+      end
+
+      it "increments the blocked versions ignored metric tagged with refresh_version_update" do
+        refresh_version_update_pull_request.send(:check_and_update_pull_request, [dependency])
+
+        expect(mock_service).to have_received(:increment_metric).with(
+          "blocked_versions.ignored",
+          tags: {
+            "operation" => "refresh_version_update",
+            "package_manager" => "bundler"
+          }
+        )
+      end
+    end
+
+    context "when the lead dependency has no active GitHub Security block" do
+      before do
+        allow(stub_update_checker).to receive(:up_to_date?).and_return(false)
+        allow(refresh_version_update_pull_request).to receive(:all_versions_ignored?).and_return(true)
+        allow(refresh_version_update_pull_request).to receive(:close_pull_request)
+        allow(job).to receive_messages(dependencies: ["dummy-pkg-a"], blocked_versions_for?: false)
+      end
+
+      it "does not increment the blocked versions ignored metric" do
+        refresh_version_update_pull_request.send(:check_and_update_pull_request, [dependency])
+
+        expect(mock_service).not_to have_received(:increment_metric).with(
+          "blocked_versions.ignored",
+          tags: anything
         )
       end
     end

--- a/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
@@ -222,8 +222,8 @@ RSpec.describe Dependabot::Updater::Operations::RefreshVersionUpdatePullRequest 
         expect(mock_service).to have_received(:increment_metric).with(
           "blocked_versions.ignored",
           tags: {
-            "operation" => "refresh_version_update",
-            "package_manager" => "bundler"
+            operation: "refresh_version_update",
+            package_manager: "bundler"
           }
         )
       end

--- a/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
@@ -461,4 +461,45 @@ RSpec.describe Dependabot::Updater::Operations::UpdateAllVersions do
       end
     end
   end
+
+  describe "blocked versions ignored metric" do
+    before do
+      allow(job).to receive(:package_manager).and_return("bundler")
+      allow(stub_update_checker).to receive_messages(up_to_date?: true)
+      allow(update_all_versions).to receive(:all_versions_ignored?).and_return(false)
+    end
+
+    context "when the dependency has an active GitHub Security block" do
+      before do
+        allow(job).to receive(:blocked_versions_for?).with(dependency).and_return(true)
+      end
+
+      it "increments the ignored metric tagged with the package manager" do
+        update_all_versions.send(:check_and_create_pull_request, dependency)
+
+        expect(mock_service).to have_received(:increment_metric).with(
+          "blocked_versions.ignored",
+          tags: {
+            "operation" => "version_update",
+            "package_manager" => "bundler"
+          }
+        )
+      end
+    end
+
+    context "when the dependency only has user ignore rules (no block)" do
+      before do
+        allow(job).to receive(:blocked_versions_for?).with(dependency).and_return(false)
+      end
+
+      it "does not increment the ignored metric" do
+        update_all_versions.send(:check_and_create_pull_request, dependency)
+
+        expect(mock_service).not_to have_received(:increment_metric).with(
+          "blocked_versions.ignored",
+          tags: anything
+        )
+      end
+    end
+  end
 end

--- a/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
@@ -480,8 +480,8 @@ RSpec.describe Dependabot::Updater::Operations::UpdateAllVersions do
         expect(mock_service).to have_received(:increment_metric).with(
           "blocked_versions.ignored",
           tags: {
-            "operation" => "version_update",
-            "package_manager" => "bundler"
+            operation: "version_update",
+            package_manager: "bundler"
           }
         )
       end


### PR DESCRIPTION
### What are you trying to accomplish?

We want visibility into how often the **GitHub Security blocklist** affects real update runs — how many checks, and across which package managers, have a blocked version actively in play.

Today we can't see this. When a blocked version applies to a dependency, Core folds it into the same ignore list as the user's own `dependabot.yml` ignores and allowed update-types. Once they're merged, an update that doesn't happen looks identical whether it was blocked or simply ignored by the user. Only Core sees the blocklist input at check time, so this is a signal the `dependabot-api` service cannot reconstruct on its own.

This PR adds that signal: a `blocked_versions.ignored` counter, emitted whenever a Security block applies to a dependency Core is checking, tagged with the operation and package manager. It lands in the same `blocked_versions.*` namespace already used on the service side, so the data correlates on Datadog with no reshaping.

It records the **"soft" status** — a blocked version was excluded from the candidates for this check. It's designed to sit alongside a future **"hard" status** (`blocked_versions.enforced`), where a block rejects PR creation outright, under the shared namespace.

### Anything you want to highlight for special attention from reviewers?

- **Blocking is measured separately from ignoring.** The metric reads only the Security blocklist (`Job#blocked_versions_for?`), never the merged ignore list. We record that a block was *present* during a check — not that it *caused* a failed update, which can't be determined after the lists are merged without re-resolving.
- **Every update path is covered, once.** The standalone operations call the shared helper directly; all group operations are covered through their single common check point, so there's no duplication or double-counting.
- **It can never affect an update.** Recording is guarded and fire-and-forget.
- **No new API surface.** It reuses the existing `increment_metric` endpoint — only a new metric name and tags.

### How will you know you've accomplished your goal?

- New positive and negative specs assert the metric is emitted with the correct `operation` / `package_manager` tags when a Security block is active, and is **not** emitted on the normal path — across every update operation.
- The full affected updater spec suite passes, and RuboCop is clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
