### PR TITLE
Fix composer specs failure due to `block-insecure` feature

### DIFF
--- a/composer/helpers/v2/src/UpdateChecker.php
+++ b/composer/helpers/v2/src/UpdateChecker.php
@@ -38,6 +38,14 @@ final class UpdateChecker
 
         $config = $composer->getConfig();
 
+        $config->merge([
+            'config' => [
+                'audit' => [
+                    'block-insecure' => false,
+                ],
+            ],
+        ]);
+
         if (0 < count($httpBasicCredentials)) {
             $config->merge([
                 'config' => [

--- a/composer/helpers/v2/src/Updater.php
+++ b/composer/helpers/v2/src/Updater.php
@@ -52,6 +52,16 @@ final class Updater
             ];
         }
 
+        $config->merge(
+            [
+                'config' => [
+                    'audit' => [
+                        'block-insecure' => false,
+                    ],
+                ],
+            ]
+        );
+
         if ($httpBasicCredentials) {
             $config->merge(
                 [

--- a/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/version_resolver_spec.rb
@@ -170,6 +170,20 @@ RSpec.describe Dependabot::Composer::UpdateChecker::VersionResolver do
       it { is_expected.to be_nil }
     end
 
+    context "with a dependency that has insecure transitive dependencies" do
+      let(:project_name) { "insecure_transitive_dependency" }
+      let(:string_req) { "^6.5" }
+      let(:latest_allowable_version) { Gem::Version.new("7.0.0") }
+      let(:dependency_name) { "guzzlehttp/guzzle" }
+      let(:dependency_version) { "6.5.8" }
+
+      it "resolves despite transitive dependencies having security advisories" do
+        # Composer 2.9+ blocks packages with security advisories by default.
+        # Our helpers disable block-insecure so resolution still works.
+        expect { resolver.latest_resolvable_version }.not_to raise_error
+      end
+    end
+
     context "with a dependency that uses a stability flag" do
       let(:project_name) { "stability_flag" }
       let(:string_req) { "@stable" }

--- a/composer/spec/fixtures/projects/insecure_transitive_dependency/composer.json
+++ b/composer/spec/fixtures/projects/insecure_transitive_dependency/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "dependabot/insecure-transitive-dependency",
+    "type": "project",
+    "license": "MIT",
+    "require": {
+        "php": ">=7.4",
+        "guzzlehttp/guzzle": "^6.5"
+    },
+    "minimum-stability": "stable"
+}


### PR DESCRIPTION
### What are you trying to accomplish?
Composer 2.9.5 introduced a `block-insecure` feature that prevents packages with known security advisories from being loaded into the dependency resolver pool. This causes resolution failures for projects depending on packages with CVEs (e.g., `guzzlehttp/psr7` 1.9.x).

Dependabot handles security updates through its own security advisories mechanism, so the Composer-level blocking is unnecessary and breaks normal dependency resolution.

This disables `block-insecure` via config in both `UpdateChecker.php` and `Updater.php`.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
- `setAudit(false)` was already set on both helpers, but that only disables the post-install audit report — it does **not** prevent `block-insecure` from rejecting packages at the resolver level.
- The fix uses `$config->merge()` with `'audit' => ['block-insecure' => false]` which is the Composer-supported way to disable this behavior programmatically.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
The failing test `Dependabot::Composer::UpdateChecker::VersionResolver latest_resolvable_version with a dependency that's provided by another dep` should pass in CI.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
