### PR TITLE
Bump bundled npm from 11.8.0 to 11.17.0

### DIFF
--- a/npm_and_yarn/Dockerfile
+++ b/npm_and_yarn/Dockerfile
@@ -21,7 +21,7 @@ ARG NODEJS_VERSION=24
 # Check for updates at https://github.com/npm/cli/releases
 # This version should be aligned with NODEJS_VERSION version declared above. See https://nodejs.org/en/download/releases as well
 # With every major release update, also update npm_and_yarn/lib/dependabot/npm_and_yarn/npm_package_manager.rb (Section : Update instructions)
-ARG NPM_VERSION=11.8.0
+ARG NPM_VERSION=11.17.0
 
 # Install Node and npm
 RUN mkdir -p /etc/apt/keyrings \


### PR DESCRIPTION
### What are you trying to accomplish?

Bump the npm version bundled in the `npm_and_yarn` updater image from `11.8.0` to `11.17.0` (the latest npm 11.x, kept aligned with the bundled Node 24 LTS).

This fixes two issues:

- **`libc` field stripped from `package-lock.json`.** When Dependabot regenerates a `lockfileVersion: 3` lockfile, npm `< 11.11.0` does not write the `libc` field back for platform-specific optional dependencies. This was an upstream npm bug, fixed in npm 11.11.0. Because Dependabot still bundled 11.8.0, every Dependabot update that touched the lockfile dropped `libc`, so `npm ci` could no longer distinguish glibc vs musl native binaries (e.g. `@valkey/valkey-glide`, `@rollup/rollup`), breaking downstream builds.
- **CVE-2026-0775** (HIGH, local privilege escalation) affects npm `<= 11.8.0`. Bumping past 11.8.0 also remediates this advisory.

Fixes #15318

### Anything you want to highlight for special attention from reviewers?

The bundled npm only needed a patch/minor bump within the existing major (11.x), so the Ruby version constants (`SUPPORTED_VERSIONS`, `NPM_DEFAULT_VERSION`) — which track only the major — did not need changes.

Note this fix applies to the default/unpinned case. Repositories that explicitly pin an older npm via `packageManager` or `engines` (e.g. `npm@11.8.0`) will still resolve to their pinned version, matching local `npm install` behaviour, and would need to update their own pin to benefit.

### How will you know you've accomplished your goal?

Regenerating the reporter's repro lockfile inside the updated image keeps the `libc` field:

```
npm install @valkey/valkey-glide@2.3.1 --package-lock-only
jq '.packages["node_modules/@valkey/valkey-glide-linux-x64-gnu"].libc' package-lock.json
# => [ "glibc" ]
```

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
