### PR TITLE
Fix no method error during fetching credentials properties

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -238,11 +238,19 @@ module Dependabot
       sig { returns(T::Array[Dependabot::Credential]) }
       def wrapped_credentials
         @wrapped_credentials ||= T.let(
-          T.unsafe(credentials).map do |cred| # rubocop:disable Sorbet/ForbidTUnsafe
-            cred.is_a?(Dependabot::Credential) ? cred : Dependabot::Credential.new(cred.dup)
-          end,
+          credentials.map { |cred| ensure_credential(cred) },
           T.nilable(T::Array[Dependabot::Credential])
         )
+      end
+
+      sig do
+        params(cred: T.any(Dependabot::Credential, T::Hash[String, T.untyped]))
+          .returns(Dependabot::Credential)
+      end
+      def ensure_credential(cred)
+        return cred if cred.is_a?(Dependabot::Credential)
+
+        Dependabot::Credential.new(cred.dup)
       end
 
       sig { returns(T::Boolean) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -218,7 +218,7 @@ module Dependabot
 
       sig { returns(T.nilable(DependencyFile)) }
       def generate_npmrc_from_credentials
-        content = NpmAndYarn::FileUpdater::NpmrcBuilder.npmrc_content_from_credentials(credentials)
+        content = NpmAndYarn::FileUpdater::NpmrcBuilder.npmrc_content_from_credentials(wrapped_credentials)
         return unless content
 
         Dependabot::DependencyFile.new(
@@ -229,7 +229,20 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def credentials_have_scope?
-        credentials.any? { |cred| cred["type"] == "npm_registry" && cred.scope }
+        wrapped_credentials.any? { |cred| cred["type"] == "npm_registry" && cred.scope }
+      end
+
+      # file_fetcher_command.rb may pass raw Hashes as credentials at runtime.
+      # Wrap them in Credential objects so we can use .scope and .replaces_base? safely.
+      # Credential#initialize destructively removes "scope"/"replaces-base" keys, so we .dup first.
+      sig { returns(T::Array[Dependabot::Credential]) }
+      def wrapped_credentials
+        @wrapped_credentials ||= T.let(
+          T.unsafe(credentials).map do |cred| # rubocop:disable Sorbet/ForbidTUnsafe
+            cred.is_a?(Dependabot::Credential) ? cred : Dependabot::Credential.new(cred.dup)
+          end,
+          T.nilable(T::Array[Dependabot::Credential])
+        )
       end
 
       sig { returns(T::Boolean) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2834,6 +2834,61 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         .not_to include(".npmrc")
     end
   end
+
+  context "with raw Hash credentials (as passed by file_fetcher_command.rb at runtime)" do
+    let(:credentials) do
+      [
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        },
+        {
+          "type" => "npm_registry",
+          "registry" => "npm.pkg.github.com",
+          "token" => "my_token",
+          "scope" => "@my-company"
+        }
+      ]
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_npmrc_credential_generation, true)
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, url + "?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_js_npm.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "package_json_content.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "package_lock_content.json"),
+          headers: json_header
+        )
+    end
+
+    it "wraps raw Hashes and generates .npmrc without NoMethodError" do
+      expect { file_fetcher_instance.files }.not_to raise_error
+      npmrc_file = file_fetcher_instance.files.find { |f| f.name == ".npmrc" }
+      expect(npmrc_file).not_to be_nil
+      expect(npmrc_file.content).to eq("@my-company:registry=https://npm.pkg.github.com")
+    end
+  end
 end
 
 def fixture_to_response(dir, file)


### PR DESCRIPTION
### What are you trying to accomplish?
Fix `NoMethodError: undefined method 'scope' for an instance of Hash` in `FileFetcher#credentials_have_scope?` when running in production.

`file_fetcher_command.rb` passes raw Hash credentials (from the job definition JSON) to FileFetcher. The scope-checking code called `.scope` on these Hashes, which only exists on `Dependabot::Credential` objects.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
- Added a `wrapped_credentials` private method in the npm FileFetcher that wraps raw Hashes into `Credential` objects (using `.dup` to avoid destructive mutation from `Credential#initialize`).
- Used `T.unsafe(credentials)` to bypass Sorbet's type narrowing — Sorbet sees `credentials` as `T::Array[Dependabot::Credential]` and marks the `is_a?` else branch as unreachable, but at runtime raw Hashes arrive.
- The fix is scoped to the npm FileFetcher only — no changes to `file_fetcher_command.rb` or other ecosystems, avoiding any risk of breaking other package managers (e.g., `bun` uses `cred["replaces-base"]` which would fail with wrapped Credentials).
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- All existing FileFetcher and NpmrcBuilder specs pass.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
