### PR TITLE
Fix pre-commit cooldown bypass and incorrect PR metadata issues with grouped updates

### DIFF
--- a/pre_commit/lib/dependabot/pre_commit/update_checker.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker.rb
@@ -114,10 +114,18 @@ module Dependabot
         frozen_ver = version_from_comment
         return super unless frozen_ver
 
-        resolved_sha = latest_commit_sha
-        return true if resolved_sha && resolved_sha == dependency.version
+        # Use latest_version (which respects cooldown) for semantic comparison.
+        # This ensures that when cooldown rejects all candidates, the dependency
+        # is correctly treated as up-to-date.
+        lv = latest_version
+        return true if lv.is_a?(Dependabot::Version) && lv <= frozen_ver
 
-        false
+        resolved_sha = latest_commit_sha
+        # If no SHA can be resolved (e.g., all candidate versions rejected by cooldown),
+        # there is nothing to update to — treat as up-to-date.
+        return true unless resolved_sha
+
+        resolved_sha == dependency.version
       end
 
       sig { override.returns(T::Boolean) }

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -48,6 +48,7 @@ module Dependabot
           @options             = options
           @cooldown_options = cooldown_options
           @cooldown_selected_tag = T.let(nil, T.nilable(T::Hash[Symbol, T.untyped]))
+          @cooldown_rejected_all = T.let(false, T::Boolean)
 
           @git_helper = T.let(git_helper, Dependabot::PreCommit::Helpers::Githelper)
           super(
@@ -92,6 +93,8 @@ module Dependabot
 
         sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
         def latest_version_tag
+          return nil if @cooldown_rejected_all
+
           @cooldown_selected_tag || available_latest_version_tag
         end
 
@@ -113,6 +116,7 @@ module Dependabot
           return result if result
 
           Dependabot.logger.info("All candidate versions are in cooldown, keeping current version #{current_version}")
+          @cooldown_rejected_all = true
           current_version
         end
 

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -242,6 +242,75 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
         expect(result.to_s).to eq("4.4.0")
       end
 
+      it "returns nil from latest_version_tag when all versions are in cooldown" do
+        recent_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
+
+        latest_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "latest_sha"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
+          .and_return([latest_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
+                        ref: "v4.4.0", branch: nil })
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .and_return(recent_date)
+
+        # Trigger cooldown evaluation
+        finder.latest_release_version
+
+        # latest_version_tag must be nil so that sha1_version_up_to_date?
+        # does not resolve a commit SHA for the cooldown-blocked version
+        expect(finder.latest_version_tag).to be_nil
+      end
+
+      it "returns the cooldown-selected tag from latest_version_tag" do
+        recent_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
+        old_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
+
+        latest_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "latest_sha"
+        }
+        older_tag = {
+          tag: "v5.0.0",
+          version: Dependabot::PreCommit::Version.new("5.0.0"),
+          commit_sha: "older_sha"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
+          .and_return([latest_tag, older_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
+                        ref: "v4.4.0", branch: nil })
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .and_return(recent_date, old_date)
+
+        # Trigger cooldown evaluation
+        finder.latest_release_version
+
+        # latest_version_tag should return the cooldown-selected tag (v5.0.0)
+        expect(finder.latest_version_tag).to eq(older_tag)
+      end
+
       context "with v-prefixed version in dependency" do
         let(:dependency) do
           Dependabot::Dependency.new(

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -148,6 +148,65 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
       end
     end
 
+    context "when SHA-pinned with frozen comment and cooldown rejects all versions" do
+      let(:reference) { "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "https://github.com/#{dependency_name}",
+          version: reference,
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: dependency_source,
+            metadata: { comment: "# frozen: v4.4.0" }
+          }],
+          package_manager: "pre_commit"
+        )
+      end
+      let(:update_cooldown) do
+        Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: 7
+        )
+      end
+
+      before do
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tag_for_pinned_sha).and_return(nil)
+
+        recent_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
+
+        v6_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions)
+          .and_return([v6_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
+                        ref: reference, branch: nil })
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .and_return(recent_date)
+      end
+
+      it "reports the dependency as up to date" do
+        expect(checker.up_to_date?).to be(true)
+      end
+
+      it "returns the current version as latest_version" do
+        expect(checker.latest_version.to_s).to eq("4.4.0")
+      end
+    end
+
     context "with shortened version ref" do
       let(:reference) { "v4.4" }
 


### PR DESCRIPTION
### What are you trying to accomplish?
Fix cooldown bypass and incorrect PR metadata for grouped pre-commit updates when dependencies are SHA-pinned with frozen version comments (e.g., `rev: <sha> # frozen: v0.17.0`).
<!-- Provide both a what and a _why_ for the change. -->
When cooldown rejected all candidate versions, `latest_version_tag` still returned the unfiltered tag. This caused two bugs:

1. **Cooldown ignored** — `sha1_version_up_to_date?` resolved the unfiltered tag's SHA, which didn't match the current SHA, so the dependency was falsely flagged as needing an update. A PR was created even though the release was within the cooldown window.
2. **Incorrect PR metadata** — The PR got `version = current_version` (from cooldown) but `ref = new_tag_sha` (from the unfiltered tag), producing titles like "bump from v0.17.0 to 0.17.0" instead of reflecting the actual update.

Fixes #15323
<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
The fix touches two files:

- **`latest_version_finder.rb`**: Added a `@cooldown_rejected_all` flag. When all candidates are rejected by cooldown, `latest_version_tag` now returns `nil` instead of the unfiltered tag. This prevents the unfiltered SHA from leaking into the update path.
- **`update_checker.rb`**: Updated `sha1_version_up_to_date?` to first compare `latest_version` (which respects cooldown) semantically against the frozen comment version. If `latest_version <= frozen_ver`, the dependency is treated as up-to-date without attempting SHA resolution.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- Added 4 new test cases:
  - `latest_version_tag` returns `nil` when all versions are in cooldown
  - `latest_version_tag` returns the cooldown-selected tag when a fallback exists
  - `up_to_date?` returns `true` for SHA-pinned deps when cooldown rejects all
  - `latest_version` returns current version when cooldown rejects all
- All 38 update checker tests pass. Full pre_commit suite (280 tests) passes with no regressions.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
