### PR TITLE
Reject updates for private registries without proper dependabot configuration

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -97,6 +97,11 @@ module Dependabot
         "error-type": "path_dependencies_not_reachable",
         "error-detail": { dependencies: error.dependencies }
       }
+    when Dependabot::PrivateRegistryConfigNotFound
+      {
+        "error-type": "private_registry_config_not_found",
+        "error-detail": { source: error.source }
+      }
     when Dependabot::PrivateSourceAuthenticationFailure
       {
         "error-type": "private_source_authentication_failure",
@@ -696,6 +701,22 @@ module Dependabot
   #######################
   # Source level errors #
   #######################
+
+  class PrivateRegistryConfigNotFound < DependabotError
+    extend T::Sig
+
+    sig { returns(String) }
+    attr_reader :source
+
+    sig { params(source: String).void }
+    def initialize(source)
+      @source = T.let(sanitize_source(source), String)
+      msg = "Private npm registries require either a .npmrc file in your repository, " \
+            "or explicit `scope`/`replaces-base` configuration in dependabot.yml. " \
+            "Registry: #{@source}"
+      super(msg)
+    end
+  end
 
   class PrivateSourceAuthenticationFailure < DependabotError
     extend T::Sig

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -161,7 +161,12 @@ module Dependabot
           end
         end
 
-        return @inferred_npmrc ||= T.let(nil, T.nilable(DependencyFile)) unless npmrc.nil? && package_lock
+        unless npmrc.nil? && package_lock
+          # If .npmrc exists in the repo, it handles things — no rejection needed.
+          # If no .npmrc AND no lockfile, we can't infer, so check for rejection.
+          reject_if_private_registry_without_config! if npmrc.nil?
+          return @inferred_npmrc ||= T.let(nil, T.nilable(DependencyFile))
+        end
 
         known_registries = []
         FileParser::JsonLock.new(T.must(package_lock)).parsed.fetch(
@@ -209,6 +214,9 @@ module Dependabot
           end
         end
 
+        # Phase 3: Reject updates when private registries exist but no config is resolvable
+        reject_if_private_registry_without_config!
+
         @inferred_npmrc ||= nil
       end
       # rubocop:enable Metrics/MethodLength
@@ -225,6 +233,20 @@ module Dependabot
           name: ".npmrc",
           content: content
         )
+      end
+
+      sig { void }
+      def reject_if_private_registry_without_config!
+        return unless Dependabot::Experiments.enabled?(:enable_npmrc_credential_generation)
+
+        private_registry_creds = wrapped_credentials.select do |cred|
+          cred["type"] == "npm_registry" &&
+            !NpmAndYarn::FileUpdater::NpmrcBuilder::CENTRAL_REGISTRIES.include?(cred["registry"])
+        end
+        return if private_registry_creds.empty?
+
+        registry = private_registry_creds.first&.fetch("registry", "unknown")
+        raise Dependabot::PrivateRegistryConfigNotFound, registry
       end
 
       sig { returns(T::Boolean) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -240,12 +240,18 @@ module Dependabot
         return unless Dependabot::Experiments.enabled?(:enable_npmrc_credential_generation)
 
         private_registry_creds = wrapped_credentials.select do |cred|
-          cred["type"] == "npm_registry" &&
-            !NpmAndYarn::FileUpdater::NpmrcBuilder::CENTRAL_REGISTRIES.include?(cred["registry"])
+          next false unless cred["type"] == "npm_registry"
+
+          registry = cred["registry"]
+          next false if registry.nil?
+
+          # Normalize: strip scheme to compare against CENTRAL_REGISTRIES (bare hostnames)
+          normalized = registry.sub(%r{^https?://}, "")
+          !NpmAndYarn::FileUpdater::NpmrcBuilder::CENTRAL_REGISTRIES.include?(normalized)
         end
         return if private_registry_creds.empty?
 
-        registry = private_registry_creds.first&.fetch("registry", "unknown")
+        registry = private_registry_creds.first&.fetch("registry", nil) || "unknown"
         raise Dependabot::PrivateRegistryConfigNotFound, registry
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2829,9 +2829,55 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
         )
     end
 
-    it "does not generate an npmrc" do
-      expect(file_fetcher_instance.files.map(&:name))
-        .not_to include(".npmrc")
+    it "raises PrivateRegistryConfigNotFound" do
+      expect { file_fetcher_instance.files }.to raise_error(
+        Dependabot::PrivateRegistryConfigNotFound,
+        /Private npm registries require either a .npmrc file.*npm.pkg.github.com/
+      )
+    end
+  end
+
+  context "with only central registry credentials and no scope/replaces-base" do
+    let(:credentials) do
+      [Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      ), Dependabot::Credential.new(
+        {
+          "type" => "npm_registry",
+          "registry" => "registry.npmjs.org",
+          "token" => "my_token"
+        }
+      )]
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_npmrc_credential_generation, true)
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, File.join(url, "package.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture_to_response("projects/npm8/private_registry_ghpr_and_npm", "package-lock.json"),
+          headers: json_header
+        )
+    end
+
+    it "does not raise an error" do
+      expect { file_fetcher_instance.files }.not_to raise_error
     end
   end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2879,6 +2879,29 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     it "does not raise an error" do
       expect { file_fetcher_instance.files }.not_to raise_error
     end
+
+    context "when registry is a full URL" do
+      let(:credentials) do
+        [Dependabot::Credential.new(
+          {
+            "type" => "git_source",
+            "host" => "github.com",
+            "username" => "x-access-token",
+            "password" => "token"
+          }
+        ), Dependabot::Credential.new(
+          {
+            "type" => "npm_registry",
+            "registry" => "https://registry.npmjs.org",
+            "token" => "my_token"
+          }
+        )]
+      end
+
+      it "does not raise an error" do
+        expect { file_fetcher_instance.files }.not_to raise_error
+      end
+    end
   end
 
   context "with raw Hash credentials (as passed by file_fetcher_command.rb at runtime)" do


### PR DESCRIPTION
### What are you trying to accomplish?
This PR adds a new `private_registry_config_not_found ` error message and rejects updates when private npm registries are configured but no explicit configuration is resolvable.
<!-- Provide both a what and a _why_ for the change. -->
When a user configured a private npm registry credential in `dependabot.yml` but didn't provide `scope`, `replaces-base`, or a committed `.npmrc`, Dependabot would silently proceed and later fail with a confusing npm auth error. Now it fails early with a clear, actionable error message telling the user exactly what's needed.

This is gated behind the existing `:enable_npmrc_credential_generation` feature flag for safe rollout.
<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
- The rejection logic is placed at two points in `inferred_npmrc`:
  1. Early return path — when there's no `.npmrc` AND no lockfile (can't even attempt inference)
  2. End of the method — after lockfile inference and `replaces-base` credential generation both fail

- Central registries (`registry.npmjs.org`, `registry.yarnpkg.com`) are explicitly excluded from rejection — credentials for these don't require scope/replaces-base configuration.

- The new `PrivateRegistryConfigNotFound` error class follows the same pattern as `PrivateSourceAuthenticationFailure` and is handled in `fetcher_error_details` for proper error reporting through the updater pipeline.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- Unit test verifies `PrivateRegistryConfigNotFound` is raised when a private registry credential exists without scope/replaces-base/committed .npmrc and lockfile inference fails
- Unit test verifies central registry credentials (`registry.npmjs.org`) do NOT trigger the error
- Existing tests for scope-based generation, replaces-base fallback, and lockfile inference continue to pass (those paths resolve before reaching the rejection point)
- The error is properly mapped in `fetcher_error_details` to `"private_registry_config_not_found"` for the updater error reporting pipeline
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
