### PR TITLE
fix(pre-commit, github-actions): use tag creation date for cooldown instead of commit date

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,6 +479,7 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
+  arm64-darwin-23
   arm64-darwin-25
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,6 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
-  arm64-darwin-23
   arm64-darwin-25
   x86_64-linux
 

--- a/common/lib/dependabot/git_cooldown_date_resolver.rb
+++ b/common/lib/dependabot/git_cooldown_date_resolver.rb
@@ -1,0 +1,114 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/clients/github_with_retries"
+require "dependabot/shared_helpers"
+require "dependabot/source"
+
+module Dependabot
+  # Shared logic for resolving release dates from git-based sources for cooldown
+  # purposes. Used by ecosystems that rely on git tags (pre-commit, GitHub Actions)
+  # rather than package registries.
+  #
+  # Priority: GitHub Release published_at > tag creation date (for-each-ref) > commit date.
+  #
+  # Including classes must implement:
+  #   - `cooldown_source_url` — returns the git source URL
+  #   - `cooldown_credentials` — returns the credentials array
+  module GitCooldownDateResolver
+    extend T::Sig
+    extend T::Helpers
+
+    abstract!
+
+    # The git source URL for the dependency (e.g. "https://github.com/owner/repo")
+    sig { abstract.returns(T.nilable(String)) }
+    def cooldown_source_url; end
+
+    # Credentials for GitHub API access
+    sig { abstract.returns(T::Array[Dependabot::Credential]) }
+    def cooldown_credentials; end
+
+    # Strips the `tags/` prefix that GitCommitChecker may add when the pinned
+    # ref starts with `tags/`, preventing construction of invalid refs like
+    # `refs/tags/tags/v1.0.0`.
+    sig { params(tag_name: String).returns(String) }
+    def normalize_tag_name(tag_name)
+      tag_name.delete_prefix("tags/")
+    end
+
+    # Resolves the best available date for a candidate tag.
+    # Priority: GitHub Release published_at > tag creation date > commit date.
+    sig { params(tag_name: String, commit_sha: String).returns(Time) }
+    def resolve_candidate_date(tag_name, commit_sha)
+      releases = cached_github_releases
+      unless releases.empty?
+        release = releases.find { |r| r.tag_name == tag_name }
+        return release.published_at if release&.published_at
+      end
+
+      tag_creation_date(tag_name, commit_sha)
+    end
+
+    # Looks up the GitHub Release published_at date for a given tag name.
+    # Returns nil if no release exists for this tag.
+    sig { params(tag_name: String).returns(T.nilable(Time)) }
+    def github_release_published_at(tag_name)
+      releases = cached_github_releases
+      return nil if releases.empty?
+
+      release = releases.find { |r| r.tag_name == tag_name }
+      return nil unless release&.published_at
+
+      release.published_at
+    rescue StandardError => e
+      Dependabot.logger.debug("Error fetching GitHub release date for #{tag_name}: #{e.message}")
+      nil
+    end
+
+    # Returns the tag creation date for cooldown purposes (used inside bare clone).
+    # Priority: tag creation date from for-each-ref > commit date fallback.
+    sig { params(tag_name: String, commit_sha: String).returns(Time) }
+    def tag_creation_date(tag_name, commit_sha)
+      tag_date_str = SharedHelpers.run_shell_command(
+        "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/#{tag_name}\"",
+        fingerprint: "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/<tag_name>\""
+      ).strip
+
+      if tag_date_str.empty?
+        tag_date_str = SharedHelpers.run_shell_command(
+          "git show --no-patch --format=\"%cd\" --date=iso #{commit_sha}",
+          fingerprint: "git show --no-patch --format=\"%cd\" --date=iso <commit_sha>"
+        ).strip
+      end
+
+      Time.parse(tag_date_str)
+    end
+
+    # Fetches and caches GitHub releases for the dependency source.
+    # Returns an empty array for non-GitHub sources.
+    sig { returns(T::Array[T.untyped]) } # rubocop:disable Sorbet/ForbidTUntyped
+    def cached_github_releases
+      @cached_github_releases ||= T.let(
+        begin
+          url = cooldown_source_url
+          source = Source.from_url(url)
+          if source&.provider == "github"
+            client = Dependabot::Clients::GithubWithRetries.for_source(
+              source: T.must(source),
+              credentials: cooldown_credentials
+            )
+            client.releases(T.must(source).repo, per_page: 100)
+          else
+            []
+          end
+        rescue StandardError => e
+          Dependabot.logger.debug("Error fetching GitHub releases: #{e.message}")
+          []
+        end,
+        T.nilable(T::Array[T.untyped]) # rubocop:disable Sorbet/ForbidTUntyped
+      )
+    end
+  end
+end

--- a/common/spec/dependabot/git_cooldown_date_resolver_spec.rb
+++ b/common/spec/dependabot/git_cooldown_date_resolver_spec.rb
@@ -1,0 +1,197 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/git_cooldown_date_resolver"
+require "dependabot/shared_helpers"
+require "dependabot/clients/github_with_retries"
+
+RSpec.describe Dependabot::GitCooldownDateResolver do
+  let(:test_class) do
+    Class.new do
+      include Dependabot::GitCooldownDateResolver
+
+      def initialize(source_url:, credentials:)
+        @source_url = source_url
+        @credentials = credentials
+      end
+
+      def cooldown_source_url
+        @source_url
+      end
+
+      def cooldown_credentials
+        @credentials
+      end
+    end
+  end
+
+  let(:credentials) do
+    [Dependabot::Credential.new(
+      {
+        "type" => "git_source",
+        "host" => "github.com",
+        "username" => "x-access-token",
+        "password" => "token"
+      }
+    )]
+  end
+
+  let(:source_url) { "https://github.com/owner/repo" }
+  let(:resolver) { test_class.new(source_url: source_url, credentials: credentials) }
+
+  describe "#normalize_tag_name" do
+    it "strips tags/ prefix" do
+      expect(resolver.normalize_tag_name("tags/v1.0.0")).to eq("v1.0.0")
+    end
+
+    it "leaves normal tag names unchanged" do
+      expect(resolver.normalize_tag_name("v1.0.0")).to eq("v1.0.0")
+    end
+
+    it "only strips the first tags/ prefix" do
+      expect(resolver.normalize_tag_name("tags/tags/v1.0.0")).to eq("tags/v1.0.0")
+    end
+  end
+
+  describe "#tag_creation_date" do
+    it "returns the tag creation date from git for-each-ref" do
+      tag_date = "2026-06-10 12:00:00 +0000"
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+        .with(/git for-each-ref/, hash_including(fingerprint: anything))
+        .and_return(tag_date)
+
+      result = resolver.tag_creation_date("v1.0.0", "abc123")
+      expect(result).to eq(Time.parse(tag_date))
+    end
+
+    it "falls back to commit date when for-each-ref returns empty" do
+      commit_date = "2026-06-08 10:00:00 +0000"
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+        .with(/git for-each-ref/, hash_including(fingerprint: anything))
+        .and_return("")
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+        .with(/git show --no-patch/, hash_including(fingerprint: anything))
+        .and_return(commit_date)
+
+      result = resolver.tag_creation_date("v1.0.0", "abc123")
+      expect(result).to eq(Time.parse(commit_date))
+    end
+  end
+
+  describe "#github_release_published_at" do
+    it "returns published_at when a matching release exists" do
+      published_at = Time.now.utc - (3 * 24 * 60 * 60)
+      mock_release = Struct.new(:tag_name, :published_at, :prerelease)
+                           .new("v1.0.0", published_at, false)
+      mock_client = instance_double(Octokit::Client, releases: [mock_release])
+      allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+      expect(resolver.github_release_published_at("v1.0.0")).to eq(published_at)
+    end
+
+    it "returns nil when no release matches the tag" do
+      mock_release = Struct.new(:tag_name, :published_at, :prerelease)
+                           .new("v2.0.0", Time.now, false)
+      mock_client = instance_double(Octokit::Client, releases: [mock_release])
+      allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+      expect(resolver.github_release_published_at("v1.0.0")).to be_nil
+    end
+
+    it "returns nil when releases are empty" do
+      mock_client = instance_double(Octokit::Client, releases: [])
+      allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+      expect(resolver.github_release_published_at("v1.0.0")).to be_nil
+    end
+  end
+
+  describe "#resolve_candidate_date" do
+    it "prefers GitHub Release published_at over git dates" do
+      published_at = Time.now.utc - (2 * 24 * 60 * 60)
+      mock_release = Struct.new(:tag_name, :published_at, :prerelease)
+                           .new("v1.0.0", published_at, false)
+      mock_client = instance_double(Octokit::Client, releases: [mock_release])
+      allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+      # Should NOT call git commands
+      expect(Dependabot::SharedHelpers).not_to receive(:run_shell_command)
+
+      result = resolver.resolve_candidate_date("v1.0.0", "abc123")
+      expect(result).to eq(published_at)
+    end
+
+    it "falls back to tag_creation_date when no release exists" do
+      mock_client = instance_double(Octokit::Client, releases: [])
+      allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+      tag_date = "2026-06-10 12:00:00 +0000"
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+        .with(/git for-each-ref/, hash_including(fingerprint: anything))
+        .and_return(tag_date)
+
+      result = resolver.resolve_candidate_date("v1.0.0", "abc123")
+      expect(result).to eq(Time.parse(tag_date))
+    end
+  end
+
+  describe "#cached_github_releases" do
+    it "fetches releases from GitHub" do
+      mock_release = Struct.new(:tag_name, :published_at, :prerelease)
+                           .new("v1.0.0", Time.now, false)
+      mock_client = instance_double(Octokit::Client, releases: [mock_release])
+      allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+      result = resolver.cached_github_releases
+      expect(result).to eq([mock_release])
+    end
+
+    it "returns empty array for non-GitHub sources" do
+      non_github_resolver = test_class.new(
+        source_url: "https://gitlab.com/owner/repo",
+        credentials: credentials
+      )
+
+      result = non_github_resolver.cached_github_releases
+      expect(result).to eq([])
+    end
+
+    it "caches the result across multiple calls" do
+      mock_client = instance_double(Octokit::Client, releases: [])
+      allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+      resolver.cached_github_releases
+      resolver.cached_github_releases
+
+      expect(Dependabot::Clients::GithubWithRetries).to have_received(:for_source).once
+    end
+
+    it "caches empty results (non-GitHub sources)" do
+      non_github_resolver = test_class.new(
+        source_url: "https://gitlab.com/owner/repo",
+        credentials: credentials
+      )
+      allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source)
+
+      non_github_resolver.cached_github_releases
+      non_github_resolver.cached_github_releases
+
+      # Should never try to create a client for non-GitHub sources
+      expect(Dependabot::Clients::GithubWithRetries).not_to have_received(:for_source)
+    end
+
+    it "returns empty array and caches on API error" do
+      allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source)
+        .and_raise(StandardError.new("API rate limit"))
+
+      result = resolver.cached_github_releases
+      expect(result).to eq([])
+
+      # Second call should not hit the API again
+      result2 = resolver.cached_github_releases
+      expect(result2).to eq([])
+      expect(Dependabot::Clients::GithubWithRetries).to have_received(:for_source).once
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -378,7 +378,7 @@ module Dependabot
                 source: T.must(source),
                 credentials: credentials
               )
-              client.releases(source.repo, per_page: 100)
+              client.releases(T.must(source).repo, per_page: 100)
             rescue StandardError => e
               Dependabot.logger.debug("Error fetching GitHub releases: #{e.message}")
               []

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -384,13 +384,15 @@ module Dependabot
             begin
               url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
               source = Source.from_url(url)
-              return [] unless source&.provider == "github"
-
-              client = Dependabot::Clients::GithubWithRetries.for_source(
-                source: T.must(source),
-                credentials: credentials
-              )
-              client.releases(T.must(source).repo, per_page: 100)
+              if source&.provider == "github"
+                client = Dependabot::Clients::GithubWithRetries.for_source(
+                  source: T.must(source),
+                  credentials: credentials
+                )
+                client.releases(T.must(source).repo, per_page: 100)
+              else
+                []
+              end
             rescue StandardError => e
               Dependabot.logger.debug("Error fetching GitHub releases: #{e.message}")
               []

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -243,27 +243,30 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def commit_metadata_details
           @commit_metadata_details ||= T.let(
-            begin
-              # First, try GitHub Release published_at via Octokit
-              tag_name = latest_version_tag&.fetch(:tag, nil)
-              if tag_name
-                release_date = github_release_published_at(tag_name)
-                if release_date
-                  Dependabot.logger.info("Found release date from GitHub Release: #{release_date}")
-                  return release_date.iso8601
-                end
-              end
-
-              # Fallback to git-based date detection
-              fetch_date_from_git(tag_name)
-            rescue StandardError => e
-              msg = "Error (github actions) while checking release date for #{dependency.name}: #{e.message}"
-              Dependabot.logger.warn(msg)
-
-              nil
-            end,
+            resolve_commit_metadata_details,
             T.nilable(String)
           )
+        end
+
+        sig { returns(T.nilable(String)) }
+        def resolve_commit_metadata_details
+          # First, try GitHub Release published_at via Octokit
+          tag_name = latest_version_tag&.fetch(:tag, nil)
+          normalized_tag = tag_name ? normalize_tag_name(tag_name) : nil
+          if normalized_tag
+            release_date = github_release_published_at(normalized_tag)
+            if release_date
+              Dependabot.logger.info("Found release date from GitHub Release: #{release_date}")
+              return release_date.iso8601
+            end
+          end
+
+          # Fallback to git-based date detection
+          fetch_date_from_git(normalized_tag)
+        rescue StandardError => e
+          msg = "Error (github actions) while checking release date for #{dependency.name}: #{e.message}"
+          Dependabot.logger.warn(msg)
+          nil
         end
 
         sig { params(tag_name: T.nilable(String)).returns(T.nilable(String)) }
@@ -295,6 +298,13 @@ module Dependabot
               date
             end
           end
+        end
+
+        # Strips the `tags/` prefix that GitCommitChecker may add when the pinned
+        # ref starts with `tags/`.
+        sig { params(tag_name: String).returns(String) }
+        def normalize_tag_name(tag_name)
+          tag_name.delete_prefix("tags/")
         end
 
         sig { params(release_date: T.nilable(String)).returns(T::Boolean) }

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -5,6 +5,7 @@ require "sorbet-runtime"
 
 require "dependabot/clients/github_with_retries"
 require "dependabot/errors"
+require "dependabot/git_cooldown_date_resolver"
 require "dependabot/github_actions/file_parser"
 require "dependabot/github_actions/package/package_details_fetcher"
 require "dependabot/github_actions/requirement"
@@ -20,6 +21,7 @@ module Dependabot
     class UpdateChecker
       class LatestVersionFinder < Dependabot::Package::PackageLatestVersionFinder
         extend T::Sig
+        include Dependabot::GitCooldownDateResolver
 
         sig do
           params(
@@ -125,6 +127,16 @@ module Dependabot
             end,
             T.nilable(T::Hash[Symbol, T.untyped])
           )
+        end
+
+        sig { override.returns(T.nilable(String)) }
+        def cooldown_source_url
+          @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
+        end
+
+        sig { override.returns(T::Array[Dependabot::Credential]) }
+        def cooldown_credentials
+          @credentials
         end
 
         private
@@ -271,7 +283,7 @@ module Dependabot
 
         sig { params(tag_name: T.nilable(String)).returns(T.nilable(String)) }
         def fetch_date_from_git(tag_name)
-          url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
+          url = cooldown_source_url
           source = T.must(Source.from_url(url))
 
           SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
@@ -298,13 +310,6 @@ module Dependabot
               date
             end
           end
-        end
-
-        # Strips the `tags/` prefix that GitCommitChecker may add when the pinned
-        # ref starts with `tags/`.
-        sig { params(tag_name: String).returns(String) }
-        def normalize_tag_name(tag_name)
-          tag_name.delete_prefix("tags/")
         end
 
         sig { params(release_date: T.nilable(String)).returns(T::Boolean) }
@@ -359,45 +364,6 @@ module Dependabot
             raise_on_ignored: raise_on_ignored,
             consider_version_branches_pinned: false,
             dependency_source_details: nil
-          )
-        end
-
-        # Looks up the GitHub Release published_at date for a given tag name.
-        # Returns nil if no release exists for this tag.
-        sig { params(tag_name: String).returns(T.nilable(Time)) }
-        def github_release_published_at(tag_name)
-          releases = cached_github_releases
-          return nil if releases.empty?
-
-          release = releases.find { |r| r.tag_name == tag_name }
-          return nil unless release&.published_at
-
-          release.published_at
-        rescue StandardError => e
-          Dependabot.logger.debug("Error fetching GitHub release date for #{tag_name}: #{e.message}")
-          nil
-        end
-
-        sig { returns(T::Array[T.untyped]) }
-        def cached_github_releases
-          @cached_github_releases ||= T.let(
-            begin
-              url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
-              source = Source.from_url(url)
-              if source&.provider == "github"
-                client = Dependabot::Clients::GithubWithRetries.for_source(
-                  source: T.must(source),
-                  credentials: credentials
-                )
-                client.releases(T.must(source).repo, per_page: 100)
-              else
-                []
-              end
-            rescue StandardError => e
-              Dependabot.logger.debug("Error fetching GitHub releases: #{e.message}")
-              []
-            end,
-            T.nilable(T::Array[T.untyped])
           )
         end
       end

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -235,6 +235,11 @@ module Dependabot
           []
         end
 
+        # Returns the release date for the latest version tag.
+        # Uses the tag creation date (tagger date for annotated tags) rather than
+        # the commit date, since a tag may point to an old commit but be newly published.
+        # Falls back to the commit's committer date for lightweight tags or if
+        # for-each-ref returns no result.
         sig { returns(T.nilable(String)) }
         def commit_metadata_details
           @commit_metadata_details ||= T.let(
@@ -247,10 +252,25 @@ module Dependabot
 
                 SharedHelpers.run_shell_command("git clone --bare --no-recurse-submodules #{url} #{repo_contents_path}")
                 Dir.chdir(repo_contents_path) do
-                  date = SharedHelpers.run_shell_command(
+                  tag_name = latest_version_tag&.fetch(:tag, nil)
+                  date = if tag_name
+                           # Prefer the tag creation date (tagger date for annotated tags,
+                           # commit date for lightweight tags)
+                           tag_date = SharedHelpers.run_shell_command(
+                             "git for-each-ref --format=\"%(creatordate:iso)\" " \
+                             "\"refs/tags/#{tag_name}\"",
+                             fingerprint: "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/<tag_name>\""
+                           ).strip
+                           tag_date.empty? ? nil : tag_date
+                         end
+
+                  # Fallback to commit date if tag lookup failed
+                  date ||= SharedHelpers.run_shell_command(
                     "git show --no-patch --format=\"%cd\" " \
-                    "--date=iso #{commit_ref}"
-                  )
+                    "--date=iso #{commit_ref}",
+                    fingerprint: "git show --no-patch --format=\"%cd\" --date=iso <commit_ref>"
+                  ).strip
+
                   Dependabot.logger.info("Found release date : #{Time.parse(date)}")
                   return date
                 end

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 
+require "dependabot/clients/github_with_retries"
 require "dependabot/errors"
 require "dependabot/github_actions/file_parser"
 require "dependabot/github_actions/package/package_details_fetcher"
@@ -236,14 +237,24 @@ module Dependabot
         end
 
         # Returns the release date for the latest version tag.
-        # Uses the tag creation date (tagger date for annotated tags) rather than
-        # the commit date, since a tag may point to an old commit but be newly published.
-        # Falls back to the commit's committer date for lightweight tags or if
-        # for-each-ref returns no result.
+        # Priority: GitHub Release published_at > tag creation date > commit date.
+        # This ensures re-tagged or republished releases are evaluated based on
+        # when they were actually made available.
         sig { returns(T.nilable(String)) }
         def commit_metadata_details
           @commit_metadata_details ||= T.let(
             begin
+              # First, try GitHub Release published_at via Octokit
+              tag_name = latest_version_tag&.fetch(:tag, nil)
+              if tag_name
+                release_date = github_release_published_at(tag_name)
+                if release_date
+                  Dependabot.logger.info("Found release date from GitHub Release: #{release_date}")
+                  return release_date.iso8601
+                end
+              end
+
+              # Fallback to git-based date detection
               url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
               source = T.must(Source.from_url(url))
 
@@ -252,7 +263,6 @@ module Dependabot
 
                 SharedHelpers.run_shell_command("git clone --bare --no-recurse-submodules #{url} #{repo_contents_path}")
                 Dir.chdir(repo_contents_path) do
-                  tag_name = latest_version_tag&.fetch(:tag, nil)
                   date = if tag_name
                            # Prefer the tag creation date (tagger date for annotated tags,
                            # commit date for lightweight tags)
@@ -337,6 +347,43 @@ module Dependabot
             raise_on_ignored: raise_on_ignored,
             consider_version_branches_pinned: false,
             dependency_source_details: nil
+          )
+        end
+
+        # Looks up the GitHub Release published_at date for a given tag name.
+        # Returns nil if no release exists for this tag.
+        sig { params(tag_name: String).returns(T.nilable(Time)) }
+        def github_release_published_at(tag_name)
+          releases = cached_github_releases
+          return nil if releases.empty?
+
+          release = releases.find { |r| r.tag_name == tag_name }
+          return nil unless release&.published_at
+
+          release.published_at
+        rescue StandardError => e
+          Dependabot.logger.debug("Error fetching GitHub release date for #{tag_name}: #{e.message}")
+          nil
+        end
+
+        sig { returns(T::Array[T.untyped]) }
+        def cached_github_releases
+          @cached_github_releases ||= T.let(
+            begin
+              url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
+              source = Source.from_url(url)
+              return [] unless source&.provider == "github"
+
+              client = Dependabot::Clients::GithubWithRetries.for_source(
+                source: T.must(source),
+                credentials: credentials
+              )
+              client.releases(source.repo, per_page: 100)
+            rescue StandardError => e
+              Dependabot.logger.debug("Error fetching GitHub releases: #{e.message}")
+              []
+            end,
+            T.nilable(T::Array[T.untyped])
           )
         end
       end

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -255,36 +255,7 @@ module Dependabot
               end
 
               # Fallback to git-based date detection
-              url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
-              source = T.must(Source.from_url(url))
-
-              SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
-                repo_contents_path = File.join(temp_dir, File.basename(source.repo))
-
-                SharedHelpers.run_shell_command("git clone --bare --no-recurse-submodules #{url} #{repo_contents_path}")
-                Dir.chdir(repo_contents_path) do
-                  date = if tag_name
-                           # Prefer the tag creation date (tagger date for annotated tags,
-                           # commit date for lightweight tags)
-                           tag_date = SharedHelpers.run_shell_command(
-                             "git for-each-ref --format=\"%(creatordate:iso)\" " \
-                             "\"refs/tags/#{tag_name}\"",
-                             fingerprint: "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/<tag_name>\""
-                           ).strip
-                           tag_date.empty? ? nil : tag_date
-                         end
-
-                  # Fallback to commit date if tag lookup failed
-                  date ||= SharedHelpers.run_shell_command(
-                    "git show --no-patch --format=\"%cd\" " \
-                    "--date=iso #{commit_ref}",
-                    fingerprint: "git show --no-patch --format=\"%cd\" --date=iso <commit_ref>"
-                  ).strip
-
-                  Dependabot.logger.info("Found release date : #{Time.parse(date)}")
-                  return date
-                end
-              end
+              fetch_date_from_git(tag_name)
             rescue StandardError => e
               msg = "Error (github actions) while checking release date for #{dependency.name}: #{e.message}"
               Dependabot.logger.warn(msg)
@@ -293,6 +264,37 @@ module Dependabot
             end,
             T.nilable(String)
           )
+        end
+
+        sig { params(tag_name: T.nilable(String)).returns(T.nilable(String)) }
+        def fetch_date_from_git(tag_name)
+          url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
+          source = T.must(Source.from_url(url))
+
+          SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
+            repo_contents_path = File.join(temp_dir, File.basename(source.repo))
+
+            SharedHelpers.run_shell_command("git clone --bare --no-recurse-submodules #{url} #{repo_contents_path}")
+            Dir.chdir(repo_contents_path) do
+              date = if tag_name
+                       tag_date = SharedHelpers.run_shell_command(
+                         "git for-each-ref --format=\"%(creatordate:iso)\" " \
+                         "\"refs/tags/#{tag_name}\"",
+                         fingerprint: "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/<tag_name>\""
+                       ).strip
+                       tag_date.empty? ? nil : tag_date
+                     end
+
+              date ||= SharedHelpers.run_shell_command(
+                "git show --no-patch --format=\"%cd\" " \
+                "--date=iso #{commit_ref}",
+                fingerprint: "git show --no-patch --format=\"%cd\" --date=iso <commit_ref>"
+              ).strip
+
+              Dependabot.logger.info("Found release date : #{Time.parse(date)}")
+              date
+            end
+          end
         end
 
         sig { params(release_date: T.nilable(String)).returns(T::Boolean) }

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe namespace::LatestVersionFinder do
 
     context "when tag is an annotated tag" do
       it "uses tag creation date from for-each-ref instead of commit date" do
-        tag_creation_date = "2026-06-18 10:00:00 +0000"
+        tag_creation_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
@@ -618,7 +618,7 @@ RSpec.describe namespace::LatestVersionFinder do
     context "when tag points to old commit but was recently created" do
       it "uses tag creation date for cooldown (not old commit date)" do
         # Tag created today, but commit is from 30 days ago
-        recent_tag_date = "2026-06-18 10:00:00 +0000"
+        recent_tag_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
@@ -647,7 +647,7 @@ RSpec.describe namespace::LatestVersionFinder do
 
     context "when GitHub Release published_at is available" do
       it "uses published_at from Octokit instead of git clone" do
-        published_at = Time.parse("2026-06-15 10:00:00 UTC")
+        published_at = Time.now.utc - (3 * 24 * 60 * 60)
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
@@ -671,7 +671,7 @@ RSpec.describe namespace::LatestVersionFinder do
 
     context "when GitHub Release does not exist for the tag" do
       it "falls back to git for-each-ref" do
-        tag_creation_date = "2026-06-10 10:00:00 +0000"
+        tag_creation_date = (Time.now.utc - (8 * 24 * 60 * 60)).strftime("%Y-%m-%d %H:%M:%S %z")
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -521,4 +521,116 @@ RSpec.describe namespace::LatestVersionFinder do
       end
     end
   end
+
+  describe "#commit_metadata_details" do
+    subject(:commit_metadata_details) { finder.send(:commit_metadata_details) }
+
+    let(:reference) { "v1" }
+    let(:dependency_version) { "1.0.0" }
+
+    let(:finder) do
+      described_class.new(
+        dependency: dependency,
+        dependency_files: [],
+        credentials: github_credentials,
+        security_advisories: security_advisories,
+        ignored_versions: ignored_versions,
+        raise_on_ignored: raise_on_ignored,
+        cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+      )
+    end
+
+    before do
+      stub_request(:get, service_pack_url)
+        .to_return(
+          status: 200,
+          body: fixture("git", "upload_packs", upload_pack_fixture),
+          headers: {
+            "content-type" => "application/x-git-upload-pack-advertisement"
+          }
+        )
+    end
+
+    context "when tag is an annotated tag" do
+      it "uses tag creation date from for-each-ref instead of commit date" do
+        tag_creation_date = "2026-06-18 10:00:00 +0000"
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
+                        ref: "v1", branch: nil })
+        allow(finder).to receive(:latest_version_tag)
+          .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
+                        commit_sha: "abc123" })
+        allow(finder).to receive(:commit_ref).and_return("abc123")
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        # for-each-ref returns the annotated tag date
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
+          .and_return(tag_creation_date)
+
+        expect(commit_metadata_details).to eq(tag_creation_date)
+      end
+    end
+
+    context "when for-each-ref returns empty (lightweight tag not found)" do
+      it "falls back to commit date from git show" do
+        commit_date = "2026-06-01 10:00:00 +0000"
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
+                        ref: "v1", branch: nil })
+        allow(finder).to receive(:latest_version_tag)
+          .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
+                        commit_sha: "abc123" })
+        allow(finder).to receive(:commit_ref).and_return("abc123")
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        # for-each-ref returns empty
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
+          .and_return("")
+        # Fallback to git show
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .and_return(commit_date)
+
+        expect(commit_metadata_details).to eq(commit_date)
+      end
+    end
+
+    context "when tag points to old commit but was recently created" do
+      it "uses tag creation date for cooldown (not old commit date)" do
+        # Tag created today, but commit is from 30 days ago
+        recent_tag_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
+                        ref: "v1", branch: nil })
+        allow(finder).to receive(:latest_version_tag)
+          .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
+                        commit_sha: "abc123" })
+        allow(finder).to receive(:commit_ref).and_return("abc123")
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
+          .and_return(recent_tag_date)
+
+        result = commit_metadata_details
+        parsed_result = Time.parse(result)
+        # The result should be recent (today), not the old commit date
+        expect(parsed_result).to be_within(60).of(Time.now)
+      end
+    end
+  end
 end

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -559,10 +559,11 @@ RSpec.describe namespace::LatestVersionFinder do
           .to receive(:dependency_source_details)
           .and_return({ type: "git", url: "https://github.com/actions/setup-node",
                         ref: "v1", branch: nil })
-        allow(finder).to receive(:latest_version_tag)
-          .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
-                        commit_sha: "abc123" })
-        allow(finder).to receive(:commit_ref).and_return("abc123")
+        allow(finder).to receive_messages(
+          latest_version_tag: { tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
+                                commit_sha: "abc123" },
+          commit_ref: "abc123"
+        )
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -584,10 +585,11 @@ RSpec.describe namespace::LatestVersionFinder do
           .to receive(:dependency_source_details)
           .and_return({ type: "git", url: "https://github.com/actions/setup-node",
                         ref: "v1", branch: nil })
-        allow(finder).to receive(:latest_version_tag)
-          .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
-                        commit_sha: "abc123" })
-        allow(finder).to receive(:commit_ref).and_return("abc123")
+        allow(finder).to receive_messages(
+          latest_version_tag: { tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
+                                commit_sha: "abc123" },
+          commit_ref: "abc123"
+        )
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -614,10 +616,11 @@ RSpec.describe namespace::LatestVersionFinder do
           .to receive(:dependency_source_details)
           .and_return({ type: "git", url: "https://github.com/actions/setup-node",
                         ref: "v1", branch: nil })
-        allow(finder).to receive(:latest_version_tag)
-          .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
-                        commit_sha: "abc123" })
-        allow(finder).to receive(:commit_ref).and_return("abc123")
+        allow(finder).to receive_messages(
+          latest_version_tag: { tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
+                                commit_sha: "abc123" },
+          commit_ref: "abc123"
+        )
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -645,8 +648,8 @@ RSpec.describe namespace::LatestVersionFinder do
           .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
                         commit_sha: "abc123" })
 
-        mock_release = double("release", tag_name: "v1.0.0", published_at: published_at)
-        mock_client = double("client", releases: [mock_release])
+        mock_release = instance_double(Sawyer::Resource, tag_name: "v1.0.0", published_at: published_at)
+        mock_client = instance_double(Octokit::Client, releases: [mock_release])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 
         # Should NOT need to clone repo
@@ -664,13 +667,14 @@ RSpec.describe namespace::LatestVersionFinder do
           .to receive(:dependency_source_details)
           .and_return({ type: "git", url: "https://github.com/actions/setup-node",
                         ref: "v1", branch: nil })
-        allow(finder).to receive(:latest_version_tag)
-          .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
-                        commit_sha: "abc123" })
-        allow(finder).to receive(:commit_ref).and_return("abc123")
+        allow(finder).to receive_messages(
+          latest_version_tag: { tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
+                                commit_sha: "abc123" },
+          commit_ref: "abc123"
+        )
 
         # No release exists
-        mock_client = double("client", releases: [])
+        mock_client = instance_double(Octokit::Client, releases: [])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 
         # Falls back to git

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -657,7 +657,7 @@ RSpec.describe namespace::LatestVersionFinder do
           .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
                         commit_sha: "abc123" })
 
-        mock_release = instance_double(Sawyer::Resource, tag_name: "v1.0.0", published_at: published_at)
+        mock_release = double("Sawyer::Resource", tag_name: "v1.0.0", published_at: published_at) # rubocop:disable RSpec/VerifiedDoubles
         mock_client = instance_double(Octokit::Client, releases: [mock_release])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -564,6 +564,10 @@ RSpec.describe namespace::LatestVersionFinder do
                                 commit_sha: "abc123" },
           commit_ref: "abc123"
         )
+        # No GitHub Release available — forces git fallback
+        mock_client = instance_double(Octokit::Client, releases: [])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -590,6 +594,10 @@ RSpec.describe namespace::LatestVersionFinder do
                                 commit_sha: "abc123" },
           commit_ref: "abc123"
         )
+        # No GitHub Release available — forces git fallback
+        mock_client = instance_double(Octokit::Client, releases: [])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -610,7 +618,7 @@ RSpec.describe namespace::LatestVersionFinder do
     context "when tag points to old commit but was recently created" do
       it "uses tag creation date for cooldown (not old commit date)" do
         # Tag created today, but commit is from 30 days ago
-        recent_tag_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
+        recent_tag_date = "2026-06-18 10:00:00 +0000"
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
@@ -621,6 +629,10 @@ RSpec.describe namespace::LatestVersionFinder do
                                 commit_sha: "abc123" },
           commit_ref: "abc123"
         )
+        # Stub GitHub releases to return empty (force git fallback)
+        mock_client = instance_double(Octokit::Client, releases: [])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -629,10 +641,7 @@ RSpec.describe namespace::LatestVersionFinder do
           .with(/git for-each-ref/, hash_including(fingerprint: anything))
           .and_return(recent_tag_date)
 
-        result = commit_metadata_details
-        parsed_result = Time.parse(result)
-        # The result should be recent (today), not the old commit date
-        expect(parsed_result).to be_within(60).of(Time.now)
+        expect(commit_metadata_details).to eq(recent_tag_date)
       end
     end
 

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -632,5 +632,58 @@ RSpec.describe namespace::LatestVersionFinder do
         expect(parsed_result).to be_within(60).of(Time.now)
       end
     end
+
+    context "when GitHub Release published_at is available" do
+      it "uses published_at from Octokit instead of git clone" do
+        published_at = Time.parse("2026-06-15 10:00:00 UTC")
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
+                        ref: "v1", branch: nil })
+        allow(finder).to receive(:latest_version_tag)
+          .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
+                        commit_sha: "abc123" })
+
+        mock_release = double("release", tag_name: "v1.0.0", published_at: published_at)
+        mock_client = double("client", releases: [mock_release])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+        # Should NOT need to clone repo
+        expect(Dependabot::SharedHelpers).not_to receive(:run_shell_command).with(/git clone/)
+
+        expect(commit_metadata_details).to eq(published_at.iso8601)
+      end
+    end
+
+    context "when GitHub Release does not exist for the tag" do
+      it "falls back to git for-each-ref" do
+        tag_creation_date = "2026-06-10 10:00:00 +0000"
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
+                        ref: "v1", branch: nil })
+        allow(finder).to receive(:latest_version_tag)
+          .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
+                        commit_sha: "abc123" })
+        allow(finder).to receive(:commit_ref).and_return("abc123")
+
+        # No release exists
+        mock_client = double("client", releases: [])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+        # Falls back to git
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
+          .and_return(tag_creation_date)
+
+        expect(commit_metadata_details).to eq(tag_creation_date)
+      end
+    end
   end
 end

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -657,7 +657,8 @@ RSpec.describe namespace::LatestVersionFinder do
           .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
                         commit_sha: "abc123" })
 
-        mock_release = double("Sawyer::Resource", tag_name: "v1.0.0", published_at: published_at, prerelease: false) # rubocop:disable RSpec/VerifiedDoubles
+        mock_release = Struct.new(:tag_name, :published_at, :prerelease)
+                             .new("v1.0.0", published_at, false)
         mock_client = instance_double(Octokit::Client, releases: [mock_release])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -657,7 +657,7 @@ RSpec.describe namespace::LatestVersionFinder do
           .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
                         commit_sha: "abc123" })
 
-        mock_release = double("Sawyer::Resource", tag_name: "v1.0.0", published_at: published_at) # rubocop:disable RSpec/VerifiedDoubles
+        mock_release = double("Sawyer::Resource", tag_name: "v1.0.0", published_at: published_at, prerelease: false) # rubocop:disable RSpec/VerifiedDoubles
         mock_client = instance_double(Octokit::Client, releases: [mock_release])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -4,6 +4,7 @@
 require "sorbet-runtime"
 require "dependabot/clients/github_with_retries"
 require "dependabot/errors"
+require "dependabot/git_cooldown_date_resolver"
 require "dependabot/pre_commit/comment_version_helper"
 require "dependabot/pre_commit/file_parser"
 require "dependabot/pre_commit/package/package_details_fetcher"
@@ -20,6 +21,7 @@ module Dependabot
     class UpdateChecker
       class LatestVersionFinder < Dependabot::Package::PackageLatestVersionFinder
         extend T::Sig
+        include Dependabot::GitCooldownDateResolver
 
         sig do
           params(
@@ -97,6 +99,16 @@ module Dependabot
           return nil if @cooldown_rejected_all
 
           @cooldown_selected_tag || available_latest_version_tag
+        end
+
+        sig { override.returns(T.nilable(String)) }
+        def cooldown_source_url
+          @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
+        end
+
+        sig { override.returns(T::Array[Dependabot::Credential]) }
+        def cooldown_credentials
+          @credentials
         end
 
         private
@@ -230,7 +242,7 @@ module Dependabot
             .returns(T.nilable(Dependabot::Version))
         end
         def check_candidates_via_git_clone(candidates)
-          url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
+          url = cooldown_source_url
           source = T.must(Source.from_url(url))
 
           SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
@@ -277,19 +289,6 @@ module Dependabot
           nil
         end
 
-        # Resolves the best available date for a candidate tag.
-        # Priority: GitHub Release published_at > tag creation date > commit date.
-        sig { params(tag_name: String, commit_sha: String).returns(Time) }
-        def resolve_candidate_date(tag_name, commit_sha)
-          releases = cached_github_releases
-          unless releases.empty?
-            release = releases.find { |r| r.tag_name == tag_name }
-            return release.published_at if release&.published_at
-          end
-
-          tag_creation_date(tag_name, commit_sha)
-        end
-
         sig do
           params(filtered_count: Integer, version: T.untyped, release_date: Time).void
         end
@@ -321,58 +320,6 @@ module Dependabot
             .select { |tag| cur_version.nil? || tag[:version] > cur_version }
             .sort_by { |tag| tag[:version] }
             .reverse
-        end
-
-        # Returns the tag creation date for cooldown purposes (used inside bare clone).
-        # Priority: tag creation date from for-each-ref > commit date fallback.
-        sig { params(tag_name: String, commit_sha: String).returns(Time) }
-        def tag_creation_date(tag_name, commit_sha)
-          # Tag creation date (tagger date for annotated tags, commit date for lightweight)
-          tag_date_str = SharedHelpers.run_shell_command(
-            "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/#{tag_name}\"",
-            fingerprint: "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/<tag_name>\""
-          ).strip
-
-          if tag_date_str.empty?
-            # Final fallback: commit's committer date
-            tag_date_str = SharedHelpers.run_shell_command(
-              "git show --no-patch --format=\"%cd\" --date=iso #{commit_sha}",
-              fingerprint: "git show --no-patch --format=\"%cd\" --date=iso <commit_sha>"
-            ).strip
-          end
-
-          Time.parse(tag_date_str)
-        end
-
-        # Strips the `tags/` prefix that GitCommitChecker may add when the pinned
-        # ref starts with `tags/`, preventing construction of invalid refs like
-        # `refs/tags/tags/v1.0.0`.
-        sig { params(tag_name: String).returns(String) }
-        def normalize_tag_name(tag_name)
-          tag_name.delete_prefix("tags/")
-        end
-
-        sig { returns(T::Array[T.untyped]) }
-        def cached_github_releases
-          @cached_github_releases ||= T.let(
-            begin
-              url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
-              source = Source.from_url(url)
-              if source&.provider == "github"
-                client = Dependabot::Clients::GithubWithRetries.for_source(
-                  source: T.must(source),
-                  credentials: credentials
-                )
-                client.releases(T.must(source).repo, per_page: 100)
-              else
-                []
-              end
-            rescue StandardError => e
-              Dependabot.logger.debug("Error fetching GitHub releases: #{e.message}")
-              []
-            end,
-            T.nilable(T::Array[T.untyped])
-          )
         end
 
         sig { params(release_date: Time).returns(T::Boolean) }

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -156,14 +156,70 @@ module Dependabot
           true
         end
 
-        # Checks versions from latest downward (among versions > current_version)
-        # in a single bare clone. Returns the newest version outside cooldown,
-        # or nil if all candidates are within cooldown.
+        # Checks versions from latest downward (among versions > current_version).
+        # First attempts to use GitHub Release published_at dates (no clone needed).
+        # Falls back to a bare clone for git-based date detection.
         sig { returns(T.nilable(Dependabot::Version)) }
         def find_latest_version_outside_cooldown
           candidates = version_candidates_descending
           return nil if candidates.empty?
 
+          # Try GitHub Release dates first (avoids clone)
+          result = check_candidates_via_github_releases(candidates)
+          return result if result
+
+          # Fallback: clone and check tag/commit dates
+          check_candidates_via_git_clone(candidates)
+        rescue StandardError => e
+          Dependabot.logger.error("Error checking cooldown for #{dependency.name}: #{e.message}")
+          nil
+        end
+
+        # Attempts to resolve cooldown using GitHub Release published_at dates.
+        # Returns the first version outside cooldown, nil if all are in cooldown,
+        # or nil if no releases are available (indicating fallback is needed).
+        sig do
+          params(candidates: T::Array[T::Hash[Symbol, T.untyped]])
+            .returns(T.nilable(Dependabot::Version))
+        end
+        def check_candidates_via_github_releases(candidates)
+          releases = cached_github_releases
+          return nil if releases.empty?
+
+          filtered_count = 0
+
+          candidates.each do |tag|
+            tag_name = normalize_tag_name(tag[:tag] || "v#{tag[:version]}")
+            release = releases.find { |r| r.tag_name == tag_name }
+            next unless release&.published_at
+
+            unless release_in_cooldown_period?(release.published_at)
+              log_cooldown_result(filtered_count, tag[:version], release.published_at)
+              @cooldown_selected_tag = tag
+              return T.cast(tag[:version], Dependabot::Version)
+            end
+
+            filtered_count += 1
+          end
+
+          return nil if filtered_count.zero?
+
+          # All candidates with releases are in cooldown
+          Dependabot.logger.info(
+            "Filtered #{filtered_count} version(s) due to cooldown for #{dependency.name}, " \
+            "no eligible version found (via GitHub Releases)"
+          )
+          @cooldown_rejected_all = true
+          T.cast(current_version, T.nilable(Dependabot::Version))
+        end
+
+        # Checks candidate tags inside a bare clone directory, returning the first
+        # version whose tag creation date falls outside the cooldown window.
+        sig do
+          params(candidates: T::Array[T::Hash[Symbol, T.untyped]])
+            .returns(T.nilable(Dependabot::Version))
+        end
+        def check_candidates_via_git_clone(candidates)
           url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
           source = T.must(Source.from_url(url))
 
@@ -175,15 +231,10 @@ module Dependabot
               return check_candidates_cooldown(candidates)
             end
           end
-        rescue StandardError => e
-          Dependabot.logger.error("Error checking cooldown for #{dependency.name}: #{e.message}")
-          nil
         end
 
         # Iterates candidate tags inside a bare clone directory, returning the first
         # version whose release date falls outside the cooldown window.
-        # Uses the tag creation date (tagger date for annotated tags) rather than
-        # the commit date, since a tag may point to an old commit but be newly published.
         sig do
           params(candidates: T::Array[T::Hash[Symbol, T.untyped]])
             .returns(T.nilable(Dependabot::Version))
@@ -195,7 +246,7 @@ module Dependabot
             commit_sha = tag[:commit_sha]
             next unless commit_sha
 
-            release_date = tag_creation_date(tag[:tag] || "v#{tag[:version]}", commit_sha)
+            release_date = tag_creation_date(normalize_tag_name(tag[:tag] || "v#{tag[:version]}"), commit_sha)
 
             if release_in_cooldown_period?(release_date)
               filtered_count += 1
@@ -246,18 +297,11 @@ module Dependabot
             .reverse
         end
 
-        # Returns the release/tag creation date for cooldown purposes.
-        # Priority order:
-        # 1. GitHub Release published_at (most accurate for re-published releases)
-        # 2. Tag creation date from for-each-ref (tagger date for annotated tags)
-        # 3. Commit date fallback (for lightweight tags when for-each-ref returns empty)
+        # Returns the tag creation date for cooldown purposes (used inside bare clone).
+        # Priority: tag creation date from for-each-ref > commit date fallback.
         sig { params(tag_name: String, commit_sha: String).returns(Time) }
         def tag_creation_date(tag_name, commit_sha)
-          # First, try GitHub Release published_at via Octokit
-          release_date = github_release_published_at(tag_name)
-          return release_date if release_date
-
-          # Fallback to git for-each-ref (tagger date for annotated tags)
+          # Tag creation date (tagger date for annotated tags, commit date for lightweight)
           tag_date_str = SharedHelpers.run_shell_command(
             "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/#{tag_name}\"",
             fingerprint: "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/<tag_name>\""
@@ -274,20 +318,12 @@ module Dependabot
           Time.parse(tag_date_str)
         end
 
-        # Looks up the GitHub Release published_at date for a given tag name.
-        # Returns nil if no release exists for this tag or if the repo isn't on GitHub.
-        sig { params(tag_name: String).returns(T.nilable(Time)) }
-        def github_release_published_at(tag_name)
-          releases = cached_github_releases
-          return nil if releases.empty?
-
-          release = releases.find { |r| r.tag_name == tag_name }
-          return nil unless release&.published_at
-
-          release.published_at
-        rescue StandardError => e
-          Dependabot.logger.debug("Error fetching GitHub release date for #{tag_name}: #{e.message}")
-          nil
+        # Strips the `tags/` prefix that GitCommitChecker may add when the pinned
+        # ref starts with `tags/`, preventing construction of invalid refs like
+        # `refs/tags/tags/v1.0.0`.
+        sig { params(tag_name: String).returns(String) }
+        def normalize_tag_name(tag_name)
+          tag_name.delete_prefix("tags/")
         end
 
         sig { returns(T::Array[T.untyped]) }

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -358,13 +358,15 @@ module Dependabot
             begin
               url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
               source = Source.from_url(url)
-              return [] unless source&.provider == "github"
-
-              client = Dependabot::Clients::GithubWithRetries.for_source(
-                source: T.must(source),
-                credentials: credentials
-              )
-              client.releases(T.must(source).repo, per_page: 100)
+              if source&.provider == "github"
+                client = Dependabot::Clients::GithubWithRetries.for_source(
+                  source: T.must(source),
+                  credentials: credentials
+                )
+                client.releases(T.must(source).repo, per_page: 100)
+              else
+                []
+              end
             rescue StandardError => e
               Dependabot.logger.debug("Error fetching GitHub releases: #{e.message}")
               []

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -181,6 +181,8 @@ module Dependabot
 
         # Iterates candidate tags inside a bare clone directory, returning the first
         # version whose release date falls outside the cooldown window.
+        # Uses the tag creation date (tagger date for annotated tags) rather than
+        # the commit date, since a tag may point to an old commit but be newly published.
         sig do
           params(candidates: T::Array[T::Hash[Symbol, T.untyped]])
             .returns(T.nilable(Dependabot::Version))
@@ -192,11 +194,7 @@ module Dependabot
             commit_sha = tag[:commit_sha]
             next unless commit_sha
 
-            date_str = SharedHelpers.run_shell_command(
-              "git show --no-patch --format=\"%cd\" --date=iso #{commit_sha}",
-              fingerprint: "git show --no-patch --format=\"%cd\" --date=iso <commit_sha>"
-            )
-            release_date = Time.parse(date_str)
+            release_date = tag_creation_date(tag[:tag] || "v#{tag[:version]}", commit_sha)
 
             if release_in_cooldown_period?(release_date)
               filtered_count += 1
@@ -245,6 +243,31 @@ module Dependabot
             .select { |tag| cur_version.nil? || tag[:version] > cur_version }
             .sort_by { |tag| tag[:version] }
             .reverse
+        end
+
+        # Returns the tag creation date for cooldown purposes.
+        # For annotated tags, uses the tagger date (when the tag was created).
+        # For lightweight tags, falls back to the commit's committer date.
+        # This ensures that re-tagged or republished releases are evaluated based
+        # on when they were actually made available, not when the underlying
+        # commit was originally authored.
+        sig { params(tag_name: String, commit_sha: String).returns(Time) }
+        def tag_creation_date(tag_name, commit_sha)
+          # Try to get the tagger date from an annotated tag
+          tag_date_str = SharedHelpers.run_shell_command(
+            "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/#{tag_name}\"",
+            fingerprint: "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/<tag_name>\""
+          ).strip
+
+          if tag_date_str.empty?
+            # Fallback: use the commit's committer date for lightweight tags
+            tag_date_str = SharedHelpers.run_shell_command(
+              "git show --no-patch --format=\"%cd\" --date=iso #{commit_sha}",
+              fingerprint: "git show --no-patch --format=\"%cd\" --date=iso <commit_sha>"
+            ).strip
+          end
+
+          Time.parse(tag_date_str)
         end
 
         sig { params(release_date: Time).returns(T::Boolean) }

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/clients/github_with_retries"
 require "dependabot/errors"
 require "dependabot/pre_commit/comment_version_helper"
 require "dependabot/pre_commit/file_parser"
@@ -245,22 +246,25 @@ module Dependabot
             .reverse
         end
 
-        # Returns the tag creation date for cooldown purposes.
-        # For annotated tags, uses the tagger date (when the tag was created).
-        # For lightweight tags, falls back to the commit's committer date.
-        # This ensures that re-tagged or republished releases are evaluated based
-        # on when they were actually made available, not when the underlying
-        # commit was originally authored.
+        # Returns the release/tag creation date for cooldown purposes.
+        # Priority order:
+        # 1. GitHub Release published_at (most accurate for re-published releases)
+        # 2. Tag creation date from for-each-ref (tagger date for annotated tags)
+        # 3. Commit date fallback (for lightweight tags when for-each-ref returns empty)
         sig { params(tag_name: String, commit_sha: String).returns(Time) }
         def tag_creation_date(tag_name, commit_sha)
-          # Try to get the tagger date from an annotated tag
+          # First, try GitHub Release published_at via Octokit
+          release_date = github_release_published_at(tag_name)
+          return release_date if release_date
+
+          # Fallback to git for-each-ref (tagger date for annotated tags)
           tag_date_str = SharedHelpers.run_shell_command(
             "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/#{tag_name}\"",
             fingerprint: "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/<tag_name>\""
           ).strip
 
           if tag_date_str.empty?
-            # Fallback: use the commit's committer date for lightweight tags
+            # Final fallback: commit's committer date
             tag_date_str = SharedHelpers.run_shell_command(
               "git show --no-patch --format=\"%cd\" --date=iso #{commit_sha}",
               fingerprint: "git show --no-patch --format=\"%cd\" --date=iso <commit_sha>"
@@ -268,6 +272,43 @@ module Dependabot
           end
 
           Time.parse(tag_date_str)
+        end
+
+        # Looks up the GitHub Release published_at date for a given tag name.
+        # Returns nil if no release exists for this tag or if the repo isn't on GitHub.
+        sig { params(tag_name: String).returns(T.nilable(Time)) }
+        def github_release_published_at(tag_name)
+          releases = cached_github_releases
+          return nil if releases.empty?
+
+          release = releases.find { |r| r.tag_name == tag_name }
+          return nil unless release&.published_at
+
+          release.published_at
+        rescue StandardError => e
+          Dependabot.logger.debug("Error fetching GitHub release date for #{tag_name}: #{e.message}")
+          nil
+        end
+
+        sig { returns(T::Array[T.untyped]) }
+        def cached_github_releases
+          @cached_github_releases ||= T.let(
+            begin
+              url = @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
+              source = Source.from_url(url)
+              return [] unless source&.provider == "github"
+
+              client = Dependabot::Clients::GithubWithRetries.for_source(
+                source: T.must(source),
+                credentials: credentials
+              )
+              client.releases(source.repo, per_page: 100)
+            rescue StandardError => e
+              Dependabot.logger.debug("Error fetching GitHub releases: #{e.message}")
+              []
+            end,
+            T.nilable(T::Array[T.untyped])
+          )
         end
 
         sig { params(release_date: Time).returns(T::Boolean) }

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -187,11 +187,16 @@ module Dependabot
           return nil if releases.empty?
 
           filtered_count = 0
+          all_have_releases = T.let(true, T::Boolean)
 
           candidates.each do |tag|
             tag_name = normalize_tag_name(tag[:tag] || "v#{tag[:version]}")
             release = releases.find { |r| r.tag_name == tag_name }
-            next unless release&.published_at
+
+            unless release&.published_at
+              all_have_releases = false
+              next
+            end
 
             unless release_in_cooldown_period?(release.published_at)
               log_cooldown_result(filtered_count, tag[:version], release.published_at)
@@ -204,7 +209,10 @@ module Dependabot
 
           return nil if filtered_count.zero?
 
-          # All candidates with releases are in cooldown
+          # Some candidates lacked releases — fall back to git clone for those
+          return nil unless all_have_releases
+
+          # Every candidate had a release and all were in cooldown
           Dependabot.logger.info(
             "Filtered #{filtered_count} version(s) due to cooldown for #{dependency.name}, " \
             "no eligible version found (via GitHub Releases)"

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -176,8 +176,10 @@ module Dependabot
         end
 
         # Attempts to resolve cooldown using GitHub Release published_at dates.
-        # Returns the first version outside cooldown, nil if all are in cooldown,
-        # or nil if no releases are available (indicating fallback is needed).
+        # Returns:
+        # - A version outside cooldown (first eligible candidate)
+        # - current_version when ALL candidates have releases and all are in cooldown
+        # - nil when no releases exist or some candidates lack releases (triggers git fallback)
         sig do
           params(candidates: T::Array[T::Hash[Symbol, T.untyped]])
             .returns(T.nilable(Dependabot::Version))
@@ -243,6 +245,8 @@ module Dependabot
 
         # Iterates candidate tags inside a bare clone directory, returning the first
         # version whose release date falls outside the cooldown window.
+        # Prefers GitHub Release published_at when available for a candidate,
+        # falling back to tag creation date from the cloned repo.
         sig do
           params(candidates: T::Array[T::Hash[Symbol, T.untyped]])
             .returns(T.nilable(Dependabot::Version))
@@ -254,7 +258,8 @@ module Dependabot
             commit_sha = tag[:commit_sha]
             next unless commit_sha
 
-            release_date = tag_creation_date(normalize_tag_name(tag[:tag] || "v#{tag[:version]}"), commit_sha)
+            tag_name = normalize_tag_name(tag[:tag] || "v#{tag[:version]}")
+            release_date = resolve_candidate_date(tag_name, commit_sha)
 
             if release_in_cooldown_period?(release_date)
               filtered_count += 1
@@ -270,6 +275,19 @@ module Dependabot
             "no eligible version found"
           )
           nil
+        end
+
+        # Resolves the best available date for a candidate tag.
+        # Priority: GitHub Release published_at > tag creation date > commit date.
+        sig { params(tag_name: String, commit_sha: String).returns(Time) }
+        def resolve_candidate_date(tag_name, commit_sha)
+          releases = cached_github_releases
+          unless releases.empty?
+            release = releases.find { |r| r.tag_name == tag_name }
+            return release.published_at if release&.published_at
+          end
+
+          tag_creation_date(tag_name, commit_sha)
         end
 
         sig do

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -302,7 +302,7 @@ module Dependabot
                 source: T.must(source),
                 credentials: credentials
               )
-              client.releases(source.repo, per_page: 100)
+              client.releases(T.must(source).repo, per_page: 100)
             rescue StandardError => e
               Dependabot.logger.debug("Error fetching GitHub releases: #{e.message}")
               []

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -631,7 +631,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
                         ref: "v4.4.0", branch: nil })
 
         # Mock GitHub Release with recent published_at (in cooldown)
-        mock_release = double("Sawyer::Resource", tag_name: "v6.0.0", published_at: recent_published_at) # rubocop:disable RSpec/VerifiedDoubles
+        mock_release = double("Sawyer::Resource", tag_name: "v6.0.0", published_at: recent_published_at, prerelease: false) # rubocop:disable RSpec/VerifiedDoubles
         mock_client = instance_double(Octokit::Client, releases: [mock_release])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -489,6 +489,122 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
         expect(result.to_s).to eq("5.1.0")
       end
     end
+
+    context "when tag creation date differs from commit date" do
+      let(:update_cooldown) do
+        Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: 7
+        )
+      end
+
+      it "uses tag creation date (not commit date) for cooldown evaluation" do
+        # Tag was created today but points to a commit from 30 days ago.
+        # The tag creation date (today) should be used for cooldown, meaning
+        # the version IS in cooldown. If the commit date were used instead,
+        # the version would incorrectly bypass cooldown.
+        tag_creation_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
+
+        latest_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "latest_sha"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
+          .and_return([latest_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
+                        ref: "v4.4.0", branch: nil })
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        # for-each-ref returns the tag creation date (today) — in cooldown
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
+          .and_return(tag_creation_date)
+
+        result = finder.latest_release_version
+        # Should stay on current version because tag was just created (in cooldown)
+        expect(result.to_s).to eq("4.4.0")
+      end
+
+      it "falls back to commit date when for-each-ref returns empty" do
+        # Simulates a lightweight tag that for-each-ref can't find (empty result)
+        # Should fall back to git show %cd
+        old_commit_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
+
+        latest_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "latest_sha"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
+          .and_return([latest_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
+                        ref: "v4.4.0", branch: nil })
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        # for-each-ref returns empty (tag not found)
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
+          .and_return("")
+        # Fallback to git show returns old commit date (outside cooldown)
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .and_return(old_commit_date)
+
+        result = finder.latest_release_version
+        # Should accept version because fallback commit date is old (outside cooldown)
+        expect(result.to_s).to eq("6.0.0")
+      end
+
+      it "correctly applies cooldown with annotated tag that points to old commit" do
+        # Annotated tag created 2 days ago pointing to a commit from 30 days ago
+        # Cooldown is 7 days — tag creation date (2 days) is within cooldown
+        tag_creation_date = (Time.now - (2 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
+        old_tag_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
+
+        latest_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "latest_sha"
+        }
+        older_tag = {
+          tag: "v5.0.0",
+          version: Dependabot::PreCommit::Version.new("5.0.0"),
+          commit_sha: "older_sha"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
+          .and_return([latest_tag, older_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
+                        ref: "v4.4.0", branch: nil })
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        # v6.0.0 tag was created 2 days ago (in cooldown), v5.0.0 tag 30 days ago (outside)
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
+          .and_return(tag_creation_date, old_tag_date)
+
+        result = finder.latest_release_version
+        # Should skip v6.0.0 (in cooldown) and select v5.0.0 (outside cooldown)
+        expect(result.to_s).to eq("5.0.0")
+      end
+    end
   end
 
   describe "version precision" do

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
           .with(/git clone --bare/, any_args).and_return("")
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
           .and_return(recent_date, old_date)
 
         result = finder.latest_release_version
@@ -263,7 +263,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
           .with(/git clone --bare/, any_args).and_return("")
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
           .and_return(recent_date)
 
         # Trigger cooldown evaluation
@@ -301,7 +301,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
           .with(/git clone --bare/, any_args).and_return("")
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
           .and_return(recent_date, old_date)
 
         # Trigger cooldown evaluation
@@ -354,7 +354,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
             .with(/git clone --bare/, any_args).and_return("")
           # All remaining candidates (v6.0.0) are in cooldown
           allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-            .with(/git show --no-patch/, hash_including(fingerprint: anything))
+            .with(/git for-each-ref/, hash_including(fingerprint: anything))
             .and_return(recent_date)
 
           result = finder.latest_release_version
@@ -433,7 +433,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
           .with(/git clone --bare/, any_args).and_return("")
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
           .and_return(old_date)
 
         result = finder.latest_release_version
@@ -480,7 +480,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .with(/git clone --bare/, any_args).and_return("")
         # v6.0.0 is in cooldown, but v5.1.0 is not
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
           .and_return(recent_date, old_date)
 
         result = finder.latest_release_version

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -631,7 +631,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
                         ref: "v4.4.0", branch: nil })
 
         # Mock GitHub Release with recent published_at (in cooldown)
-        mock_release = instance_double(Sawyer::Resource, tag_name: "v6.0.0", published_at: recent_published_at)
+        mock_release = double("Sawyer::Resource", tag_name: "v6.0.0", published_at: recent_published_at) # rubocop:disable RSpec/VerifiedDoubles
         mock_client = instance_double(Octokit::Client, releases: [mock_release])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -631,7 +631,8 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
                         ref: "v4.4.0", branch: nil })
 
         # Mock GitHub Release with recent published_at (in cooldown)
-        mock_release = double("Sawyer::Resource", tag_name: "v6.0.0", published_at: recent_published_at, prerelease: false) # rubocop:disable RSpec/VerifiedDoubles
+        mock_release = Struct.new(:tag_name, :published_at, :prerelease)
+                             .new("v6.0.0", recent_published_at, false)
         mock_client = instance_double(Octokit::Client, releases: [mock_release])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -631,8 +631,8 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
                         ref: "v4.4.0", branch: nil })
 
         # Mock GitHub Release with recent published_at (in cooldown)
-        mock_release = double("release", tag_name: "v6.0.0", published_at: recent_published_at)
-        mock_client = double("client", releases: [mock_release])
+        mock_release = instance_double(Sawyer::Resource, tag_name: "v6.0.0", published_at: recent_published_at)
+        mock_client = instance_double(Octokit::Client, releases: [mock_release])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 
         # Should NOT clone the repo since we got the date from Octokit
@@ -661,7 +661,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
                         ref: "v4.4.0", branch: nil })
 
         # No release for this tag
-        mock_client = double("client", releases: [])
+        mock_client = instance_double(Octokit::Client, releases: [])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
 
         # Falls back to git clone

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -605,6 +605,79 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
         expect(result.to_s).to eq("5.0.0")
       end
     end
+
+    context "when GitHub Release published_at is available" do
+      let(:update_cooldown) do
+        Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: 7
+        )
+      end
+
+      it "uses GitHub Release published_at for cooldown (bypasses git clone)" do
+        recent_published_at = Time.now - (2 * 24 * 60 * 60) # 2 days ago
+
+        latest_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "latest_sha"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
+          .and_return([latest_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
+                        ref: "v4.4.0", branch: nil })
+
+        # Mock GitHub Release with recent published_at (in cooldown)
+        mock_release = double("release", tag_name: "v6.0.0", published_at: recent_published_at)
+        mock_client = double("client", releases: [mock_release])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+        # Should NOT clone the repo since we got the date from Octokit
+        expect(Dependabot::SharedHelpers).not_to receive(:run_shell_command).with(/git clone/)
+
+        result = finder.latest_release_version
+        # v6.0.0 is in cooldown (published 2 days ago, cooldown is 7 days)
+        expect(result.to_s).to eq("4.4.0")
+      end
+
+      it "falls back to git when no GitHub Release exists for the tag" do
+        old_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
+
+        latest_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "latest_sha"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
+          .and_return([latest_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
+                        ref: "v4.4.0", branch: nil })
+
+        # No release for this tag
+        mock_client = double("client", releases: [])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
+        # Falls back to git clone
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
+          .and_return(old_date)
+
+        result = finder.latest_release_version
+        # Falls back to for-each-ref, date is old (outside cooldown)
+        expect(result.to_s).to eq("6.0.0")
+      end
+    end
   end
 
   describe "version precision" do

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -189,12 +189,16 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
           .to receive(:dependency_source_details)
           .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
                         ref: reference, branch: nil })
+        # Stub GitHub Releases (empty — forces git clone fallback)
+        mock_client = instance_double(Octokit::Client, releases: [])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
           .with(/git clone --bare/, any_args).and_return("")
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git show --no-patch/, hash_including(fingerprint: anything))
+          .with(/git for-each-ref/, hash_including(fingerprint: anything))
           .and_return(recent_date)
       end
 


### PR DESCRIPTION
## Summary

Previously, cooldown in the **pre-commit** and **GitHub Actions** ecosystems used the commit's committer date (`%cd`) to determine when a version was released. This is inaccurate when a tag points to an older commit — for example, when a tag is republished, force-pushed, or created long after the commit was authored.

## Changes

Implements a three-tier date resolution strategy for cooldown:

1. **GitHub Release `published_at`** (via Octokit) — most accurate, reflects actual publication time even after re-tagging
2. **Tag creation date** (`git for-each-ref %(creatordate:iso)`) — tagger date for annotated tags
3. **Commit date** (`git show %cd`) — final fallback for lightweight tags

### Key implementation details:
- GitHub releases are fetched once and cached per finder instance (`cached_github_releases`)
- Falls back gracefully: no GitHub Release → try tag date → use commit date
- Works for non-GitHub repos (gracefully falls back to git-based detection)
- No clone needed when GitHub Release exists (saves time)

## Why this matters

| Scenario | Old behavior | New behavior |
|----------|-------------|--------------|
| Tag points to 30-day-old commit, published today | Bypasses cooldown ❌ | Correctly in cooldown ✅ |
| Mutable tag (v4) force-pushed to new commit | Uses old commit date ❌ | Uses release publish date ✅ |
| Re-tagged release | Uses commit date ❌ | Uses new publish date ✅ |

## Testing

Added tests for both ecosystems covering:
- GitHub Release `published_at` used when available (skips git clone)
- Fallback to `for-each-ref` when no release exists
- Fallback to commit date when `for-each-ref` returns empty
- Annotated tags with old commits correctly apply cooldown
- Existing cooldown tests continue to pass (they hit the fallback path)