### PR TITLE
Bundler: surface invalid registry gem metadata as a private source error

### DIFF
--- a/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb
@@ -38,6 +38,12 @@ module Dependabot
         GIT_REGEX = /reset --hard [^\s]*` in directory (?<path>[^\s]*)/
         GIT_REF_REGEX = /not exist in the repository (?<path>[^\s]*)\./
         PATH_REGEX = /The path `(?<path>.*)` does not exist/
+        # Raised by Bundler when a registry's compact index (`/info/<gem>`) returns
+        # gem metadata it can't parse (e.g. an illformed `ruby:`/`rubygems:`
+        # requirement). This means the *registry* served bad data, not that the
+        # user's dependency files are broken.
+        REGISTRY_METADATA_ERROR_REGEX =
+          /error parsing the metadata for the gem (?<gem>\S+) \((?<version>[^)]+)\)/
 
         module BundlerErrorPatterns
           MISSING_AUTH_REGEX = /bundle config set --global (?<source>.*) username:password/
@@ -118,7 +124,7 @@ module Dependabot
           case error.error_class
           when "Bundler::Dsl::DSLError", "Bundler::GemspecError"
             # We couldn't evaluate the Gemfile, let alone resolve it
-            raise Dependabot::DependencyFileNotEvaluatable, msg
+            raise registry_metadata_error(error) || Dependabot::DependencyFileNotEvaluatable.new(msg)
           when "Bundler::Source::Git::MissingGitRevisionError"
             match_data = error.message.match(GIT_REF_REGEX)
             gem_name = T.must(T.must(match_data).named_captures["path"])
@@ -195,6 +201,31 @@ module Dependabot
         # rubocop:enable Metrics/PerceivedComplexity
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/MethodLength
+
+        # When Bundler fails to parse gem metadata served by a registry's compact
+        # index, surface it as a private source error (the registry returned bad
+        # data) rather than blaming the user's dependency files. Returns nil when
+        # the error isn't a registry metadata error so the caller can fall back.
+        sig do
+          params(error: Dependabot::SharedHelpers::HelperSubprocessFailed)
+            .returns(T.nilable(Dependabot::PrivateSourceBadResponse))
+        end
+        def registry_metadata_error(error)
+          match = error.message.match(REGISTRY_METADATA_ERROR_REGEX)
+          return nil unless match
+
+          source = private_registry_source
+          return nil unless source
+
+          detail = "Invalid gem metadata returned for #{match[:gem]} (#{match[:version]}) " \
+                   "by the source: #{source}"
+          Dependabot::PrivateSourceBadResponse.new(source, detail)
+        end
+
+        sig { returns(T.nilable(String)) }
+        def private_registry_source
+          private_registry_credentials.filter_map { |cred| cred["host"] }.first
+        end
 
         sig { returns(T::Array[T::Hash[String, T.untyped]]) }
         def inaccessible_git_dependencies

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -16,15 +16,18 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
       ignored_versions: ignored_versions,
       raise_on_ignored: raise_on_ignored,
       security_advisories: security_advisories,
-      credentials: [{
-        "type" => "git_source",
-        "host" => "github.com",
-        "username" => "x-access-token",
-        "password" => "token"
-      }],
+      credentials: credentials,
       cooldown_options: cooldown_options,
       options: {}
     )
+  end
+  let(:credentials) do
+    [{
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "x-access-token",
+      "password" => "token"
+    }]
   end
   let(:dependency_files) { bundler_project_dependency_files("gemfile") }
   let(:bundler_version) { PackageManagerHelper.bundler_version }
@@ -547,6 +550,88 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
               expect(error.source)
                 .to eq("https://repo.fury.io/<redacted>")
             end
+        end
+      end
+
+      context "when the registry returns invalid gem metadata" do
+        let(:credentials) do
+          [Dependabot::Credential.new(
+            {
+              "type" => "rubygems_server",
+              "host" => "rubygems.pkg.github.com",
+              "token" => "secret_token"
+            }
+          )]
+        end
+
+        let(:error_message) do
+          <<~ERR
+            There was an error parsing the metadata for the gem failbot (2.0.1): Gem::Requirement::BadRequirementError
+            Illformed requirement [">= notaruby"]
+            The metadata was [["checksum", ["abc123"]], ["ruby", [">= notaruby"]]]
+          ERR
+        end
+
+        let(:error_class) { "Bundler::GemspecError" }
+
+        before do
+          allow(Dependabot::Bundler::NativeHelpers)
+            .to receive(:run_bundler_subprocess)
+            .with({
+              bundler_version: bundler_version,
+              function: "private_registry_versions",
+              options: anything,
+              args: anything
+            })
+            .and_raise(subprocess_error)
+        end
+
+        it "raises a PrivateSourceBadResponse error naming the gem and source" do
+          expect { finder.latest_version_details }
+            .to raise_error do |error|
+              expect(error).to be_a(Dependabot::PrivateSourceBadResponse)
+              expect(error.source).to eq("rubygems.pkg.github.com")
+              expect(error.message)
+                .to eq(
+                  "Invalid gem metadata returned for failbot (2.0.1) " \
+                  "by the source: rubygems.pkg.github.com"
+                )
+            end
+        end
+      end
+
+      context "when a local gemspec is invalid (not a registry metadata error)" do
+        let(:credentials) do
+          [Dependabot::Credential.new(
+            {
+              "type" => "rubygems_server",
+              "host" => "rubygems.pkg.github.com",
+              "token" => "secret_token"
+            }
+          )]
+        end
+
+        let(:error_message) do
+          "There was an error while loading `business.gemspec`: undefined method `foo'"
+        end
+
+        let(:error_class) { "Bundler::GemspecError" }
+
+        before do
+          allow(Dependabot::Bundler::NativeHelpers)
+            .to receive(:run_bundler_subprocess)
+            .with({
+              bundler_version: bundler_version,
+              function: "private_registry_versions",
+              options: anything,
+              args: anything
+            })
+            .and_raise(subprocess_error)
+        end
+
+        it "still raises a DependencyFileNotEvaluatable error" do
+          expect { finder.latest_version_details }
+            .to raise_error(Dependabot::DependencyFileNotEvaluatable)
         end
       end
 

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -722,7 +722,7 @@ module Dependabot
     sig { params(source: T.nilable(String), error_message: T.nilable(String)).void }
     def initialize(source, error_message = nil)
       @source = T.let(sanitize_source(T.must(source)), String)
-      msg = error_message || "Bad response error while accessing source: #{@source}"
+      msg = error_message ? sanitize_source(error_message) : "Bad response error while accessing source: #{@source}"
       super(msg)
     end
   end

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -719,10 +719,10 @@ module Dependabot
     sig { returns(String) }
     attr_reader :source
 
-    sig { params(source: T.nilable(String)).void }
-    def initialize(source)
+    sig { params(source: T.nilable(String), error_message: T.nilable(String)).void }
+    def initialize(source, error_message = nil)
       @source = T.let(sanitize_source(T.must(source)), String)
-      msg = "Bad response error while accessing source: #{@source}"
+      msg = error_message || "Bad response error while accessing source: #{@source}"
       super(msg)
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

When a RubyGems registry's compact index (`/info/<gem>`) returns gem metadata that Bundler cannot parse — for example an illformed `ruby:`/`rubygems:` requirement on a single version — Bundler raises `Bundler::GemspecError`. Dependabot mapped that to `DependencyFileNotEvaluatable`, which is surfaced to users as "Dependabot can't evaluate your Ruby dependency files."

That message wrongly blames the user's Gemfile/gemspec for what is actually bad data served by the registry, making these failures very hard to triage.

This change detects the registry-metadata parse failure and, when a private RubyGems source is configured, raises `PrivateSourceBadResponse` naming the gem, version and source instead. Genuine local gemspec problems continue to map to `DependencyFileNotEvaluatable`.

### Anything you want to highlight for special attention from reviewers?

The behaviour is gated on Bundler's distinctive "error parsing the metadata for the gem ..." message, which only originates from remote compact-index parsing — local gemspec errors use different wording, so they are unaffected. The new private-source error is only raised when a `rubygems_server` credential is present; otherwise the previous behaviour is preserved.

`PrivateSourceBadResponse` gained an optional message argument so the Bundler handler can provide actionable context. The change is backward compatible — all existing single-argument callers are unaffected.

### How will you know you've accomplished your goal?

The mapping was verified empirically against the real native helper (Bundler 4 and Bundler 2), confirming that a malformed `/info` requirement is the case that produces the user-visible error. New specs cover both the registry-metadata case (now `PrivateSourceBadResponse`) and the local-gemspec case (still `DependencyFileNotEvaluatable`). Existing Bundler update-checker specs continue to pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
