### PR TITLE
test: characterize moving-tag SHA cooldown behavior across ecosystems

### DIFF
--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -329,6 +329,22 @@ RSpec.describe namespace::LatestVersionFinder do
     let(:commit_two) { "b" * 40 }   # v3.0.0 HEAD after the move, 8 days old
     let(:reference) { commit_three }
     let(:dependency_version) { nil }
+    # Mirror what the file parser emits for a SHA pin: the declaration string
+    # references the pinned SHA, not the top-level "@master" default.
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: dependency_name,
+        version: dependency_version,
+        requirements: [{
+          requirement: nil,
+          groups: [],
+          file: ".github/workflows/workflow.yml",
+          source: dependency_source,
+          metadata: { declaration_string: "#{dependency_name}@#{reference}" }
+        }],
+        package_manager: "github_actions"
+      )
+    end
     let(:head_commit_date) do
       (Time.now - (8 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
     end

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -314,6 +314,76 @@ RSpec.describe namespace::LatestVersionFinder do
     end
   end
 
+  # Characterization tests for the agreed scenario:
+  #
+  #   cooldown = 7 days
+  #   latest tag v3.0.0 was force-moved (re-pointed) within the same version:
+  #     commit-2 -> released  8 days ago, now the HEAD of v3.0.0 (OUTSIDE cooldown)
+  #     commit-3 -> released 15 days ago, the pinned commit
+  #
+  # For GitHub Actions, resolution of a SHA pin is commit-driven: it follows the
+  # moving tag's HEAD commit. A trailing version comment is cosmetic and does not
+  # change resolution. Both pin styles therefore update to commit-2.
+  describe "moving tag (same version v3.0.0) SHA characterization" do
+    let(:commit_three) { "c" * 40 } # pinned, 15 days old
+    let(:commit_two) { "b" * 40 }   # v3.0.0 HEAD after the move, 8 days old
+    let(:reference) { commit_three }
+    let(:dependency_version) { nil }
+    let(:head_commit_date) do
+      (Time.now - (8 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
+    end
+    let(:finder) do
+      described_class.new(
+        dependency: dependency,
+        dependency_files: [],
+        credentials: github_credentials,
+        security_advisories: security_advisories,
+        ignored_versions: ignored_versions,
+        raise_on_ignored: raise_on_ignored,
+        cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+      )
+    end
+
+    before do
+      allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+        .to receive(:head_commit_for_pinned_ref).and_return(commit_two)
+
+      # Stub the git boundary used by #commit_metadata_details so no real clone happens.
+      allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+      allow(Dir).to receive(:chdir).and_yield
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd, *_rest|
+        cmd.include?("git show") ? head_commit_date : ""
+      end
+    end
+
+    context "when commit-3 is pinned with NO version comment" do
+      it "moves to commit-2 (the moved tag's HEAD, outside cooldown)" do
+        expect(finder.latest_release_version).to eq(commit_two)
+      end
+    end
+
+    context "when commit-3 is pinned WITH a version comment" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: dependency_version,
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".github/workflows/workflow.yml",
+            source: dependency_source,
+            metadata: { declaration_string: "#{dependency_name}@#{reference} # v3.0.0" }
+          }],
+          package_manager: "github_actions"
+        )
+      end
+
+      it "moves to commit-2 (the comment is cosmetic; resolution is commit-driven)" do
+        expect(finder.latest_release_version).to eq(commit_two)
+      end
+    end
+  end
+
   # Regression test for version tag prefix handling
   # Bug: Dependabot returns main branch commit instead of latest tag when
   # dependency refs like "0.0.13" don't match prefixed tags like "v0.0.13"

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -247,7 +247,10 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
   #   - bare SHA pin         => commit-driven, follows the moving tag => commit-2
   #   - SHA + frozen comment => version-driven; the tag stays the same version
   #     (v3.0.0), so the version filter never offers the newer commit => stays on
-  #     commit-3 (regression introduced by #15346).
+  #     commit-3.
+  #
+  # These specs document the current behavior as-is; see the PR discussion for
+  # context on where this divergence may have originated.
   describe "moving tag (same version v3.0.0) SHA characterization" do
     let(:commit_three) { "c" * 40 } # pinned, 15 days old
     let(:commit_two) { "b" * 40 }   # v3.0.0 HEAD after the move, 8 days old

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -236,6 +236,84 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
     end
   end
 
+  # Characterization tests for the agreed scenario:
+  #
+  #   cooldown = 7 days
+  #   latest tag v3.0.0 was force-moved (re-pointed) within the same version:
+  #     commit-2 -> released  8 days ago, now the HEAD of v3.0.0 (OUTSIDE cooldown)
+  #     commit-3 -> released 15 days ago, the pinned commit
+  #
+  # Pre-commit resolves the two pin styles differently:
+  #   - bare SHA pin         => commit-driven, follows the moving tag => commit-2
+  #   - SHA + frozen comment => version-driven; the tag stays the same version
+  #     (v3.0.0), so the version filter never offers the newer commit => stays on
+  #     commit-3 (regression introduced by #15346).
+  describe "moving tag (same version v3.0.0) SHA characterization" do
+    let(:commit_three) { "c" * 40 } # pinned, 15 days old
+    let(:commit_two) { "b" * 40 }   # v3.0.0 HEAD after the move, 8 days old
+    let(:reference) { commit_three }
+    let(:dependency_version) { commit_three }
+    let(:update_cooldown) do
+      Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+    end
+
+    before do
+      allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+        .to receive(:local_tag_for_pinned_sha).and_return(nil)
+      allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+        .to receive(:head_commit_for_pinned_ref).and_return(commit_two)
+    end
+
+    context "when commit-3 is pinned with NO version comment (bare SHA)" do
+      it "moves to commit-2 (cooldown is skipped for SHAs; follows the moving tag)" do
+        expect(checker.latest_version).to eq(commit_two)
+      end
+    end
+
+    context "when commit-3 is pinned WITH a frozen version comment (# frozen: v3.0.0)" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "https://github.com/#{dependency_name}",
+          version: commit_three,
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: dependency_source,
+            metadata: { comment: "# frozen: v3.0.0" }
+          }],
+          package_manager: "pre_commit"
+        )
+      end
+
+      before do
+        # v3.0.0 is the latest tag and has been re-pointed to commit-2. Because
+        # the version label is unchanged, the version filter (3.0.0 > 3.0.0 == false)
+        # offers no newer candidate.
+        v3_tag = {
+          tag: "v3.0.0",
+          version: Dependabot::PreCommit::Version.new("3.0.0"),
+          commit_sha: commit_two
+        }
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions).and_return([v3_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions_matching_existing_precision).and_return([v3_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
+                        ref: reference, branch: nil })
+      end
+
+      it "stays on commit-3 and reports the dependency as up to date" do
+        # The newer commit-2 (8 days old, outside cooldown) is never surfaced
+        # because resolution is version-driven and the version did not change.
+        expect(checker.latest_version.to_s).to eq("3.0.0")
+        expect(checker.up_to_date?).to be(true)
+      end
+    end
+  end
+
   describe "#updated_requirements" do
     subject(:updated_requirements) { checker.updated_requirements }
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR adds spec-only characterization tests that demonstrate a behavioral inconsistency in how cooldown handles SHA-pinned dependencies when a tag is force-moved (re-pointed) within the same version label.

The goal is to make the current behavior explicit and verifiable, so we can have an informed discussion about whether it is intended.

**Scenario under test**
```
cooldown = 7 days
latest tag v3.0.0 (force-moved within the same version):
  commit-2 -> released  8 days ago, now the HEAD of v3.0.0 (outside cooldown)
  commit-3 -> released 15 days ago, the pinned commit
```

For the **same user intent** — "pin a SHA, optionally annotate it with a version comment" — the four setups resolve differently:


Ecosystem | Pin style | Behavior | Updates to commit-2?
-- | -- | -- | --
GitHub Actions | Bare SHA | Commit-driven; follows the moving tag | ✅ Yes
GitHub Actions | SHA + version comment | Comment is cosmetic; resolution unchanged | ✅ Yes
pre-commit | Bare SHA | Commit-driven; cooldown skipped for SHAs | ✅ Yes
pre-commit | SHA + frozen comment | Version-driven; unchanged version label yields no candidate | ❌ No (stays on commit-3)

Three of the four identical-intent configurations advance to `commit-2`. Only pre-commit with a frozen version comment stays on `commit-3`, because resolution there becomes version-driven and the unchanged v3.0.0 label produces no newer candidate.

This divergence appears to have been introduced by #15346. I would like to confirm whether this difference is intentional before proposing any change to the production behavior.

**What this PR does and does not change**
- ✅ Adds characterization tests in both ecosystems documenting the current behavior.
- ❌ Does not modify any production code — the tests pass against main as-is.

### Anything you want to highlight for special attention from reviewers?

The pre-commit "stays on commit-3" outcome is specific to the case where the frozen version is also the latest tag (re-pointed within the same version). When a genuinely higher tag exists, pre-commit still updates as expected — so this is not a blanket "frozen comments block updates" behavior, but specifically a same-version moving-tag case. I'd appreciate confirmation on whether this is the desired contract.

### How will you know you've accomplished your goal?

- New characterization specs pass on main without any production changes (GitHub Actions: 26 examples, 0 failures; pre-commit: 23 examples, 0 failures).
- The behavioral difference between the version-commented and non-version-commented pin styles is captured and reproducible for both ecosystems.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
