### PR TITLE
gradle: bump updater image to 9.4.1

### DIFF
--- a/gradle/Dockerfile
+++ b/gradle/Dockerfile
@@ -5,7 +5,7 @@
 # If you perform a manual update, make sure to update the tag as well.
 # Including the tag with the digest is for documentation purposes, as Docker ignores the tag when a digest is provided
 # It is useful because mapping tags to digests is challenging without OCI metadata, and many images do not provide this metadata.
-FROM docker.io/gradle:9.2.1-jdk21-ubi-minimal@sha256:9049dc0698f42c2c1cd5c45a8e8a34f86602e7dd9a217e65da899e5077be3c21 AS gradle
+FROM docker.io/gradle:9.4.1-jdk21-ubi@sha256:a634aaaf8517f3933d4d12de5aed714a3e3ec3699031107c686f2d5cfe4632d7 AS gradle
 
 FROM ghcr.io/dependabot/dependabot-updater-core
 


### PR DESCRIPTION
### What are you trying to accomplish?

Bump the Gradle runtime used by the Dependabot Gradle updater image from 9.2.1 to 9.4.1.

Why: Android/Gradle plugin combinations now require a newer Gradle runtime than 9.2.1 during updater execution (notably lockfile update flows), so the pinned image version needs to be aligned.

This affects/fixes runtime-version mismatch failures in Gradle updater runs that require Gradle >= 9.4.1.

### Anything you want to highlight for special attention from reviewers?

The change is intentionally minimal and scoped to the Gradle updater image pin only:
- update image tag from 9.2.1-jdk21-ubi-minimal to 9.4.1-jdk21-ubi
- update pinned digest to the corresponding multi-platform digest

No behavioral changes are introduced in updater Ruby logic in this PR.

### How will you know you've accomplished your goal?

Success criteria:
- the Gradle updater image builds with the updated tag+digest
- updater execution no longer fails due to "minimum supported Gradle version" errors caused by using 9.2.1

Note: TLS/proxy certificate issues are environmental and out of scope for this PR.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
