### PR TITLE
NuGet: Filter all editable files not present prior to discovery

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ModifiedFilesTrackerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ModifiedFilesTrackerTests.cs
@@ -27,9 +27,9 @@ public class ModifiedFilesTrackerTests
         var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
         var logger = new TestLogger();
 
-        // Record initial lock files (none exist yet)
-        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
-        Assert.Empty(initialLockFiles);
+        // Record initial files (only the .csproj exists)
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+        Assert.Single(initialFiles);
 
         // Simulate discovery creating a lock file (as restore would)
         var lockFilePath = Path.Combine(tempDirectory.DirectoryPath, "packages.lock.json");
@@ -52,8 +52,8 @@ public class ModifiedFilesTrackerTests
             ],
         };
 
-        // Create tracker with initial lock files (empty set)
-        var tracker = new ModifiedFilesTracker(repoContentsPath, initialLockFiles, logger);
+        // Create tracker with initial files (only .csproj)
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
         await tracker.StartTrackingAsync(discoveryResult);
 
         // The lock file should not be in the tracked contents
@@ -85,9 +85,9 @@ public class ModifiedFilesTrackerTests
         var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
         var logger = new TestLogger();
 
-        // Record initial lock files (the lock file exists)
-        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
-        Assert.Single(initialLockFiles);
+        // Record initial files (the lock file and .csproj exist)
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+        Assert.Equal(2, initialFiles.Count);
 
         // Create discovery result that includes the lock file
         var discoveryResult = new WorkspaceDiscoveryResult()
@@ -106,8 +106,8 @@ public class ModifiedFilesTrackerTests
             ],
         };
 
-        // Create tracker with initial lock files
-        var tracker = new ModifiedFilesTracker(repoContentsPath, initialLockFiles, logger);
+        // Create tracker with initial files
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
         await tracker.StartTrackingAsync(discoveryResult);
 
         // The lock file SHOULD be tracked
@@ -121,5 +121,373 @@ public class ModifiedFilesTrackerTests
         var updatedFiles = await tracker.StopTrackingAsync();
         Assert.Single(updatedFiles);
         Assert.Equal("packages.lock.json", updatedFiles[0].Name);
+    }
+
+    [Fact]
+    public async Task PropsFileCreatedDuringRestoreIsNotTracked()
+    {
+        // Simulates the scenario where a .props file is created during restore (e.g., a build-generated file)
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("project.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """)
+        );
+
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new TestLogger();
+
+        // Record initial files (only the .csproj exists)
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+        Assert.Single(initialFiles);
+
+        // Simulate restore creating a .props file
+        var propsFilePath = Path.Combine(tempDirectory.DirectoryPath, "Directory.Build.props");
+        File.WriteAllText(propsFilePath, "<Project />");
+
+        // Create discovery result that includes the .props file as an imported file
+        var discoveryResult = new WorkspaceDiscoveryResult()
+        {
+            Path = "/",
+            Projects = [
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = ["Directory.Build.props"],
+                    AdditionalFiles = [],
+                }
+            ],
+        };
+
+        // Create tracker with initial files (only .csproj)
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
+        await tracker.StartTrackingAsync(discoveryResult);
+
+        // The props file should NOT be in the tracked contents
+        Assert.DoesNotContain("Directory.Build.props", tracker.OriginalDependencyFileContents.Keys.Select(Path.GetFileName));
+
+        // Modify the props file to simulate an update
+        File.WriteAllText(propsFilePath, "<Project><PropertyGroup><Foo>bar</Foo></PropertyGroup></Project>");
+
+        // Stop tracking - should NOT report the props file as modified
+        var updatedFiles = await tracker.StopTrackingAsync();
+        Assert.Empty(updatedFiles);
+    }
+
+    [Fact]
+    public async Task ExistingPropsFileIsTrackedAndReported()
+    {
+        // When a .props file IS checked in, it should be tracked and reported as modified after an update
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("project.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """),
+            ("Directory.Build.props", "<Project />")
+        );
+
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new TestLogger();
+
+        // Record initial files (both exist)
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+        Assert.Equal(2, initialFiles.Count);
+
+        // Create discovery result that includes the .props file
+        var discoveryResult = new WorkspaceDiscoveryResult()
+        {
+            Path = "/",
+            Projects = [
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = ["Directory.Build.props"],
+                    AdditionalFiles = [],
+                }
+            ],
+        };
+
+        // Create tracker with initial files
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
+        await tracker.StartTrackingAsync(discoveryResult);
+
+        // The props file SHOULD be tracked
+        Assert.Contains("Directory.Build.props", tracker.OriginalDependencyFileContents.Keys.Select(Path.GetFileName));
+
+        // Modify the props file
+        var propsFilePath = Path.Combine(tempDirectory.DirectoryPath, "Directory.Build.props");
+        File.WriteAllText(propsFilePath, "<Project><PropertyGroup><Foo>bar</Foo></PropertyGroup></Project>");
+
+        // Stop tracking - SHOULD report the props file as modified
+        var updatedFiles = await tracker.StopTrackingAsync();
+        Assert.Single(updatedFiles);
+        Assert.Equal("Directory.Build.props", updatedFiles[0].Name);
+    }
+
+    [Fact]
+    public async Task ProjectFileCreatedDuringRestoreIsNotTracked()
+    {
+        // Simulates the scenario where a project file appears during restore that wasn't originally present
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("project.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """)
+        );
+
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new TestLogger();
+
+        // Record initial files (only the main .csproj exists)
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+        Assert.Single(initialFiles);
+
+        // Simulate a second project file appearing during restore/build
+        var newProjectPath = Path.Combine(tempDirectory.DirectoryPath, "generated.csproj");
+        File.WriteAllText(newProjectPath, "<Project />");
+
+        // Create discovery result that includes both projects
+        var discoveryResult = new WorkspaceDiscoveryResult()
+        {
+            Path = "/",
+            Projects = [
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
+                },
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "generated.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
+                }
+            ],
+        };
+
+        // Create tracker with initial files (only original .csproj)
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
+        await tracker.StartTrackingAsync(discoveryResult);
+
+        // The generated project file should NOT be in the tracked contents
+        Assert.DoesNotContain("generated.csproj", tracker.OriginalDependencyFileContents.Keys.Select(Path.GetFileName));
+        // The original project file SHOULD be tracked
+        Assert.Contains("project.csproj", tracker.OriginalDependencyFileContents.Keys.Select(Path.GetFileName));
+
+        // Modify both project files
+        File.WriteAllText(newProjectPath, "<Project><PropertyGroup><Foo>bar</Foo></PropertyGroup></Project>");
+
+        // Stop tracking - should NOT report the generated project file
+        var updatedFiles = await tracker.StopTrackingAsync();
+        Assert.Empty(updatedFiles);
+    }
+
+    [Fact]
+    public async Task GlobalJsonCreatedDuringRestoreIsNotTracked()
+    {
+        // Simulates the scenario where a global.json file is created during restore
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("project.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """)
+        );
+
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new TestLogger();
+
+        // Record initial files (no global.json exists)
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+        Assert.Single(initialFiles);
+
+        // Simulate global.json being created during restore
+        var globalJsonPath = Path.Combine(tempDirectory.DirectoryPath, "global.json");
+        File.WriteAllText(globalJsonPath, """{"sdk": {"version": "9.0.100"}}""");
+
+        // Create discovery result that includes global.json
+        var discoveryResult = new WorkspaceDiscoveryResult()
+        {
+            Path = "/",
+            Projects = [
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
+                }
+            ],
+            GlobalJson = new GlobalJsonDiscoveryResult()
+            {
+                FilePath = "global.json",
+                Dependencies = [],
+            },
+        };
+
+        // Create tracker with initial files (no global.json)
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
+        await tracker.StartTrackingAsync(discoveryResult);
+
+        // The global.json should NOT be in the tracked contents
+        Assert.DoesNotContain("global.json", tracker.OriginalDependencyFileContents.Keys.Select(Path.GetFileName));
+
+        // Modify global.json
+        File.WriteAllText(globalJsonPath, """{"sdk": {"version": "10.0.100"}}""");
+
+        // Stop tracking - should NOT report global.json as modified
+        var updatedFiles = await tracker.StopTrackingAsync();
+        Assert.Empty(updatedFiles);
+    }
+
+    [Fact]
+    public async Task DotNetToolsJsonCreatedDuringRestoreIsNotTracked()
+    {
+        // Simulates the scenario where a dotnet-tools.json file is created during restore
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("project.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """)
+        );
+
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new TestLogger();
+
+        // Record initial files (no dotnet-tools.json exists)
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+        Assert.Single(initialFiles);
+
+        // Simulate dotnet-tools.json being created
+        var toolsDir = Path.Combine(tempDirectory.DirectoryPath, ".config");
+        Directory.CreateDirectory(toolsDir);
+        var toolsJsonPath = Path.Combine(toolsDir, "dotnet-tools.json");
+        File.WriteAllText(toolsJsonPath, """{"version": 1, "tools": {}}""");
+
+        // Create discovery result that includes dotnet-tools.json
+        var discoveryResult = new WorkspaceDiscoveryResult()
+        {
+            Path = "/",
+            Projects = [
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
+                }
+            ],
+            DotNetToolsJson = new DotNetToolsJsonDiscoveryResult()
+            {
+                FilePath = ".config/dotnet-tools.json",
+                Dependencies = [],
+            },
+        };
+
+        // Create tracker with initial files (no dotnet-tools.json)
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
+        await tracker.StartTrackingAsync(discoveryResult);
+
+        // The dotnet-tools.json should NOT be in the tracked contents
+        Assert.DoesNotContain("dotnet-tools.json", tracker.OriginalDependencyFileContents.Keys.Select(Path.GetFileName));
+
+        // Modify dotnet-tools.json
+        File.WriteAllText(toolsJsonPath, """{"version": 1, "tools": {"dotnet-ef": {"version": "9.0.0"}}}""");
+
+        // Stop tracking - should NOT report dotnet-tools.json as modified
+        var updatedFiles = await tracker.StopTrackingAsync();
+        Assert.Empty(updatedFiles);
+    }
+
+    [Fact]
+    public async Task GetInitiallyExistingFiles_FindsAllEditableFileTypes()
+    {
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("project.csproj", "<Project />"),
+            ("lib.fsproj", "<Project />"),
+            ("app.vbproj", "<Project />"),
+            ("Directory.Build.props", "<Project />"),
+            ("Directory.Build.targets", "<Project />"),
+            ("app.config", "<configuration />"),
+            ("web.config", "<configuration />"),
+            ("packages.config", "<packages />"),
+            ("packages.lock.json", "{}"),
+            ("global.json", "{}"),
+            (".config/dotnet-tools.json", "{}"),
+            ("readme.md", "# Readme"),
+            ("src/code.cs", "class C {}")
+        );
+
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+
+        // Should find all 11 editable file types
+        Assert.Contains("project.csproj", initialFiles);
+        Assert.Contains("lib.fsproj", initialFiles);
+        Assert.Contains("app.vbproj", initialFiles);
+        Assert.Contains("Directory.Build.props", initialFiles);
+        Assert.Contains("Directory.Build.targets", initialFiles);
+        Assert.Contains("app.config", initialFiles);
+        Assert.Contains("web.config", initialFiles);
+        Assert.Contains("packages.config", initialFiles);
+        Assert.Contains("packages.lock.json", initialFiles);
+        Assert.Contains("global.json", initialFiles);
+        Assert.Contains(".config/dotnet-tools.json", initialFiles);
+
+        // Should NOT find non-editable files
+        Assert.DoesNotContain("readme.md", initialFiles);
+        Assert.DoesNotContain("src/code.cs", initialFiles);
+    }
+
+    [Theory]
+    [InlineData("global.json", true)]
+    [InlineData("dotnet-tools.json", true)]
+    [InlineData("project.csproj", true)]
+    [InlineData("lib.fsproj", true)]
+    [InlineData("app.vbproj", true)]
+    [InlineData("Directory.Build.props", true)]
+    [InlineData("Directory.Build.targets", true)]
+    [InlineData("app.config", true)]
+    [InlineData("web.config", true)]
+    [InlineData("packages.config", true)]
+    [InlineData("packages.lock.json", true)]
+    [InlineData("readme.md", false)]
+    [InlineData("nuget.config", false)]
+    [InlineData("code.cs", false)]
+    [InlineData("some.dll", false)]
+    public void MatchesAllowedEditablePattern(string fileName, bool expected)
+    {
+        Assert.Equal(expected, ModifiedFilesTracker.MatchesAllowedEditablePattern(fileName));
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdatedDependencyListTests.cs
@@ -86,7 +86,7 @@ public class UpdatedDependencyListTests
                 ]
             }
         };
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: temp.DirectoryPath, new TestLogger(), ModifiedFilesTracker.GetExistingLockFiles(new DirectoryInfo(temp.DirectoryPath)));
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: temp.DirectoryPath, new TestLogger(), ModifiedFilesTracker.GetInitiallyExistingFiles(new DirectoryInfo(temp.DirectoryPath)));
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies =
@@ -210,7 +210,7 @@ public class UpdatedDependencyListTests
         };
 
         // act
-        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: tempDir.DirectoryPath, new TestLogger(), ModifiedFilesTracker.GetExistingLockFiles(new DirectoryInfo(tempDir.DirectoryPath)));
+        var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discovery, repoRoot: tempDir.DirectoryPath, new TestLogger(), ModifiedFilesTracker.GetInitiallyExistingFiles(new DirectoryInfo(tempDir.DirectoryPath)));
         var expectedDependencyList = new UpdatedDependencyList()
         {
             Dependencies = [],

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
@@ -18,27 +18,56 @@ public class ModifiedFilesTracker
     private readonly Dictionary<string, EOLType> _originalDependencyFileEOFs = [];
     private readonly Dictionary<string, bool> _originalDependencyFileBOMs = [];
     private string[] _nonProjectFiles = [];
-    private readonly HashSet<string> _initiallyExistingLockFiles;
+    private readonly HashSet<string> _initiallyExistingFiles;
+
+    /// <summary>
+    /// The set of file name patterns (case-insensitive) that are allowed to be edited during an update run.
+    /// Files matching these patterns are tracked for pre-existence; any file not present before discovery
+    /// will not be reported as modified.
+    /// </summary>
+    internal static readonly string[] AllowedEditableFilePatterns =
+    [
+        "global.json",
+        "dotnet-tools.json",
+        "*.csproj",
+        "*.fsproj",
+        "*.vbproj",
+        "*.props",
+        "*.targets",
+        "app.config",
+        "web.config",
+        "packages.config",
+        "packages.lock.json",
+    ];
 
     public IReadOnlyDictionary<string, string> OriginalDependencyFileContents => _originalDependencyFileContents;
     //public IReadOnlyDictionary<string, EOLType> OriginalDependencyFileEOFs => _originalDependencyFileEOFs;
     public IReadOnlyDictionary<string, bool> OriginalDependencyFileBOMs => _originalDependencyFileBOMs;
 
-    public ModifiedFilesTracker(DirectoryInfo repoContentsPath, HashSet<string> initiallyExistingLockFiles, ILogger logger)
+    public ModifiedFilesTracker(DirectoryInfo repoContentsPath, HashSet<string> initiallyExistingFiles, ILogger logger)
     {
         RepoContentsPath = repoContentsPath;
-        _initiallyExistingLockFiles = initiallyExistingLockFiles;
+        _initiallyExistingFiles = initiallyExistingFiles;
         _logger = logger;
     }
 
     /// <summary>
-    /// Returns the set of lock file paths (relative to repo root, unix-style) that currently exist on disk.
+    /// Returns the set of editable file paths (relative to repo root, unix-style) that currently exist on disk
+    /// and match the allowed editable file patterns.
     /// </summary>
-    public static HashSet<string> GetExistingLockFiles(DirectoryInfo repoContentsPath)
+    public static HashSet<string> GetInitiallyExistingFiles(DirectoryInfo repoContentsPath)
     {
-        return Directory.EnumerateFiles(repoContentsPath.FullName, ProjectHelper.PackagesLockJsonFileName, SearchOption.AllDirectories)
-            .Select(f => Path.GetRelativePath(repoContentsPath.FullName, f).NormalizePathToUnix())
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var file in Directory.EnumerateFiles(repoContentsPath.FullName, "*", SearchOption.AllDirectories))
+        {
+            var fileName = Path.GetFileName(file);
+            if (MatchesAllowedEditablePattern(fileName))
+            {
+                result.Add(Path.GetRelativePath(repoContentsPath.FullName, file).NormalizePathToUnix());
+            }
+        }
+
+        return result;
     }
 
     public async Task StartTrackingAsync(WorkspaceDiscoveryResult discoveryResult)
@@ -65,11 +94,16 @@ public class ModifiedFilesTracker
         foreach (var project in _currentDiscoveryResult.Projects)
         {
             var projectDirectory = Path.GetDirectoryName(project.FilePath);
+            if (IsFileNotInitiallyPresent(Path.Join(_currentDiscoveryResult.Path, project.FilePath).NormalizePathToUnix()))
+            {
+                continue;
+            }
+
             await TrackOriginalContentsAsync(_currentDiscoveryResult.Path, project.FilePath);
             foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
             {
                 var extraFilePath = Path.Join(projectDirectory, extraFile);
-                if (IsLockFileNotInitiallyPresent(Path.Join(_currentDiscoveryResult.Path, extraFilePath).NormalizePathToUnix()))
+                if (IsFileNotInitiallyPresent(Path.Join(_currentDiscoveryResult.Path, extraFilePath).NormalizePathToUnix()))
                 {
                     continue;
                 }
@@ -82,7 +116,9 @@ public class ModifiedFilesTracker
         {
             _currentDiscoveryResult.GlobalJson?.FilePath,
             _currentDiscoveryResult.DotNetToolsJson?.FilePath,
-        }.Where(f => f is not null).Cast<string>().ToArray();
+        }.Where(f => f is not null).Cast<string>()
+         .Where(f => !IsFileNotInitiallyPresent(Path.Join(_currentDiscoveryResult.Path, f).NormalizePathToUnix()))
+         .ToArray();
         foreach (var nonProjectFile in _nonProjectFiles)
         {
             await TrackOriginalContentsAsync(_currentDiscoveryResult.Path, nonProjectFile);
@@ -138,12 +174,17 @@ public class ModifiedFilesTracker
 
         foreach (var project in _currentDiscoveryResult.Projects)
         {
+            if (IsFileNotInitiallyPresent(Path.Join(_currentDiscoveryResult.Path, project.FilePath).NormalizePathToUnix()))
+            {
+                continue;
+            }
+
             await AddUpdatedFileIfDifferentAsync(_currentDiscoveryResult.Path, project.FilePath);
             var projectDirectory = Path.GetDirectoryName(project.FilePath);
             foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
             {
                 var extraFilePath = Path.Join(projectDirectory, extraFile);
-                if (IsLockFileNotInitiallyPresent(Path.Join(_currentDiscoveryResult.Path, extraFilePath).NormalizePathToUnix()))
+                if (IsFileNotInitiallyPresent(Path.Join(_currentDiscoveryResult.Path, extraFilePath).NormalizePathToUnix()))
                 {
                     continue;
                 }
@@ -173,20 +214,46 @@ public class ModifiedFilesTracker
         return correctedRepoFullPath;
     }
 
-    private bool IsLockFileNotInitiallyPresent(string repoRelativePath)
+    private bool IsFileNotInitiallyPresent(string repoRelativePath)
     {
-        return IsLockFileNotInitiallyPresent(repoRelativePath, _initiallyExistingLockFiles);
+        return IsFileNotInitiallyPresent(repoRelativePath, _initiallyExistingFiles);
     }
 
-    public static bool IsLockFileNotInitiallyPresent(string repoRelativePath, HashSet<string> initiallyExistingLockFiles)
+    public static bool IsFileNotInitiallyPresent(string repoRelativePath, HashSet<string> initiallyExistingFiles)
     {
         var normalizedPath = repoRelativePath.NormalizePathToUnix().NormalizeUnixPathParts().TrimStart('/');
-        if (!Path.GetFileName(normalizedPath).Equals(ProjectHelper.PackagesLockJsonFileName, StringComparison.OrdinalIgnoreCase))
+        var fileName = Path.GetFileName(normalizedPath);
+
+        if (!MatchesAllowedEditablePattern(fileName))
         {
             return false;
         }
 
-        return !initiallyExistingLockFiles.Contains(normalizedPath);
+        return !initiallyExistingFiles.Contains(normalizedPath);
+    }
+
+    internal static bool MatchesAllowedEditablePattern(string fileName)
+    {
+        foreach (var pattern in AllowedEditableFilePatterns)
+        {
+            if (pattern.StartsWith("*"))
+            {
+                var extension = pattern[1..]; // e.g., ".csproj"
+                if (fileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                if (fileName.Equals(pattern, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     public static ImmutableArray<DependencyFile> MergeUpdatedFileSet(ImmutableArray<DependencyFile> setA, ImmutableArray<DependencyFile> setB)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -264,7 +264,7 @@ public class RunWorker
         return relativeResolvedName;
     }
 
-    internal static UpdatedDependencyList GetUpdatedDependencyListFromDiscovery(WorkspaceDiscoveryResult discoveryResult, string repoRoot, ILogger logger, HashSet<string> initiallyExistingLockFiles)
+    internal static UpdatedDependencyList GetUpdatedDependencyListFromDiscovery(WorkspaceDiscoveryResult discoveryResult, string repoRoot, ILogger logger, HashSet<string> initiallyExistingFiles)
     {
         string GetFullRepoPath(string path)
         {
@@ -272,12 +272,17 @@ public class RunWorker
             return Path.Join(discoveryResult.Path, path).FullyNormalizedRootedPath();
         }
 
+        bool IsInitiallyPresent(string filePath)
+        {
+            return !ModifiedFilesTracker.IsFileNotInitiallyPresent(Path.Join(discoveryResult.Path, filePath).NormalizePathToUnix(), initiallyExistingFiles);
+        }
+
         var auxiliaryFiles = new List<string>();
-        if (discoveryResult.GlobalJson is not null)
+        if (discoveryResult.GlobalJson is not null && IsInitiallyPresent(discoveryResult.GlobalJson.FilePath))
         {
             auxiliaryFiles.Add(GetFullRepoPath(discoveryResult.GlobalJson.FilePath));
         }
-        if (discoveryResult.DotNetToolsJson is not null)
+        if (discoveryResult.DotNetToolsJson is not null && IsInitiallyPresent(discoveryResult.DotNetToolsJson.FilePath))
         {
             auxiliaryFiles.Add(GetFullRepoPath(discoveryResult.DotNetToolsJson.FilePath));
         }
@@ -288,7 +293,7 @@ public class RunWorker
             foreach (var extraFile in project.ImportedFiles.Concat(project.AdditionalFiles))
             {
                 var extraFileFullPath = Path.Join(projectDirectory, extraFile);
-                if (ModifiedFilesTracker.IsLockFileNotInitiallyPresent(Path.Join(discoveryResult.Path, extraFileFullPath).NormalizePathToUnix(), initiallyExistingLockFiles))
+                if (!IsInitiallyPresent(extraFileFullPath))
                 {
                     continue;
                 }
@@ -298,28 +303,30 @@ public class RunWorker
             }
         }
 
-        var allDependenciesWithFilePath = discoveryResult.Projects.SelectMany(p =>
-        {
-            return p.Dependencies
-                .Where(d => d.Version is not null)
-                .Select(d =>
-                    (p.FilePath, new ReportedDependency()
-                    {
-                        Name = d.Name,
-                        Requirements = [new ReportedRequirement()
-                            {
-                                File = GetFullRepoPath(p.FilePath),
-                                Requirement = d.Version!,
-                                Groups = ["dependencies"],
-                            }],
-                        Version = d.Version,
-                    }));
-        }).ToList();
+        var allDependenciesWithFilePath = discoveryResult.Projects
+            .Where(p => IsInitiallyPresent(p.FilePath))
+            .SelectMany(p =>
+            {
+                return p.Dependencies
+                    .Where(d => d.Version is not null)
+                    .Select(d =>
+                        (p.FilePath, new ReportedDependency()
+                        {
+                            Name = d.Name,
+                            Requirements = [new ReportedRequirement()
+                                {
+                                    File = GetFullRepoPath(p.FilePath),
+                                    Requirement = d.Version!,
+                                    Groups = ["dependencies"],
+                                }],
+                            Version = d.Version,
+                        }));
+            }).ToList();
 
         var nonProjectDependencySet = new (string?, IEnumerable<Dependency>)[]
         {
-            (discoveryResult.GlobalJson?.FilePath, discoveryResult.GlobalJson?.Dependencies ?? []),
-            (discoveryResult.DotNetToolsJson?.FilePath, discoveryResult.DotNetToolsJson?.Dependencies ?? []),
+            (discoveryResult.GlobalJson is not null && IsInitiallyPresent(discoveryResult.GlobalJson.FilePath) ? discoveryResult.GlobalJson.FilePath : null, discoveryResult.GlobalJson?.Dependencies ?? []),
+            (discoveryResult.DotNetToolsJson is not null && IsInitiallyPresent(discoveryResult.DotNetToolsJson.FilePath) ? discoveryResult.DotNetToolsJson.FilePath : null, discoveryResult.DotNetToolsJson?.Dependencies ?? []),
         };
 
         foreach (var (filePath, dependencies) in nonProjectDependencySet)
@@ -352,6 +359,7 @@ public class RunWorker
             .ToArray();
 
         var dependencyFiles = discoveryResult.Projects
+            .Where(p => IsInitiallyPresent(p.FilePath))
             .Select(p => GetFullRepoPath(p.FilePath))
             .Concat(auxiliaryFiles)
             .Select(p => EnsureCorrectFileCasing(p, repoRoot, logger))

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -31,7 +31,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
         var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -42,7 +42,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -62,7 +62,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
 
             logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialFiles, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -52,7 +52,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
     private async Task RunGroupedDependencyUpdates(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
-        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
         foreach (var group in job.DependencyGroups)
         {
             logger.Info($"Starting update for group {group.Name}");
@@ -70,10 +70,10 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     return;
                 }
 
-                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
+                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialFiles, logger);
                 await tracker.StartTrackingAsync(discoveryResult);
 
-                var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
+                var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialFiles);
                 await apiHandler.UpdateDependencyList(updatedDependencyList);
 
                 var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
@@ -180,7 +180,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
     private async Task RunUngroupedDependencyUpdates(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
-        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -191,7 +191,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
 
             var updateOperationsToPerformByDependency = CollectUpdateOperationsByDependency(discoveryResult);
@@ -200,7 +200,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 logger.Info($"Starting dependency update for {sameDependencySet.Key}");
                 var updateOperationsPerformed = new List<UpdateOperationBase>();
                 var updatedDependencies = new List<ReportedDependency>();
-                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
+                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialFiles, logger);
                 await tracker.StartTrackingAsync(discoveryResult);
 
                 foreach (var (projectPath, dependency) in sameDependencySet)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -68,7 +68,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
         var updateOperationsPerformed = new List<UpdateOperationBase>();
         var updatedDependencies = new List<ReportedDependency>();
         var allUpdatedDependencyFiles = ImmutableArray.Create<DependencyFile>();
-        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -79,7 +79,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
 
             var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
@@ -90,7 +90,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.OrdinalIgnoreCase);
             logger.Info($"Updating dependencies: {string.Join(", ", groupedUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialFiles, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -30,7 +30,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
         var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -42,7 +42,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -76,7 +76,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 continue;
             }
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialFiles, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyGroupToUpdate in groupedUpdateOperationsToPerform)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -30,7 +30,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
     {
         var repoContentsPath = caseInsensitiveRepoContentsPath ?? originalRepoContentsPath;
         var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var initialLockFiles = ModifiedFilesTracker.GetExistingLockFiles(repoContentsPath);
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
             var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -41,7 +41,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                 return;
             }
 
-            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialLockFiles);
+            var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialFiles);
             await apiHandler.UpdateDependencyList(updatedDependencyList);
             await this.ReportUpdaterStarted(apiHandler);
 
@@ -75,7 +75,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
 
             logger.Info($"Updating dependencies: {string.Join(", ", relevantUpdateOperationsToPerform.Select(g => g.Key).Distinct().OrderBy(d => d, StringComparer.OrdinalIgnoreCase))}");
 
-            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialLockFiles, logger);
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialFiles, logger);
             await tracker.StartTrackingAsync(discoveryResult);
             foreach (var dependencyUpdatesToPerform in relevantUpdateOperationsToPerform)
             {


### PR DESCRIPTION
## Summary

Generalizes the lock-file-only pre-existence check from #15030 to cover **all** editable file types that NuGet discovery/restore might generate as side effects. This builds on the submodule filtering added in #15093.

## Problem

During a NuGet restore or discovery, side effects can generate files like `.props`, `.targets`, project files, or other MSBuild artifacts that were not originally in the repository. Previously, only `packages.lock.json` was filtered. This PR extends the filtering to all editable file types so that no updates are attempted for files that did not exist prior to the update run.

## Changes

- **`ModifiedFilesTracker`**: Added `AllowedEditableFilePatterns` defining the full set of trackable file types. Renamed `GetExistingLockFiles` to `GetInitiallyExistingFiles` and `IsLockFileNotInitiallyPresent` to `IsFileNotInitiallyPresent` to reflect the generalized behavior.
- **All 5 update handlers**: Updated to use the new method names.
- **`RunWorker`**: Updated `GetUpdatedDependencyListFromDiscovery` to use the generalized check.
- **Tests**: Expanded `ModifiedFilesTrackerTests` with 6 new test methods covering `.props`, `.csproj`, `global.json`, and `dotnet-tools.json` scenarios, plus a pattern-matching theory test.

## Allowed Editable File Patterns

```
global.json, dotnet-tools.json, *.csproj, *.fsproj, *.vbproj,
*.props, *.targets, app.config, web.config, packages.config, packages.lock.json
```
