### PR TITLE
Bundler: tolerate empty registry checksum metadata in v4 helper

### DIFF
--- a/bundler/helpers/v4/monkey_patches/endpoint_specification_metadata_patch.rb
+++ b/bundler/helpers/v4/monkey_patches/endpoint_specification_metadata_patch.rb
@@ -1,0 +1,32 @@
+# typed: false
+# frozen_string_literal: true
+
+require "bundler/endpoint_specification"
+
+# Bundler 4 parses the metadata a registry's compact index (`/info/<gem>`)
+# returns per gem version. Its guard is `next unless v`, but an empty array
+# `[]` is truthy, so for an empty `checksum` it calls `Checksum.from_api(nil)`
+# -> `nil.match?(...)` and raises `Bundler::GemspecError` ("There was an error
+# parsing the metadata for the gem ..."), aborting the whole resolution.
+#
+# GitHub Packages serves this empty-checksum shape for some old gems (e.g.
+# failbot 2.0.1), so one such gem blocks every update for the repo. Bundler 2
+# didn't parse compact-index checksums, so this only surfaced once the updater
+# moved to the Bundler 4 helper.
+#
+# Drop nil/empty metadata values before Bundler parses them. An empty checksum
+# carries nothing to verify, so skipping it is safe; well-formed values (and
+# genuinely malformed ones, which still raise) are untouched.
+module BundlerEndpointSpecificationMetadataPatch
+  def parse_metadata(data)
+    if data.respond_to?(:reject)
+      data = data.reject do |_key, value|
+        value.nil? || (value.respond_to?(:empty?) && value.empty?)
+      end
+    end
+
+    super
+  end
+end
+
+Bundler::EndpointSpecification.prepend(BundlerEndpointSpecificationMetadataPatch)

--- a/bundler/helpers/v4/run.rb
+++ b/bundler/helpers/v4/run.rb
@@ -24,6 +24,7 @@ end
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
 require "git_source_patch"
+require "endpoint_specification_metadata_patch"
 
 require "functions"
 

--- a/bundler/helpers/v4/spec/bundler_endpoint_specification_metadata_patch_spec.rb
+++ b/bundler/helpers/v4/spec/bundler_endpoint_specification_metadata_patch_spec.rb
@@ -1,0 +1,49 @@
+# typed: false
+# frozen_string_literal: true
+
+require "native_spec_helper"
+
+RSpec.describe BundlerEndpointSpecificationMetadataPatch do
+  let(:spec_fetcher) { instance_double(Bundler::Fetcher, uri: URI("https://example.com")) }
+
+  def build_spec(metadata)
+    Bundler::EndpointSpecification.new("failbot", "2.0.1", "ruby", spec_fetcher, [], metadata)
+  end
+
+  it "does not raise when the registry serves an empty checksum array" do
+    expect { build_spec([["checksum", []]]) }.not_to raise_error
+  end
+
+  it "leaves the checksum unset for an empty checksum array" do
+    spec = build_spec([["checksum", []]])
+    expect(spec.checksum).to be_nil
+  end
+
+  # The compact-index parser can emit a value-less entry (`["checksum"]`) rather
+  # than an empty array, depending on the RubyGems GemParser version. Both shapes
+  # reach this code, so both must be tolerated.
+  it "does not raise when the checksum entry has no value at all" do
+    expect { build_spec([["checksum"]]) }.not_to raise_error
+  end
+
+  it "ignores nil and blank metadata values" do
+    expect { build_spec([["checksum", nil], ["ruby", []]]) }.not_to raise_error
+  end
+
+  it "still parses a well-formed checksum" do
+    digest = "f" * 64
+    spec = build_spec([["checksum", [digest]]])
+    expect(spec.checksum).not_to be_nil
+  end
+
+  it "still parses ruby and rubygems requirements" do
+    spec = build_spec([["ruby", [">= 3.1"]], ["rubygems", [">= 3.0"]], ["checksum", []]])
+    expect(spec.required_ruby_version.to_s).to eq(">= 3.1")
+    expect(spec.required_rubygems_version.to_s).to eq(">= 3.0")
+  end
+
+  it "still raises on a genuinely malformed (non-empty) checksum" do
+    expect { build_spec([["checksum", ["not-a-valid-digest"]]]) }
+      .to raise_error(Bundler::GemspecError)
+  end
+end

--- a/bundler/helpers/v4/spec/native_spec_helper.rb
+++ b/bundler/helpers/v4/spec/native_spec_helper.rb
@@ -21,6 +21,7 @@ $LOAD_PATH.unshift(File.expand_path("../../spec_helpers", __dir__))
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
 require "git_source_patch"
+require "endpoint_specification_metadata_patch"
 
 require "functions"
 

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -26,7 +26,9 @@ module Dependabot
         LOCKFILE_ENDING = /(?<ending>\s*(?:RUBY VERSION|BUNDLED WITH).*)/m
         GIT_DEPENDENCIES_SECTION = /GIT\n.*?\n\n(?!GIT)/m
         GIT_DEPENDENCY_DETAILS = /GIT\n.*?\n\n/m
-        CHECKSUMS_SECTION = /(^CHECKSUMS\n)(?<entries>(?:^  .*\n)+)/m
+        # No `/m`: it would let the greedy `.*` in `entries` match newlines and
+        # swallow the trailing `BUNDLED WITH` section. `^` is line-anchored anyway.
+        CHECKSUMS_SECTION = /(^CHECKSUMS\n)(?<entries>(?:^  .*\n)+)/
         BUNDLED_WITH_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+\.\d+\.\d+)/m
         BUNDLER_CHECKSUM_ENTRY_REGEX = /^  bundler \([^)]+\).*\n?$/
         MIN_BUNDLER_CHECKSUM_VERSION = Gem::Version.new("4.0.11")

--- a/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
@@ -206,6 +206,34 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
     end
   end
 
+  describe "CHECKSUMS_SECTION" do
+    let(:lockfile_body) do
+      <<~LOCKFILE
+        DEPENDENCIES
+          business (~> 1.5)
+
+        CHECKSUMS
+          business (1.5.0) sha256=abc
+          bundler (4.0.8) sha256=def
+
+        BUNDLED WITH
+           4.0.8
+      LOCKFILE
+    end
+
+    # Regression: the constant used the `/m` flag, which made the greedy `.*`
+    # in `entries` match newlines and swallow everything to EOF — including the
+    # trailing `BUNDLED WITH` section. See #15193 / #15229.
+    it "captures only the indented checksum lines, not the BUNDLED WITH section" do
+      match = lockfile_body.match(described_class::CHECKSUMS_SECTION)
+
+      expect(match[:entries]).to eq(
+        "  business (1.5.0) sha256=abc\n  bundler (4.0.8) sha256=def\n"
+      )
+      expect(match[:entries]).not_to include("BUNDLED WITH")
+    end
+  end
+
   describe "with multiple path gems" do
     let(:dependency) do
       Dependabot::Dependency.new(


### PR DESCRIPTION
### What are you trying to accomplish?

Bundler updates were failing for repos pulling gems from GitHub Packages, with the generic "Dependabot can't evaluate your Ruby dependency files" error.

The cause: GitHub Packages serves an empty checksum (`checksum: []`) for some old gems (e.g. `failbot 2.0.1`). Bundler 4 still tries to parse it — its guard only skips `nil`, but an empty array slips through and ends up calling `nil.match?`, raising a `NoMethodError` that aborts the whole resolution. This only started after we moved the updater to the Bundler 4 helper (#15180); Bundler 2 didn't parse checksums.

This PR patches the Bundler 4 helper to drop empty/nil checksum metadata before Bundler parses it, so a single old gem no longer blocks every update.

Fixes github/dependabot-updates#13888

### Anything you want to highlight for special attention from reviewers?

- The fix is a small prepend on `Bundler::EndpointSpecification` that strips empty/nil metadata values, following the existing `bundler/helpers/v4/monkey_patches/` pattern. Genuinely malformed (non-empty) metadata still raises, so we don't swallow real corruption.
- Also drops a stray `/m` flag from `CHECKSUMS_SECTION` in `lockfile_updater.rb` left over from #15229, with a regression test.

### How will you know you've accomplished your goal?

- New specs run against real Bundler 4 covering empty/value-less/nil checksums (parse cleanly) and a malformed checksum (still raises).
- Complements #15351, which made bad metadata legible as a private-source error; this prevents the empty-checksum case from erroring at all.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request.
- [x] I have ensured that the code is well-documented and easy to understand.
