### PR TITLE
fix(npm_and_yarn): fix pnpm lockfileVersion 9.0 parsing error for packages without resolution

### DIFF
--- a/npm_and_yarn/helpers/lib/pnpm/lockfile-parser.ts
+++ b/npm_and_yarn/helpers/lib/pnpm/lockfile-parser.ts
@@ -106,7 +106,7 @@ function nameVerDevFromPkgSnapshot(
     name: name,
     version: version,
     resolved:
-      "tarball" in pkgSnapshot.resolution
+      pkgSnapshot.resolution && "tarball" in pkgSnapshot.resolution
         ? pkgSnapshot.resolution.tarball
         : undefined,
     dev: "dev" in pkgSnapshot && pkgSnapshot.dev === true,

--- a/npm_and_yarn/helpers/test/pnpm/fixtures/parser/lockfile_v9_with_tarball/pnpm-lock.yaml
+++ b/npm_and_yarn/helpers/test/pnpm/fixtures/parser/lockfile_v9_with_tarball/pnpm-lock.yaml
@@ -1,0 +1,33 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      foo:
+        specifier: imtoo/foo#master
+        version: https://codeload.github.com/imtoo/foo/tar.gz/abc1234def5678abc1234def5678abc1234def56
+    devDependencies:
+      etag:
+        specifier: ^1.0.0
+        version: 1.8.1
+
+packages:
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  foo@https://codeload.github.com/imtoo/foo/tar.gz/abc1234def5678abc1234def5678abc1234def56:
+    resolution: {tarball: https://codeload.github.com/imtoo/foo/tar.gz/abc1234def5678abc1234def5678abc1234def56}
+    version: 1.0.0
+
+snapshots:
+
+  etag@1.8.1: {}
+
+  foo@https://codeload.github.com/imtoo/foo/tar.gz/abc1234def5678abc1234def5678abc1234def56: {}

--- a/npm_and_yarn/helpers/test/pnpm/lockfile-parser.test.ts
+++ b/npm_and_yarn/helpers/test/pnpm/lockfile-parser.test.ts
@@ -55,4 +55,31 @@ describe("generates an updated pnpm lock for the original file", () => {
 
     expect(result.length).toEqual(9);
   });
+
+  // pnpm v9+ lockfiles don't have resolution.tarball for npm packages,
+  // and GitHub tarball dependencies use a URL as the package key
+  it("that uses lockfileVersion 9.0 format with a GitHub tarball dependency", async () => {
+    copyDependencies("lockfile_v9_with_tarball", tempDir);
+    const result = await parseLockfile(tempDir);
+
+    expect(result).toEqual([
+      {
+        name: "etag",
+        version: "1.8.1",
+        resolved: undefined,
+        dev: false,
+        specifiers: ["^1.0.0"],
+        aliased: false,
+      },
+      {
+        name: "foo",
+        version: "",
+        resolved:
+          "https://codeload.github.com/imtoo/foo/tar.gz/abc1234def5678abc1234def5678abc1234def56",
+        dev: false,
+        specifiers: [],
+        aliased: false,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
### What are you trying to accomplish?

  Fix a `TypeError: Cannot use 'in' operator to search for 'tarball' in undefined`
  crash when parsing pnpm lockfiles with `lockfileVersion: '9.0'` in the
  `npm_and_yarn` ecosystem.

  In pnpm v9+, snapshot entries have no `resolution` field. The parser accesses
  `"tarball" in pkgSnapshot.resolution` unconditionally, which throws when
  `resolution` is `undefined`, making the entire lockfile unparseable.

  #13959 fixed this for the `bun` ecosystem — this PR brings the same fix to
  `npm_and_yarn/helpers/lib/pnpm/lockfile-parser.ts`.

### Anything you want to highlight for special attention from reviewers?

The fix also covers GitHub tarball dependencies (e.g. `"foo": "owner/repo#master"`),
  which produce a URL-based package key in pnpm v9 lockfiles
  (`foo@https://codeload.github.com/...`) with `resolution: undefined` in the
  snapshot entry.

### How will you know you've accomplished your goal?

- New test fixture `lockfile_v9_with_tarball` covers both a regular npm package
  and a GitHub tarball dependency in pnpm v9 format
- Parser returns the tarball URL correctly in the `resolved` field for GitHub
  tarball packages
- Previously failing `pnpm-lock.yaml` files now parse without error

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
