### PR TITLE
Avoid following cloned symlink targets

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -267,24 +267,32 @@ module Dependabot
       def load_cloned_file_if_present(filename)
         path = Pathname.new(File.join(directory, filename)).cleanpath.to_path
         repo_path = File.join(clone_repo_contents, path)
-        raise Dependabot::DependencyFileNotFound, path unless File.exist?(repo_path)
+
+        if File.lstat(repo_path).symlink?
+          symlink_target = File.readlink(repo_path)
+          raise Dependabot::DependencyFileNotFound, path unless safe_symlink_target?(path, symlink_target)
+
+          return DependencyFile.new(
+            name: Pathname.new(filename).cleanpath.to_path,
+            directory: directory,
+            type: "symlink",
+            content: nil,
+            symlink_target: symlink_target,
+            support_file: in_submodule?(path)
+          )
+        end
 
         content = decode_binary_string(Base64.encode64(File.read(repo_path)))
-        type = if File.symlink?(repo_path)
-                 symlink_target = File.readlink(repo_path)
-                 "symlink"
-               else
-                 "file"
-               end
 
         DependencyFile.new(
           name: Pathname.new(filename).cleanpath.to_path,
           directory: directory,
-          type: type,
+          type: "file",
           content: content,
-          symlink_target: symlink_target,
           support_file: in_submodule?(path)
         )
+      rescue Errno::ENOENT, Errno::ENOTDIR
+        raise Dependabot::DependencyFileNotFound, path
       end
 
       sig do
@@ -321,6 +329,17 @@ module Dependabot
       sig { params(path: String).returns(T.nilable(String)) }
       def symlinked_subpath(path)
         subpaths(path).find { |subpath| @linked_paths.key?(subpath) }
+      end
+
+      sig { params(path: String, symlink_target: String).returns(T::Boolean) }
+      def safe_symlink_target?(path, symlink_target)
+        return false if symlink_target.empty?
+        return false if Pathname.new(symlink_target).absolute?
+
+        relative_path = path.delete_prefix("/")
+        resolved_target = Pathname.new(File.join(File.dirname(relative_path), symlink_target)).cleanpath.to_path
+
+        resolved_target != ".." && !resolved_target.start_with?("../")
       end
 
       sig { params(path: String).returns(T::Boolean) }

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -1528,9 +1528,39 @@ RSpec.describe Dependabot::FileFetchers::Base do
 
           it { is_expected.to be_a(Dependabot::DependencyFile) }
           its(:type) { is_expected.to include("symlink") }
+          its(:content) { is_expected.to be_nil }
 
           its(:symlink_target) do
             is_expected.to include("symlinked/requirements.txt")
+          end
+        end
+      end
+
+      context "when the file is an absolute symlink" do
+        let(:fill_repo) do
+          File.symlink("/etc/passwd", "requirements.txt")
+        end
+
+        it "raises DependencyFileNotFound" do
+          expect { files }
+            .to raise_error(Dependabot::DependencyFileNotFound) do |error|
+            expect(error.file_path).to eq("/requirements.txt")
+          end
+        end
+      end
+
+      context "when the file is a symlink that escapes the repo" do
+        after { FileUtils.rm_f(File.join(repo_path, "..", "secret")) }
+
+        let(:fill_repo) do
+          File.write("../secret", contents)
+          File.symlink("../secret", "requirements.txt")
+        end
+
+        it "raises DependencyFileNotFound" do
+          expect { files }
+            .to raise_error(Dependabot::DependencyFileNotFound) do |error|
+            expect(error.file_path).to eq("/requirements.txt")
           end
         end
       end


### PR DESCRIPTION
## Summary
- Detect cloned symlinks before reading file contents from the checkout.
- Preserve symlink metadata without dereferencing the target during cloned-file fetches.
- Reject symlink targets that are absolute or resolve outside the repo checkout.

## Testing
- `bundle exec rspec spec/dependabot/file_fetchers/base_spec.rb`
- `bundle exec rubocop common/lib/dependabot/file_fetchers/base.rb common/spec/dependabot/file_fetchers/base_spec.rb`
- `bundle exec srb tc`
