### PR TITLE
don't fail if nuget cred is missing url

### DIFF
--- a/nuget/updater/common.ps1
+++ b/nuget/updater/common.ps1
@@ -281,6 +281,10 @@ function Get-NuGetConfigContents([PSObject[]]$creds) {
             $baseSourceLines = @()
         }
 
+        if ("url" -notin $cred.PSObject.Properties.Name -or [string]::IsNullOrWhiteSpace([string]$cred.url)) {
+            continue
+        }
+
         $sourceName = "nuget_source_$i"
         $i++
         $url = $cred.url

--- a/nuget/updater/test.ps1
+++ b/nuget/updater/test.ps1
@@ -199,6 +199,46 @@ try {
             '  </packageSources>',
             '</configuration>'
         )
+
+    Test-NuGetConfig `
+        -scenarioName "feed-without-url-is-ignored" `
+        -jobString @"
+{
+  "credentials-metadata": [
+    {"type":"nuget_feed", "url":"https://nuget.example.com/v3/index.json"},
+    {"type":"nuget_feed", "host":"nuget.host.example.com"}
+  ]
+}
+"@ `
+        -expectedLines @(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<configuration>',
+            '  <packageSources>',
+            '    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />',
+            '    <add key="nuget_source_1" value="https://nuget.example.com/v3/index.json" />',
+            '  </packageSources>',
+            '</configuration>'
+        )
+
+    Test-NuGetConfig `
+        -scenarioName "feed-with-null-url-is-ignored" `
+        -jobString @"
+{
+  "credentials-metadata": [
+    {"type":"nuget_feed", "url":"https://nuget.example.com/v3/index.json"},
+    {"type":"nuget_feed", "url":null}
+  ]
+}
+"@ `
+        -expectedLines @(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<configuration>',
+            '  <packageSources>',
+            '    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />',
+            '    <add key="nuget_source_1" value="https://nuget.example.com/v3/index.json" />',
+            '  </packageSources>',
+            '</configuration>'
+        )
 }
 catch {
     Write-Host $_


### PR DESCRIPTION
When creating a local `NuGet.Config` if a credential object is missing the `url` parameter, just skip it.  Previously referencing the `$cred.url` value would fail.