### PR TITLE
Type RequirementsUpdater base and gradle/maven/sbt with DependencyRequirement

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1835
+# Offense count: 1822
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -323,7 +323,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/pull_request_updater/github.rb"
     - "common/lib/dependabot/pull_request_updater/gitlab.rb"
     - "common/lib/dependabot/registry_client.rb"
-    - "common/lib/dependabot/requirements_updater/base.rb"
     - "common/lib/dependabot/shared_helpers.rb"
     - "common/lib/dependabot/simple_instrumentor.rb"
     - "common/lib/dependabot/update_checkers/base.rb"
@@ -374,7 +373,6 @@ Sorbet/ForbidTUntyped:
     - "go_modules/lib/dependabot/go_modules/package/package_details_fetcher.rb"
     - "go_modules/lib/dependabot/go_modules/replace_stubber.rb"
     - "go_modules/lib/dependabot/go_modules/update_checker.rb"
-    - "gradle/lib/dependabot/gradle/distributions.rb"
     - "gradle/lib/dependabot/gradle/file_parser.rb"
     - "gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb"
     - "gradle/lib/dependabot/gradle/file_updater.rb"
@@ -384,7 +382,6 @@ Sorbet/ForbidTUntyped:
     - "gradle/lib/dependabot/gradle/package/version_release_date_fallback_fetcher.rb"
     - "gradle/lib/dependabot/gradle/update_checker.rb"
     - "gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb"
-    - "gradle/lib/dependabot/gradle/update_checker/requirements_updater.rb"
     - "gradle/lib/dependabot/gradle/update_checker/version_finder.rb"
     - "gradle/lib/dependabot/gradle/version.rb"
     - "helm/lib/dependabot/helm/file_parser.rb"
@@ -420,7 +417,6 @@ Sorbet/ForbidTUntyped:
     - "maven/lib/dependabot/maven/token_bucket.rb"
     - "maven/lib/dependabot/maven/update_checker.rb"
     - "maven/lib/dependabot/maven/update_checker/property_updater.rb"
-    - "maven/lib/dependabot/maven/update_checker/requirements_updater.rb"
     - "maven/lib/dependabot/maven/update_checker/version_finder.rb"
     - "maven/lib/dependabot/maven/utils/auth_headers_finder.rb"
     - "nix/lib/dependabot/nix/file_fetcher.rb"
@@ -521,7 +517,6 @@ Sorbet/ForbidTUntyped:
     - "sbt/lib/dependabot/sbt/file_updater.rb"
     - "sbt/lib/dependabot/sbt/package/package_details_fetcher.rb"
     - "sbt/lib/dependabot/sbt/update_checker.rb"
-    - "sbt/lib/dependabot/sbt/update_checker/requirements_updater.rb"
     - "silent/lib/dependabot/silent/file_updater.rb"
     - "silent/lib/dependabot/silent/update_checker.rb"
     - "swift/lib/dependabot/swift/file_parser/dependency_parser.rb"

--- a/common/lib/dependabot/requirements_updater/base.rb
+++ b/common/lib/dependabot/requirements_updater/base.rb
@@ -3,6 +3,8 @@
 
 require "sorbet-runtime"
 
+require "dependabot/dependency_requirement"
+
 module Dependabot
   module RequirementsUpdater
     module Base
@@ -15,7 +17,7 @@ module Dependabot
 
       interface!
 
-      sig { abstract.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { abstract.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements; end
 
       private

--- a/gradle/lib/dependabot/gradle/distributions.rb
+++ b/gradle/lib/dependabot/gradle/distributions.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "dependabot/dependency_requirement"
+
 module Dependabot
   module Gradle
     module Distributions
@@ -9,7 +11,7 @@ module Dependabot
       DISTRIBUTION_REPOSITORY_URL = "https://services.gradle.org"
       DISTRIBUTION_DEPENDENCY_TYPE = "gradle-distribution"
 
-      sig { params(requirements: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Boolean) }
+      sig { params(requirements: T::Array[Dependabot::DependencyRequirement]).returns(T::Boolean) }
       def self.distribution_requirements?(requirements)
         requirements.any? do |req|
           req.dig(:source, :type) == DISTRIBUTION_DEPENDENCY_TYPE

--- a/gradle/lib/dependabot/gradle/update_checker.rb
+++ b/gradle/lib/dependabot/gradle/update_checker.rb
@@ -68,14 +68,12 @@ module Dependabot
           declarations_using_a_property
           .map { |req| req.dig(:metadata, :property_name) }
 
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            latest_version: preferred_resolvable_version&.to_s,
-            source_url: preferred_version_details&.fetch(:source_url),
-            properties_to_update: property_names
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          latest_version: preferred_resolvable_version&.to_s,
+          source_url: preferred_version_details&.fetch(:source_url),
+          properties_to_update: property_names
+        ).updated_requirements
       end
 
       sig { override.returns(T::Boolean) }

--- a/gradle/lib/dependabot/gradle/update_checker/requirements_updater.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/requirements_updater.rb
@@ -8,6 +8,7 @@
 
 require "sorbet-runtime"
 
+require "dependabot/dependency_requirement"
 require "dependabot/requirements_updater/base"
 require "dependabot/gradle/distributions"
 require "dependabot/gradle/package/distributions_fetcher"
@@ -29,7 +30,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             latest_version: T.nilable(T.any(Version, String)),
             source_url: T.nilable(String),
             properties_to_update: T::Array[String]
@@ -51,7 +52,7 @@ module Dependabot
           @is_distribution = T.let(Distributions.distribution_requirements?(requirements), T::Boolean)
         end
 
-        sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements unless latest_version
           return updated_distribution_requirements if @is_distribution
@@ -67,13 +68,13 @@ module Dependabot
             next req if property_name && !properties_to_update.include?(property_name)
 
             new_req = update_requirement(req[:requirement])
-            req.merge(requirement: new_req, source: updated_source)
+            Dependabot::DependencyRequirement.create(req.merge(requirement: new_req, source: updated_source))
           end
         end
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(Version)) }
@@ -118,7 +119,7 @@ module Dependabot
           end
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_distribution_requirements
           distribution_url = T.let(nil, T.nilable(String))
 
@@ -132,15 +133,19 @@ module Dependabot
               version = update_exact_requirement(requirement)
               distribution_url = source[:url].gsub(requirement, version)
 
-              req.merge(
-                requirement: version,
-                source: source.merge(url: distribution_url)
+              Dependabot::DependencyRequirement.create(
+                req.merge(
+                  requirement: version,
+                  source: source.merge(url: distribution_url)
+                )
               )
             when "distributionSha256Sum"
               checksum_url, checksum = Gradle::Package::DistributionsFetcher.resolve_checksum(T.must(distribution_url))
-              req.merge(
-                requirement: checksum,
-                source: source.merge(url: checksum_url)
+              Dependabot::DependencyRequirement.create(
+                req.merge(
+                  requirement: checksum,
+                  source: source.merge(url: checksum_url)
+                )
               )
             else
               next req

--- a/maven/lib/dependabot/maven/update_checker.rb
+++ b/maven/lib/dependabot/maven/update_checker.rb
@@ -96,14 +96,12 @@ module Dependabot
           declarations_using_a_property
           .map { |req| req.dig(:metadata, :property_name) }
 
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            latest_version: preferred_resolvable_version&.to_s,
-            source_url: preferred_version_details&.fetch(:source_url),
-            properties_to_update: property_names
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          latest_version: preferred_resolvable_version&.to_s,
+          source_url: preferred_version_details&.fetch(:source_url),
+          properties_to_update: property_names
+        ).updated_requirements
       end
 
       sig { override.returns(T::Boolean) }

--- a/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
@@ -6,6 +6,7 @@
 # https://maven.apache.org/pom.html#Dependencies      #
 #######################################################
 
+require "dependabot/dependency_requirement"
 require "dependabot/requirements_updater/base"
 require "dependabot/maven/update_checker"
 require "dependabot/maven/version"
@@ -25,7 +26,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             latest_version: T.nilable(T.any(Version, String)),
             source_url: T.nilable(String),
             properties_to_update: T::Array[String]
@@ -45,7 +46,7 @@ module Dependabot
           @latest_version = T.let(version_class.new(latest_version), Version)
         end
 
-        sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements unless latest_version
 
@@ -62,13 +63,13 @@ module Dependabot
             new_req = update_requirement(req[:requirement])
             next req if new_req == req[:requirement]
 
-            req.merge(requirement: new_req, source: updated_source)
+            Dependabot::DependencyRequirement.create(req.merge(requirement: new_req, source: updated_source))
           end
         end
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(Version)) }

--- a/sbt/lib/dependabot/sbt/update_checker.rb
+++ b/sbt/lib/dependabot/sbt/update_checker.rb
@@ -53,14 +53,12 @@ module Dependabot
           declarations_using_a_property
           .filter_map { |req| req.dig(:metadata, :property_name) }
 
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            latest_version: preferred_resolvable_version&.to_s,
-            source_url: preferred_version_details&.fetch(:source_url),
-            properties_to_update: property_names
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          latest_version: preferred_resolvable_version&.to_s,
+          source_url: preferred_version_details&.fetch(:source_url),
+          properties_to_update: property_names
+        ).updated_requirements
       end
 
       sig { override.returns(T::Boolean) }

--- a/sbt/lib/dependabot/sbt/update_checker/requirements_updater.rb
+++ b/sbt/lib/dependabot/sbt/update_checker/requirements_updater.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/dependency_requirement"
 require "dependabot/requirements_updater/base"
 require "dependabot/sbt/update_checker"
 require "dependabot/sbt/version"
@@ -21,7 +22,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             latest_version: T.nilable(T.any(Version, String)),
             source_url: T.nilable(String),
             properties_to_update: T::Array[String]
@@ -41,7 +42,7 @@ module Dependabot
           @latest_version = T.let(version_class.new(latest_version), Version)
         end
 
-        sig { override.returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements unless latest_version
 
@@ -53,13 +54,13 @@ module Dependabot
             next req if property_name && !properties_to_update.include?(property_name)
 
             new_req = update_requirement(req[:requirement])
-            req.merge(requirement: new_req, source: updated_source)
+            Dependabot::DependencyRequirement.create(req.merge(requirement: new_req, source: updated_source))
           end
         end
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(Version)) }
@@ -88,7 +89,7 @@ module Dependabot
           Sbt::Requirement
         end
 
-        sig { returns(T::Hash[Symbol, T.untyped]) }
+        sig { returns(T::Hash[Symbol, T.nilable(String)]) }
         def updated_source
           { type: "maven_repo", url: source_url }
         end


### PR DESCRIPTION
### What are you trying to accomplish?

Sorbet `ForbidTUntyped` burndown, and the first step of moving the requirements flow onto `DependencyRequirement`.

`Dependency#requirements` already returns `T::Array[Dependabot::DependencyRequirement]` (wrapped in `initialize`), so callers already pass real instances; the params were just annotated loosely. This tightens them. The abstract `RequirementsUpdater::Base#updated_requirements` and its three implementers (gradle, maven, sbt) move together, since sorbet-runtime checks override returns invariantly. The UpdateCheckers drop the now-redundant `wrap_requirements`. Clears five files (1843 → 1830).

### Anything you want to highlight for special attention from reviewers?

Sorbet types `Hash#merge` as returning `Hash`, not the subclass, so `req.merge(...)` results are wrapped in `DependencyRequirement.create(...)`; the `next req` and `return requirements` paths need none. The standalone updaters follow in a separate PR.

### How will you know you've accomplished your goal?

`srb tc`, the three bump checks, and RuboCop pass. A runtime check confirms the gradle updater returns real `DependencyRequirement`s, and the gradle/maven/sbt requirements_updater and update_checker specs pass (176 examples).

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
