### PR TITLE
Type standalone RequirementsUpdaters with DependencyRequirement

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,13 +239,12 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1822
+# Offense count: 1695
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
     - "bazel/lib/dependabot/bazel/file_parser/starlark_parser.rb"
     - "bazel/lib/dependabot/bazel/update_checker/registry_client.rb"
-    - "bazel/lib/dependabot/bazel/update_checker/requirements_updater.rb"
     - "bun/lib/dependabot/bun.rb"
     - "bun/lib/dependabot/bun/dependency_files_filterer.rb"
     - "bun/lib/dependabot/bun/file_fetcher.rb"
@@ -342,7 +341,6 @@ Sorbet/ForbidTUntyped:
     - "conda/lib/dependabot/conda/requirement.rb"
     - "conda/lib/dependabot/conda/update_checker.rb"
     - "conda/lib/dependabot/conda/update_checker/latest_version_finder.rb"
-    - "conda/lib/dependabot/conda/update_checker/requirements_updater.rb"
     - "conda/lib/dependabot/conda/version.rb"
     - "deno/lib/dependabot/deno/file_fetcher.rb"
     - "deno/lib/dependabot/deno/file_parser.rb"
@@ -393,7 +391,6 @@ Sorbet/ForbidTUntyped:
     - "hex/lib/dependabot/hex/metadata_finder.rb"
     - "hex/lib/dependabot/hex/update_checker.rb"
     - "hex/lib/dependabot/hex/update_checker/latest_version_finder.rb"
-    - "hex/lib/dependabot/hex/update_checker/requirements_updater.rb"
     - "julia/lib/dependabot/julia/file_fetcher.rb"
     - "julia/lib/dependabot/julia/file_parser.rb"
     - "julia/lib/dependabot/julia/file_updater.rb"
@@ -402,7 +399,6 @@ Sorbet/ForbidTUntyped:
     - "julia/lib/dependabot/julia/registry_client.rb"
     - "julia/lib/dependabot/julia/update_checker.rb"
     - "julia/lib/dependabot/julia/update_checker/latest_version_finder.rb"
-    - "julia/lib/dependabot/julia/update_checker/requirements_updater.rb"
     - "maven/lib/dependabot/maven/file_parser.rb"
     - "maven/lib/dependabot/maven/file_parser/maven_dependency_parser.rb"
     - "maven/lib/dependabot/maven/file_parser/property_value_finder.rb"
@@ -461,7 +457,6 @@ Sorbet/ForbidTUntyped:
     - "opentofu/lib/dependabot/opentofu/file_updater.rb"
     - "opentofu/lib/dependabot/opentofu/package/package_details_fetcher.rb"
     - "opentofu/lib/dependabot/opentofu/registry_client.rb"
-    - "opentofu/lib/dependabot/opentofu/requirements_updater.rb"
     - "opentofu/lib/dependabot/opentofu/update_checker.rb"
     - "opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb"
     - "pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/base.rb"
@@ -506,7 +501,6 @@ Sorbet/ForbidTUntyped:
     - "python/lib/dependabot/python/update_checker/latest_version_finder.rb"
     - "python/lib/dependabot/python/update_checker/pip_version_resolver.rb"
     - "python/lib/dependabot/python/update_checker/poetry_version_resolver.rb"
-    - "python/lib/dependabot/python/update_checker/requirements_updater.rb"
     - "rakelib/support/helpers.rb"
     - "rust_toolchain/lib/dependabot/rust_toolchain/models/rust_toolchain_config.rb"
     - "rust_toolchain/lib/dependabot/rust_toolchain/models/rust_toolchain_toml.rb"
@@ -536,7 +530,6 @@ Sorbet/ForbidTUntyped:
     - "terraform/lib/dependabot/terraform/file_updater.rb"
     - "terraform/lib/dependabot/terraform/file_updater/provider_cli_config_builder.rb"
     - "terraform/lib/dependabot/terraform/package/package_details_fetcher.rb"
-    - "terraform/lib/dependabot/terraform/requirements_updater.rb"
     - "terraform/lib/dependabot/terraform/update_checker.rb"
     - "terraform/lib/dependabot/terraform/update_checker/latest_version_resolver.rb"
     - "updater/lib/dependabot/api_client.rb"

--- a/bazel/lib/dependabot/bazel/update_checker.rb
+++ b/bazel/lib/dependabot/bazel/update_checker.rb
@@ -38,12 +38,10 @@ module Dependabot
       def updated_requirements
         return dependency.requirements unless latest_version
 
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            latest_version: latest_version.to_s
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          latest_version: latest_version.to_s
+        ).updated_requirements
       end
 
       sig { returns(T.class_of(Dependabot::Bazel::Version)) }

--- a/bazel/lib/dependabot/bazel/update_checker/requirements_updater.rb
+++ b/bazel/lib/dependabot/bazel/update_checker/requirements_updater.rb
@@ -1,6 +1,7 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "dependabot/dependency_requirement"
 require "dependabot/bazel/update_checker"
 
 module Dependabot
@@ -9,13 +10,16 @@ module Dependabot
       class RequirementsUpdater
         extend T::Sig
 
-        sig { params(requirements: T::Array[T::Hash[Symbol, T.untyped]], latest_version: String).void }
+        sig { params(requirements: T::Array[Dependabot::DependencyRequirement], latest_version: String).void }
         def initialize(requirements:, latest_version:)
-          @requirements = requirements
+          @requirements = T.let(
+            requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @latest_version = latest_version
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           @requirements.map do |requirement|
             updated_requirement = requirement.dup
@@ -26,7 +30,7 @@ module Dependabot
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(String) }

--- a/bun/lib/dependabot/bun/update_checker.rb
+++ b/bun/lib/dependabot/bun/update_checker.rb
@@ -176,14 +176,12 @@ module Dependabot
           end
 
         @updated_requirements ||=
-          wrap_requirements(
-            RequirementsUpdater.new(
-              requirements: dependency.requirements,
-              updated_source: updated_source,
-              latest_resolvable_version: resolvable_version,
-              update_strategy: T.must(requirements_update_strategy)
-            ).updated_requirements
-          )
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            updated_source: updated_source,
+            latest_resolvable_version: resolvable_version,
+            update_strategy: T.must(requirements_update_strategy)
+          ).updated_requirements
       end
 
       sig { returns(T::Boolean) }

--- a/bun/lib/dependabot/bun/update_checker/requirements_updater.rb
+++ b/bun/lib/dependabot/bun/update_checker/requirements_updater.rb
@@ -11,6 +11,7 @@ require "sorbet-runtime"
 require "dependabot/bun/requirement"
 require "dependabot/bun/update_checker"
 require "dependabot/bun/version"
+require "dependabot/dependency_requirement"
 require "dependabot/requirements_update_strategy"
 
 module Dependabot
@@ -33,7 +34,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             updated_source: T.nilable(T::Hash[Symbol, T.untyped]),
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             latest_resolvable_version: T.nilable(T.any(String, Gem::Version))
@@ -46,7 +47,10 @@ module Dependabot
           update_strategy:,
           latest_resolvable_version:
         )
-          @requirements = requirements
+          @requirements = T.let(
+            requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @updated_source = updated_source
           @update_strategy = update_strategy
 
@@ -60,12 +64,12 @@ module Dependabot
           )
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements if update_strategy.lockfile_only?
 
           requirements.map do |req|
-            req = req.merge(source: updated_source)
+            req = Dependabot::DependencyRequirement.create(req.merge(source: updated_source))
             next req unless latest_resolvable_version
             next initial_req_after_source_change(req) unless req[:requirement]
             next req if req[:requirement].match?(/^([A-Za-uw-z]|v[^\d])/)
@@ -82,7 +86,7 @@ module Dependabot
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -109,15 +113,15 @@ module Dependabot
           original_source&.fetch(:type) == "git"
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def initial_req_after_source_change(req)
           return req unless updating_from_git_to_npm?
           return req unless req[:requirement].nil?
 
-          req.merge(requirement: "^#{latest_resolvable_version}")
+          Dependabot::DependencyRequirement.create(req.merge(requirement: "^#{latest_resolvable_version}"))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement(req)
           current_requirement = req[:requirement]
 
@@ -126,14 +130,14 @@ module Dependabot
             return req if ruby_req&.satisfied_by?(latest_resolvable_version)
 
             updated_req = update_range_requirement(current_requirement)
-            return req.merge(requirement: updated_req)
+            return Dependabot::DependencyRequirement.create(req.merge(requirement: updated_req))
           end
 
           reqs = current_requirement.strip.split(SEPARATOR).map(&:strip)
-          req.merge(requirement: update_version_string(reqs.first))
+          Dependabot::DependencyRequirement.create(req.merge(requirement: update_version_string(reqs.first)))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement_if_needed(req)
           current_requirement = req[:requirement]
           version = latest_resolvable_version
@@ -145,7 +149,7 @@ module Dependabot
           update_version_requirement(req)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def widen_requirement(req)
           current_requirement = req[:requirement]
           version = latest_resolvable_version
@@ -165,7 +169,7 @@ module Dependabot
               current_requirement
             end
 
-          req.merge(requirement: updated_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: updated_requirement))
         end
 
         sig { params(requirement_string: String).returns(T::Array[Bun::Requirement]) }

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -80,15 +80,13 @@ module Dependabot
         latest_version_for_req_updater = latest_version_details&.fetch(:version)&.to_s
         latest_resolvable_version_for_req_updater = preferred_resolvable_version_details&.fetch(:version)&.to_s
 
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            update_strategy: T.must(requirements_update_strategy),
-            updated_source: updated_source,
-            latest_version: latest_version_for_req_updater,
-            latest_resolvable_version: latest_resolvable_version_for_req_updater
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          update_strategy: T.must(requirements_update_strategy),
+          updated_source: updated_source,
+          latest_version: latest_version_for_req_updater,
+          latest_resolvable_version: latest_resolvable_version_for_req_updater
+        ).updated_requirements
       end
 
       sig { returns(T::Boolean) }

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -4,6 +4,7 @@
 require "sorbet-runtime"
 
 require "dependabot/bundler/update_checker"
+require "dependabot/dependency_requirement"
 require "dependabot/requirements_update_strategy"
 
 module Dependabot
@@ -25,7 +26,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             updated_source: T.nilable(T::Hash[Symbol, T.untyped]),
             latest_version: T.nilable(String),
@@ -39,7 +40,10 @@ module Dependabot
           latest_version:,
           latest_resolvable_version:
         )
-          @requirements = requirements
+          @requirements = T.let(
+            requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @latest_version = T.let(
             (T.cast(Dependabot::Bundler::Version.new(latest_version), Dependabot::Bundler::Version) if latest_version),
             T.nilable(Dependabot::Bundler::Version)
@@ -57,7 +61,7 @@ module Dependabot
           )
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements if update_strategy.lockfile_only?
 
@@ -74,7 +78,7 @@ module Dependabot
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -96,9 +100,9 @@ module Dependabot
           raise "Unknown update strategy: #{update_strategy}"
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_gemfile_requirement(req)
-          req = req.merge(source: updated_source)
+          req = Dependabot::DependencyRequirement.create(req.merge(source: updated_source))
           return req unless latest_resolvable_version
 
           case update_strategy
@@ -110,14 +114,14 @@ module Dependabot
           end
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement_if_needed(req)
           return req if new_version_satisfies?(req)
 
           update_version_requirement(req)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement(req)
           requirements =
             req[:requirement].split(",").map { |r| Gem::Requirement.new(r) }
@@ -131,10 +135,10 @@ module Dependabot
               update_gemfile_range(requirements).join(", ")
             end
 
-          req.merge(requirement: new_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
         def new_version_satisfies?(req)
           return false unless latest_resolvable_version
 
@@ -179,9 +183,9 @@ module Dependabot
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_gemspec_requirement(req)
-          req = req.merge(source: updated_source) if req.fetch(:source)
+          req = Dependabot::DependencyRequirement.create(req.merge(source: updated_source)) if req.fetch(:source)
           return req unless latest_version && latest_resolvable_version
 
           requirements =
@@ -202,9 +206,9 @@ module Dependabot
             end
 
           updated_requirements = binding_requirements(updated_requirements)
-          req.merge(requirement: updated_requirements.join(", "))
+          Dependabot::DependencyRequirement.create(req.merge(requirement: updated_requirements.join(", ")))
         rescue UnfixableRequirement
-          req.merge(requirement: :unfixable)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: :unfixable))
         end
         # rubocop:enable Metrics/PerceivedComplexity
 

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -90,14 +90,12 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            updated_source: updated_source,
-            target_version: target_version,
-            update_strategy: requirements_update_strategy
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          updated_source: updated_source,
+          target_version: target_version,
+          update_strategy: requirements_update_strategy
+        ).updated_requirements
       end
 
       sig { override.returns(T::Boolean) }

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -12,6 +12,7 @@ require "sorbet-runtime"
 require "dependabot/cargo/update_checker"
 require "dependabot/cargo/requirement"
 require "dependabot/cargo/version"
+require "dependabot/dependency_requirement"
 require "dependabot/requirements_update_strategy"
 
 module Dependabot
@@ -34,7 +35,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             updated_source: T.nilable(T::Hash[T.any(String, Symbol), T.untyped]),
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             target_version: T.nilable(T.any(String, Gem::Version))
@@ -46,7 +47,10 @@ module Dependabot
           update_strategy:,
           target_version:
         )
-          @requirements = T.let(requirements, T::Array[T::Hash[Symbol, T.untyped]])
+          @requirements = T.let(
+            requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @updated_source = T.let(updated_source, T.nilable(T::Hash[T.any(String, Symbol), T.untyped]))
           @update_strategy = T.let(update_strategy, Dependabot::RequirementsUpdateStrategy)
 
@@ -57,7 +61,7 @@ module Dependabot
           @target_version = T.let(version_class.new(target_version), Gem::Version)
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements if update_strategy.lockfile_only?
 
@@ -65,7 +69,7 @@ module Dependabot
           # requirement at index `i` to correspond to the previous requirement
           # at the same index.
           requirements.map do |req|
-            req = req.merge(source: updated_source)
+            req = Dependabot::DependencyRequirement.create(req.merge(source: updated_source))
             next req unless target_version
             next req if req[:requirement].nil?
 
@@ -80,7 +84,7 @@ module Dependabot
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
@@ -99,7 +103,7 @@ module Dependabot
           raise "Unknown update strategy: #{update_strategy}"
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement(req)
           string_reqs = req[:requirement].split(",").map(&:strip)
 
@@ -119,10 +123,10 @@ module Dependabot
               update_range_requirements(string_reqs)
             end
 
-          req.merge(requirement: new_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement_if_needed(req)
           string_reqs = req[:requirement].split(",").map(&:strip)
           ruby_reqs = string_reqs.map { |r| Dependabot::Cargo::Requirement.new(r) }

--- a/conda/lib/dependabot/conda/update_checker.rb
+++ b/conda/lib/dependabot/conda/update_checker.rb
@@ -96,13 +96,11 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            update_strategy: requirements_update_strategy,
-            latest_resolvable_version: preferred_resolvable_version&.to_s
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          update_strategy: requirements_update_strategy,
+          latest_resolvable_version: preferred_resolvable_version&.to_s
+        ).updated_requirements
       end
 
       sig { override.returns(Dependabot::RequirementsUpdateStrategy) }

--- a/conda/lib/dependabot/conda/update_checker/requirements_updater.rb
+++ b/conda/lib/dependabot/conda/update_checker/requirements_updater.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/dependency_requirement"
 require "dependabot/conda/requirement"
 require "dependabot/conda/update_checker"
 require "dependabot/conda/version"
@@ -13,7 +14,7 @@ module Dependabot
       class RequirementsUpdater
         extend T::Sig
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(Dependabot::RequirementsUpdateStrategy) }
@@ -24,13 +25,16 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             latest_resolvable_version: T.nilable(String)
           ).void
         end
         def initialize(requirements:, update_strategy:, latest_resolvable_version:)
-          @requirements = requirements
+          @requirements = T.let(
+            requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @update_strategy = update_strategy
           @latest_resolvable_version = T.let(
             (Conda::Version.new(latest_resolvable_version) if latest_resolvable_version),
@@ -38,7 +42,7 @@ module Dependabot
           )
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements if update_strategy.lockfile_only?
           return requirements unless latest_resolvable_version
@@ -59,14 +63,14 @@ module Dependabot
 
         private
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_requirement_if_needed(req)
           return req if new_version_satisfies?(req)
 
           update_requirement(req)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_requirement(req)
           return req unless req[:requirement]
           return req if ["", "*"].include?(req[:requirement])
@@ -74,10 +78,17 @@ module Dependabot
           requirement_strings = req[:requirement].split(",").map(&:strip)
           new_req = calculate_updated_requirement(req, requirement_strings)
 
-          new_req == :unfixable ? req.merge(requirement: :unfixable) : req.merge(requirement: new_req)
+          Dependabot::DependencyRequirement.create(
+            new_req == :unfixable ? req.merge(requirement: :unfixable) : req.merge(requirement: new_req)
+          )
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped], requirement_strings: T::Array[String]).returns(T.any(String, Symbol)) }
+        sig do
+          params(
+            req: Dependabot::DependencyRequirement,
+            requirement_strings: T::Array[String]
+          ).returns(T.any(String, Symbol))
+        end
         def calculate_updated_requirement(req, requirement_strings)
           # Step 1: Check for equality match first (e.g., "==1.21.0" or bare "1.21.0")
           return handle_equality_match(requirement_strings) if equality_match?(requirement_strings)
@@ -99,7 +110,12 @@ module Dependabot
           find_and_update_equality_match(requirement_strings, latest_resolvable_version)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped], requirement_strings: T::Array[String]).returns(T.any(String, Symbol)) }
+        sig do
+          params(
+            req: Dependabot::DependencyRequirement,
+            requirement_strings: T::Array[String]
+          ).returns(T.any(String, Symbol))
+        end
         def handle_range_requirement(req, requirement_strings)
           # Only skip update if using BumpVersionsIfNecessary strategy and version already satisfies
           # For BumpVersions strategy, always update to the new version
@@ -111,7 +127,7 @@ module Dependabot
           update_requirements_range(requirement_strings)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T.any(String, Symbol)) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(T.any(String, Symbol)) }
         def handle_single_constraint(req)
           # Only skip update if using BumpVersionsIfNecessary strategy and version already satisfies
           # For BumpVersions strategy, always update to the new version
@@ -156,7 +172,7 @@ module Dependabot
           "#{operator}#{latest_version}"
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def widen_requirement(req)
           return req unless req[:requirement]
           return req if ["", "*"].include?(req[:requirement])
@@ -164,10 +180,10 @@ module Dependabot
           # For WidenRanges, always widen to ensure proper upper bounds
           # Don't return early even if version satisfies - we want to add/update bounds
           new_requirement = widen_requirement_string(req[:requirement])
-          req.merge(requirement: new_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
         def new_version_satisfies?(req)
           return false unless req[:requirement]
 

--- a/hex/lib/dependabot/hex/update_checker.rb
+++ b/hex/lib/dependabot/hex/update_checker.rb
@@ -59,13 +59,11 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            updated_source: updated_source,
-            latest_resolvable_version: latest_resolvable_version&.to_s
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          updated_source: updated_source,
+          latest_resolvable_version: latest_resolvable_version&.to_s
+        ).updated_requirements
       end
 
       private

--- a/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
+++ b/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 
+require "dependabot/dependency_requirement"
 require "dependabot/hex/version"
 require "dependabot/hex/requirement"
 require "dependabot/hex/update_checker"
@@ -20,7 +21,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             latest_resolvable_version: T.nilable(String),
             updated_source: T.nilable(T::Hash[Symbol, T.nilable(String)])
           ).void
@@ -30,7 +31,10 @@ module Dependabot
           latest_resolvable_version:,
           updated_source:
         )
-          @requirements = T.let(requirements, T::Array[T::Hash[Symbol, T.untyped]])
+          @requirements = T.let(
+            requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @updated_source = T.let(updated_source, T.nilable(T::Hash[Symbol, T.nilable(String)]))
           @latest_resolvable_version = T.let(nil, T.nilable(Dependabot::Version))
 
@@ -40,14 +44,14 @@ module Dependabot
           @latest_resolvable_version = Hex::Version.new(latest_resolvable_version)
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           requirements.map { |req| updated_mixfile_requirement(req) }
         end
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(Dependabot::Version)) }
@@ -58,7 +62,7 @@ module Dependabot
 
         # rubocop:disable Metrics/PerceivedComplexity
         # rubocop:disable Metrics/AbcSize
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def updated_mixfile_requirement(req)
           req = update_source(req)
           return req unless latest_resolvable_version && req[:requirement]
@@ -81,18 +85,20 @@ module Dependabot
 
           new_requirement = req[:requirement] + " or " + new_requirement if or_string_reqs.count > 1
 
-          req.merge(requirement: new_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         end
         # rubocop:enable Metrics/AbcSize
         # rubocop:enable Metrics/PerceivedComplexity
 
-        sig { params(requirement_hash: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig do
+          params(requirement_hash: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement)
+        end
         def update_source(requirement_hash)
           # Only git sources ever need to be updated. Anything else should be
           # left alone.
           return requirement_hash unless requirement_hash.dig(:source, :type) == "git"
 
-          requirement_hash.merge(source: updated_source)
+          Dependabot::DependencyRequirement.create(requirement_hash.merge(source: updated_source))
         end
 
         sig { params(requirement_string: String).returns(T::Boolean) }

--- a/julia/lib/dependabot/julia/update_checker.rb
+++ b/julia/lib/dependabot/julia/update_checker.rb
@@ -93,13 +93,11 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        wrap_requirements(
-          Dependabot::Julia::RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            target_version: latest_resolvable_version&.to_s,
-            update_strategy: requirements_update_strategy&.to_s&.to_sym
-          ).updated_requirements
-        )
+        Dependabot::Julia::RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          target_version: latest_resolvable_version&.to_s,
+          update_strategy: requirements_update_strategy&.to_s&.to_sym
+        ).updated_requirements
       end
 
       private

--- a/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
+++ b/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "dependabot/dependency_requirement"
 require "dependabot/julia/requirement"
 require "dependabot/julia/version"
 
@@ -11,18 +12,21 @@ module Dependabot
 
       sig do
         params(
-          requirements: T::Array[T::Hash[Symbol, T.untyped]],
+          requirements: T::Array[Dependabot::DependencyRequirement],
           target_version: T.nilable(String),
           update_strategy: T.nilable(Symbol)
         ).void
       end
       def initialize(requirements:, target_version:, update_strategy:)
-        @requirements = requirements
+        @requirements = T.let(
+          requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+          T::Array[Dependabot::DependencyRequirement]
+        )
         @target_version = target_version
         @update_strategy = T.let(update_strategy || :bump_versions, Symbol)
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         return requirements unless target_version
 
@@ -35,7 +39,7 @@ module Dependabot
 
       private
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       attr_reader :requirements
 
       sig { returns(T.nilable(String)) }
@@ -46,9 +50,9 @@ module Dependabot
 
       sig do
         params(
-          requirement: T::Hash[Symbol, T.untyped],
+          requirement: Dependabot::DependencyRequirement,
           target_version: Dependabot::Julia::Version
-        ).returns(T::Hash[Symbol, T.untyped])
+        ).returns(Dependabot::DependencyRequirement)
       end
       def update_requirement(requirement, target_version)
         current_requirement = requirement[:requirement]
@@ -60,7 +64,7 @@ module Dependabot
                             updated_version_requirement(current_requirement, target_version)
                           end
 
-        requirement.merge(requirement: new_requirement)
+        Dependabot::DependencyRequirement.create(requirement.merge(requirement: new_requirement))
       end
 
       sig { params(requirement_string: String, target_version: Dependabot::Julia::Version).returns(String) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -177,14 +177,12 @@ module Dependabot
           end
 
         @updated_requirements ||=
-          wrap_requirements(
-            RequirementsUpdater.new(
-              requirements: dependency.requirements,
-              updated_source: updated_source,
-              latest_resolvable_version: resolvable_version,
-              update_strategy: T.must(requirements_update_strategy)
-            ).updated_requirements
-          )
+          RequirementsUpdater.new(
+            requirements: dependency.requirements,
+            updated_source: updated_source,
+            latest_resolvable_version: resolvable_version,
+            update_strategy: T.must(requirements_update_strategy)
+          ).updated_requirements
       end
 
       sig { returns(T::Boolean) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
@@ -11,6 +11,7 @@ require "sorbet-runtime"
 require "dependabot/npm_and_yarn/requirement"
 require "dependabot/npm_and_yarn/update_checker"
 require "dependabot/npm_and_yarn/version"
+require "dependabot/dependency_requirement"
 require "dependabot/requirements_update_strategy"
 
 module Dependabot
@@ -33,7 +34,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             updated_source: T.nilable(T::Hash[Symbol, T.untyped]),
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             latest_resolvable_version: T.nilable(T.any(String, Gem::Version))
@@ -41,7 +42,10 @@ module Dependabot
             .void
         end
         def initialize(requirements:, updated_source:, update_strategy:, latest_resolvable_version:)
-          @requirements = requirements
+          @requirements = T.let(
+            requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @updated_source = updated_source
           @update_strategy = update_strategy
 
@@ -55,12 +59,12 @@ module Dependabot
           )
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements if update_strategy.lockfile_only?
 
           requirements.map do |req|
-            req = req.merge(source: updated_source)
+            req = Dependabot::DependencyRequirement.create(req.merge(source: updated_source))
             next req unless latest_resolvable_version
             next initial_req_after_source_change(req) unless req[:requirement]
             next req if req[:requirement].sub(NpmAndYarn::Requirement::JSR_PREFIX, "")
@@ -78,7 +82,7 @@ module Dependabot
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -105,15 +109,15 @@ module Dependabot
           original_source&.fetch(:type) == "git"
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def initial_req_after_source_change(req)
           return req unless updating_from_git_to_npm?
           return req unless req[:requirement].nil?
 
-          req.merge(requirement: "^#{latest_resolvable_version}")
+          Dependabot::DependencyRequirement.create(req.merge(requirement: "^#{latest_resolvable_version}"))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement(req)
           current_requirement = req[:requirement]
 
@@ -122,14 +126,14 @@ module Dependabot
             return req if ruby_req&.satisfied_by?(latest_resolvable_version)
 
             updated_req = update_range_requirement(current_requirement)
-            return req.merge(requirement: updated_req)
+            return Dependabot::DependencyRequirement.create(req.merge(requirement: updated_req))
           end
 
           reqs = current_requirement.strip.split(SEPARATOR).map(&:strip)
-          req.merge(requirement: update_version_string(reqs.first))
+          Dependabot::DependencyRequirement.create(req.merge(requirement: update_version_string(reqs.first)))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement_if_needed(req)
           current_requirement = req[:requirement]
           version = latest_resolvable_version
@@ -141,7 +145,7 @@ module Dependabot
           update_version_requirement(req)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def widen_requirement(req)
           current_requirement = req[:requirement]
           version = latest_resolvable_version
@@ -161,7 +165,7 @@ module Dependabot
               current_requirement
             end
 
-          req.merge(requirement: updated_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: updated_requirement))
         end
 
         sig { params(requirement_string: String).returns(T::Array[NpmAndYarn::Requirement]) }

--- a/opentofu/lib/dependabot/opentofu/requirements_updater.rb
+++ b/opentofu/lib/dependabot/opentofu/requirements_updater.rb
@@ -51,7 +51,7 @@ module Dependabot
     class RequirementsUpdater
       extend T::Sig
 
-      # @param requirements [Hash{Symbol => String, Array, Hash}]
+      # @param requirements [Array<Dependabot::DependencyRequirement>]
       # @param latest_version [Dependabot::Opentofu::Version]
       # @param tag_for_latest_version [String, NilClass]
       sig do
@@ -74,7 +74,7 @@ module Dependabot
         @latest_version = T.let(version_class.new(latest_version), Dependabot::Opentofu::Version)
       end
 
-      # @return requirements [Hash{Symbol => String, Array, Hash}]
+      # @return requirements [Array<Dependabot::DependencyRequirement>]
       #   * requirement [String, NilClass] the updated version constraint
       #   * groups [Array] no-op for OpenTofu
       #   * file [String] the file that specified this dependency

--- a/opentofu/lib/dependabot/opentofu/requirements_updater.rb
+++ b/opentofu/lib/dependabot/opentofu/requirements_updater.rb
@@ -8,6 +8,7 @@
 
 require "sorbet-runtime"
 
+require "dependabot/dependency_requirement"
 require "dependabot/opentofu/version"
 require "dependabot/opentofu/requirement"
 
@@ -55,13 +56,16 @@ module Dependabot
       # @param tag_for_latest_version [String, NilClass]
       sig do
         params(
-          requirements: T::Array[T::Hash[Symbol, T.untyped]],
+          requirements: T::Array[Dependabot::DependencyRequirement],
           latest_version: T.nilable(Dependabot::Version::VersionParameter),
           tag_for_latest_version: T.nilable(String)
         ).void
       end
       def initialize(requirements:, latest_version:, tag_for_latest_version:)
-        @requirements = requirements
+        @requirements = T.let(
+          requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+          T::Array[Dependabot::DependencyRequirement]
+        )
         @tag_for_latest_version = tag_for_latest_version
 
         return unless latest_version
@@ -75,7 +79,7 @@ module Dependabot
       #   * groups [Array] no-op for OpenTofu
       #   * file [String] the file that specified this dependency
       #   * source [Hash{Symbol => String}] The updated git or registry source details
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         # NOTE: Order is important here. The FileUpdater needs the updated
         # requirement at index `i` to correspond to the previous requirement
@@ -92,7 +96,7 @@ module Dependabot
 
       private
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       attr_reader :requirements
 
       sig { returns(Dependabot::Opentofu::Version) }
@@ -101,15 +105,15 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       attr_reader :tag_for_latest_version
 
-      sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_git_requirement(req)
         return req unless req.dig(:source, :ref)
         return req unless tag_for_latest_version
 
-        req.merge(source: req[:source].merge(ref: tag_for_latest_version))
+        Dependabot::DependencyRequirement.create(req.merge(source: req[:source].merge(ref: tag_for_latest_version)))
       end
 
-      sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_oci_requirement(req)
         return req unless defined?(@latest_version) && @latest_version
         return req if req.dig(:source, :digest)
@@ -118,12 +122,14 @@ module Dependabot
         new_tag = latest_version.to_s
         return req if req.dig(:source, :tag) == new_tag
 
-        req.merge(
-          source: req[:source].merge(tag: new_tag, version: new_tag)
+        Dependabot::DependencyRequirement.create(
+          req.merge(
+            source: req[:source].merge(tag: new_tag, version: new_tag)
+          )
         )
       end
 
-      sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_registry_requirement(req)
         return req if req.fetch(:requirement).nil?
 
@@ -139,7 +145,7 @@ module Dependabot
             update_range(string_req).join(", ")
           end
 
-        req.merge(requirement: new_req)
+        Dependabot::DependencyRequirement.create(req.merge(requirement: new_req))
       end
 
       # Updates the version in a "~>" constraint to allow the given version

--- a/opentofu/lib/dependabot/opentofu/update_checker.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker.rb
@@ -48,13 +48,11 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            latest_version: latest_version&.to_s,
-            tag_for_latest_version: tag_for_latest_version
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          latest_version: latest_version&.to_s,
+          tag_for_latest_version: tag_for_latest_version
+        ).updated_requirements
       end
 
       sig { returns(T::Boolean) }

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/python.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/python.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 require "dependabot/dependency"
+require "dependabot/dependency_requirement"
 require "dependabot/update_checkers"
 require "dependabot/requirements_update_strategy"
 require "dependabot/python/update_checker/requirements_updater"
@@ -165,12 +166,14 @@ module Dependabot
           return ">=#{new_version}" unless original_requirement
 
           updater = Dependabot::Python::UpdateChecker::RequirementsUpdater.new(
-            requirements: [{
-              requirement: original_requirement,
-              file: "requirements.txt",
-              groups: [],
-              source: nil
-            }],
+            requirements: [Dependabot::DependencyRequirement.create(
+              {
+                requirement: original_requirement,
+                file: "requirements.txt",
+                groups: [],
+                source: nil
+              }
+            )],
             update_strategy: Dependabot::RequirementsUpdateStrategy::BumpVersions,
             has_lockfile: false,
             latest_resolvable_version: new_version

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -6,6 +6,7 @@ require "toml-rb"
 require "sorbet-runtime"
 
 require "dependabot/dependency"
+require "dependabot/dependency_requirement"
 require "dependabot/errors"
 require "dependabot/python/name_normaliser"
 require "dependabot/python/requirement_parser"
@@ -95,16 +96,14 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        return wrap_requirements(updated_git_requirements) if git_dependency?
+        return updated_git_requirements if git_dependency?
 
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: requirements,
-            latest_resolvable_version: preferred_resolvable_version&.to_s,
-            update_strategy: requirements_update_strategy,
-            has_lockfile: !(pipfile_lock || poetry_lock).nil?
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          latest_resolvable_version: preferred_resolvable_version&.to_s,
+          update_strategy: requirements_update_strategy,
+          has_lockfile: !(pipfile_lock || poetry_lock).nil?
+        ).updated_requirements
       end
 
       sig { override.returns(T::Boolean) }
@@ -139,13 +138,13 @@ module Dependabot
         latest_version_for_git_dependency
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_git_requirements
         updated_source = updated_git_source
-        return requirements unless updated_source
+        return dependency.requirements unless updated_source
 
-        requirements.map do |req|
-          req.merge(source: updated_source)
+        dependency.requirements.map do |req|
+          Dependabot::DependencyRequirement.create(req.merge(source: updated_source))
         end
       end
 

--- a/python/lib/dependabot/python/update_checker/requirements_updater.rb
+++ b/python/lib/dependabot/python/update_checker/requirements_updater.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/dependency_requirement"
 require "dependabot/python/requirement_parser"
 require "dependabot/python/requirement"
 require "dependabot/python/update_checker"
@@ -21,7 +22,7 @@ module Dependabot
 
         class UnfixableRequirement < StandardError; end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(Dependabot::RequirementsUpdateStrategy) }
@@ -35,7 +36,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             has_lockfile: T::Boolean,
             latest_resolvable_version: T.nilable(String)
@@ -47,7 +48,10 @@ module Dependabot
           has_lockfile:,
           latest_resolvable_version:
         )
-          @requirements = T.let(requirements, T::Array[T::Hash[Symbol, T.untyped]])
+          @requirements = T.let(
+            requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @update_strategy = T.let(update_strategy, Dependabot::RequirementsUpdateStrategy)
           @has_lockfile = T.let(has_lockfile, T::Boolean)
           @latest_resolvable_version = T.let(nil, T.nilable(Dependabot::Python::Version))
@@ -57,7 +61,7 @@ module Dependabot
           @latest_resolvable_version = Python::Version.new(latest_resolvable_version)
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements if update_strategy.lockfile_only?
 
@@ -75,7 +79,7 @@ module Dependabot
         private
 
         # rubocop:disable Metrics/PerceivedComplexity
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def updated_setup_requirement(req)
           return req unless latest_resolvable_version
           return req unless req.fetch(:requirement)
@@ -96,20 +100,20 @@ module Dependabot
               update_requirements_range(req_strings)
             end
 
-          req.merge(requirement: new_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         rescue UnfixableRequirement
-          req.merge(requirement: :unfixable)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: :unfixable))
         end
         # rubocop:enable Metrics/PerceivedComplexity
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def updated_pipfile_requirement(req)
           # For now, we just proxy to updated_requirement. In future this
           # method may treat Pipfile requirements differently.
           updated_requirement(req)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def updated_pyproject_requirement(req)
           return req unless latest_resolvable_version
           return req unless req.fetch(:requirement)
@@ -117,16 +121,16 @@ module Dependabot
 
           pyproject_update_for_strategy(req)
         rescue UnfixableRequirement
-          req.merge(requirement: :unfixable)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: :unfixable))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
         def skip_pyproject_update?(req)
           new_version_satisfies?(req) && !has_lockfile &&
             update_strategy != RequirementsUpdateStrategy::BumpVersions
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def pyproject_update_for_strategy(req)
           # If the requirement uses || syntax then we always want to widen it
           return widen_pyproject_requirement(req) if req.fetch(:requirement).match?(PYPROJECT_OR_SEPARATOR)
@@ -142,14 +146,14 @@ module Dependabot
           end
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_pyproject_version_if_needed(req)
           return req if new_version_satisfies?(req)
 
           update_pyproject_version_core(req, bump_lower_bound: false)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_pyproject_version(req)
           return req if req[:requirement] == "*"
 
@@ -158,9 +162,9 @@ module Dependabot
 
         sig do
           params(
-            req: T::Hash[Symbol, T.untyped],
+            req: Dependabot::DependencyRequirement,
             bump_lower_bound: T::Boolean
-          ).returns(T::Hash[Symbol, T.untyped])
+          ).returns(Dependabot::DependencyRequirement)
         end
         def update_pyproject_version_core(req, bump_lower_bound:)
           requirement_strings = req[:requirement].split(",").map(&:strip)
@@ -177,10 +181,10 @@ module Dependabot
               update_requirements_range(requirement_strings)
             end
 
-          req.merge(requirement: new_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def widen_pyproject_requirement(req)
           return req if new_version_satisfies?(req)
 
@@ -191,7 +195,7 @@ module Dependabot
               widen_requirement_range(req[:requirement])
             end
 
-          req.merge(requirement: new_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         end
 
         sig { params(req_string: String).returns(String) }
@@ -241,7 +245,7 @@ module Dependabot
         end
         # rubocop:enable Metrics/PerceivedComplexity
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def updated_requirement(req)
           return req unless latest_resolvable_version
           return req unless req.fetch(:requirement)
@@ -258,22 +262,22 @@ module Dependabot
           end
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_requirement_if_needed(req)
           return req if new_version_satisfies?(req)
 
           update_requirement(req)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_requirement(req)
           new_requirement = updated_requirement_string(req)
-          req.merge(requirement: new_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         rescue UnfixableRequirement
-          req.merge(requirement: :unfixable)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: :unfixable))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T.any(String, Symbol)) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(T.any(String, Symbol)) }
         def updated_requirement_string(req)
           requirement_strings = req[:requirement].split(",").map(&:strip)
 
@@ -297,16 +301,16 @@ module Dependabot
             requirement_strings.any? { |r| r.strip.start_with?(">") }
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def widen_requirement(req)
           return req if new_version_satisfies?(req)
 
           new_requirement = widen_requirement_range(req[:requirement])
 
-          req.merge(requirement: new_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
         def new_version_satisfies?(req)
           requirement_class
             .requirements_array(req.fetch(:requirement))

--- a/swift/lib/dependabot/swift/update_checker.rb
+++ b/swift/lib/dependabot/swift/update_checker.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/dependency_requirement"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
 require "dependabot/update_checkers/version_filters"
@@ -52,23 +53,21 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        return wrap_requirements(updated_xcode_requirements) if xcode_spm_mode?
+        return updated_xcode_requirements if xcode_spm_mode?
 
         # If no target version is available, return old requirements unchanged
         target = preferred_resolvable_version
-        return wrap_requirements(old_requirements) unless target
+        return old_requirements unless target
 
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: old_requirements,
-            target_version: target
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: old_requirements,
+          target_version: target
+        ).updated_requirements
       end
 
       private
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_xcode_requirements
         # If no target version is available (e.g., revision-only or branch-pinned
         # dependency), return old requirements unchanged
@@ -94,7 +93,7 @@ module Dependabot
         ).updated_requirements
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def old_requirements
         dependency.requirements
       end

--- a/swift/lib/dependabot/swift/update_checker/requirements_updater.rb
+++ b/swift/lib/dependabot/swift/update_checker/requirements_updater.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "dependabot/dependency_requirement"
 require "dependabot/update_checkers/base"
 require "dependabot/swift/native_requirement"
 require "dependabot/swift/version"
@@ -13,14 +14,17 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             target_version: T.nilable(T.any(String, Gem::Version)),
             xcode_mode: T::Boolean,
             target_commit_sha: T.nilable(String)
           ).void
         end
         def initialize(requirements:, target_version:, xcode_mode: false, target_commit_sha: nil)
-          @requirements = requirements
+          @requirements = T.let(
+            requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @xcode_mode = xcode_mode
           @target_commit_sha = T.let(target_commit_sha, T.nilable(String))
 
@@ -29,18 +33,19 @@ module Dependabot
           @target_version = T.let(Version.new(target_version), Dependabot::Version)
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return updated_xcode_requirements if xcode_mode
 
-          NativeRequirement.map_requirements(requirements) do |requirement|
+          updated = NativeRequirement.map_requirements(requirements) do |requirement|
             T.must(requirement.update_if_needed(T.must(target_version)))
           end
+          updated.map { |req| Dependabot::DependencyRequirement.create(req) }
         end
 
         private
 
-        sig { returns(T::Array[T.untyped]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(Gem::Version)) }
@@ -53,7 +58,7 @@ module Dependabot
         attr_reader :target_commit_sha
 
         # For Xcode projects, we update the version in the requirement while preserving the kind.
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_xcode_requirements
           requirements.map do |req|
             next req unless target_version
@@ -63,7 +68,7 @@ module Dependabot
           end
         end
 
-        sig { params(requirement: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(requirement: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_xcode_requirement(requirement)
           metadata = requirement[:metadata] || {}
           requirement_string = metadata[:requirement_string]
@@ -75,12 +80,14 @@ module Dependabot
           # Update source ref to target version
           updated_source = update_source_ref(requirement[:source])
 
-          requirement.merge(
-            requirement: new_requirement,
-            source: updated_source,
-            metadata: metadata.merge(
-              requirement_string: new_requirement_string
-            ).compact
+          Dependabot::DependencyRequirement.create(
+            requirement.merge(
+              requirement: new_requirement,
+              source: updated_source,
+              metadata: metadata.merge(
+                requirement_string: new_requirement_string
+              ).compact
+            )
           )
         end
 

--- a/terraform/lib/dependabot/terraform/requirements_updater.rb
+++ b/terraform/lib/dependabot/terraform/requirements_updater.rb
@@ -51,7 +51,7 @@ module Dependabot
     class RequirementsUpdater
       extend T::Sig
 
-      # @param requirements [Hash{Symbol => String, Array, Hash}]
+      # @param requirements [Array<Dependabot::DependencyRequirement>]
       # @param latest_version [Dependabot::Terraform::Version]
       # @param tag_for_latest_version [String, NilClass]
       sig do
@@ -74,7 +74,7 @@ module Dependabot
         @latest_version = T.let(version_class.new(latest_version), Dependabot::Terraform::Version)
       end
 
-      # @return requirements [Hash{Symbol => String, Array, Hash}]
+      # @return requirements [Array<Dependabot::DependencyRequirement>]
       #   * requirement [String, NilClass] the updated version constraint
       #   * groups [Array] no-op for terraform
       #   * file [String] the file that specified this dependency

--- a/terraform/lib/dependabot/terraform/requirements_updater.rb
+++ b/terraform/lib/dependabot/terraform/requirements_updater.rb
@@ -8,6 +8,7 @@
 
 require "sorbet-runtime"
 
+require "dependabot/dependency_requirement"
 require "dependabot/terraform/version"
 require "dependabot/terraform/requirement"
 
@@ -55,13 +56,16 @@ module Dependabot
       # @param tag_for_latest_version [String, NilClass]
       sig do
         params(
-          requirements: T::Array[T::Hash[Symbol, T.untyped]],
+          requirements: T::Array[Dependabot::DependencyRequirement],
           latest_version: T.nilable(Dependabot::Version::VersionParameter),
           tag_for_latest_version: T.nilable(String)
         ).void
       end
       def initialize(requirements:, latest_version:, tag_for_latest_version:)
-        @requirements = requirements
+        @requirements = T.let(
+          requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
+          T::Array[Dependabot::DependencyRequirement]
+        )
         @tag_for_latest_version = tag_for_latest_version
 
         return unless latest_version
@@ -75,7 +79,7 @@ module Dependabot
       #   * groups [Array] no-op for terraform
       #   * file [String] the file that specified this dependency
       #   * source [Hash{Symbol => String}] The updated git or registry source details
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         # NOTE: Order is important here. The FileUpdater needs the updated
         # requirement at index `i` to correspond to the previous requirement
@@ -91,7 +95,7 @@ module Dependabot
 
       private
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       attr_reader :requirements
 
       sig { returns(Dependabot::Terraform::Version) }
@@ -100,15 +104,15 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       attr_reader :tag_for_latest_version
 
-      sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_git_requirement(req)
         return req unless req.dig(:source, :ref)
         return req unless tag_for_latest_version
 
-        req.merge(source: req[:source].merge(ref: tag_for_latest_version))
+        Dependabot::DependencyRequirement.create(req.merge(source: req[:source].merge(ref: tag_for_latest_version)))
       end
 
-      sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_registry_requirement(req)
         return req if req.fetch(:requirement).nil?
 
@@ -124,7 +128,7 @@ module Dependabot
             update_range(string_req).join(", ")
           end
 
-        req.merge(requirement: new_req)
+        Dependabot::DependencyRequirement.create(req.merge(requirement: new_req))
       end
 
       # Updates the version in a "~>" constraint to allow the given version

--- a/terraform/lib/dependabot/terraform/update_checker.rb
+++ b/terraform/lib/dependabot/terraform/update_checker.rb
@@ -47,13 +47,11 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: dependency.requirements,
-            latest_version: latest_version&.to_s,
-            tag_for_latest_version: tag_for_latest_version
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          latest_version: latest_version&.to_s,
+          tag_for_latest_version: tag_for_latest_version
+        ).updated_requirements
       end
 
       sig { returns(T::Boolean) }

--- a/uv/lib/dependabot/uv/update_checker.rb
+++ b/uv/lib/dependabot/uv/update_checker.rb
@@ -6,6 +6,7 @@ require "toml-rb"
 require "sorbet-runtime"
 
 require "dependabot/dependency"
+require "dependabot/dependency_requirement"
 require "dependabot/errors"
 require "dependabot/uv/name_normaliser"
 require "dependabot/uv/requirement_parser"
@@ -33,14 +34,12 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        wrap_requirements(
-          RequirementsUpdater.new(
-            requirements: requirements,
-            latest_resolvable_version: preferred_resolvable_version&.to_s,
-            update_strategy: requirements_update_strategy,
-            has_lockfile: requirements_text_file?
-          ).updated_requirements
-        )
+        RequirementsUpdater.new(
+          requirements: dependency.requirements,
+          latest_resolvable_version: preferred_resolvable_version&.to_s,
+          update_strategy: requirements_update_strategy,
+          has_lockfile: requirements_text_file?
+        ).updated_requirements
       end
 
       private


### PR DESCRIPTION
### What are you trying to accomplish?

Continues the `DependencyRequirement` migration for the standalone (non-`Base`) updaters. Stacked on #15380.

Since `Dependency#requirements` already returns `DependencyRequirement`s, this retypes the `requirements` param, reader, `updated_requirements`, and per-requirement helpers across bazel, bundler, bun, cargo, conda, hex, julia, npm_and_yarn, opentofu, python, swift, and terraform, and drops the redundant `wrap_requirements`. Clears seven files (1830 → 1703). composer, elm, and uv were already clean; the polymorphic `updated_source` hashes in bundler/bun/cargo/npm_and_yarn/swift stay untyped.

### Anything you want to highlight for special attention from reviewers?

Each constructor wraps its input via `DependencyRequirement.create` (specs pass plain hashes, and sorbet-runtime checks helper params strictly), and `req.merge(...)` results are wrapped in `.create(...)` since `Hash#merge` is typed as `Hash`. uv and pre_commit reuse python's updater, so their callers change too; uv's `requirements` was already `dependency.requirements`, so that is equivalent.

### How will you know you've accomplished your goal?

`srb tc`, the three bump checks, and RuboCop pass, and `rubocop --only Sorbet/ForbidTUntyped` reports zero offences. The requirements_updater specs pass for every migrated ecosystem (508 examples). hex/cargo/bundler update-checker specs fail locally only on missing native helpers; CI runs them in the right images.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
