### PR TITLE
Fix pre-commit update checking logic for force moved tags in sha pinned dependencies

### DIFF
--- a/pre_commit/lib/dependabot/pre_commit/update_checker.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker.rb
@@ -117,8 +117,10 @@ module Dependabot
         # Use latest_version (which respects cooldown) for semantic comparison.
         # This ensures that when cooldown rejects all candidates, the dependency
         # is correctly treated as up-to-date.
+        # Use strict < so that equal versions (force-moved tags) fall through
+        # to SHA comparison below.
         lv = latest_version
-        return true if lv.is_a?(Dependabot::Version) && lv <= frozen_ver
+        return true if lv.is_a?(Dependabot::Version) && lv < frozen_ver
 
         resolved_sha = latest_commit_sha
         # If no SHA can be resolved (e.g., all candidate versions rejected by cooldown),

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -128,14 +128,15 @@ module Dependabot
           result = find_latest_version_outside_cooldown
           return result if result
 
-          # If no newer version exists outside cooldown but the release version
+          # If no newer version exists outside cooldown but the dependency is
+          # SHA-pinned with a frozen version comment and the release version
           # equals current_version, the tag may have been force-moved to a new
           # commit. Don't block the unfiltered tag — let SHA comparison in
           # sha1_version_up_to_date? detect whether the commit actually changed.
           cur = current_version
-          if cur && release.is_a?(Dependabot::Version) && release == cur
+          if sha_pinned_with_version_comment? && cur && release.is_a?(Dependabot::Version) && release == cur
             Dependabot.logger.info(
-              "Same-version tag detected for #{dependency.name}, deferring to SHA comparison"
+              "Same-version tag detected for SHA-pinned #{dependency.name}, deferring to SHA comparison"
             )
             return release
           end

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -128,9 +128,21 @@ module Dependabot
           result = find_latest_version_outside_cooldown
           return result if result
 
-          Dependabot.logger.info("All candidate versions are in cooldown, keeping current version #{current_version}")
+          # If no newer version exists outside cooldown but the release version
+          # equals current_version, the tag may have been force-moved to a new
+          # commit. Don't block the unfiltered tag — let SHA comparison in
+          # sha1_version_up_to_date? detect whether the commit actually changed.
+          cur = current_version
+          if cur && release.is_a?(Dependabot::Version) && release == cur
+            Dependabot.logger.info(
+              "Same-version tag detected for #{dependency.name}, deferring to SHA comparison"
+            )
+            return release
+          end
+
+          Dependabot.logger.info("All candidate versions are in cooldown, keeping current version #{cur}")
           @cooldown_rejected_all = true
-          current_version
+          cur
         end
 
         sig { returns(T.nilable(Dependabot::PreCommit::Package::PackageDetailsFetcher)) }

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -681,6 +681,69 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
     end
   end
 
+  describe "force-moved tag detection" do
+    context "when SHA-pinned with frozen comment and tag is force-moved within the same version" do
+      # Scenario: User is pinned to commit "6f6a02c..." with frozen comment "v6.0.0".
+      # The v6.0.0 tag has been force-moved to a different commit "3e8a8703..."
+      # (which is what the upload pack fixture reports). No higher version exists.
+      let(:reference) { "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "https://github.com/#{dependency_name}",
+          version: "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: dependency_source,
+            metadata: { comment: "# frozen: v6.0.0" }
+          }],
+          package_manager: "pre_commit"
+        )
+      end
+      let(:update_cooldown) do
+        Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: 7
+        )
+      end
+
+      before do
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tag_for_pinned_sha).and_return(nil)
+
+        # The v6.0.0 tag now points to the new commit (from the upload pack fixture)
+        v6_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions)
+          .and_return([v6_tag])
+
+        mock_client = instance_double(Octokit::Client, releases: [])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+      end
+
+      it "returns the version (defers to SHA comparison for force-moved tag detection)" do
+        result = finder.latest_release_version
+        # Version equals frozen comment → returned without setting cooldown_rejected_all
+        expect(result).to be_a(Dependabot::PreCommit::Version)
+        expect(result.to_s).to eq("6.0.0")
+      end
+
+      it "does not set cooldown_rejected_all so latest_version_tag remains available" do
+        finder.latest_release_version
+
+        # latest_version_tag must NOT be nil so that sha1_version_up_to_date?
+        # can resolve the new commit SHA and detect the force-moved tag
+        expect(finder.latest_version_tag).not_to be_nil
+        expect(finder.latest_version_tag[:version].to_s).to eq("6.0.0")
+      end
+    end
+  end
+
   describe "version precision" do
     context "with shortened version ref" do
       let(:reference) { "v4.4" }

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -211,6 +211,57 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
       end
     end
 
+    context "when SHA-pinned with frozen comment and tag is force-moved to a new commit" do
+      # User is pinned to "6f6a02c..." which was the old commit for v6.0.0.
+      # The v6.0.0 tag has been force-moved to "3e8a8703..." (from the upload pack fixture).
+      let(:reference) { "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "https://github.com/#{dependency_name}",
+          version: "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: dependency_source,
+            metadata: { comment: "# frozen: v6.0.0" }
+          }],
+          package_manager: "pre_commit"
+        )
+      end
+      let(:update_cooldown) do
+        Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: 7
+        )
+      end
+
+      before do
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tag_for_pinned_sha).and_return(nil)
+
+        v6_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions)
+          .and_return([v6_tag])
+
+        mock_client = instance_double(Octokit::Client, releases: [])
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
+      end
+
+      it "detects that the dependency is NOT up to date (SHA differs)" do
+        expect(checker.up_to_date?).to be(false)
+      end
+
+      it "returns the version from the force-moved tag" do
+        expect(checker.latest_version.to_s).to eq("6.0.0")
+      end
+    end
+
     context "with shortened version ref" do
       let(:reference) { "v4.4" }
 


### PR DESCRIPTION
### What are you trying to accomplish?
Fix a behavioral gap where force-moved (re-pointed) tags within the same version label were not detected by the pre-commit cooldown logic when a dependency is SHA-pinned with a frozen version comment.

Previously, `sha1_version_up_to_date?` used `<=` to compare `latest_version` against the frozen comment version. When a tag was force-moved to a new commit but kept the same version label, this short-circuited to "up-to-date" without checking whether the actual commit SHA had changed.

This was identified as a follow-up concern to #15346.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
The fix spans two files with minimal changes:

- **`update_checker.rb`**: Changed `lv <= frozen_ver` to `lv < frozen_ver` in `sha1_version_up_to_date?`. When versions are equal, execution now falls through to the SHA comparison, which detects the force-moved commit.

- **`latest_version_finder.rb`**: In `filter_release_with_cooldown`, when `find_latest_version_outside_cooldown` returns nil but the release version equals the current version, we no longer set `@cooldown_rejected_all = true`. Instead, we return the release as-is so that `latest_version_tag` remains available for SHA resolution.

Both changes are required together — the `<` change alone is insufficient because `latest_version_tag` would return `nil` (due to `cooldown_rejected_all`), causing `latest_commit_sha` to return `nil`, which would still short-circuit to "up-to-date".
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- 4 new specs added covering the force-moved tag scenario:
  - `latest_version_finder_spec`: verifies `latest_release_version` returns the version (not nil) and `latest_version_tag` remains available when the tag version equals the frozen comment
  - `update_checker_spec`: verifies `up_to_date?` returns `false` when the tag SHA differs from the pinned SHA, and `latest_version` returns the correct version
- All 47 update checker/latest version finder tests pass with 0 failures
- The original cooldown bypass fix from #15346 is preserved (the "all candidates in cooldown" path still works correctly when a genuinely newer version exists)
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
