### PR TITLE
Fake MSBuild SolutionDir during NuGet discovery (#13756)

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -45,6 +45,7 @@ public class DiscoveryWorkerTestBase : TestBase
         ValidateResultWithDependencies(expectedResult.DotNetToolsJson, actualResult.DotNetToolsJson);
         ValidateProjectResults(expectedResult.Projects, actualResult.Projects);
         Assert.Equal(expectedResult.ExpectedProjectCount ?? expectedResult.Projects.Length, actualResult.Projects.Length);
+        Assert.Equal(expectedResult.SolutionDirectory?.NormalizePathToUnix(), actualResult.SolutionDirectory?.NormalizePathToUnix());
         ValidateDiscoveryOperationResult(expectedResult, actualResult);
 
         return;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -518,6 +518,7 @@ public partial class DiscoveryWorkerTests
                 expectedResult: new()
                 {
                     Path = "solutions",
+                    SolutionDirectory = "solutions",
                     Projects = [
                         new()
                         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.cs
@@ -269,6 +269,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             expectedResult: new()
             {
                 Path = "src",
+                SolutionDirectory = "src",
                 Projects = [
                     new()
                     {
@@ -550,6 +551,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             expectedResult: new()
             {
                 Path = "",
+                SolutionDirectory = ".",
                 Projects = [
                     new()
                     {
@@ -816,6 +818,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             expectedResult: new()
             {
                 Path = "src",
+                SolutionDirectory = "src",
                 Projects = [
                     new()
                     {
@@ -831,6 +834,58 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
                         FilePath = "server/server.csproj",
                         TargetFrameworks = ["net8.0"],
                         Dependencies = [new("Package.B", "4.5.6", DependencyType.PackageReference, TargetFrameworks: ["net8.0"])],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                    }
+                ]
+            }
+        );
+    }
+
+    [Fact]
+    public async Task TestRepo_SolutionDirectoryIsCapturedAndHonored()
+    {
+        // the workspace directly contains a solution file, so the `SolutionDir` MSBuild property is faked during
+        // discovery; the project only references the package when `$(SolutionDir)` is set, and the resolved solution
+        // directory is reported on the discovery result so it can be retrieved later
+        await TestDiscoveryAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Solution.Scoped.Package", "9.0.1", "net8.0"),
+            ],
+            workspacePath: "",
+            files: new[]
+            {
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+
+                      <ItemGroup Condition="Exists('$(SolutionDir)')">
+                        <PackageReference Include="Solution.Scoped.Package" Version="9.0.1" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("solution.slnx", """
+                    <Solution>
+                      <Project Path="project.csproj" />
+                    </Solution>
+                    """)
+            },
+            expectedResult: new()
+            {
+                Path = "",
+                SolutionDirectory = ".",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies = [
+                            new("Solution.Scoped.Package", "9.0.1", DependencyType.PackageReference, TargetFrameworks: ["net8.0"])
+                        ],
                         ReferencedProjectPaths = [],
                         ImportedFiles = [],
                         AdditionalFiles = [],
@@ -874,6 +929,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             expectedResult: new()
             {
                 Path = "",
+                SolutionDirectory = ".",
                 Projects = [
                     new()
                     {
@@ -954,6 +1010,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             expectedResult: new()
             {
                 Path = "",
+                SolutionDirectory = ".",
                 Projects = [
                     new()
                     {
@@ -1037,6 +1094,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             expectedResult: new()
             {
                 Path = "",
+                SolutionDirectory = ".",
                 Projects = [
                     new()
                     {
@@ -2088,6 +2146,7 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
             expectedResult: new()
             {
                 Path = "",
+                SolutionDirectory = ".",
                 Projects = [
                     new()
                     {
@@ -2326,3 +2385,4 @@ public partial class DiscoveryWorkerTests : DiscoveryWorkerTestBase
         );
     }
 }
+

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/ExpectedDiscoveryResults.cs
@@ -12,6 +12,7 @@ public record ExpectedWorkspaceDiscoveryResult : NativeResult
     public int? ExpectedProjectCount { get; init; }
     public ExpectedDependencyDiscoveryResult? GlobalJson { get; init; }
     public ExpectedDependencyDiscoveryResult? DotNetToolsJson { get; init; }
+    public string? SolutionDirectory { get; init; }
     public string? ErrorRegex { get; init; } = null;
 }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
@@ -13,6 +13,91 @@ namespace NuGetUpdater.Core.Test.Discover;
 public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
 {
     [Fact]
+    public async Task DiscoveryInSingleProject_SolutionDirPropertyIsHonored()
+    {
+        // the project only references the package when the MSBuild `SolutionDir` property is set, which mimics
+        // project files that rely on `$(SolutionDir)` being defined by a solution-level build; the concatenated path
+        // also asserts that the faked value ends with a directory separator like VS/MSBuild solution builds
+        await TestDiscoverAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Solution.Scoped.Package", "1.2.3", "net8.0"),
+            ],
+            startingDirectory: "src",
+            projectPath: "src/library.csproj",
+            solutionDir: "src",
+            files:
+            [
+                ("src/library.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup Condition="Exists('$(SolutionDir)library.csproj')">
+                        <PackageReference Include="Solution.Scoped.Package" Version="1.2.3" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            expectedProjects:
+            [
+                new()
+                {
+                    FilePath = "library.csproj",
+                    Dependencies =
+                    [
+                        new("Solution.Scoped.Package", "1.2.3", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                    ],
+                    ImportedFiles = [],
+                    TargetFrameworks = ["net8.0"],
+                    ReferencedProjectPaths = [],
+                    AdditionalFiles = [],
+                }
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task DiscoveryInSingleProject_SolutionDirPropertyIsUnsetWhenNotProvided()
+    {
+        // without a solution directory the `$(SolutionDir)` property is undefined, so the conditional package
+        // reference is not evaluated and the package is not discovered
+        await TestDiscoverAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Solution.Scoped.Package", "1.2.3", "net8.0"),
+            ],
+            startingDirectory: "src",
+            projectPath: "src/library.csproj",
+            files:
+            [
+                ("src/library.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup Condition="Exists('$(SolutionDir)library.csproj')">
+                        <PackageReference Include="Solution.Scoped.Package" Version="1.2.3" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            expectedProjects:
+            [
+                new()
+                {
+                    FilePath = "library.csproj",
+                    Dependencies = [],
+                    ImportedFiles = [],
+                    TargetFrameworks = ["net8.0"],
+                    ReferencedProjectPaths = [],
+                    AdditionalFiles = [],
+                }
+            ]
+        );
+    }
+
+    [Fact]
     public async Task DiscoveryInSingleProject_TopLevelAndTransitive()
     {
         await TestDiscoverAsync(
@@ -697,7 +782,8 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
         string projectPath,
         TestFile[] files,
         ImmutableArray<ExpectedSdkProjectDiscoveryResult> expectedProjects,
-        MockNuGetPackage[]? packages = null
+        MockNuGetPackage[]? packages = null,
+        string? solutionDir = null
     )
     {
         using var testDirectory = await TemporaryDirectory.CreateWithContentsAsync(files);
@@ -707,7 +793,9 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
         var logger = new TestLogger();
         var fullProjectPath = Path.Combine(testDirectory.DirectoryPath, projectPath);
         var experimentsManager = new ExperimentsManager();
-        var projectDiscovery = await SdkProjectDiscovery.DiscoverAsync(testDirectory.DirectoryPath, Path.GetDirectoryName(fullProjectPath)!, fullProjectPath, experimentsManager, logger);
+        var resolvedSolutionDir = solutionDir is null ? null : Path.Combine(testDirectory.DirectoryPath, solutionDir);
+        var projectDiscovery = await SdkProjectDiscovery.DiscoverAsync(testDirectory.DirectoryPath, Path.GetDirectoryName(fullProjectPath)!, fullProjectPath, experimentsManager, resolvedSolutionDir, logger);
         ValidateProjectResults(expectedProjects, projectDiscovery);
     }
 }
+

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/DiscoveryWorker.cs
@@ -88,9 +88,19 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         ImmutableArray<ProjectDiscoveryResult> projectResults = [];
         WorkspaceDiscoveryResult result;
 
+        // if the workspace directory directly contains a solution file, capture its directory so that the MSBuild
+        // `SolutionDir` property can be faked during discovery; this allows project files that reference
+        // `$(SolutionDir)` to be evaluated correctly
+        string? solutionDir = null;
+
         if (Directory.Exists(workspacePath))
         {
             _logger.Info($"Discovering build files in workspace [{workspacePath}].");
+
+            if (DirectoryContainsSolutionFile(workspacePath))
+            {
+                solutionDir = workspacePath;
+            }
 
             dotNetToolsJsonDiscovery = DotNetToolsJsonDiscovery.Discover(repoRootPath, workspacePath, _logger);
             globalJsonDiscovery = GlobalJsonDiscovery.Discover(repoRootPath, workspacePath, _logger);
@@ -101,7 +111,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             }
 
             // this next line should throw or something
-            projectResults = await RunForDirectoryAsync(repoRootPath, workspacePath);
+            projectResults = await RunForDirectoryAsync(repoRootPath, workspacePath, solutionDir);
         }
         else
         {
@@ -149,6 +159,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                 DotNetToolsJson = null,
                 GlobalJson = null,
                 Projects = projectResults.Where(p => p.IsSuccess).OrderBy(p => p.FilePath).ToImmutableArray(),
+                SolutionDirectory = GetRelativeSolutionDirectory(repoRootPath, solutionDir),
                 Error = failedProjectResult.Error,
                 IsSuccess = false,
             };
@@ -162,6 +173,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             DotNetToolsJson = dotNetToolsJsonDiscovery,
             GlobalJson = globalJsonDiscovery,
             Projects = projectResults.OrderBy(p => p.FilePath).ToImmutableArray(),
+            SolutionDirectory = GetRelativeSolutionDirectory(repoRootPath, solutionDir),
         };
 
         _logger.Info("Discovery complete.");
@@ -196,7 +208,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         return await NuGetHelper.DownloadNuGetPackagesAsync(repoRootPath, workspacePath, msbuildSdks, logger);
     }
 
-    private async Task<ImmutableArray<ProjectDiscoveryResult>> RunForDirectoryAsync(string repoRootPath, string workspacePath)
+    private async Task<ImmutableArray<ProjectDiscoveryResult>> RunForDirectoryAsync(string repoRootPath, string workspacePath, string? solutionDir)
     {
         _logger.Info($"  Discovering projects beneath [{Path.GetRelativePath(repoRootPath, workspacePath)}].");
         var entryPoints = FindEntryPoints(workspacePath);
@@ -227,7 +239,24 @@ public partial class DiscoveryWorker : IDiscoveryWorker
             return [];
         }
 
-        return await RunForProjectPathsAsync(repoRootPath, workspacePath, projects);
+        return await RunForProjectPathsAsync(repoRootPath, workspacePath, projects, solutionDir);
+    }
+
+    private static bool DirectoryContainsSolutionFile(string directoryPath)
+    {
+        return Directory.EnumerateFiles(directoryPath)
+            .Any(path =>
+            {
+                string extension = Path.GetExtension(path).ToLowerInvariant();
+                return extension is ".sln" or ".slnx";
+            });
+    }
+
+    private static string? GetRelativeSolutionDirectory(string repoRootPath, string? solutionDir)
+    {
+        return solutionDir is null
+            ? null
+            : Path.GetRelativePath(repoRootPath, solutionDir).NormalizePathToUnix();
     }
 
     private static ImmutableArray<string> FindEntryPoints(string workspacePath)
@@ -378,7 +407,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
         return foundItems;
     }
 
-    private async Task<ImmutableArray<ProjectDiscoveryResult>> RunForProjectPathsAsync(string repoRootPath, string workspacePath, IEnumerable<string> projectPaths)
+    private async Task<ImmutableArray<ProjectDiscoveryResult>> RunForProjectPathsAsync(string repoRootPath, string workspacePath, IEnumerable<string> projectPaths, string? solutionDir)
     {
         var normalizedProjectPaths = projectPaths.SelectMany(p => PathHelper.ResolveCaseInsensitivePathsInsideRepoRoot(p, repoRootPath) ?? []).Distinct().ToImmutableArray();
 
@@ -437,7 +466,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                 _processedProjectPaths.Add(projectPath);
 
                 var relativeProjectPath = Path.GetRelativePath(workspacePath, projectPath).NormalizePathToUnix();
-                var projectResults = await SdkProjectDiscovery.DiscoverAsync(repoRootPath, workspacePath, projectPath, _experimentsManager, _logger);
+                var projectResults = await SdkProjectDiscovery.DiscoverAsync(repoRootPath, workspacePath, projectPath, _experimentsManager, solutionDir, _logger);
 
                 // Determine if there were unrestored MSBuildSdks
                 var msbuildSdks = projectResults.SelectMany(p => p.Dependencies.Where(d => d.Type == DependencyType.MSBuildSdk)).ToImmutableArray();
@@ -446,7 +475,7 @@ public partial class DiscoveryWorker : IDiscoveryWorker
                     // If new SDKs were restored, then we need to rerun SdkProjectDiscovery.
                     if (await TryRestoreMSBuildSdksAsync(repoRootPath, workspacePath, msbuildSdks, _logger))
                     {
-                        projectResults = await SdkProjectDiscovery.DiscoverAsync(repoRootPath, workspacePath, projectPath, _experimentsManager, _logger);
+                        projectResults = await SdkProjectDiscovery.DiscoverAsync(repoRootPath, workspacePath, projectPath, _experimentsManager, solutionDir, _logger);
                     }
                 }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -71,7 +71,7 @@ internal static class SdkProjectDiscovery
     // this seems to be the maximum number of TFMs that can be restored in parallel without running into race conditions
     private const int MaximumParallelTargetFrameworkRestores = 2;
 
-    public static async Task<ImmutableArray<ProjectDiscoveryResult>> DiscoverAsync(string repoRootPath, string workspacePath, string startingProjectPath, ExperimentsManager experimentsManager, ILogger logger)
+    public static async Task<ImmutableArray<ProjectDiscoveryResult>> DiscoverAsync(string repoRootPath, string workspacePath, string startingProjectPath, ExperimentsManager experimentsManager, string? solutionDir, ILogger logger)
     {
         var extension = Path.GetExtension(startingProjectPath)?.ToLowerInvariant();
         switch (extension)
@@ -188,6 +188,15 @@ internal static class SdkProjectDiscovery
                 if (isIndividualTfmRestore)
                 {
                     args.Add($"/p:TargetFramework={tfm}");
+                }
+
+                // if the project lives alongside a solution file, fake the MSBuild `SolutionDir` property so that
+                // project files referencing `$(SolutionDir)` can be evaluated correctly; MSBuild expects this value
+                // to end with a directory separator so that `$(SolutionDir)foo` concatenations form valid paths
+                if (solutionDir is not null)
+                {
+                    var normalizedSolutionDir = $"{solutionDir.TrimEnd('/', Path.DirectorySeparatorChar)}/";
+                    args.Add($"/p:SolutionDir={normalizedSolutionDir}");
                 }
 
                 // if using CPM and a project also sets TreatWarningsAsErrors to true, this can cause discovery to fail; explicitly don't allow that
@@ -446,6 +455,7 @@ internal static class SdkProjectDiscovery
                 packagesPerProject,
                 explicitPackageVersionsPerProject,
                 experimentsManager,
+                solutionDir,
                 logger
             );
         }
@@ -809,6 +819,7 @@ internal static class SdkProjectDiscovery
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packagesPerProject,
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> explicitPackageVersionsPerProject,
         ExperimentsManager experimentsManager,
+        string? solutionDir,
         ILogger logger
     )
     {
@@ -831,7 +842,7 @@ internal static class SdkProjectDiscovery
 
             var tempProjectPath = await MSBuildHelper.CreateTempProjectAsync(tempDirectory, repoRootPath, projectPath, targetFrameworks, topLevelDependencies, logger);
             var tempProjectDirectory = Path.GetDirectoryName(tempProjectPath)!;
-            var rediscoveredDependencies = await DiscoverAsync(tempProjectDirectory, tempProjectDirectory, tempProjectPath, experimentsManager, logger);
+            var rediscoveredDependencies = await DiscoverAsync(tempProjectDirectory, tempProjectDirectory, tempProjectPath, experimentsManager, solutionDir, logger);
             var tempProjectFileName = Path.GetFileName(tempProjectPath);
             var rediscoveredDependenciesForThisProject = rediscoveredDependencies.FirstOrDefault(r => PathComparer.Instance.Equals(r.FilePath, tempProjectFileName));
             if (rediscoveredDependenciesForThisProject is null)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/WorkspaceDiscoveryResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/WorkspaceDiscoveryResult.cs
@@ -10,6 +10,10 @@ public sealed record WorkspaceDiscoveryResult : NativeResult
     public GlobalJsonDiscoveryResult? GlobalJson { get; init; }
     public DotNetToolsJsonDiscoveryResult? DotNetToolsJson { get; init; }
 
+    // when the workspace directly contains a solution file, this is the directory that was used to fake the MSBuild
+    // `SolutionDir` property during discovery; it is `null` when no solution file was present
+    public string? SolutionDirectory { get; init; }
+
     public ProjectDiscoveryResult? GetProjectDiscoveryFromPath(string repoPath)
     {
         var projectDiscovery = Projects.FirstOrDefault(p => System.IO.Path.Join(Path, p.FilePath).FullyNormalizedRootedPath().Equals(repoPath, StringComparison.OrdinalIgnoreCase));

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -514,7 +514,7 @@ internal static partial class MSBuildHelper
             var tempProjectPath = await CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, targetFramework, packages, logger, importDependencyTargets: false);
 
             var experimentsManager = new ExperimentsManager();
-            var projectDiscovery = await SdkProjectDiscovery.DiscoverAsync(repoRoot, tempDirectory.FullName, tempProjectPath, experimentsManager, logger);
+            var projectDiscovery = await SdkProjectDiscovery.DiscoverAsync(repoRoot, tempDirectory.FullName, tempProjectPath, experimentsManager, solutionDir: null, logger);
             var allDependencies = projectDiscovery
                 .Where(p => p.FilePath == Path.GetFileName(tempProjectPath))
                 .FirstOrDefault()


### PR DESCRIPTION
Fixes #13756.

### Problem

The NuGet updater runs MSBuild directly against project files rather than through a solution-level pipeline, so the `$(SolutionDir)` property is never defined. Project files (and imported `.props`/`.targets`) that build paths from `$(SolutionDir)` therefore fail to evaluate, causing discovery to error out with `dependency_file_not_parseable`.

### Fix

When the discovery worker enumerates a workspace directory that directly contains a `.sln`/`.slnx` file, it captures that directory and threads it down to `SdkProjectDiscovery.DiscoverAsync`. When set, discovery passes `/p:SolutionDir=...` to MSBuild so project files referencing `$(SolutionDir)` evaluate correctly.

The resolved (repo-relative) solution directory is also surfaced on `WorkspaceDiscoveryResult.SolutionDirectory` so it can be retrieved later in the pipeline.

### Notes

- Only `SolutionDir` is faked; `SolutionName` is intentionally not set.
- `SdkProjectDiscovery.DiscoverAsync` gains a required `string? solutionDir` parameter; internal temp-project discovery paths pass `null`.

### Tests

- `SdkProjectDiscoveryTests`: verifies the faked `SolutionDir` is honored when set and absent otherwise (using `Exists('$(SolutionDir)')`, since MSBuild defaults the property to the `*Undefined*` sentinel).
- `DiscoveryWorkerTests`: verifies the property is faked end-to-end and the resolved `SolutionDirectory` is reported on the result.
