### PR TITLE
Fix private registry config not found error not being raised issue in npm_and_yarn

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -80,7 +80,7 @@ module Dependabot
       end
 
       sig { override.returns(T::Array[DependencyFile]) }
-      def fetch_files
+      def fetch_files # rubocop:disable Metrics/PerceivedComplexity
         fetched_files = T.let([], T::Array[DependencyFile])
         fetched_files << package_json
         fetched_files << T.must(npmrc) if npmrc && !scope_overrides_npmrc?
@@ -91,10 +91,13 @@ module Dependabot
         fetched_files += workspace_package_jsons
         fetched_files += path_dependencies(fetched_files)
 
-        # Ensure private registry rejection runs even when npm_version is nil
-        # (e.g. no lockfile, no packageManager, no engines), since inferred_npmrc
-        # is only called from npm_files which is gated on npm_version.
-        reject_if_private_registry_without_config! unless npm_version
+        # When no package manager version is detected at all (no lockfile, no
+        # packageManager, no engines) AND no committed .npmrc exists, the
+        # inferred_npmrc path inside npm_files is never reached. Run the
+        # private-registry rejection check directly so users get an actionable
+        # error instead of a confusing 404 from registry.npmjs.org.
+        # Skip for yarn/pnpm-only projects where npm isn't the relevant manager.
+        reject_if_private_registry_without_config! if no_package_manager_detected? && npmrc.nil?
 
         # Filter excluded files from final collection
         filtered_files = fetched_files.uniq.reject do |file|
@@ -289,6 +292,11 @@ module Dependabot
       sig { returns(T::Boolean) }
       def scope_overrides_npmrc?
         Dependabot::Experiments.enabled?(:enable_npmrc_credential_generation) && credentials_have_scope?
+      end
+
+      sig { returns(T::Boolean) }
+      def no_package_manager_detected?
+        !npm_version && !yarn_version && !pnpm_version
       end
 
       sig { returns(T.nilable(T.any(Integer, String))) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -91,6 +91,11 @@ module Dependabot
         fetched_files += workspace_package_jsons
         fetched_files += path_dependencies(fetched_files)
 
+        # Ensure private registry rejection runs even when npm_version is nil
+        # (e.g. no lockfile, no packageManager, no engines), since inferred_npmrc
+        # is only called from npm_files which is gated on npm_version.
+        reject_if_private_registry_without_config! unless npm_version
+
         # Filter excluded files from final collection
         filtered_files = fetched_files.uniq.reject do |file|
           Dependabot::Experiments.enabled?(:enable_exclude_paths_subdirectory_manifest_files) &&
@@ -156,7 +161,7 @@ module Dependabot
         if Dependabot::Experiments.enabled?(:enable_npmrc_credential_generation) && credentials_have_scope?
           npmrc_from_credentials = generate_npmrc_from_credentials
           if npmrc_from_credentials
-            Dependabot.logger.info("Generated .npmrc from credential scope configuration (overrides committed .npmrc)")
+            Dependabot.logger.warn("Generated .npmrc from credential scope configuration (overrides committed .npmrc)")
             return @inferred_npmrc ||= T.let(npmrc_from_credentials, T.nilable(DependencyFile))
           end
         end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2837,6 +2837,57 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
   end
 
+  context "with no .npmrc, no lockfile at all, and no credential scope/replaces-base" do
+    let(:credentials) do
+      [Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      ), Dependabot::Credential.new(
+        {
+          "type" => "npm_registry",
+          "registry" => "npm.pkg.github.com",
+          "token" => "my_token"
+        }
+      )]
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_npmrc_credential_generation, true)
+      allow(file_fetcher_instance).to receive(:commit).and_return("sha")
+
+      stub_request(:get, url + "?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_js_library.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "package_json_content.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 404)
+    end
+
+    it "raises PrivateRegistryConfigNotFound" do
+      expect { file_fetcher_instance.files }.to raise_error(
+        Dependabot::PrivateRegistryConfigNotFound,
+        /npm.pkg.github.com/
+      )
+    end
+  end
+
   context "with only central registry credentials and no scope/replaces-base" do
     let(:credentials) do
       [Dependabot::Credential.new(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2832,7 +2832,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     it "raises PrivateRegistryConfigNotFound" do
       expect { file_fetcher_instance.files }.to raise_error(
         Dependabot::PrivateRegistryConfigNotFound,
-        /Private npm registries require either a .npmrc file.*npm.pkg.github.com/
+        /Private npm registries require either a \.npmrc file.*npm\.pkg\.github\.com/
       )
     end
   end
@@ -2883,7 +2883,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     it "raises PrivateRegistryConfigNotFound" do
       expect { file_fetcher_instance.files }.to raise_error(
         Dependabot::PrivateRegistryConfigNotFound,
-        /npm.pkg.github.com/
+        /npm\.pkg\.github\.com/
       )
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?
Fix `PrivateRegistryConfigNotFound` error not being raised when a project has private npm registry credentials but no lockfile, no `.npmrc`, no `packageManager`, and no `engines` in `package.json`.

<!-- Provide both a what and a _why_ for the change. -->
**Root cause**: `reject_if_private_registry_without_config!` method is only called from `inferred_npmrc`, which is called from `npm_files`, which is gated on `npm_version` being non-nil. When there's no lockfile and no `packageManager`/`engines` field, `PackageManagerHelper#setup("npm")` returns `nil`, so `npm_files` is never called and the rejection check is skipped entirely. The update then proceeds using `registry.npmjs.org`, failing with a confusing 404 instead of the intended actionable error.

**Fix**: Call `reject_if_private_registry_without_config!` directly in `fetch_files` when `npm_version` is nil, ensuring the check runs regardless of package manager detection. Also changed the `.npmrc` generation log from `info` to `warn` so it appears in production logs.
<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
The `unless npm_version` guard ensures this is additive — when `npm_version` IS detected, the existing path through `inferred_npmrc` handles rejection as before. The new call only covers the gap where no package manager version could be determined.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- Reproduced locally using `dependabot-cli` against a test repo with only a `package.json` (no lockfile), a private JFrog registry credential, and no `scope`/`replaces-base` config. Before the fix: silent 404 from `registry.npmjs.org`. After the fix: `PrivateRegistryConfigNotFound` error raised during file fetching.
- Existing spec `"with no .npmrc, no lockfile at all, and no credential scope/replaces-base"` covers this scenario.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
