### PR TITLE
Parse DependencyGroup rules into typed readers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1695
+# Offense count: 1694
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -299,7 +299,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/command_helpers.rb"
     - "common/lib/dependabot/config/file.rb"
     - "common/lib/dependabot/dependency.rb"
-    - "common/lib/dependabot/dependency_group.rb"
     - "common/lib/dependabot/errors.rb"
     - "common/lib/dependabot/experiments.rb"
     - "common/lib/dependabot/file_fetchers/base.rb"

--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/experiments"
@@ -28,10 +28,23 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_reader :group_by
 
+    # The following readers are parsed once from the raw rules hash so callers
+    # get typed access instead of repeatedly casting rules["patterns"] and
+    # friends at every use site. A nil value means the rule is absent (which the
+    # matching logic treats differently from an empty list).
+    sig { returns(T.nilable(T::Array[String])) }
+    attr_reader :patterns
+
+    sig { returns(T.nilable(T::Array[String])) }
+    attr_reader :exclude_patterns
+
+    sig { returns(T.nilable(T::Array[String])) }
+    attr_reader :update_types
+
     sig do
       params(
         name: String,
-        rules: T::Hash[String, T.untyped],
+        rules: T::Hash[String, T.any(String, T::Array[String])],
         applies_to: T.nilable(String)
       )
         .void
@@ -41,7 +54,10 @@ module Dependabot
       # For backwards compatibility, if no applies_to is provided, default to "version-updates"
       @applies_to = T.let(applies_to || "version-updates", String)
       @rules = rules
-      @group_by = T.let(rules["group-by"], T.nilable(String))
+      @group_by = T.let(string_rule(rules, "group-by"), T.nilable(String))
+      @patterns = T.let(string_array_rule(rules, "patterns"), T.nilable(T::Array[String]))
+      @exclude_patterns = T.let(string_array_rule(rules, "exclude-patterns"), T.nilable(T::Array[String]))
+      @update_types = T.let(string_array_rule(rules, "update-types"), T.nilable(T::Array[String]))
       @dependencies = T.let([], T::Array[Dependabot::Dependency])
     end
 
@@ -75,16 +91,18 @@ module Dependabot
 
     sig { params(dependency_name: String).returns(T::Boolean) }
     def matches_pattern?(dependency_name)
-      return true unless rules.key?("patterns") # If no patterns are defined, we pass this check by default
+      patterns = self.patterns
+      return true if patterns.nil? # If no patterns are defined, we pass this check by default
 
-      T.unsafe(rules["patterns"]).any? { |rule| WildcardMatcher.match?(rule, dependency_name) }
+      patterns.any? { |rule| WildcardMatcher.match?(rule, dependency_name) }
     end
 
     sig { params(dependency_name: String).returns(T::Boolean) }
     def matches_excluded_pattern?(dependency_name)
-      return false unless rules.key?("exclude-patterns") # If there are no exclusions, fail by default
+      exclude_patterns = self.exclude_patterns
+      return false if exclude_patterns.nil? # If there are no exclusions, fail by default
 
-      T.unsafe(rules["exclude-patterns"]).any? { |rule| WildcardMatcher.match?(rule, dependency_name) }
+      exclude_patterns.any? { |rule| WildcardMatcher.match?(rule, dependency_name) }
     end
 
     sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
@@ -101,6 +119,43 @@ module Dependabot
     sig { returns(T::Boolean) }
     def experimental_rules_enabled?
       Dependabot::Experiments.enabled?(:grouped_updates_experimental_rules)
+    end
+
+    # Reads a rule whose value is expected to be a single string (e.g.
+    # "group-by"), returning nil when the key is absent or the value is not a
+    # string.
+    sig do
+      params(
+        rules: T::Hash[String, T.any(String, T::Array[String])],
+        key: String
+      )
+        .returns(T.nilable(String))
+    end
+    def string_rule(rules, key)
+      value = rules[key]
+      value.is_a?(String) ? value : nil
+    end
+
+    # Reads a rule whose value is expected to be a list of strings (e.g.
+    # "patterns", "exclude-patterns", "update-types"). Returns nil when the key
+    # is absent so callers can distinguish "rule not set" from "empty list", and
+    # coerces a lone string into a single-element list.
+    sig do
+      params(
+        rules: T::Hash[String, T.any(String, T::Array[String])],
+        key: String
+      )
+        .returns(T.nilable(T::Array[String]))
+    end
+    def string_array_rule(rules, key)
+      return nil unless rules.key?(key)
+
+      value = rules[key]
+      case value
+      when Array then value.grep(String)
+      when String then [value]
+      else []
+      end
     end
   end
 end

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -196,10 +196,10 @@ module Dependabot
       # Groups with update-types rules are complementary, not competing.
       # Filter out groups with non-overlapping update-types so they don't
       # prevent each other from receiving dependencies during assignment.
-      current_update_types = T.cast(group.rules["update-types"], T.nilable(T::Array[String]))
+      current_update_types = group.update_types
       eligible_groups = if current_update_types
                           @dependency_groups.reject do |other|
-                            other_update_types = T.cast(other.rules["update-types"], T.nilable(T::Array[String]))
+                            other_update_types = other.update_types
                             next false unless other_update_types
 
                             !current_update_types.intersect?(other_update_types)

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -441,8 +441,9 @@ module Dependabot
           .returns(T::Boolean)
       end
       def semver_rules_allow_grouping?(group, dependency, checker)
+        update_types = group.update_types
         # There are no group rules defined, so this dependency can be included in the group.
-        return true unless group.rules["update-types"]
+        return true unless update_types
 
         version_class = Dependabot::Utils.version_class_for_package_manager(job.package_manager)
         unless version_class.correct?(dependency.version.to_s) && version_class.correct?(checker.latest_version)
@@ -461,9 +462,9 @@ module Dependabot
         # Ensure that semver components are of the same type and can be compared with each other.
         return false unless %i(major minor patch).all? { |k| current[k].instance_of?(latest[k].class) }
 
-        return T.must(group.rules["update-types"]).include?("major") if T.must(latest[:major]) > T.must(current[:major])
-        return T.must(group.rules["update-types"]).include?("minor") if T.must(latest[:minor]) > T.must(current[:minor])
-        return T.must(group.rules["update-types"]).include?("patch") if T.must(latest[:patch]) > T.must(current[:patch])
+        return update_types.include?("major") if T.must(latest[:major]) > T.must(current[:major])
+        return update_types.include?("minor") if T.must(latest[:minor]) > T.must(current[:minor])
+        return update_types.include?("patch") if T.must(latest[:patch]) > T.must(current[:patch])
 
         # some ecosystems don't do semver exactly, so anything lower gets individual for now
         false
@@ -484,7 +485,7 @@ module Dependabot
         return true unless Dependabot::Cargo::Version.respond_to?(:update_type)
 
         actual_update_type = Dependabot::Cargo::Version.update_type(version.to_s, latest_version.to_s)
-        group_update_types = T.cast(group.rules["update-types"], T.nilable(T::Array[String]))
+        group_update_types = group.update_types
         return true unless group_update_types
 
         group_update_types.include?(actual_update_type)

--- a/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
+++ b/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
@@ -61,7 +61,7 @@ module Dependabot
         applies_to: nil,
         update_type: nil
       )
-        patterns = cast_patterns(current_group)
+        patterns = current_group.patterns
         return false unless patterns&.any?
 
         return false if excluded_by_group?(current_group, dep.name)
@@ -119,7 +119,7 @@ module Dependabot
 
       sig { params(group: Dependabot::DependencyGroup, dep: Dependabot::Dependency).returns(T::Boolean) }
       def can_check_specificity?(group, dep)
-        patterns = cast_patterns(group)
+        patterns = group.patterns
         return false unless patterns&.any?
 
         !excluded_by_group?(group, dep.name)
@@ -183,7 +183,7 @@ module Dependabot
         return EXPLICIT_MEMBER_SCORE if group.dependencies.include?(dep)
         return 0 if excluded_by_group?(group, dep.name)
 
-        patterns = cast_patterns(group)
+        patterns = group.patterns
         return NO_PATTERNS_SCORE unless patterns
 
         matching_patterns = patterns.select { |pattern| WildcardMatcher.match?(pattern, dep.name) }
@@ -208,7 +208,7 @@ module Dependabot
 
       sig { params(group: Dependabot::DependencyGroup, dep_name: String).returns(T::Boolean) }
       def excluded_by_group?(group, dep_name)
-        exclude_patterns = T.cast(group.rules["exclude-patterns"], T.nilable(T::Array[String]))
+        exclude_patterns = group.exclude_patterns
         return false unless exclude_patterns
 
         exclude_patterns.any? { |pattern| WildcardMatcher.match?(pattern, dep_name) }
@@ -218,7 +218,7 @@ module Dependabot
       def update_type_allowed?(group, update_type)
         return true if update_type.nil?
 
-        group_update_types = T.cast(group.rules["update-types"], T.nilable(T::Array[String]))
+        group_update_types = group.update_types
         return true unless group_update_types
 
         group_update_types.include?(update_type)
@@ -232,11 +232,6 @@ module Dependabot
         return true if group_applies_to.nil?
 
         group_applies_to == applies_to
-      end
-
-      sig { params(group: Dependabot::DependencyGroup).returns(T.nilable(T::Array[String])) }
-      def cast_patterns(group)
-        T.cast(group.rules["patterns"], T.nilable(T::Array[String]))
       end
     end
   end

--- a/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
+++ b/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
@@ -8,10 +8,24 @@ require "dependabot/job"
 require "dependabot/updater/group_dependency_selector"
 
 RSpec.describe Dependabot::Updater::GroupDependencySelector do
-  let(:group_name) { "backend-dependencies" }
-  let(:dependency_group) do
+  # Builds a DependencyGroup instance_double, deriving the typed rule readers
+  # (patterns/exclude_patterns/update_types) from the same rules hash so the
+  # double matches how DependencyGroup parses its rules. A nil reader means the
+  # rule is absent, mirroring DependencyGroup#string_array_rule.
+  def group_double(rules:, **attrs)
     instance_double(
       Dependabot::DependencyGroup,
+      rules: rules,
+      patterns: rules.key?("patterns") ? Array(rules["patterns"]) : nil,
+      exclude_patterns: rules.key?("exclude-patterns") ? Array(rules["exclude-patterns"]) : nil,
+      update_types: rules.key?("update-types") ? Array(rules["update-types"]) : nil,
+      **attrs
+    )
+  end
+
+  let(:group_name) { "backend-dependencies" }
+  let(:dependency_group) do
+    group_double(
       name: group_name,
       dependencies: [],
       rules: group_rules,
@@ -318,8 +332,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
     let(:redis_dep) { create_dependency("redis-client", "0.11.0") }
 
     let(:generic_group) do
-      instance_double(
-        Dependabot::DependencyGroup,
+      group_double(
         name: "all-dependencies",
         dependencies: [],
         rules: { "patterns" => ["*"] }
@@ -327,8 +340,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
     end
 
     let(:docker_group) do
-      instance_double(
-        Dependabot::DependencyGroup,
+      group_double(
         name: "docker-dependencies",
         dependencies: [],
         rules: { "patterns" => ["docker*"] }
@@ -336,8 +348,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
     end
 
     let(:exact_group) do
-      instance_double(
-        Dependabot::DependencyGroup,
+      group_double(
         name: "exact-nginx",
         dependencies: [],
         rules: { "patterns" => ["nginx"] }
@@ -400,8 +411,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         )
       end
       let(:generic_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "all-dependencies",
           dependencies: [],
           rules: { "patterns" => ["*"] }
@@ -409,8 +419,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       let(:docker_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-dependencies",
           dependencies: [],
           rules: { "patterns" => ["docker*"], "update-types" => ["patch"] }
@@ -635,8 +644,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
 
     describe "applies_to aware specificity" do
       let(:generic_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "all-dependencies",
           dependencies: [],
           applies_to: "version-updates",
@@ -645,8 +653,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       let(:security_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "security-dependencies",
           dependencies: [],
           applies_to: "security-updates",
@@ -705,8 +712,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
 
     context "with all group rule options" do
       let(:generic_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "generic",
           dependencies: [],
           applies_to: "version-updates",
@@ -715,8 +721,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       let(:docker_minor_prod_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-minor-prod",
           dependencies: [],
           applies_to: "version-updates",
@@ -725,8 +730,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       let(:docker_exact_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-compose-exact",
           dependencies: [],
           applies_to: nil,
@@ -735,8 +739,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       let(:docker_security_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-security",
           dependencies: [],
           applies_to: "security-updates",
@@ -745,8 +748,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       let(:excluded_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-excluded",
           dependencies: [],
           applies_to: "version-updates",
@@ -755,8 +757,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       let(:explicit_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "explicit",
           dependencies: [],
           applies_to: nil,
@@ -849,8 +850,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
     context "with complete multi-group interaction integration tests" do
       context "with complete routing through multiple competing groups" do
         let(:generic_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "generic",
             dependencies: [],
             applies_to: "version-updates",
@@ -859,8 +859,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         let(:minor_updates_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "minor-updates",
             dependencies: [],
             applies_to: "version-updates",
@@ -869,8 +868,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         let(:exact_rails_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "exact-rails",
             dependencies: [],
             applies_to: "version-updates",
@@ -964,8 +962,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
 
       context "with applies_to filtering across version and security updates" do
         let(:version_generic_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "version-generic",
             dependencies: [],
             applies_to: "version-updates",
@@ -974,8 +971,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         let(:security_rails_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "security-rails",
             dependencies: [],
             applies_to: "security-updates",
@@ -984,8 +980,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         let(:version_rails_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "version-rails",
             dependencies: [],
             applies_to: "version-updates",
@@ -1054,8 +1049,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
 
       context "with explicit membership overriding pattern matching" do
         let(:generic_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "generic",
             dependencies: [],
             applies_to: "version-updates",
@@ -1064,8 +1058,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         let(:express_explicit_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "express-explicit",
             dependencies: ["express"],
             applies_to: "version-updates",
@@ -1074,8 +1067,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         let(:prod_deps_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "prod-deps",
             dependencies: [],
             applies_to: "version-updates",
@@ -1178,8 +1170,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
 
       context "with update-type filtering splitting dependencies by version change magnitude" do
         let(:generic_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "generic",
             dependencies: [],
             applies_to: "version-updates",
@@ -1188,8 +1179,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         let(:minor_patch_only_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "minor-patch-only",
             dependencies: [],
             applies_to: "version-updates",
@@ -1198,8 +1188,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         let(:major_only_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "major-only",
             dependencies: [],
             applies_to: "version-updates",
@@ -1282,8 +1271,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
 
       context "with exclude-patterns affecting specificity routing" do
         let(:generic_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "generic",
             dependencies: [],
             applies_to: "version-updates",
@@ -1292,8 +1280,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
         end
 
         let(:rails_except_test_group) do
-          instance_double(
-            Dependabot::DependencyGroup,
+          group_double(
             name: "rails-except-test",
             dependencies: [],
             applies_to: "version-updates",

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_spec.rb
@@ -610,7 +610,11 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
     end
 
     let(:group) do
-      instance_double(Dependabot::DependencyGroup, rules: { "update-types" => update_types })
+      instance_double(
+        Dependabot::DependencyGroup,
+        rules: { "update-types" => update_types },
+        update_types: update_types
+      )
     end
 
     let(:dependency) do

--- a/updater/spec/dependabot/updater/pattern_specificity_calculator_spec.rb
+++ b/updater/spec/dependabot/updater/pattern_specificity_calculator_spec.rb
@@ -9,13 +9,27 @@ require "dependabot/updater/pattern_specificity_calculator"
 RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
   let(:calculator) { described_class.new }
 
+  # Builds a DependencyGroup instance_double, deriving the typed rule readers
+  # (patterns/exclude_patterns/update_types) from the same rules hash so the
+  # double matches how DependencyGroup parses its rules. A nil reader means the
+  # rule is absent, mirroring DependencyGroup#string_array_rule.
+  def group_double(rules:, **attrs)
+    instance_double(
+      Dependabot::DependencyGroup,
+      rules: rules,
+      patterns: rules.key?("patterns") ? Array(rules["patterns"]) : nil,
+      exclude_patterns: rules.key?("exclude-patterns") ? Array(rules["exclude-patterns"]) : nil,
+      update_types: rules.key?("update-types") ? Array(rules["update-types"]) : nil,
+      **attrs
+    )
+  end
+
   describe "#dependency_belongs_to_more_specific_group?" do
     let(:dependency) { create_dependency("docker-compose", "2.0.0") }
     let(:directory) { "/api" }
 
     let(:generic_group) do
-      instance_double(
-        Dependabot::DependencyGroup,
+      group_double(
         name: "all-dependencies",
         dependencies: [],
         rules: { "patterns" => ["*"] }
@@ -23,8 +37,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
     end
 
     let(:docker_group) do
-      instance_double(
-        Dependabot::DependencyGroup,
+      group_double(
         name: "docker-dependencies",
         dependencies: [],
         rules: { "patterns" => ["docker*"] }
@@ -32,8 +45,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
     end
 
     let(:exact_group) do
-      instance_double(
-        Dependabot::DependencyGroup,
+      group_double(
         name: "exact-docker-compose",
         dependencies: [],
         rules: { "patterns" => ["docker-compose"] }
@@ -41,8 +53,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
     end
 
     let(:explicit_group) do
-      instance_double(
-        Dependabot::DependencyGroup,
+      group_double(
         name: "explicit-dependencies",
         dependencies: [dependency],
         rules: { "patterns" => ["other*"] }
@@ -78,8 +89,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
 
       it "returns true when dependency belongs to exact match group" do
         nginx_dep = create_dependency("nginx", "1.21.0")
-        nginx_exact_group = instance_double(
-          Dependabot::DependencyGroup,
+        nginx_exact_group = group_double(
           name: "nginx-exact",
           dependencies: [],
           rules: { "patterns" => ["nginx"] }
@@ -105,8 +115,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
 
     context "when dependency is excluded by current group" do
       let(:generic_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "all-dependencies",
           dependencies: [],
           rules: { "patterns" => ["*"], "exclude-patterns" => ["docker-compose"] }
@@ -123,8 +132,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
 
     context "when other groups restrict update types" do
       let(:docker_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-dependencies",
           dependencies: [],
           rules: { "patterns" => ["docker*"], "update-types" => ["minor"] }
@@ -150,8 +158,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
 
     context "when other groups have different applies_to" do
       let(:generic_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "all-dependencies",
           dependencies: [],
           applies_to: "version-updates",
@@ -160,8 +167,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
       end
 
       let(:security_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "security-dependencies",
           dependencies: [],
           applies_to: "security-updates",
@@ -209,8 +215,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
 
       it "returns false when no more specific group exists" do
         redis_dep = create_dependency("redis-client", "0.11.0")
-        redis_group = instance_double(
-          Dependabot::DependencyGroup,
+        redis_group = group_double(
           name: "redis-dependencies",
           dependencies: [],
           rules: { "patterns" => ["redis*"] }
@@ -265,8 +270,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
 
     context "when current group has no patterns" do
       let(:no_patterns_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "patch-updates",
           dependencies: [],
           rules: { "update-types" => ["patch"] }
@@ -287,8 +291,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
       end
 
       it "returns false when group has nil patterns" do
-        nil_patterns_group = instance_double(
-          Dependabot::DependencyGroup,
+        nil_patterns_group = group_double(
           name: "nil-patterns",
           dependencies: [],
           rules: { "patterns" => nil, "update-types" => ["patch"] }
@@ -301,8 +304,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
       end
 
       it "returns false when group has empty patterns array" do
-        empty_patterns_group = instance_double(
-          Dependabot::DependencyGroup,
+        empty_patterns_group = group_double(
           name: "empty-patterns",
           dependencies: [],
           rules: { "patterns" => [], "update-types" => ["patch"] }
@@ -317,8 +319,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
 
     context "with complex pattern hierarchy" do
       let(:multi_wildcard_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "multi-wildcard",
           dependencies: [],
           rules: { "patterns" => ["*docker*"] }
@@ -326,8 +327,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
       end
 
       let(:prefix_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "prefix-group",
           dependencies: [],
           rules: { "patterns" => ["docker*"] }
@@ -373,8 +373,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
 
     context "with length bonus considerations" do
       let(:short_pattern_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "short-pattern",
           dependencies: [],
           rules: { "patterns" => ["doc*"] }
@@ -382,8 +381,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
       end
 
       let(:long_pattern_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "long-pattern",
           dependencies: [],
           rules: { "patterns" => ["docker-compose*"] }
@@ -415,8 +413,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
 
     context "with complex group rules" do
       let(:generic_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "generic",
           dependencies: [],
           applies_to: "version-updates",
@@ -425,8 +422,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
       end
 
       let(:docker_minor_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-minor",
           dependencies: [],
           applies_to: "version-updates",
@@ -435,8 +431,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
       end
 
       let(:docker_exact_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-compose-exact",
           dependencies: [],
           applies_to: nil,
@@ -445,8 +440,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
       end
 
       let(:docker_security_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-security",
           dependencies: [],
           applies_to: "security-updates",
@@ -455,8 +449,7 @@ RSpec.describe Dependabot::Updater::PatternSpecificityCalculator do
       end
 
       let(:excluded_group) do
-        instance_double(
-          Dependabot::DependencyGroup,
+        group_double(
           name: "docker-exclude-compose",
           dependencies: [],
           applies_to: "version-updates",


### PR DESCRIPTION
### What are you trying to accomplish?

Parse `DependencyGroup#rules` once into typed `patterns`/`exclude_patterns`/`update_types` readers, instead of re-casting `rules[...]` with `T.unsafe`/`T.cast`/`T.must` at every call site across the grouping code. Clears `dependency_group.rb` from the `Sorbet/ForbidTUntyped` todo.

### Anything you want to highlight for special attention from reviewers?

A `nil` reader means the rule is absent, which the matchers treat differently from an empty list. The raw `rules` hash stays for serialisation (`to_config_yaml`) and the subgroup `.merge`.

### How will you know you've accomplished your goal?

`srb tc`, RuboCop, and the common + updater grouping specs pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
