### PR TITLE
Type provider_metadata as integer-keyed

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1694
+# Offense count: 1691
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -316,7 +316,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb"
     - "common/lib/dependabot/pull_request_creator/message_builder/title_builder.rb"
     - "common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb"
-    - "common/lib/dependabot/pull_request_updater.rb"
     - "common/lib/dependabot/pull_request_updater/azure.rb"
     - "common/lib/dependabot/pull_request_updater/github.rb"
     - "common/lib/dependabot/pull_request_updater/gitlab.rb"

--- a/common/lib/dependabot/pull_request_updater.rb
+++ b/common/lib/dependabot/pull_request_updater.rb
@@ -40,7 +40,7 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_reader :commit_message
 
-    sig { returns(T::Hash[Symbol, T.untyped]) }
+    sig { returns(T::Hash[Symbol, Integer]) }
     attr_reader :provider_metadata
 
     sig do
@@ -54,7 +54,7 @@ module Dependabot
         author_details: T.nilable(T::Hash[Symbol, String]),
         signature_key: T.nilable(String),
         commit_message: T.nilable(String),
-        provider_metadata: T::Hash[Symbol, T.untyped]
+        provider_metadata: T::Hash[Symbol, Integer]
       )
         .void
     end
@@ -84,7 +84,7 @@ module Dependabot
 
     # TODO: Each implementation returns a client-specific type.
     #       We should standardise this to return a `Dependabot::Branch` type instead.
-    sig { returns(T.untyped) }
+    sig { returns(T.untyped) } # rubocop:disable Sorbet/ForbidTUntyped
     def update
       case source.provider
       when "github" then github_updater.update
@@ -120,7 +120,7 @@ module Dependabot
         files: files,
         credentials: credentials,
         pull_request_number: pull_request_number,
-        target_project_id: T.cast(provider_metadata[:target_project_id], T.nilable(Integer))
+        target_project_id: provider_metadata[:target_project_id]
       )
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

`provider_metadata` only ever carries integer IDs and was already cast to `Integer`, so type it `T::Hash[Symbol, Integer]` and drop the redundant cast. Clears `pull_request_updater.rb` from the `Sorbet/ForbidTUntyped` todo.

### Anything you want to highlight for special attention from reviewers?

Stacked on #15395. The `update` return is genuinely client-specific (per its existing standardisation TODO), so it keeps one inline `rubocop:disable`. No code constructs `PullRequestUpdater` internally, so narrowing the public param is safe.

### How will you know you've accomplished your goal?

`srb tc`, RuboCop, and the common PR-updater specs pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
