### PR TITLE
Stub docker manifest request in helm update_checker spec

### DIFF
--- a/helm/spec/dependabot/helm/update_checker_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
 
         stub_request(:get, repo_url + "tags/list")
           .and_return(status: 200, body: repo_tags)
+
+        # The docker update checker fetches the current tag's manifest to
+        # compare platform digests (same_image_contents?). ubuntu:#{version} is
+        # a single-platform image, so return a non-manifest-list mediaType to
+        # make that check a no-op.
+        stub_request(:get, repo_url + "manifests/#{version}")
+          .and_return(
+            status: 200,
+            body: { mediaType: "application/vnd.docker.distribution.manifest.v2+json" }.to_json
+          )
       end
 
       it { is_expected.to eq(Dependabot::Helm::Version.new("17.10")) }


### PR DESCRIPTION
### What are you trying to accomplish?

The helm update checker delegates `docker_image` dependencies to `Docker::UpdateChecker`, which now fetches the current tag's manifest to compare platform digests (`same_image_contents?`). The helm spec never stubbed that GET, so `update_checker_spec.rb:91` failed with `VCR::UnhandledHTTPRequestError`. Stub the `manifests/<version>` request to return a single-platform image, making the digest check a no-op.

### Anything you want to highlight for special attention from reviewers?

This mirrors how the docker spec neutralises the same check (it stubs `fetch_platform_digests` to `{}` for single-platform fixtures); the helm spec can't stub the internally-built checker, so it stubs the HTTP instead. The failure surfaces on any PR that touches `common/`, since that triggers the helm spec suite.

### How will you know you've accomplished your goal?

The "when dependency is a docker image" examples pass and the helm CI job goes green.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
