### PR TITLE
Swift: add SemVer-compliant version comparison and validation

### DIFF
--- a/swift/lib/dependabot/swift/requirement.rb
+++ b/swift/lib/dependabot/swift/requirement.rb
@@ -5,11 +5,38 @@ require "sorbet-runtime"
 
 require "dependabot/requirement"
 require "dependabot/utils"
+require "dependabot/swift/version"
 
 module Dependabot
   module Swift
     class Requirement < Dependabot::Requirement
       extend T::Sig
+
+      quoted = OPS.keys.map { |k| Regexp.quote(k) }.join("|")
+      # Swift requirement grammar (intentionally not strict SemVer): allows multi-segment numeric
+      # cores like "4.2.5.1"/"3.0.0.0" for compatibility bounds.
+      num = "(?:0|[1-9][0-9]*)"
+      pre_id = "(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+      version_pattern = "#{num}(?:\\.#{num})*" \
+                        "(?:-#{pre_id}(?:\\.#{pre_id})*)?" \
+                        '(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?'
+
+      PATTERN = T.let(/\A\s*(#{quoted})?\s*(#{version_pattern})\s*\z/, Regexp)
+
+      # Parse each boundary into a Swift::Version so prerelease boundaries use SemVer section 11 ordering.
+      sig { override.params(obj: T.any(Gem::Version, String)).returns([String, Gem::Version]) }
+      def self.parse(obj)
+        # Preserve an existing version object; reconstructing from #to_s would be lossy.
+        return ["=", obj] if obj.is_a?(Gem::Version)
+
+        unless (matches = PATTERN.match(obj.to_s))
+          raise BadRequirementError, "Illformed requirement [#{obj.inspect}]"
+        end
+
+        return DefaultRequirement if matches[1] == ">=" && matches[2] == "0"
+
+        [matches[1] || "=", Swift::Version.new(T.must(matches[2]))]
+      end
 
       # For consistency with other languages, we define a requirements array.
       # Swift doesn't have an `OR` separator for requirements, so it

--- a/swift/lib/dependabot/swift/version.rb
+++ b/swift/lib/dependabot/swift/version.rb
@@ -1,12 +1,189 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 require "dependabot/utils"
 require "dependabot/version"
 
 module Dependabot
   module Swift
+    # Swift uses SemVer: strict validation in .correct?, section 11 pre-release precedence in #<=>.
+    # #initialize stays tolerant because GitCommitChecker builds unchecked versions (e.g. "0.0.0.0").
     class Version < Dependabot::Version
+      extend T::Sig
+
+      # SEMVER_REGEX uses ^/$ line anchors; anchor to the whole string to reject multiline.
+      SEMVER_ANCHORED = T.let(/\A#{SEMVER_REGEX.source}\z/x, Regexp)
+
+      sig { override.params(version: VersionParameter).returns(T::Boolean) }
+      def self.correct?(version)
+        return false if version.nil?
+
+        # Strict SemVer only: rejects "1.0.0.alpha", "0.0.0.0", "01.2.3" and multiline input.
+        version.to_s.delete_prefix("v").match?(SEMVER_ANCHORED)
+      end
+
+      sig { override.params(version: VersionParameter).void }
+      def initialize(version)
+        @version_string = T.let(version.to_s.dup.freeze, String)
+        # Canonical SemVer form (build metadata stripped) used by to_semver/eql?/hash.
+        @semver = T.let(T.must(version.to_s.delete_prefix("v").split("+").first).freeze, String)
+
+        base, suffix = @semver.split("-", 2)
+        release, inferred = normalize_release(T.must(base))
+        # Keep the raw suffix (explicit "-" or inferred from a non-SemVer tail) for section 11 ordering.
+        @prerelease_suffix = T.let(suffix || inferred, T.nilable(String))
+        @release_core = T.let(Gem::Version.new(release), Gem::Version)
+        # Seed the superclass with a strict-SemVer form so tolerant tags never raise, while mixed
+        # comparisons still see the pre-release state.
+        super(semver_seed(release, @prerelease_suffix))
+      end
+
+      sig { override.returns(String) }
+      def to_s
+        @version_string
+      end
+
+      sig { override.returns(String) }
+      def to_semver
+        @semver
+      end
+
+      sig { override.returns(T::Boolean) }
+      def prerelease?
+        return true unless @prerelease_suffix.nil?
+
+        super
+      end
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def eql?(other)
+        return false unless other.is_a?(Version)
+
+        to_semver == other.to_semver
+      end
+
+      sig { override.returns(Integer) }
+      def hash
+        to_semver.hash
+      end
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def ==(other)
+        cmp = self <=> other
+        !cmp.nil? && cmp.zero?
+      end
+
+      sig { params(other: Object).returns(T.nilable(Integer)) }
+      def <=>(other)
+        return nil if other.nil?
+
+        resolved = coerce_operand(other)
+        return nil if resolved.nil?
+
+        # Compare release cores directly (not via super, whose seeded state uses RubyGems
+        # pre-release ordering) so section 11 governs the pre-release tiebreak.
+        release_cmp = release_core <=> resolved.release_core
+        return release_cmp unless release_cmp&.zero?
+
+        compare_semver_prerelease(@prerelease_suffix, resolved.prerelease_suffix)
+      rescue ArgumentError
+        nil
+      end
+
+      protected
+
+      sig { returns(T.nilable(String)) }
+      attr_reader :prerelease_suffix
+
+      sig { returns(Gem::Version) }
+      attr_reader :release_core
+
+      private
+
+      # Coerce an operand to a Swift::Version for section 11 ordering, or nil if not orderable.
+      # A raw Gem::Version pre-release is declined (lossy #to_s, divergent RubyGems ordering); any
+      # #to_s failure also yields nil to keep comparison safe (never raises).
+      sig { params(other: Object).returns(T.nilable(Version)) }
+      def coerce_operand(other)
+        return other if other.is_a?(Version)
+        return nil if other.is_a?(Gem::Version) && other.prerelease?
+
+        normalized = other.to_s.delete_prefix("v")
+        if normalized.include?("+")
+          return nil unless Version.correct?(normalized)
+
+          normalized = T.must(normalized.split("+").first)
+        end
+        return nil unless Gem::Version.correct?(normalized)
+
+        T.cast(Version.new(normalized), Version)
+      rescue StandardError
+        nil
+      end
+
+      # Returns [release core, inferred pre-release or nil]: a non-SemVer tag is reduced to its
+      # numeric core with the non-numeric tail as pre-release ("1.0.0.alpha" -> "alpha").
+      sig { params(base: String).returns([String, T.nilable(String)]) }
+      def normalize_release(base)
+        return [base, nil] if self.class.correct?(base)
+
+        parts = base.split(".")
+        numeric = parts.take_while { |s| s.match?(/\A\d+\z/) }
+        raise ArgumentError, "Malformed version number string #{@version_string}" if numeric.empty?
+
+        tail = parts.drop(numeric.length)
+        # Preserve every numeric segment so multi-segment requirement bounds keep full precision.
+        release = numeric.map { |s| s.to_i.to_s }.join(".")
+        [release, tail.empty? ? nil : tail.join(".")]
+      end
+
+      # Strict-SemVer seed for the Gem superclass: a 3-segment core plus the suffix only when it is
+      # valid SemVer, so tolerant construction of odd tags (e.g. "1.0.0-01") never raises.
+      sig { params(release: String, suffix: T.nilable(String)).returns(String) }
+      def semver_seed(release, suffix)
+        core = (release.split(".").first(3) + %w(0 0 0)).first(3).join(".")
+        return core unless suffix && self.class.correct?("0.0.0-#{suffix}")
+
+        "#{core}-#{suffix}"
+      end
+
+      # SemVer section 11 pre-release precedence: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0.
+      sig { params(left: T.nilable(String), right: T.nilable(String)).returns(Integer) }
+      def compare_semver_prerelease(left, right)
+        return 0 if left.nil? && right.nil?
+        return 1 if left.nil?
+        return -1 if right.nil?
+
+        left_ids = left.split(".")
+        right_ids = right.split(".")
+
+        # Compare identifiers pairwise over the common prefix.
+        [left_ids.length, right_ids.length].min.times do |i|
+          cmp = compare_semver_identifier(T.must(left_ids[i]), T.must(right_ids[i]))
+          return cmp unless cmp.zero?
+        end
+
+        # All shared identifiers equal: more pre-release fields ranks higher.
+        left_ids.length <=> right_ids.length
+      end
+
+      sig { params(left: String, right: String).returns(Integer) }
+      def compare_semver_identifier(left, right)
+        left_numeric = left.match?(/\A\d+\z/)
+        right_numeric = right.match?(/\A\d+\z/)
+
+        if left_numeric && right_numeric
+          left.to_i <=> right.to_i
+        elsif left_numeric
+          -1
+        elsif right_numeric
+          1
+        else
+          T.must(left <=> right)
+        end
+      end
     end
   end
 end

--- a/swift/spec/dependabot/swift/file_parser/pbxproj_parser_spec.rb
+++ b/swift/spec/dependabot/swift/file_parser/pbxproj_parser_spec.rb
@@ -166,7 +166,9 @@ RSpec.describe Dependabot::Swift::FileParser::PbxprojParser do
 
       it "parses prerelease versions" do
         req = parser.parse["github.com/apple/swift-nio"]
-        expect(req[:requirement]).to eq(">= 2.54.0.pre.beta.1, < 3.0.0.0")
+        # Rendered in canonical SemVer form (not the RubyGems-normalized "2.54.0.pre.beta.1")
+        # because boundaries are parsed as Swift::Version.
+        expect(req[:requirement]).to eq(">= 2.54.0-beta.1, < 3.0.0.0")
         expect(req[:requirement_string]).to eq("from: \"2.54.0-beta.1\"")
         expect(req[:kind]).to eq("upToNextMajorVersion")
       end

--- a/swift/spec/dependabot/swift/requirement_spec.rb
+++ b/swift/spec/dependabot/swift/requirement_spec.rb
@@ -1,0 +1,157 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/swift/requirement"
+require "dependabot/swift/version"
+
+RSpec.describe Dependabot::Swift::Requirement do
+  describe "#satisfied_by?" do
+    subject(:satisfied_by?) { requirement.satisfied_by?(Dependabot::Swift::Version.new(version)) }
+
+    let(:requirement) { described_class.new(">= 2.54.0, < 3.0.0") }
+
+    context "with a version inside the range" do
+      let(:version) { "2.55.0" }
+
+      it { is_expected.to be true }
+    end
+
+    context "with the lower boundary" do
+      let(:version) { "2.54.0" }
+
+      it { is_expected.to be true }
+    end
+
+    context "with a version below the lower boundary" do
+      let(:version) { "2.53.0" }
+
+      it { is_expected.to be false }
+    end
+
+    context "with a version at the upper boundary" do
+      let(:version) { "3.0.0" }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#satisfied_by? with the default '>= 0' requirement" do
+    subject(:satisfied_by?) { requirement.satisfied_by?(Dependabot::Swift::Version.new(version)) }
+
+    let(:requirement) { described_class.new(">= 0") }
+    let(:version) { "1.0.0" }
+
+    # '>= 0' resolves to Gem's DefaultRequirement whose boundary is a plain Gem::Version(0);
+    # comparison must not raise.
+    it { is_expected.to be true }
+  end
+
+  describe "#satisfied_by? with pre-release boundaries (SemVer section 11)" do
+    subject(:satisfied_by?) { requirement.satisfied_by?(Dependabot::Swift::Version.new(version)) }
+
+    context "when numeric identifiers rank below alphanumeric" do
+      let(:requirement) { described_class.new(">= 1.0.0-1") }
+
+      context "with an alphanumeric prerelease above the numeric boundary" do
+        let(:version) { "1.0.0-alpha" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when the boundary is alphanumeric" do
+      let(:requirement) { described_class.new(">= 1.0.0-alpha") }
+
+      context "with a numeric prerelease below it" do
+        let(:version) { "1.0.0-1" }
+
+        it { is_expected.to be false }
+      end
+
+      context "with more pre-release fields sharing the prefix" do
+        let(:version) { "1.0.0-alpha.1" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "with a numeric pre-release range" do
+      let(:requirement) { described_class.new("< 1.0.0-beta.11") }
+
+      context "with a lower numeric identifier (not lexical)" do
+        let(:version) { "1.0.0-beta.2" }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when a pre-release is below its final release" do
+      let(:requirement) { described_class.new(">= 1.0.0") }
+
+      let(:version) { "1.0.0-rc.1" }
+
+      it { is_expected.to be false }
+    end
+
+    context "with a multi-segment numeric boundary" do
+      # Multi-segment bounds (e.g. ">= 4.2.5.1") must keep full precision, not truncate to 4.2.5.
+      let(:requirement) { described_class.new(">= 4.2.5.1") }
+
+      context "with the lower three-segment version" do
+        let(:version) { "4.2.5" }
+
+        it { is_expected.to be false }
+      end
+
+      context "with the exact four-segment version" do
+        let(:version) { "4.2.5.1" }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+
+  describe "#satisfied_by? with build metadata" do
+    subject(:satisfied_by?) { requirement.satisfied_by?(Dependabot::Swift::Version.new(version)) }
+
+    # SemVer build metadata is ignored for comparison and must not raise BadRequirementError.
+    let(:requirement) { described_class.new("= 1.0.0+build") }
+
+    let(:version) { "1.0.0" }
+
+    it { is_expected.to be true }
+  end
+
+  describe "with malformed build metadata" do
+    # Only well-formed build metadata is accepted by the grammar; malformed "+" forms are rejected.
+    ["= 1.0.0+build.", "= 1.0.0+foo+bar", "= 1.0.0+"].each do |requirement|
+      it "raises BadRequirementError for #{requirement.inspect}" do
+        expect { described_class.new(requirement) }
+          .to raise_error(Dependabot::BadRequirementError)
+      end
+    end
+  end
+
+  describe "with SemVer-invalid leading zeros" do
+    # SemVer forbids leading zeros in numeric identifiers; the grammar rejects them.
+    ["= 01.2.3", "= 1.0.0-01"].each do |requirement|
+      it "raises BadRequirementError for #{requirement.inspect}" do
+        expect { described_class.new(requirement) }
+          .to raise_error(Dependabot::BadRequirementError)
+      end
+    end
+  end
+
+  describe ".parse" do
+    it "preserves a supplied version object instead of reconstructing from #to_s" do
+      # Reconstructing via Swift::Version.new(obj.to_s) would reinterpret RubyGems'
+      # lossy ".pre." normalization of a prerelease; the object must be kept as-is.
+      version = Gem::Version.new("1.0.0-alpha")
+      operator, boundary = described_class.parse(version)
+
+      expect(operator).to eq("=")
+      expect(boundary).to equal(version)
+    end
+  end
+end

--- a/swift/spec/dependabot/swift/version_spec.rb
+++ b/swift/spec/dependabot/swift/version_spec.rb
@@ -1,0 +1,320 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/swift/version"
+
+RSpec.describe Dependabot::Swift::Version do
+  describe ".correct?" do
+    it "returns true for standard versions" do
+      expect(described_class.correct?("1.0.0")).to be true
+      expect(described_class.correct?("0.1.0")).to be true
+      expect(described_class.correct?("10.20.30")).to be true
+    end
+
+    it "returns true for prerelease versions" do
+      expect(described_class.correct?("1.0.0-alpha.1")).to be true
+      expect(described_class.correct?("1.0.0-beta.2")).to be true
+      expect(described_class.correct?("1.0.0-rc.1")).to be true
+      expect(described_class.correct?("2.0.0-0.3.7")).to be true
+    end
+
+    it "returns true for versions with build metadata" do
+      expect(described_class.correct?("1.0.0+build")).to be true
+      expect(described_class.correct?("1.0.0+build.123")).to be true
+      expect(described_class.correct?("1.0.0-beta.1+build.456")).to be true
+    end
+
+    it "returns false for non-version strings" do
+      expect(described_class.correct?("potato")).to be false
+      expect(described_class.correct?("")).to be false
+      expect(described_class.correct?(nil)).to be false
+    end
+
+    it "returns false for non-SemVer (Gem-style) versions" do
+      expect(described_class.correct?("1.0.0.alpha")).to be false
+      expect(described_class.correct?("0.0.0.0")).to be false
+      expect(described_class.correct?("01.2.3")).to be false
+    end
+
+    it "rejects prerelease identifiers with leading zeros" do
+      expect(described_class.correct?("1.0.0-01")).to be false
+      expect(described_class.correct?("1.0.0-0.1")).to be true
+    end
+
+    it "rejects multiline strings (anchors to the whole string)" do
+      expect(described_class.correct?("1.0.0\ninvalid")).to be false
+    end
+
+    it "returns false for invalid build metadata" do
+      expect(described_class.correct?("1.0.0+")).to be false
+      expect(described_class.correct?("1.0.0+bad@")).to be false
+    end
+
+    it "returns true for v-prefixed versions" do
+      expect(described_class.correct?("v1.0.0")).to be true
+      expect(described_class.correct?("v1.0.0-alpha.1")).to be true
+      expect(described_class.correct?("v2.3.4+build")).to be true
+    end
+  end
+
+  describe ".new" do
+    it "creates a version from a standard string" do
+      version = described_class.new("1.0.0")
+      expect(version.to_s).to eq("1.0.0")
+    end
+
+    it "handles v-prefixed versions" do
+      version = described_class.new("v1.2.3")
+      expect(version.to_s).to eq("v1.2.3")
+      expect(version).to eq(described_class.new("1.2.3"))
+    end
+
+    it "preserves build metadata in to_s" do
+      version = described_class.new("1.0.0+build123")
+      expect(version.to_s).to eq("1.0.0+build123")
+    end
+
+    it "strips build metadata for comparison" do
+      v1 = described_class.new("1.0.0+build1")
+      v2 = described_class.new("1.0.0+build2")
+      v3 = described_class.new("1.0.0")
+      expect(v1).to eq(v2)
+      expect(v1).to eq(v3)
+    end
+
+    it "rejects malformed build/prerelease forms via .correct?" do
+      expect(described_class.correct?("1.0.0+")).to be false
+      expect(described_class.correct?("1.0.0-")).to be false
+    end
+
+    it "preserves a hyphenated pre-release identifier as a single SemVer token" do
+      # "alpha-1" is one SemVer identifier and must not be split on the hyphen.
+      version = described_class.new("1.0.0-alpha-1")
+      expect(version.to_semver).to eq("1.0.0-alpha-1")
+      expect(version).to be > described_class.new("1.0.0-alpha.1")
+    end
+
+    it "tolerantly constructs non-SemVer tags (sorting by their numeric core) without raising" do
+      # The shared GitCommitChecker builds versions for any VERSION_REGEX-matching tag, so
+      # construction must not raise even though .correct? rejects these as non-SemVer.
+      expect(described_class.correct?("0.0.0.0")).to be false
+      version = described_class.new("0.0.0.0")
+      expect(version.to_s).to eq("0.0.0.0")
+      expect(version).to be < described_class.new("0.0.1")
+    end
+
+    it "keeps a Gem-style non-SemVer tag sorting below its release (not masquerading as stable)" do
+      # "1.0.0.alpha" is rejected by .correct?, but the tolerant path must not coerce it
+      # into a stable 1.0.0: its non-numeric tail is surfaced as an inferred pre-release.
+      expect(described_class.correct?("1.0.0.alpha")).to be false
+      version = described_class.new("1.0.0.alpha")
+      expect(version.to_s).to eq("1.0.0.alpha")
+      expect(version.prerelease?).to be true
+      expect(version).to be < described_class.new("1.0.0")
+    end
+
+    it "tolerantly constructs tags with a SemVer-invalid explicit suffix without raising" do
+      # GitCommitChecker builds versions for any VERSION_REGEX tag, including "1.0.0-01"/"1.0.0-",
+      # whose suffix is not valid SemVer; construction must not raise.
+      expect { described_class.new("1.0.0-01") }.not_to raise_error
+      expect { described_class.new("1.0.0-") }.not_to raise_error
+    end
+
+    it "treats an empty explicit suffix as a pre-release that sorts below the release" do
+      # "1.0.0-" must not masquerade as the stable "1.0.0" (which would let it survive prerelease
+      # filtering as a stable maximum).
+      version = described_class.new("1.0.0-")
+      expect(version.prerelease?).to be true
+      expect(version).to be < described_class.new("1.0.0")
+    end
+
+    it "treats a RubyGems-normalized prerelease tag as a pre-release" do
+      version = described_class.new("2.54.0.pre.beta.1")
+      expect(version.prerelease?).to be true
+      expect(version).to be < described_class.new("2.54.0")
+    end
+  end
+
+  describe "#to_semver" do
+    it "returns version without build metadata" do
+      expect(described_class.new("1.0.0-rc.1+build").to_semver).to eq("1.0.0-rc.1")
+    end
+
+    it "returns full version when no build metadata" do
+      expect(described_class.new("1.0.0-alpha.1").to_semver).to eq("1.0.0-alpha.1")
+    end
+
+    it "returns numeric version for stable releases" do
+      expect(described_class.new("2.3.4").to_semver).to eq("2.3.4")
+    end
+  end
+
+  describe "#prerelease?" do
+    it "returns false for stable versions" do
+      expect(described_class.new("1.0.0").prerelease?).to be false
+    end
+
+    it "returns false for versions with only build metadata" do
+      expect(described_class.new("1.0.0+build").prerelease?).to be false
+    end
+
+    it "returns true for prerelease versions" do
+      expect(described_class.new("1.0.0-alpha.1").prerelease?).to be true
+      expect(described_class.new("1.0.0-beta.2").prerelease?).to be true
+      expect(described_class.new("1.0.0-rc.1").prerelease?).to be true
+    end
+
+    it "returns true for prerelease with build metadata" do
+      expect(described_class.new("1.0.0-rc.1+build").prerelease?).to be true
+    end
+  end
+
+  describe "comparison" do
+    it "orders prereleases before stable" do
+      expect(described_class.new("1.0.0-beta.1")).to be < described_class.new("1.0.0")
+    end
+
+    it "orders versions numerically" do
+      expect(described_class.new("1.9.0")).to be < described_class.new("1.10.0")
+    end
+
+    it "ignores build metadata in ordering" do
+      v1 = described_class.new("1.0.0+build1")
+      v2 = described_class.new("1.0.0+build2")
+      expect(v1).to eq(v2)
+      expect(v1).not_to be > v2
+    end
+
+    it "returns nil for non-version strings" do
+      v = described_class.new("1.0.0")
+      expect(v <=> "potato").to be_nil
+    end
+
+    it "returns nil (never raises) for a hostile operand whose #to_s raises" do
+      hostile = Object.new
+      def hostile.to_s = raise("boom")
+
+      expect(described_class.new("1.0.0") <=> hostile).to be_nil
+    end
+
+    it "compares Gem-style pre-release formats via Gem::Version fallback" do
+      v = described_class.new("1.0.0")
+      expect(v <=> "1.0.0.alpha").to eq(1)
+    end
+
+    it "ignores build metadata on a non-Version operand (does not return nil)" do
+      # Build metadata is ignored for comparison even when the operand is a bare string
+      # whose "+build" RubyGems cannot parse.
+      expect(described_class.new("1.0.0") <=> "1.0.0+build").to eq(0)
+    end
+
+    it "returns nil for a malformed '+' operand" do
+      # Only genuinely valid SemVer build metadata is stripped; junk stays invalid.
+      expect(described_class.new("1.0.0") <=> "1.0.0++").to be_nil
+    end
+
+    it "compares symmetrically against a plain Gem::Version pre-release/release boundary" do
+      # The Gem superclass is seeded with the full pre-release-aware version, so the reverse
+      # `Gem::Version <=> Swift::Version` direction is not seen as a bare (stable) release.
+      swift_prerelease = described_class.new("1.0.0-alpha")
+      gem_release = Gem::Version.new("1.0.0")
+
+      expect(swift_prerelease <=> gem_release).to eq(-1)
+      expect(gem_release <=> swift_prerelease).to eq(1)
+    end
+
+    it "orders a SemVer string operand by section 11, consistent with Swift-vs-Swift" do
+      expect(described_class.new("1.0.0-1") <=> "1.0.0-alpha").to eq(-1)
+      expect(described_class.new("1.0.0-alpha") <=> "1.0.0-1").to eq(1)
+    end
+
+    it "declines to order an ambiguous raw Gem::Version pre-release (returns nil)" do
+      # A Gem::Version pre-release has a lossy #to_s and RubyGems orders identifiers differently,
+      # so ordering it against section 11 would be inconsistent; refuse rather than guess.
+      expect(described_class.new("1.0.0-1") <=> Gem::Version.new("1.0.0-1")).to be_nil
+    end
+
+    it "returns nil for nil" do
+      v = described_class.new("1.0.0")
+      expect(v <=> nil).to be_nil
+    end
+
+    it "distinguishes prereleases in hash/eql?" do
+      v1 = described_class.new("1.0.0-alpha")
+      v2 = described_class.new("1.0.0-beta")
+      expect(v1.eql?(v2)).to be false
+      expect(v1.hash).not_to eq(v2.hash)
+    end
+
+    it "treats build metadata variants as eql? in hash" do
+      v1 = described_class.new("1.0.0+build1")
+      v2 = described_class.new("1.0.0+build2")
+      expect(v1.eql?(v2)).to be true
+      expect(v1.hash).to eq(v2.hash)
+    end
+
+    it "handles hyphenated prerelease identifiers" do
+      v1 = described_class.new("1.0.0-alpha-1")
+      v2 = described_class.new("1.0.0-alpha.1")
+      expect(v1).to be > v2
+    end
+
+    it "compares across different major versions with prereleases" do
+      expect(described_class.new("1.0.0-alpha")).to be < described_class.new("2.0.0-alpha")
+      expect(described_class.new("2.0.0-alpha")).to be > described_class.new("1.0.0")
+    end
+
+    describe "#==" do
+      it "does not treat a prerelease as equal to its release" do
+        expect(described_class.new("1.0.0-alpha") == described_class.new("1.0.0")).to be false
+      end
+
+      it "does not treat distinct prereleases as equal" do
+        expect(described_class.new("1.0.0-alpha") == described_class.new("1.0.0-beta")).to be false
+      end
+
+      it "treats versions differing only in build metadata as equal" do
+        expect(described_class.new("1.0.0+build1") == described_class.new("1.0.0+build2")).to be true
+      end
+
+      it "returns false for non-version values" do
+        expect(described_class.new("1.0.0") == "potato").to be false
+      end
+    end
+
+    context "with SemVer section 11 pre-release precedence" do
+      it "orders numeric identifiers before alphanumeric" do
+        expect(described_class.new("1.0.0-1")).to be < described_class.new("1.0.0-alpha")
+      end
+
+      it "orders fewer fields before more fields" do
+        expect(described_class.new("1.0.0-alpha")).to be < described_class.new("1.0.0-alpha.1")
+      end
+
+      it "orders alphanumeric after numeric in mixed comparisons" do
+        expect(described_class.new("1.0.0-alpha.1")).to be < described_class.new("1.0.0-alpha.beta")
+      end
+
+      it "follows full SemVer section 11 example ordering" do
+        versions = %w(
+          1.0.0-alpha
+          1.0.0-alpha.1
+          1.0.0-alpha.beta
+          1.0.0-beta
+          1.0.0-beta.2
+          1.0.0-beta.11
+          1.0.0-rc.1
+          1.0.0
+        )
+
+        parsed = versions.map { |v| described_class.new(v) }
+        expect(parsed.shuffle.sort).to eq(parsed)
+      end
+
+      it "compares numeric identifiers as integers, not strings" do
+        expect(described_class.new("1.0.0-beta.2")).to be < described_class.new("1.0.0-beta.11")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes the Swift versioning gap identified in the versioning-tags audit. Swift uses SemVer, but Dependabot's  Swift::Version  previously inherited generic  Dependabot::Version  /  Gem::Version  behavior.  Gem::Version  does not fully match SemVer prerelease precedence and does not treat build metadata per spec. This could cause wrong version ordering for Swift prereleases and inconsistent equality behavior for versions that differ only by build metadata.

This PR adds Swift-specific SemVer handling on top of  Dependabot::Version , with a compatibility fallback to  Gem::Version  for non- Version  operands where needed.

### What changed:

• SemVer section 11 pre-release precedence — pre-release identifiers now compare per spec: • numeric identifiers compared as integers ( beta.2 < beta.11 , not lexical), • numeric identifiers rank lower than alphanumeric ( 1.0.0-1 < 1.0.0-alpha ), • a larger set of pre-release fields has higher precedence when the shared prefix is equal ( alpha < alpha.1 ), • pre-release versions rank below their release ( 1.0.0-rc.1 < 1.0.0 ).

• SemVer section 10 build metadata — preserved in  to_s  for display, but ignored for precedence and equality ( 1.0.0+build1 == 1.0.0+build2 ). Build metadata is likewise ignored on requirement boundaries (e.g.  = 1.0.0+build ) and on non- Version  comparison operands, rather than raising.

• Strict validation —  correct?  is now strict SemVer validation for Swift versions, anchored to the whole string. It accepts valid SemVer (including  v -prefixed versions) and rejects non-SemVer forms such as dot-style prereleases ( 1.0.0.alpha ), four-segment versions ( 0.0.0.0 ), leading zeros ( 01.2.3 ), invalid build metadata, and multiline input.

• Tolerant construction (compatibility path) — while  correct?  is strict,  #initialize  stays tolerant on purpose. The shared  GitCommitChecker  constructs a version for every tag matching its  VERSION_REGEX  (e.g. the real  0.0.0.0  tag) without first calling  correct? , and  Gem::Version#initialize  validates via  self.class.correct? . To avoid raising during git-tag handling, a non-SemVer tag is reduced to its leading numeric  major.minor.patch  and simply sorts low. This is the "separate compatibility path" suggested in review;  correct?  remains the strict gate for validation.

• Safe comparison — <=> returns nil for non-comparable/invalid input instead of raising. Swift requirement boundaries are parsed into Swift::Version (and already-parsed version objects are preserved as-is, not lossily rebuilt from  #to_s ), so SemVer section 11 prerelease precedence applies during requirement satisfaction. For genuinely non-Version external operands, comparison validates the operand as SemVer, ignores any build metadata, and falls back to Gem::Version ordering in a shared normalized space; malformed input still returns nil.

• Consistency —  eql?  /  hash  use the build-metadata-stripped SemVer form, so build metadata does not affect set/map key behavior.

• Tests — added Swift-specific specs covering strict SemVer validation,  v -prefixed versions, build-metadata preservation vs comparison semantics, prerelease ordering (including the SemVer section 11 example ordering), tolerant construction of non-SemVer git tags, equality/hash behavior, and requirement satisfaction for standard and prerelease version ranges.

### Anything you want to highlight for special attention from reviewers?

1. Scope — limited to Swift version comparison/validation and its specs:  version.rb  and  requirement.rb  plus tests ( version_spec.rb ,  requirement_spec.rb ). No  common/  changes.
2. The  correct?  vs  new  split is intentional.  correct?  is strict SemVer (validation), but construction is tolerant (compatibility for the git-tag contract described above). This means a junk tag like  0.0.0.0  is rejected by  correct?  yet still constructs (sorting low). Under strict  correct? , four-segment junk tags collapse to their three-part numeric core ( 0.0.0.5  and  0.0.0.9  compare equal); this only affects non-SemVer tags, which real Swift/SPM dependencies never use and which are never selected as "latest".
3. No lossy prerelease reconstruction. Comparison never reverses a Gem-normalized  .pre.  form back into a SemVer suffix, and  Requirement.parse  preserves an already-parsed version object rather than rebuilding it from  #to_s . Both operands are normalized into the same space before comparison, so the previously-raised ambiguity around hyphenated /  pre -containing prerelease identifiers does not occur.

### Checklist

✓  correct?  accepts valid SemVer Swift versions and rejects malformed/non-SemVer forms.
✓ Pre-release versions compare according to SemVer section 11.
✓ Pre-release versions sort below the corresponding final release.
✓ Build metadata is preserved in  to_s  but ignored for precedence and equality.
✓ Construction never raises for git tags matching the shared  VERSION_REGEX .