### PR TITLE
Support Central Package Versions updates in XmlFileWriter

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/FileWriterTestsBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/FileWriterTestsBase.cs
@@ -16,14 +16,15 @@ public abstract class FileWriterTestsBase
         ImmutableArray<string> initialProjectDependencyStrings,
         ImmutableArray<string> requiredDependencyStrings,
         (string path, string contents)[] expectedFiles,
-        PackageManagementKind packageManagementKind = PackageManagementKind.Default
+        PackageManagementKind packageManagementKind = PackageManagementKind.Default,
+        string? packageManagementSpecialFileRelativePath = null
     )
     {
         using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(files);
         var repoContentsPath = new DirectoryInfo(tempDir.DirectoryPath);
         var initialProjectDependencies = initialProjectDependencyStrings.Select(s => new Dependency(s.Split('/')[0], s.Split('/')[1], DependencyType.Unknown)).ToImmutableArray();
         var requiredDependencies = requiredDependencyStrings.Select(s => new Dependency(s.Split('/')[0], s.Split('/')[1], DependencyType.Unknown)).ToImmutableArray();
-        var success = await FileWriter.UpdatePackageVersionsAsync(repoContentsPath, [.. files.Select(f => f.path)], initialProjectDependencies, requiredDependencies, packageManagementKind);
+        var success = await FileWriter.UpdatePackageVersionsAsync(repoContentsPath, [.. files.Select(f => f.path)], initialProjectDependencies, requiredDependencies, packageManagementKind, packageManagementSpecialFileRelativePath);
         Assert.True(success, "Expected UpdatePackageVersionsAsync to succeed.");
 
         var expectedFileNames = expectedFiles.Select(f => f.path).ToHashSet();
@@ -39,14 +40,15 @@ public abstract class FileWriterTestsBase
         (string path, string contents)[] files,
         ImmutableArray<string> initialProjectDependencyStrings,
         ImmutableArray<string> requiredDependencyStrings,
-        PackageManagementKind packageManagementKind = PackageManagementKind.Default
+        PackageManagementKind packageManagementKind = PackageManagementKind.Default,
+        string? packageManagementSpecialFileRelativePath = null
     )
     {
         using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(files);
         var repoContentsPath = new DirectoryInfo(tempDir.DirectoryPath);
         var initialProjectDependencies = initialProjectDependencyStrings.Select(s => new Dependency(s.Split('/')[0], s.Split('/')[1], DependencyType.Unknown)).ToImmutableArray();
         var requiredDependencies = requiredDependencyStrings.Select(s => new Dependency(s.Split('/')[0], s.Split('/')[1], DependencyType.Unknown)).ToImmutableArray();
-        var success = await FileWriter.UpdatePackageVersionsAsync(repoContentsPath, [.. files.Select(f => f.path)], initialProjectDependencies, requiredDependencies, packageManagementKind);
+        var success = await FileWriter.UpdatePackageVersionsAsync(repoContentsPath, [.. files.Select(f => f.path)], initialProjectDependencies, requiredDependencies, packageManagementKind, packageManagementSpecialFileRelativePath);
         Assert.False(success);
 
         var expectedFileNames = files.Select(f => f.path).ToHashSet();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/TestFileWriterReturnsConstantResult.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/TestFileWriterReturnsConstantResult.cs
@@ -14,7 +14,7 @@ internal class TestFileWriterReturnsConstantResult : IFileWriter
         Result = result;
     }
 
-    public Task<bool> UpdatePackageVersionsAsync(DirectoryInfo repoContentsPath, ImmutableArray<string> relativeFilePaths, ImmutableArray<Dependency> originalDependencies, ImmutableArray<Dependency> requiredPackageVersions, PackageManagementKind packageManagementKind)
+    public Task<bool> UpdatePackageVersionsAsync(DirectoryInfo repoContentsPath, ImmutableArray<string> relativeFilePaths, ImmutableArray<Dependency> originalDependencies, ImmutableArray<Dependency> requiredPackageVersions, PackageManagementKind packageManagementKind, string? packageManagementSpecialFileRelativePath)
     {
         return Task.FromResult(Result);
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -304,6 +304,674 @@ public class XmlFileWriterTests : FileWriterTestsBase
     }
 
     [Fact]
+    public async Task SingleDependency_CentralPackageVersions_DirectUpdate()
+    {
+        // update the existing version attribute
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="1.1.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinnedWithExistingVersion()
+    {
+        // add a new PackageReference element to the project; version attribute in central file needs no change
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/0.9.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.0.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinnedWithUpdatedVersion()
+    {
+        // add a new PackageReference element to the project and update the attribute in the central file
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="1.1.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinnedWithNewVersion()
+    {
+        // add a PackageReference element to the project and package version file
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Not.This.Dependency" Version="2.0.0" />
+                        <PackageReference Update="Unrelated.Dependency" Version="2.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Not.This.Dependency" Version="2.0.0" />
+                        <PackageReference Update="Some.Dependency" Version="1.1.0" />
+                        <PackageReference Update="Unrelated.Dependency" Version="2.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_RangeAlreadyContainsRequiredVersion()
+    {
+        // the central file already pins an exact version range matching the required version; only add the
+        // `PackageReference` to the project and leave the central `Version` attribute untouched
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="[1.1.0]" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="[1.1.0]" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_ExactRangeIsUpdatedPreservingRangeForm()
+    {
+        // the central file pins an exact version range that needs updating; the bracketed range form is preserved
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="[1.0.0]" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Not.This.Dependency" />
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="[1.1.0]" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_AddedAtFrontOfItemGroup_NonStandardIndentation()
+    {
+        // new `PackageReference` sorts before the existing entries, so it's added at the front of each `ItemGroup`;
+        // 3-space indentation is used to ensure the new elements match the surrounding formatting
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Include="Zzz.Dependency" />
+                       </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Update="Zzz.Dependency" Version="2.0.0" />
+                       </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Include="Some.Dependency" />
+                          <PackageReference Include="Zzz.Dependency" />
+                       </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Update="Some.Dependency" Version="1.1.0" />
+                          <PackageReference Update="Zzz.Dependency" Version="2.0.0" />
+                       </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_AddedInMiddleOfItemGroup_NonStandardIndentation()
+    {
+        // new `PackageReference` sorts between the existing entries, so it's added in the middle of each `ItemGroup`;
+        // 3-space indentation is used to ensure the new elements match the surrounding formatting
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Include="Aaa.Dependency" />
+                          <PackageReference Include="Zzz.Dependency" />
+                       </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Update="Aaa.Dependency" Version="2.0.0" />
+                          <PackageReference Update="Zzz.Dependency" Version="2.0.0" />
+                       </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Include="Aaa.Dependency" />
+                          <PackageReference Include="Some.Dependency" />
+                          <PackageReference Include="Zzz.Dependency" />
+                       </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Update="Aaa.Dependency" Version="2.0.0" />
+                          <PackageReference Update="Some.Dependency" Version="1.1.0" />
+                          <PackageReference Update="Zzz.Dependency" Version="2.0.0" />
+                       </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_AddedAtEndOfItemGroup_NonStandardIndentation()
+    {
+        // new `PackageReference` sorts after the existing entries, so it's added at the end of each `ItemGroup`;
+        // 3-space indentation is used to ensure the new elements match the surrounding formatting
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Include="Aaa.Dependency" />
+                          <PackageReference Include="Bbb.Dependency" />
+                       </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Update="Aaa.Dependency" Version="2.0.0" />
+                          <PackageReference Update="Bbb.Dependency" Version="2.0.0" />
+                       </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Include="Aaa.Dependency" />
+                          <PackageReference Include="Bbb.Dependency" />
+                          <PackageReference Include="Some.Dependency" />
+                       </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Update="Aaa.Dependency" Version="2.0.0" />
+                          <PackageReference Update="Bbb.Dependency" Version="2.0.0" />
+                          <PackageReference Update="Some.Dependency" Version="1.1.0" />
+                       </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_NewItemGroupAddedToProject_NonStandardIndentation()
+    {
+        // the project has no `ItemGroup`, so a new one is created to hold the pinned `PackageReference`; the central
+        // file's existing `Version` is updated in place. 3-space indentation is used throughout.
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                       <PropertyGroup>
+                          <TargetFramework>net9.0</TargetFramework>
+                       </PropertyGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Update="Some.Dependency" Version="1.0.0" />
+                       </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                       <PropertyGroup>
+                          <TargetFramework>net9.0</TargetFramework>
+                       </PropertyGroup>
+                       <ItemGroup>
+                          <PackageReference Include="Some.Dependency" />
+                       </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                       <ItemGroup>
+                          <PackageReference Update="Some.Dependency" Version="1.1.0" />
+                       </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_NoExistingCentralElement_ElementAddedToCentralFile()
+    {
+        // CPV is in use and the central file has no `<PackageReference Update=...>` elements yet; the package is being
+        // pinned as a transitive dependency, so a new `<PackageReference Update=...>` element is added to the central file.
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="1.1.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_CentralVersionFromProperty_UpdatesProperty()
+    {
+        // the central `<PackageReference Update=...>` element's version is expressed via an MSBuild property; pinning
+        // the transitive dependency must update the backing property rather than clobbering the `$(...)` reference
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <SomeDependencyVersion>1.0.0</SomeDependencyVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="$(SomeDependencyVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <PropertyGroup>
+                        <SomeDependencyVersion>1.1.0</SomeDependencyVersion>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="$(SomeDependencyVersion)" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_NoPackagesPropsFile_NoUpdatePerformed()
+    {
+        // CPV is in use but there's no `Packages.props` file (the central file is named differently) and no existing
+        // `<PackageReference Update=...>` element, so there's no reliable location to record the version; rather than
+        // writing a versionless, unresolvable `PackageReference`, no update is performed and the files are left unchanged.
+        await TestNoChangeAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Versions.props", """
+                    <Project>
+                      <ItemGroup>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_RangeSatisfiesBothOldAndRequired_FloorIsRaised()
+    {
+        // the central file pins an open range (`[1.0.0,)`) that satisfies both the old and required versions; the
+        // floor must be raised to the required version rather than left untouched, otherwise resolution could fall
+        // back to a now-undesired older version
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="[1.0.0,)" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/2.0.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="2.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_CentralElementHasNoVersionAttribute_NoUpdatePerformed()
+    {
+        // the matched central `<PackageReference Update=...>` element has no `Version` attribute, so there's no
+        // location to record the version; rather than reporting success with a versionless, unresolvable pin, no
+        // update is performed and the files are left unchanged
+        await TestNoChangeAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Packages.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"]
+        );
+    }
+
+    [Fact]
     public async Task SingleDependency_SingleFile_AttributeDirectUpdate_ExactMatchVersionRangeFromPropertyValue()
     {
         await TestAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/XmlFileWriterTests.cs
@@ -869,10 +869,56 @@ public class XmlFileWriterTests : FileWriterTestsBase
     }
 
     [Fact]
-    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_NoPackagesPropsFile_NoUpdatePerformed()
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_CentralPackagesFileFromDiscovery_ElementAddedToDiscoveredFile()
     {
-        // CPV is in use but there's no `Packages.props` file (the central file is named differently) and no existing
-        // `<PackageReference Update=...>` element, so there's no reliable location to record the version; rather than
+        // CPV is in use with a non-conventionally-named central file (`Versions.props`) that has no
+        // `<PackageReference Update=...>` elements yet; because the discovered `CentralPackagesFile` path is supplied,
+        // the new central element is added to that file rather than relying on the `Packages.props` filename heuristic.
+        await TestAsync(
+            packageManagementKind: PackageManagementKind.CentralPackageVersions,
+            packageManagementSpecialFileRelativePath: "Versions.props",
+            files: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Versions.props", """
+                    <Project>
+                      <ItemGroup>
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ],
+            initialProjectDependencyStrings: ["Some.Dependency/1.0.0"],
+            requiredDependencyStrings: ["Some.Dependency/1.1.0"],
+            expectedFiles: [
+                ("project.csproj", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Dependency" />
+                        <PackageReference Include="Unrelated.Dependency" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+                ("Versions.props", """
+                    <Project>
+                      <ItemGroup>
+                        <PackageReference Update="Some.Dependency" Version="1.1.0" />
+                      </ItemGroup>
+                    </Project>
+                    """)
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task SingleDependency_CentralPackageVersions_TransitiveIsPinned_NoCentralFileFound_NoUpdatePerformed()
+    {
+        // CPV is in use but there's no `Packages.props` file, no existing `<PackageReference Update=...>` element, and
+        // no discovered `CentralPackagesFile` path, so there's no reliable location to record the version; rather than
         // writing a versionless, unresolvable `PackageReference`, no update is performed and the files are left unchanged.
         await TestNoChangeAsync(
             packageManagementKind: PackageManagementKind.CentralPackageVersions,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
@@ -406,7 +406,7 @@ public class FileWriterWorker
             .ToImmutableArray();
 
         // try update
-        var success = await fileWriter.UpdatePackageVersionsAsync(repoContentsPath, relativeFilePaths, projectDiscovery.Dependencies, requiredPackageVersions, projectDiscovery.PackageManagementKind);
+        var success = await fileWriter.UpdatePackageVersionsAsync(repoContentsPath, relativeFilePaths, projectDiscovery.Dependencies, requiredPackageVersions, projectDiscovery.PackageManagementKind, projectDiscovery.PackageManagementSpecialFileRelativePath);
         var updatedFiles = new List<string>();
         foreach (var (filePath, originalContents) in originalFileContents)
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/IFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/IFileWriter.cs
@@ -11,6 +11,7 @@ public interface IFileWriter
         ImmutableArray<string> relativeFilePaths,
         ImmutableArray<Dependency> originalDependencies,
         ImmutableArray<Dependency> requiredPackageVersions,
-        PackageManagementKind packageManagementKind
+        PackageManagementKind packageManagementKind,
+        string? packageManagementSpecialFileRelativePath
     );
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -23,6 +23,8 @@ public class XmlFileWriter : IFileWriter
     private const string PackageVersionElementName = "PackageVersion";
     private const string PropertyGroupElementName = "PropertyGroup";
 
+    private const string PackagesPropsFileName = "Packages.props";
+
     private const string UpdaterAnnotationKind = "dependabot";
 
     private readonly ILogger _logger;
@@ -80,6 +82,7 @@ public class XmlFileWriter : IFileWriter
             .ToArray();
         var filesAndContents = (await Task.WhenAll(filesAndContentsTasks))
             .ToDictionary();
+
         foreach (var requiredPackageVersion in requiredPackageVersions)
         {
             var oldVersionString = originalDependencies.FirstOrDefault(d => d.Name.Equals(requiredPackageVersion.Name, StringComparison.OrdinalIgnoreCase))?.Version;
@@ -116,7 +119,13 @@ public class XmlFileWriter : IFileWriter
                 .Where(pair =>
                 {
                     var element = pair.Key;
-                    var attributeValue = element.GetAttributeValue(IncludeAttributeName) ?? element.GetAttributeValue(UpdateAttributeName) ?? string.Empty;
+
+                    // find the matching <PackageReference> element; if using Central Package Versions don't consider any `Update=` attributes
+                    var attributeValue = element.GetAttributeValue(IncludeAttributeName)
+                        ?? (packageManagementKind == PackageManagementKind.CentralPackageVersions
+                            ? string.Empty
+                            : element.GetAttributeValue(UpdateAttributeName))
+                        ?? string.Empty;
                     var packageNames = attributeValue.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
                     return packageNames.Any(name => name.Equals(requiredPackageVersion.Name, StringComparison.OrdinalIgnoreCase));
                 })
@@ -377,9 +386,198 @@ public class XmlFileWriter : IFileWriter
                     }
                     else
                     {
-                        // add a direct `Version` attribute
-                        var newElementWithVersion = newElement.WithAttribute(VersionMetadataName, requiredVersion.ToString());
-                        newElement = (IXmlElementSyntax)ReplaceNode(projectRelativePath, newElement.AsNode, newElementWithVersion.AsNode);
+                        if (packageManagementKind == PackageManagementKind.CentralPackageVersions)
+                        {
+                            // find or update the matching `<PackageReference Update=...>` element in the central package versions file
+                            var allCpvElementsAndPaths = filesAndContents
+                                .SelectMany(kvp =>
+                                {
+                                    var path = kvp.Key;
+                                    var doc = kvp.Value;
+                                    return doc.Descendants()
+                                        .Where(e => e.Name.Equals(PackageReferenceElementName, StringComparison.OrdinalIgnoreCase))
+                                        .Where(e => e.GetAttributeValue(UpdateAttributeName) is not null)
+                                        .Select(element => KeyValuePair.Create(element, path));
+                                })
+                                .ToArray();
+                            var matchingCpvElementAndPath = allCpvElementsAndPaths
+                                .FirstOrDefault(pair => (pair.Key.GetAttributeValue(UpdateAttributeName) ?? string.Empty).Trim().Equals(requiredPackageVersion.Name, StringComparison.OrdinalIgnoreCase));
+                            if (matchingCpvElementAndPath.Key is not null)
+                            {
+                                // found matching `<PackageReference Update=...>` element; update the version it points at,
+                                // walking back through property references (e.g. `$(SomeVersion)`) so they aren't clobbered
+                                var (cpvElement, cpvFilePath) = matchingCpvElementAndPath;
+                                var cpvVersionAttribute = cpvElement.GetAttributeCaseInsensitive(VersionMetadataName);
+                                if (cpvVersionAttribute is not null)
+                                {
+                                    bool TryUpdateCentralVersion(string startVersionString, Action<string> startUpdater)
+                                    {
+                                        var candidateLocations = new Queue<(string VersionString, Action<string> Updater)>();
+                                        candidateLocations.Enqueue((startVersionString, startUpdater));
+                                        while (candidateLocations.TryDequeue(out var candidate))
+                                        {
+                                            var (candidateVersionString, candidateUpdater) = candidate;
+                                            if (NuGetVersion.TryParse(candidateVersionString, out var candidateVersion))
+                                            {
+                                                if (candidateVersion == requiredVersion)
+                                                {
+                                                    _logger.Info($"Dependency {requiredPackageVersion.Name} already set to {requiredVersion} in file {cpvFilePath}; no update needed.");
+                                                    return true;
+                                                }
+
+                                                if (candidateVersion == oldVersion)
+                                                {
+                                                    _logger.Info($"Dependency {requiredPackageVersion.Name} updated to version {requiredVersion} in file {cpvFilePath}.");
+                                                    candidateUpdater(requiredVersion.ToString());
+                                                    return true;
+                                                }
+                                            }
+                                            else if (VersionRange.TryParse(candidateVersionString, out var candidateRange))
+                                            {
+                                                if (candidateRange.Satisfies(oldVersion))
+                                                {
+                                                    // update the value, preserving the range structure where applicable
+                                                    _logger.Info($"Dependency {requiredPackageVersion.Name} updated to version {requiredVersion} in file {cpvFilePath}.");
+                                                    candidateUpdater(CreateUpdatedVersionRangeString(candidateRange, oldVersion, requiredVersion));
+                                                    return true;
+                                                }
+
+                                                if (candidateRange.MinVersion == requiredVersion || candidateRange.Satisfies(requiredVersion))
+                                                {
+                                                    // the version range (e.g. `[1.1.0]`) already includes the required version; no update needed
+                                                    _logger.Info($"Dependency {requiredPackageVersion.Name} already includes {requiredVersion} in file {cpvFilePath}; no update needed.");
+                                                    return true;
+                                                }
+                                            }
+
+                                            // the value may be (or contain) a property reference; walk back to the property definition(s)
+                                            var propertyInSubstringPattern = new Regex(@"(?<Prefix>[^$]*)\$\((?<PropertyName>[A-Za-z0-9_]+)\)(?<Suffix>.*$)");
+                                            var propertyMatch = propertyInSubstringPattern.Match(candidateVersionString);
+                                            if (propertyMatch.Success)
+                                            {
+                                                var propertyName = propertyMatch.Groups["PropertyName"].Value;
+                                                var propertyDefinitionsAndPaths = filesAndContents
+                                                    .SelectMany(kvp => kvp.Value.Descendants()
+                                                        .Where(e => e.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase))
+                                                        .Where(e => e.Parent?.Name.Equals(PropertyGroupElementName, StringComparison.OrdinalIgnoreCase) == true)
+                                                        .Select(e => KeyValuePair.Create(e, kvp.Key)))
+                                                    .ToArray();
+                                                foreach (var (propertyDefinition, propertyFilePath) in propertyDefinitionsAndPaths)
+                                                {
+                                                    candidateLocations.Enqueue((propertyDefinition.GetContentValue(), version => ReplaceNode(propertyFilePath, propertyDefinition.AsNode, propertyDefinition.WithContent(version).AsNode)));
+                                                }
+                                            }
+                                        }
+
+                                        return false;
+                                    }
+
+                                    var centralUpdatePerformed = TryUpdateCentralVersion(cpvVersionAttribute.Value, version => ReplaceNode(cpvFilePath, cpvVersionAttribute, cpvVersionAttribute.WithValue(version)));
+                                    if (!centralUpdatePerformed)
+                                    {
+                                        // couldn't find a literal version (or backing property) to update; don't leave a broken pin
+                                        updatesPerformed[requiredPackageVersion.Name] = false;
+                                        _logger.Warn($"Unable to find an appropriate location to set {requiredPackageVersion.Name} to version {requiredVersion} in file {cpvFilePath}; no update performed.");
+                                    }
+                                }
+                                else
+                                {
+                                    // the matched central element has no `Version` attribute, so there's no location to
+                                    // record the version; don't leave a versionless, unresolvable pin
+                                    updatesPerformed[requiredPackageVersion.Name] = false;
+                                    _logger.Warn($"Central element for {requiredPackageVersion.Name} has no `{VersionMetadataName}` attribute to set to version {requiredVersion}; no update performed.");
+                                }
+                            }
+                            else if (allCpvElementsAndPaths.Length > 0)
+                            {
+                                // add a new `<PackageReference Update=...>` element in sorted order
+                                var newCpvElement = XmlExtensions.CreateSingleLineXmlElementSyntax(PackageReferenceElementName)
+                                    .WithAttribute(UpdateAttributeName, requiredPackageVersion.Name)
+                                    .WithAttribute(VersionMetadataName, requiredVersion.ToString());
+                                var priorCpvElementsAndPaths = allCpvElementsAndPaths
+                                    .TakeWhile(pair => (pair.Key.GetAttributeValue(UpdateAttributeName) ?? string.Empty).Trim().CompareTo(requiredPackageVersion.Name) < 0)
+                                    .ToArray();
+                                if (priorCpvElementsAndPaths.Length > 0)
+                                {
+                                    _logger.Info($"Adding new `<{PackageReferenceElementName}>` element for {requiredPackageVersion.Name} with version {requiredVersion}.");
+                                    var (lastPriorCpvElement, filePath) = priorCpvElementsAndPaths.Last();
+                                    var trivia = lastPriorCpvElement.AsNode.GetLeadingTrivia().ToList();
+                                    var priorEolIndex = trivia.FindLastIndex(t => t.Kind == SyntaxKind.EndOfLineTrivia);
+                                    var indentTrivia = trivia
+                                        .Skip(priorEolIndex + 1)
+                                        .Select(t => SyntaxFactory.WhitespaceTrivia(t.ToFullString()))
+                                        .ToArray();
+                                    var newTrivia = new SyntaxTriviaList([SyntaxFactory.EndOfLineTrivia("\n"), .. indentTrivia]);
+                                    newCpvElement = (IXmlElementSyntax)newCpvElement.AsNode.WithLeadingTrivia(newTrivia).WithoutTrailingTrivia();
+                                    var insertionIndex = lastPriorCpvElement.Parent.Content.IndexOf(lastPriorCpvElement.AsNode) + 1;
+                                    var replacementParent = lastPriorCpvElement.Parent
+                                        .InsertChild(newCpvElement, insertionIndex);
+                                    ReplaceNode(filePath, lastPriorCpvElement.Parent.AsNode, replacementParent.AsNode);
+                                }
+                                else
+                                {
+                                    // no prior elements; add to the front of the document
+                                    _logger.Info($"Adding new `<{PackageReferenceElementName}>` element for {requiredPackageVersion.Name} with version {requiredVersion} at the start of the document.");
+                                    var (cpvGroup, filePath) = allCpvElementsAndPaths.First();
+                                    cpvGroup = cpvGroup.Parent;
+                                    var groupTrivia = cpvGroup.AsNode.GetLeadingTrivia().ToList();
+                                    var priorEolIndex = groupTrivia.FindLastIndex(t => t.Kind == SyntaxKind.EndOfLineTrivia);
+                                    var indentTrivia = groupTrivia
+                                        .Skip(priorEolIndex + 1)
+                                        .Select(t => SyntaxFactory.WhitespaceTrivia(t.ToFullString()))
+                                        .ToArray();
+                                    var cpvDocument = filesAndContents[filePath];
+                                    var cpvIndentation = GetDocumentIndentationCharacters(cpvDocument);
+                                    var newTrivia = new SyntaxTriviaList([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia(cpvIndentation), .. indentTrivia]);
+                                    newCpvElement = (IXmlElementSyntax)newCpvElement.AsNode.WithLeadingTrivia(newTrivia).WithoutTrailingTrivia();
+                                    var replacementGroup = cpvGroup.InsertChild(newCpvElement, 0);
+                                    ReplaceNode(filePath, cpvGroup.AsNode, replacementGroup.AsNode);
+                                }
+                            }
+                            else
+                            {
+                                // CPV is in use but there's no existing central `<PackageReference Update=...>` element;
+                                // the package is being pinned as a transitive dependency, so add a new element to the
+                                // first `Packages.props` file (its last `<ItemGroup>`).
+                                var packagesPropsPath = filesAndContents.Keys
+                                    .FirstOrDefault(path => Path.GetFileName(path).Equals(PackagesPropsFileName, StringComparison.OrdinalIgnoreCase));
+                                var centralItemGroup = packagesPropsPath is null
+                                    ? null
+                                    : filesAndContents[packagesPropsPath].Descendants()
+                                        .LastOrDefault(e => e.Name.Equals(ItemGroupElementName, StringComparison.OrdinalIgnoreCase));
+                                if (packagesPropsPath is not null && centralItemGroup is not null)
+                                {
+                                    _logger.Info($"Adding new `<{PackageReferenceElementName}>` element for {requiredPackageVersion.Name} with version {requiredVersion} to file {packagesPropsPath}.");
+                                    var newCpvElement = XmlExtensions.CreateSingleLineXmlElementSyntax(PackageReferenceElementName)
+                                        .WithAttribute(UpdateAttributeName, requiredPackageVersion.Name)
+                                        .WithAttribute(VersionMetadataName, requiredVersion.ToString());
+                                    var itemGroupTrivia = centralItemGroup.AsNode.GetLeadingTrivia().ToList();
+                                    var priorEolIndex = itemGroupTrivia.FindLastIndex(t => t.Kind == SyntaxKind.EndOfLineTrivia);
+                                    var indentTrivia = itemGroupTrivia
+                                        .Skip(priorEolIndex + 1)
+                                        .Select(t => SyntaxFactory.WhitespaceTrivia(t.ToFullString()))
+                                        .ToArray();
+                                    var centralIndentation = GetDocumentIndentationCharacters(filesAndContents[packagesPropsPath]);
+                                    var newTrivia = new SyntaxTriviaList([SyntaxFactory.EndOfLineTrivia("\n"), SyntaxFactory.WhitespaceTrivia(centralIndentation), .. indentTrivia]);
+                                    newCpvElement = (IXmlElementSyntax)newCpvElement.AsNode.WithLeadingTrivia(newTrivia).WithoutTrailingTrivia();
+                                    ReplaceNode(packagesPropsPath, centralItemGroup.AsNode, centralItemGroup.InsertChild(newCpvElement, 0).AsNode);
+                                }
+                                else
+                                {
+                                    // there's no `Packages.props` file to record the version; emitting a versionless
+                                    // `<PackageReference Include=...>` would produce an unresolvable reference, so report
+                                    // that no update was performed.
+                                    updatesPerformed[requiredPackageVersion.Name] = false;
+                                    _logger.Warn($"Unable to find a `{PackagesPropsFileName}` file to set {requiredPackageVersion.Name} to version {requiredVersion}; no update performed.");
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // add a direct `Version` attribute
+                            var newElementWithVersion = newElement.WithAttribute(VersionMetadataName, requiredVersion.ToString());
+                            newElement = (IXmlElementSyntax)ReplaceNode(projectRelativePath, newElement.AsNode, newElementWithVersion.AsNode);
+                        }
                     }
                 }
             }
@@ -451,6 +649,33 @@ public class XmlFileWriter : IFileWriter
                             {
                                 currentVersionString = cpmVersionElement.GetContentValue();
                                 updateVersionLocation = version => ReplaceNode(packageVersionFilePath, cpmVersionElement.AsNode, cpmVersionElement.WithContent(version).AsNode);
+                                goto doVersionUpdate;
+                            }
+                        }
+                    }
+
+                    // check for matching `<PackageReference Update=...>` element (Central Package Versions)
+                    if (packageManagementKind == PackageManagementKind.CentralPackageVersions)
+                    {
+                        var cpvElementAndPath = filesAndContents
+                            .SelectMany(kvp =>
+                            {
+                                var path = kvp.Key;
+                                var doc = kvp.Value;
+                                return doc.Descendants()
+                                    .Where(e => e.Name.Equals(PackageReferenceElementName, StringComparison.OrdinalIgnoreCase))
+                                    .Where(e => (e.GetAttributeValue(UpdateAttributeName) ?? string.Empty).Trim().Equals(requiredPackageVersion.Name, StringComparison.OrdinalIgnoreCase))
+                                    .Select(element => KeyValuePair.Create(element, path));
+                            })
+                            .FirstOrDefault();
+                        if (cpvElementAndPath.Key is not null)
+                        {
+                            var (cpvElement, cpvFilePath) = cpvElementAndPath;
+                            var cpvVersionAttribute = cpvElement.GetAttributeCaseInsensitive(VersionMetadataName);
+                            if (cpvVersionAttribute is not null)
+                            {
+                                currentVersionString = cpvVersionAttribute.Value;
+                                updateVersionLocation = version => ReplaceNode(cpvFilePath, cpvVersionAttribute, cpvVersionAttribute.WithValue(version));
                                 goto doVersionUpdate;
                             }
                         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -54,7 +54,8 @@ public class XmlFileWriter : IFileWriter
         ImmutableArray<string> relativeFilePaths,
         ImmutableArray<Dependency> originalDependencies,
         ImmutableArray<Dependency> requiredPackageVersions,
-        PackageManagementKind packageManagementKind
+        PackageManagementKind packageManagementKind,
+        string? packageManagementSpecialFileRelativePath
     )
     {
         if (relativeFilePaths.IsDefaultOrEmpty)
@@ -494,8 +495,13 @@ public class XmlFileWriter : IFileWriter
                                 var newCpvElement = XmlExtensions.CreateSingleLineXmlElementSyntax(PackageReferenceElementName)
                                     .WithAttribute(UpdateAttributeName, requiredPackageVersion.Name)
                                     .WithAttribute(VersionMetadataName, requiredVersion.ToString());
-                                var priorCpvElementsAndPaths = allCpvElementsAndPaths
-                                    .TakeWhile(pair => (pair.Key.GetAttributeValue(UpdateAttributeName) ?? string.Empty).Trim().CompareTo(requiredPackageVersion.Name) < 0)
+                                // sort by the `Update` value so placement is deterministic regardless of document/dictionary
+                                // traversal order; use ordinal (case-insensitive) comparison to match NuGet's package id semantics
+                                var sortedCpvElementsAndPaths = allCpvElementsAndPaths
+                                    .OrderBy(pair => (pair.Key.GetAttributeValue(UpdateAttributeName) ?? string.Empty).Trim(), StringComparer.OrdinalIgnoreCase)
+                                    .ToArray();
+                                var priorCpvElementsAndPaths = sortedCpvElementsAndPaths
+                                    .TakeWhile(pair => string.Compare((pair.Key.GetAttributeValue(UpdateAttributeName) ?? string.Empty).Trim(), requiredPackageVersion.Name, StringComparison.OrdinalIgnoreCase) < 0)
                                     .ToArray();
                                 if (priorCpvElementsAndPaths.Length > 0)
                                 {
@@ -518,7 +524,7 @@ public class XmlFileWriter : IFileWriter
                                 {
                                     // no prior elements; add to the front of the document
                                     _logger.Info($"Adding new `<{PackageReferenceElementName}>` element for {requiredPackageVersion.Name} with version {requiredVersion} at the start of the document.");
-                                    var (cpvGroup, filePath) = allCpvElementsAndPaths.First();
+                                    var (cpvGroup, filePath) = sortedCpvElementsAndPaths.First();
                                     cpvGroup = cpvGroup.Parent;
                                     var groupTrivia = cpvGroup.AsNode.GetLeadingTrivia().ToList();
                                     var priorEolIndex = groupTrivia.FindLastIndex(t => t.Kind == SyntaxKind.EndOfLineTrivia);
@@ -538,8 +544,26 @@ public class XmlFileWriter : IFileWriter
                             {
                                 // CPV is in use but there's no existing central `<PackageReference Update=...>` element;
                                 // the package is being pinned as a transitive dependency, so add a new element to the
-                                // first `Packages.props` file (its last `<ItemGroup>`).
-                                var packagesPropsPath = filesAndContents.Keys
+                                // central file's last `<ItemGroup>`.  Prefer the central file discovered upstream (the
+                                // `CentralPackagesFile` MSBuild property); fall back to the conventional `Packages.props`
+                                // filename when it wasn't provided or couldn't be matched.
+                                string? packagesPropsPath = null;
+                                if (packageManagementSpecialFileRelativePath is not null)
+                                {
+                                    var lastSeparatorIndex = projectRelativePath.LastIndexOf('/');
+                                    var projectDirectory = lastSeparatorIndex >= 0
+                                        ? projectRelativePath.Substring(0, lastSeparatorIndex + 1)
+                                        : "/";
+                                    var resolvedCentralPath = (projectDirectory + packageManagementSpecialFileRelativePath).FullyNormalizedRootedPath();
+                                    packagesPropsPath = filesAndContents.Keys
+                                        .FirstOrDefault(path => path.FullyNormalizedRootedPath().Equals(resolvedCentralPath, StringComparison.OrdinalIgnoreCase));
+                                    if (packagesPropsPath is null)
+                                    {
+                                        _logger.Warn($"Discovered central package management file `{packageManagementSpecialFileRelativePath}` was not found among the updatable files; falling back to `{PackagesPropsFileName}`.");
+                                    }
+                                }
+
+                                packagesPropsPath ??= filesAndContents.Keys
                                     .FirstOrDefault(path => Path.GetFileName(path).Equals(PackagesPropsFileName, StringComparison.OrdinalIgnoreCase));
                                 var centralItemGroup = packagesPropsPath is null
                                     ? null
@@ -564,11 +588,11 @@ public class XmlFileWriter : IFileWriter
                                 }
                                 else
                                 {
-                                    // there's no `Packages.props` file to record the version; emitting a versionless
+                                    // there's no central file to record the version; emitting a versionless
                                     // `<PackageReference Include=...>` would produce an unresolvable reference, so report
                                     // that no update was performed.
                                     updatesPerformed[requiredPackageVersion.Name] = false;
-                                    _logger.Warn($"Unable to find a `{PackagesPropsFileName}` file to set {requiredPackageVersion.Name} to version {requiredVersion}; no update performed.");
+                                    _logger.Warn($"Unable to find a central package management file to set {requiredPackageVersion.Name} to version {requiredVersion}; no update performed.");
                                 }
                             }
                         }


### PR DESCRIPTION
Adds Central Package Versions (CPV) support to the NuGet updater's `XmlFileWriter`.

## What

CPV stores package versions centrally in a props file (e.g. `Packages.props`) as `<PackageReference Update="X" Version="..." />` elements, while projects reference packages via versionless `<PackageReference Include="X" />`. This change teaches `XmlFileWriter` to:

- **Direct updates**: when a project already has an `Include`, update the version it points at (including `$(Property)` references).
- **Transitive pinning**: add a versionless `Include` to the project and update or create the central `Version` entry.
  - Update an existing central `<PackageReference Update=...>` element.
  - Add a new sorted entry when none exists.
  - When no central element exists, add one to the first `Packages.props` file; if none is found, log a warning and perform no update.

## Notes

- Central `Version` attributes are parsed as version ranges so exact-pin forms like `[1.1.0]` are preserved and not needlessly rewritten, and open ranges have their floor raised correctly.
- Property-backed central versions (`$(SomeVersion)`) are resolved back to the backing property definition rather than clobbered.
- Updates are all-or-nothing: if a version can't be reliably recorded, no files are written and the operation reports no update.

## Tests

Adds tests covering direct updates, transitive pinning at the front/middle/end of an `ItemGroup`, new `ItemGroup` creation, range handling, property resolution, and non-standard indentation. All `XmlFileWriterTests` pass.
