### PR TITLE
Nix: skip flake inputs pinned to a bare commit SHA

### DIFF
--- a/nix/lib/dependabot/nix/file_parser.rb
+++ b/nix/lib/dependabot/nix/file_parser.rb
@@ -134,6 +134,9 @@ module Dependabot
         source_type = locked.fetch("type", nil)
         return unless SUPPORTED_SOURCE_TYPES.include?(source_type)
 
+        # Skip inputs pinned to a bare commit SHA: no branch or tag to track.
+        return if revision_pinned?(original)
+
         rev = locked.fetch("rev", nil)
         return unless rev
 
@@ -153,6 +156,11 @@ module Dependabot
             groups: []
           }]
         )
+      end
+
+      sig { params(original: T::Hash[String, T.untyped]).returns(T::Boolean) }
+      def revision_pinned?(original)
+        !original.fetch("rev", nil).nil?
       end
 
       sig { params(locked: T::Hash[String, T.untyped]).returns(T.nilable(String)) }

--- a/nix/spec/dependabot/nix/file_parser_spec.rb
+++ b/nix/spec/dependabot/nix/file_parser_spec.rb
@@ -113,6 +113,15 @@ RSpec.describe Dependabot::Nix::FileParser do
       end
     end
 
+    context "with a commit-pinned (bare SHA) input that should be skipped" do
+      let(:flake_lock_content) { fixture("flake_with_rev_pinned.lock") }
+
+      it "skips inputs pinned to an immutable revision" do
+        expect(dependencies.length).to eq(1)
+        expect(dependencies.first.name).to eq("nixpkgs")
+      end
+    end
+
     context "with gitlab inputs" do
       let(:flake_lock_content) { fixture("flake_with_gitlab.lock") }
 

--- a/nix/spec/dependabot/nix/fixtures/flake_with_rev_pinned.lock
+++ b/nix/spec/dependabot/nix/fixtures/flake_with_rev_pinned.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709961763,
+        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QCiGM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Dependabot failed on flakes whose inputs are pinned to a bare commit SHA (e.g. `github:NixOS/nixpkgs/<sha>`). With no branch or tag to track, it proposed a commit it couldn't apply and raised `DependencyFileContentNotChanged` (seen on NixOS/nix). The parser now skips these inputs.

### Anything you want to highlight for special attention from reviewers?

Detection keys off `original.rev` in flake.lock, which is set only for bare-SHA pins. Tag and branch pins use `original.ref` and still update normally.

### How will you know you've accomplished your goal?

Added a parser spec covering a skipped rev-pinned input. The full nix suite passes (121 examples) and RuboCop is clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
