### PR TITLE
Nix: update NixOS channel tarball inputs

### DIFF
--- a/nix/lib/dependabot/nix/channel.rb
+++ b/nix/lib/dependabot/nix/channel.rb
@@ -13,12 +13,14 @@ module Dependabot
       extend T::Sig
 
       CHANNEL_HOST = "channels.nixos.org"
+      DEFAULT_EXTENSION = "xz"
 
       # e.g. https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz
+      # The suffix is captured so a bump keeps the flake's existing format.
       CHANNEL_URL_PATTERN = %r{
         \Ahttps?://channels\.nixos\.org/
         (?<channel>[a-zA-Z0-9][a-zA-Z0-9._-]*)
-        /nixexprs\.tar\.(?:xz|gz|bz2)\z
+        /nixexprs\.tar\.(?<extension>xz|gz|bz2)\z
       }x
 
       sig { params(url: T.nilable(String)).returns(T::Boolean) }
@@ -35,9 +37,18 @@ module Dependabot
         CHANNEL_URL_PATTERN.match(url)&.[](:channel)
       end
 
-      sig { params(channel_name: String).returns(String) }
-      def self.url_for(channel_name)
-        "https://#{CHANNEL_HOST}/#{channel_name}/nixexprs.tar.xz"
+      # The compression suffix (xz, gz, bz2) of a channel tarball URL.
+      sig { params(url: T.nilable(String)).returns(T.nilable(String)) }
+      def self.extension_from_url(url)
+        return unless url
+
+        CHANNEL_URL_PATTERN.match(url)&.[](:extension)
+      end
+
+      # Preserves the flake's suffix so a bump keeps its compression format.
+      sig { params(channel_name: String, extension: String).returns(String) }
+      def self.url_for(channel_name, extension: DEFAULT_EXTENSION)
+        "https://#{CHANNEL_HOST}/#{channel_name}/nixexprs.tar.#{extension}"
       end
     end
   end

--- a/nix/lib/dependabot/nix/channel.rb
+++ b/nix/lib/dependabot/nix/channel.rb
@@ -1,0 +1,44 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/nix/versioned_name"
+
+module Dependabot
+  module Nix
+    # A NixOS channel: a VersionedName plus helpers for channel tarball URLs
+    # (channels.nixos.org/<channel>/nixexprs.tar.xz).
+    class Channel < VersionedName
+      extend T::Sig
+
+      CHANNEL_HOST = "channels.nixos.org"
+
+      # e.g. https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz
+      CHANNEL_URL_PATTERN = %r{
+        \Ahttps?://channels\.nixos\.org/
+        (?<channel>[a-zA-Z0-9][a-zA-Z0-9._-]*)
+        /nixexprs\.tar\.(?:xz|gz|bz2)\z
+      }x
+
+      sig { params(url: T.nilable(String)).returns(T::Boolean) }
+      def self.channel_url?(url)
+        return false unless url
+
+        CHANNEL_URL_PATTERN.match?(url)
+      end
+
+      sig { params(url: T.nilable(String)).returns(T.nilable(String)) }
+      def self.channel_name_from_url(url)
+        return unless url
+
+        CHANNEL_URL_PATTERN.match(url)&.[](:channel)
+      end
+
+      sig { params(channel_name: String).returns(String) }
+      def self.url_for(channel_name)
+        "https://#{CHANNEL_HOST}/#{channel_name}/nixexprs.tar.xz"
+      end
+    end
+  end
+end

--- a/nix/lib/dependabot/nix/file_parser.rb
+++ b/nix/lib/dependabot/nix/file_parser.rb
@@ -8,6 +8,7 @@ require "dependabot/dependency"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/shared_helpers"
+require "dependabot/nix/channel"
 require "dependabot/nix/package_manager"
 
 module Dependabot
@@ -15,8 +16,8 @@ module Dependabot
     class FileParser < Dependabot::FileParsers::Base
       extend T::Sig
 
-      # Source types that are backed by git and can be updated via revision tracking
-      SUPPORTED_SOURCE_TYPES = T.let(%w(github gitlab sourcehut git).freeze, T::Array[String])
+      # Updatable source types: git-backed sources plus NixOS channel tarballs.
+      SUPPORTED_SOURCE_TYPES = T.let(%w(github gitlab sourcehut git tarball).freeze, T::Array[String])
 
       SUPPORTED_LOCK_VERSION = 7
 
@@ -140,6 +141,22 @@ module Dependabot
         rev = locked.fetch("rev", nil)
         return unless rev
 
+        if source_type == "tarball"
+          build_tarball_dependency(input_name, original, rev)
+        else
+          build_git_dependency(input_name, locked, original, rev)
+        end
+      end
+
+      sig do
+        params(
+          input_name: String,
+          locked: T::Hash[String, T.untyped],
+          original: T::Hash[String, T.untyped],
+          rev: String
+        ).returns(T.nilable(Dependabot::Dependency))
+      end
+      def build_git_dependency(input_name, locked, original, rev)
         url = build_url(locked)
         return unless url
 
@@ -161,6 +178,33 @@ module Dependabot
       sig { params(original: T::Hash[String, T.untyped]).returns(T::Boolean) }
       def revision_pinned?(original)
         !original.fetch("rev", nil).nil?
+      end
+
+      # Channel tarballs track a channel in the URL (e.g. nixos-26.05), not a git
+      # ref. Non-channel tarballs aren't updatable, so they're skipped.
+      sig do
+        params(
+          input_name: String,
+          original: T::Hash[String, T.untyped],
+          rev: String
+        ).returns(T.nilable(Dependabot::Dependency))
+      end
+      def build_tarball_dependency(input_name, original, rev)
+        url = original.fetch("url", nil)
+        channel = Channel.channel_name_from_url(url)
+        return unless channel
+
+        Dependency.new(
+          name: input_name,
+          version: rev,
+          package_manager: "nix",
+          requirements: [{
+            requirement: nil,
+            file: "flake.lock",
+            source: { type: "tarball", url: url, branch: nil, ref: channel },
+            groups: []
+          }]
+        )
       end
 
       sig { params(locked: T::Hash[String, T.untyped]).returns(T.nilable(String)) }

--- a/nix/lib/dependabot/nix/flake_nix_parser.rb
+++ b/nix/lib/dependabot/nix/flake_nix_parser.rb
@@ -3,6 +3,8 @@
 
 require "sorbet-runtime"
 
+require "dependabot/nix/channel"
+
 module Dependabot
   module Nix
     # Parses flake.nix content to locate input URL declarations and extract
@@ -62,35 +64,9 @@ module Dependabot
 
         url_str = match[:url]
 
-        # Try shorthand scheme first (github:, gitlab:, sourcehut:)
-        url_match = FLAKE_URL_PATTERN.match(url_str)
-        if url_match
-          return InputUrl.new(
-            full_url: url_str,
-            scheme: T.must(url_match[:scheme]),
-            owner: T.must(url_match[:owner]),
-            repo: T.must(url_match[:repo]),
-            ref: url_match[:ref],
-            query: url_match[:query],
-            match_start: match[:url_start],
-            match_end: match[:url_end]
-          )
-        end
-
-        # Try indirect/registry shorthand (e.g. nixpkgs/nixos-24.11)
-        indirect_match = INDIRECT_URL_PATTERN.match(url_str)
-        return unless indirect_match
-
-        InputUrl.new(
-          full_url: url_str,
-          scheme: "indirect",
-          owner: T.must(indirect_match[:id]),
-          repo: "",
-          ref: indirect_match[:ref],
-          query: nil,
-          match_start: match[:url_start],
-          match_end: match[:url_end]
-        )
+        build_shorthand_input(url_str, match) ||
+          build_tarball_input(url_str, match) ||
+          build_indirect_input(url_str, match)
       end
 
       sig { params(new_ref: String).returns(T.nilable(String)) }
@@ -116,6 +92,60 @@ module Dependabot
 
       sig { returns(String) }
       attr_reader :input_name
+
+      # Shorthand scheme URLs: github:, gitlab:, sourcehut:
+      sig { params(url_str: String, match: T::Hash[Symbol, T.untyped]).returns(T.nilable(InputUrl)) }
+      def build_shorthand_input(url_str, match)
+        url_match = FLAKE_URL_PATTERN.match(url_str)
+        return unless url_match
+
+        InputUrl.new(
+          full_url: url_str,
+          scheme: T.must(url_match[:scheme]),
+          owner: T.must(url_match[:owner]),
+          repo: T.must(url_match[:repo]),
+          ref: url_match[:ref],
+          query: url_match[:query],
+          match_start: match[:url_start],
+          match_end: match[:url_end]
+        )
+      end
+
+      # NixOS channel tarball URL, e.g. channels.nixos.org/nixos-26.05/nixexprs.tar.xz
+      sig { params(url_str: String, match: T::Hash[Symbol, T.untyped]).returns(T.nilable(InputUrl)) }
+      def build_tarball_input(url_str, match)
+        channel = Channel.channel_name_from_url(url_str)
+        return unless channel
+
+        InputUrl.new(
+          full_url: url_str,
+          scheme: "tarball",
+          owner: "",
+          repo: "",
+          ref: channel,
+          query: nil,
+          match_start: match[:url_start],
+          match_end: match[:url_end]
+        )
+      end
+
+      # Indirect/registry shorthand (e.g. nixpkgs/nixos-24.11)
+      sig { params(url_str: String, match: T::Hash[Symbol, T.untyped]).returns(T.nilable(InputUrl)) }
+      def build_indirect_input(url_str, match)
+        indirect_match = INDIRECT_URL_PATTERN.match(url_str)
+        return unless indirect_match
+
+        InputUrl.new(
+          full_url: url_str,
+          scheme: "indirect",
+          owner: T.must(indirect_match[:id]),
+          repo: "",
+          ref: indirect_match[:ref],
+          query: nil,
+          match_start: match[:url_start],
+          match_end: match[:url_end]
+        )
+      end
 
       # Returns a hash with :url, :url_start, :url_end if found, or nil.
       sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -180,8 +210,12 @@ module Dependabot
 
       sig { params(input_url: InputUrl, new_ref: String).returns(String) }
       def build_updated_url(input_url, new_ref)
-        if input_url.scheme == "indirect"
+        case input_url.scheme
+        when "indirect"
           "#{input_url.owner}/#{new_ref}"
+        when "tarball"
+          old_channel = T.must(input_url.ref)
+          input_url.full_url.sub("/#{old_channel}/", "/#{new_ref}/")
         else
           base = "#{input_url.scheme}:#{input_url.owner}/#{input_url.repo}/#{new_ref}"
           input_url.query ? "#{base}?#{input_url.query}" : base

--- a/nix/lib/dependabot/nix/ignore_filter.rb
+++ b/nix/lib/dependabot/nix/ignore_filter.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/nix/lib/dependabot/nix/ignore_filter.rb
+++ b/nix/lib/dependabot/nix/ignore_filter.rb
@@ -1,0 +1,44 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/nix/requirement"
+
+module Dependabot
+  module Nix
+    # Tests YY.MM version strings against Dependabot ignore conditions.
+    class IgnoreFilter
+      extend T::Sig
+
+      sig { params(ignored_versions: T::Array[String]).void }
+      def initialize(ignored_versions)
+        @ignored_versions = ignored_versions
+        @requirements = T.let(nil, T.nilable(T::Array[Gem::Requirement]))
+      end
+
+      sig { params(version_str: T.nilable(String)).returns(T::Boolean) }
+      def ignored?(version_str)
+        return false unless version_str
+        return false if requirements.empty?
+
+        gem_version = Gem::Version.new(version_str)
+        requirements.any? { |req| req.satisfied_by?(gem_version) }
+      end
+
+      private
+
+      sig { returns(T::Array[String]) }
+      attr_reader :ignored_versions
+
+      sig { returns(T::Array[Gem::Requirement]) }
+      def requirements
+        @requirements ||= ignored_versions.flat_map do |req|
+          Dependabot::Nix::Requirement.requirements_array(req)
+        rescue Gem::Requirement::BadRequirementError
+          []
+        end
+      end
+    end
+  end
+end

--- a/nix/lib/dependabot/nix/metadata_finder.rb
+++ b/nix/lib/dependabot/nix/metadata_finder.rb
@@ -5,18 +5,24 @@ require "sorbet-runtime"
 
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
+require "dependabot/nix/channel"
 
 module Dependabot
   module Nix
     class MetadataFinder < Dependabot::MetadataFinders::Base
       extend T::Sig
 
+      # Channel tarballs resolve to nixpkgs revisions, so metadata points there.
+      NIXPKGS_SOURCE_URL = "https://github.com/NixOS/nixpkgs"
+
       private
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        url = dependency.requirements.first&.fetch(:source)&.fetch(:url) ||
-              dependency.requirements.first&.fetch(:source)&.fetch("url")
+        source = dependency.requirements.first&.fetch(:source, nil)
+        url = source && (source[:url] || source["url"])
+
+        return Source.from_url(NIXPKGS_SOURCE_URL) if Channel.channel_url?(url)
 
         Source.from_url(url)
       end

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -7,6 +7,7 @@ require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
 require "dependabot/nix/version"
 require "dependabot/nix/requirement"
+require "dependabot/nix/channel"
 require "dependabot/git_commit_checker"
 
 module Dependabot
@@ -16,6 +17,7 @@ module Dependabot
 
       require_relative "update_checker/latest_version_finder"
       require_relative "update_checker/versioned_branch_finder"
+      require_relative "update_checker/channel_version_finder"
 
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_version
@@ -38,7 +40,9 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        if ref_pinned_to_version_tag?
+        if tarball_channel_input?
+          wrap_requirements(updated_requirements_for_channel)
+        elsif ref_pinned_to_version_tag?
           wrap_requirements(updated_requirements_for_tag)
         elsif ref_is_versioned_branch?
           wrap_requirements(updated_requirements_for_versioned_branch)
@@ -61,13 +65,68 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def fetch_latest_version
-        if ref_pinned_to_version_tag?
+        if tarball_channel_input?
+          fetch_latest_version_for_channel
+        elsif ref_pinned_to_version_tag?
           fetch_latest_version_for_tag
         elsif ref_is_versioned_branch?
           fetch_latest_version_for_versioned_branch || fetch_latest_version_for_commit
         else
           fetch_latest_version_for_commit
         end
+      end
+
+      # --- Tarball channel support ---
+
+      sig { returns(T::Boolean) }
+      def tarball_channel_input?
+        source = dependency.source_details(allowed_types: ["tarball"])
+        return false unless source
+
+        Channel.channel_url?(source[:url])
+      end
+
+      sig { returns(T.nilable(String)) }
+      def fetch_latest_version_for_channel
+        latest_channel&.fetch(:commit_sha) || channel_version_finder.current_channel_revision
+      end
+
+      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      def updated_requirements_for_channel
+        result = latest_channel
+        return dependency.requirements unless result
+
+        dependency.requirements.map do |req|
+          source = req[:source]
+          next req unless source
+
+          req.merge(source: source.merge(ref: result[:channel], url: result[:url]))
+        end
+      end
+
+      sig { returns(T.nilable(T::Hash[Symbol, String])) }
+      def latest_channel
+        @latest_channel ||= T.let(
+          channel_version_finder.latest_channel,
+          T.nilable(T::Hash[Symbol, String])
+        )
+      end
+
+      sig { returns(ChannelVersionFinder) }
+      def channel_version_finder
+        @channel_version_finder ||= T.let(
+          ChannelVersionFinder.new(
+            current_channel: T.must(tarball_channel_name),
+            credentials: credentials,
+            ignored_versions: ignored_versions
+          ),
+          T.nilable(ChannelVersionFinder)
+        )
+      end
+
+      sig { returns(T.nilable(String)) }
+      def tarball_channel_name
+        dependency.source_details(allowed_types: ["tarball"])&.fetch(:ref, nil)
       end
 
       # --- Tag-pinned ref support ---

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -83,7 +83,7 @@ module Dependabot
         source = dependency.source_details(allowed_types: ["tarball"])
         return false unless source
 
-        Channel.channel_url?(source[:url])
+        Channel.channel_url?(source[:url] || source["url"])
       end
 
       sig { returns(T.nilable(String)) }
@@ -118,7 +118,8 @@ module Dependabot
           ChannelVersionFinder.new(
             current_channel: T.must(tarball_channel_name),
             credentials: credentials,
-            ignored_versions: ignored_versions
+            ignored_versions: ignored_versions,
+            extension: tarball_channel_extension
           ),
           T.nilable(ChannelVersionFinder)
         )
@@ -126,7 +127,22 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def tarball_channel_name
-        dependency.source_details(allowed_types: ["tarball"])&.fetch(:ref, nil)
+        source = dependency.source_details(allowed_types: ["tarball"])
+        return unless source
+
+        ref = source[:ref] || source["ref"]
+        return ref if ref
+
+        # Fall back to the URL's channel when the source omits a ref.
+        Channel.channel_name_from_url(source[:url] || source["url"])
+      end
+
+      # Preserve the flake's existing tarball suffix (xz, gz, bz2) on a bump.
+      sig { returns(String) }
+      def tarball_channel_extension
+        source = dependency.source_details(allowed_types: ["tarball"])
+        url = source && (source[:url] || source["url"])
+        Channel.extension_from_url(url) || Channel::DEFAULT_EXTENSION
       end
 
       # --- Tag-pinned ref support ---

--- a/nix/lib/dependabot/nix/update_checker/channel_version_finder.rb
+++ b/nix/lib/dependabot/nix/update_checker/channel_version_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -24,13 +24,15 @@ module Dependabot
           params(
             current_channel: String,
             credentials: T::Array[Dependabot::Credential],
-            ignored_versions: T::Array[String]
+            ignored_versions: T::Array[String],
+            extension: String
           ).void
         end
-        def initialize(current_channel:, credentials:, ignored_versions: [])
+        def initialize(current_channel:, credentials:, ignored_versions: [], extension: Channel::DEFAULT_EXTENSION)
           @current_channel = T.let(Channel.new(current_channel), Channel)
           @credentials = credentials
           @ignored_versions = ignored_versions
+          @extension = extension
           @available_channels = T.let(nil, T.nilable(T::Array[String]))
           @ignore_filter = T.let(nil, T.nilable(IgnoreFilter))
         end
@@ -47,7 +49,7 @@ module Dependabot
           rev = resolve_revision(candidate.name)
           return unless rev
 
-          { channel: candidate.name, url: Channel.url_for(candidate.name), commit_sha: rev }
+          { channel: candidate.name, url: Channel.url_for(candidate.name, extension: extension), commit_sha: rev }
         end
 
         # Current channel's revision (refresh path).
@@ -66,6 +68,9 @@ module Dependabot
 
         sig { returns(T::Array[String]) }
         attr_reader :ignored_versions
+
+        sig { returns(String) }
+        attr_reader :extension
 
         sig { returns(T.nilable(Channel)) }
         def newest_candidate

--- a/nix/lib/dependabot/nix/update_checker/channel_version_finder.rb
+++ b/nix/lib/dependabot/nix/update_checker/channel_version_finder.rb
@@ -1,0 +1,121 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/nix/update_checker"
+require "dependabot/nix/channel"
+require "dependabot/nix/ignore_filter"
+require "dependabot/registry_client"
+
+module Dependabot
+  module Nix
+    class UpdateChecker
+      # Finds the latest NixOS channel and its revision: channels come from the
+      # channels.nixos.org S3 listing, revisions from each channel's git-revision marker.
+      class ChannelVersionFinder
+        extend T::Sig
+
+        CHANNELS_BASE_URL = "https://channels.nixos.org"
+        CHANNEL_KEY_PATTERN = %r{<Key>([^<]+)</Key>}
+        SHA_PATTERN = /\A[0-9a-f]{40}\z/
+
+        sig do
+          params(
+            current_channel: String,
+            credentials: T::Array[Dependabot::Credential],
+            ignored_versions: T::Array[String]
+          ).void
+        end
+        def initialize(current_channel:, credentials:, ignored_versions: [])
+          @current_channel = T.let(Channel.new(current_channel), Channel)
+          @credentials = credentials
+          @ignored_versions = ignored_versions
+          @available_channels = T.let(nil, T.nilable(T::Array[String]))
+          @ignore_filter = T.let(nil, T.nilable(IgnoreFilter))
+        end
+
+        # Newest same-family channel with its revision, or nil (rolling channel,
+        # already latest, or revision unresolvable).
+        sig { returns(T.nilable(T::Hash[Symbol, String])) }
+        def latest_channel
+          return unless current_channel.versioned?
+
+          candidate = newest_candidate
+          return unless candidate
+
+          rev = resolve_revision(candidate.name)
+          return unless rev
+
+          { channel: candidate.name, url: Channel.url_for(candidate.name), commit_sha: rev }
+        end
+
+        # Current channel's revision (refresh path).
+        sig { returns(T.nilable(String)) }
+        def current_channel_revision
+          resolve_revision(current_channel.name)
+        end
+
+        private
+
+        sig { returns(Channel) }
+        attr_reader :current_channel
+
+        sig { returns(T::Array[Dependabot::Credential]) }
+        attr_reader :credentials
+
+        sig { returns(T::Array[String]) }
+        attr_reader :ignored_versions
+
+        sig { returns(T.nilable(Channel)) }
+        def newest_candidate
+          candidates = available_channels
+                       .map { |name| Channel.new(name) }
+                       .select { |channel| channel.same_family?(current_channel) }
+                       .select { |channel| channel.newer_than?(current_channel) }
+                       .reject { |channel| ignore_filter.ignored?(channel.version_string) }
+
+          candidates.max_by { |channel| T.must(channel.version) }
+        end
+
+        sig { returns(T::Array[String]) }
+        def available_channels
+          @available_channels ||= fetch_available_channels
+        end
+
+        sig { returns(T::Array[String]) }
+        def fetch_available_channels
+          prefix = current_channel.prefix
+          return [] unless prefix
+
+          url = "#{CHANNELS_BASE_URL}/?delimiter=/&list-type=2&prefix=#{prefix}"
+          response = Dependabot::RegistryClient.get(url: url)
+          return [] unless response.status == 200
+
+          response.body.to_s.scan(CHANNEL_KEY_PATTERN).flatten
+        rescue StandardError => e
+          Dependabot.logger.info("Failed to list NixOS channels: #{e.class}: #{e.message}")
+          []
+        end
+
+        sig { params(channel: String).returns(T.nilable(String)) }
+        def resolve_revision(channel)
+          url = "#{CHANNELS_BASE_URL}/#{channel}/git-revision"
+          response = Dependabot::RegistryClient.get(url: url)
+          return unless response.status == 200
+
+          rev = response.body.to_s.strip
+          rev if rev.match?(SHA_PATTERN)
+        rescue StandardError => e
+          Dependabot.logger.info("Failed to resolve revision for #{channel}: #{e.class}: #{e.message}")
+          nil
+        end
+
+        sig { returns(IgnoreFilter) }
+        def ignore_filter
+          @ignore_filter ||= IgnoreFilter.new(ignored_versions)
+        end
+      end
+    end
+  end
+end

--- a/nix/lib/dependabot/nix/update_checker/versioned_branch_finder.rb
+++ b/nix/lib/dependabot/nix/update_checker/versioned_branch_finder.rb
@@ -4,7 +4,8 @@
 require "sorbet-runtime"
 
 require "dependabot/nix/update_checker"
-require "dependabot/nix/requirement"
+require "dependabot/nix/versioned_name"
+require "dependabot/nix/ignore_filter"
 require "dependabot/git_metadata_fetcher"
 require "dependabot/git_ref"
 
@@ -15,14 +16,6 @@ module Dependabot
       # and finds the latest branch matching the same prefix.
       class VersionedBranchFinder
         extend T::Sig
-
-        # Matches branch names with a YY.MM version segment and optional suffix.
-        # Captures: prefix (including separator), version, and optional suffix.
-        # Examples: "nixos-24.11" => prefix="nixos-", version="24.11", suffix=nil
-        #           "nixos-24.11-small" => prefix="nixos-", version="24.11", suffix="-small"
-        #           "release-24.11-aarch64" => prefix="release-", version="24.11", suffix="-aarch64"
-        VERSIONED_BRANCH_PATTERN = /\A(.+[.\-_])(\d{2}\.\d{2})(-[a-zA-Z0-9]+)?\z/
-        private_constant :VERSIONED_BRANCH_PATTERN
 
         sig do
           params(
@@ -42,22 +35,16 @@ module Dependabot
         # Returns true if the current ref looks like a versioned branch.
         sig { returns(T::Boolean) }
         def versioned_branch?
-          !branch_version_match.nil?
+          current_name.versioned?
         end
 
         # Returns the latest versioned branch info or nil if no newer branch exists.
         # Returns { branch: "nixos-25.05", commit_sha: "abc123" } or nil.
         sig { returns(T.nilable(T::Hash[Symbol, String])) }
         def latest_versioned_branch
-          match = branch_version_match
-          return unless match
+          return unless current_name.versioned?
 
-          prefix = match[1]
-          current_version = parse_version(T.must(match[2]))
-          return unless current_version
-
-          suffix = match[3] # nil if no suffix, e.g. "-small" if present
-          find_latest_branch(T.must(prefix), current_version, suffix)
+          find_latest_branch
         end
 
         private
@@ -74,25 +61,14 @@ module Dependabot
         sig { returns(T::Array[String]) }
         attr_reader :ignored_versions
 
-        sig { returns(T.nilable(MatchData)) }
-        def branch_version_match
-          @branch_version_match ||= T.let(
-            VERSIONED_BRANCH_PATTERN.match(current_ref),
-            T.nilable(MatchData)
-          )
+        sig { returns(VersionedName) }
+        def current_name
+          @current_name ||= T.let(VersionedName.new(current_ref), T.nilable(VersionedName))
         end
 
-        sig do
-          params(
-            prefix: String,
-            current_version: T::Array[Integer],
-            suffix: T.nilable(String)
-          ).returns(T.nilable(T::Hash[Symbol, String]))
-        end
-        def find_latest_branch(prefix, current_version, suffix)
-          candidates = remote_branches.filter_map do |ref|
-            build_candidate(ref, prefix, current_version, suffix)
-          end
+        sig { returns(T.nilable(T::Hash[Symbol, String])) }
+        def find_latest_branch
+          candidates = remote_branches.filter_map { |ref| build_candidate(ref) }
 
           latest = candidates.max_by { |c| c[:version] }
           return unless latest
@@ -100,62 +76,19 @@ module Dependabot
           { branch: latest[:branch].to_s, commit_sha: latest[:commit_sha].to_s }
         end
 
-        sig do
-          params(
-            ref: Dependabot::GitRef,
-            prefix: String,
-            current_version: T::Array[Integer],
-            suffix: T.nilable(String)
-          ).returns(T.nilable(T::Hash[Symbol, T.untyped]))
-        end
-        def build_candidate(ref, prefix, current_version, suffix)
-          branch_match = VERSIONED_BRANCH_PATTERN.match(ref.name)
-          return unless branch_match
-          return unless branch_match[1] == prefix
-          return unless branch_match[3] == suffix
+        sig { params(ref: Dependabot::GitRef).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+        def build_candidate(ref)
+          candidate = VersionedName.new(ref.name)
+          return unless candidate.same_family?(current_name)
+          return unless candidate.newer_than?(current_name)
+          return if ignore_filter.ignored?(candidate.version_string)
 
-          version_str = T.must(branch_match[2])
-          version = parse_version(version_str)
-          return unless version
-          return unless (version <=> current_version) == 1
-          return if version_ignored?(version_str)
-
-          { branch: ref.name, commit_sha: ref.commit_sha, version: version }
+          { branch: ref.name, commit_sha: ref.commit_sha, version: candidate.version }
         end
 
-        sig { params(version_str: String).returns(T::Boolean) }
-        def version_ignored?(version_str)
-          return false if ignore_requirements.empty?
-
-          gem_version = Gem::Version.new(version_str)
-          ignore_requirements.any? { |req| req.satisfied_by?(gem_version) }
-        end
-
-        # Parses "YY.MM" into [year, month] for comparison.
-        sig { params(version_str: String).returns(T.nilable(T::Array[Integer])) }
-        def parse_version(version_str)
-          parts = version_str.split(".")
-          return unless parts.length == 2
-
-          year = Integer(T.must(parts[0]), 10)
-          month = Integer(T.must(parts[1]), 10)
-          return unless month.between?(1, 12)
-
-          [year, month]
-        rescue ArgumentError
-          nil
-        end
-
-        sig { returns(T::Array[Gem::Requirement]) }
-        def ignore_requirements
-          @ignore_requirements ||= T.let(
-            ignored_versions.flat_map do |req|
-              Dependabot::Nix::Requirement.requirements_array(req)
-            rescue Gem::Requirement::BadRequirementError
-              []
-            end,
-            T.nilable(T::Array[Gem::Requirement])
-          )
+        sig { returns(IgnoreFilter) }
+        def ignore_filter
+          @ignore_filter ||= T.let(IgnoreFilter.new(ignored_versions), T.nilable(IgnoreFilter))
         end
 
         sig { returns(T::Array[Dependabot::GitRef]) }

--- a/nix/lib/dependabot/nix/versioned_name.rb
+++ b/nix/lib/dependabot/nix/versioned_name.rb
@@ -1,0 +1,88 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  module Nix
+    # Parses a NixOS-style versioned name (e.g. "nixos-26.05", "nixpkgs-24.11-darwin")
+    # into prefix, YY.MM version, and suffix, and compares names within a family.
+    class VersionedName
+      extend T::Sig
+
+      # prefix + YY.MM version + optional suffix, e.g. "nixpkgs-26.05-darwin".
+      VERSIONED_NAME_PATTERN =
+        /\A(?<prefix>.+[.\-_])(?<version>\d{2}\.\d{2})(?<suffix>-[a-zA-Z0-9]+)?\z/
+
+      sig { params(name: String).void }
+      def initialize(name)
+        @name = name
+        @match = T.let(VERSIONED_NAME_PATTERN.match(name), T.nilable(MatchData))
+      end
+
+      sig { returns(String) }
+      attr_reader :name
+
+      sig { returns(T::Boolean) }
+      def versioned?
+        !@match.nil?
+      end
+
+      sig { returns(T.nilable(String)) }
+      def prefix
+        @match&.[](:prefix)
+      end
+
+      sig { returns(T.nilable(String)) }
+      def suffix
+        @match&.[](:suffix)
+      end
+
+      sig { returns(T.nilable(String)) }
+      def version_string
+        @match&.[](:version)
+      end
+
+      # YY.MM as a comparable [year, month], or nil.
+      sig { returns(T.nilable(T::Array[Integer])) }
+      def version
+        version_str = version_string
+        return unless version_str
+
+        parse_version(version_str)
+      end
+
+      # Same prefix and suffix, so bumps stay within e.g. nixos-* (not nixos-*-small).
+      sig { params(other: VersionedName).returns(T::Boolean) }
+      def same_family?(other)
+        versioned? && other.versioned? &&
+          prefix == other.prefix && suffix == other.suffix
+      end
+
+      sig { params(other: VersionedName).returns(T::Boolean) }
+      def newer_than?(other)
+        this_version = version
+        other_version = other.version
+        return false unless this_version && other_version
+
+        (this_version <=> other_version) == 1
+      end
+
+      private
+
+      sig { params(version_str: String).returns(T.nilable(T::Array[Integer])) }
+      def parse_version(version_str)
+        parts = version_str.split(".")
+        return unless parts.length == 2
+
+        year = Integer(T.must(parts[0]), 10)
+        month = Integer(T.must(parts[1]), 10)
+        return unless month.between?(1, 12)
+
+        [year, month]
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/nix/spec/dependabot/nix/channel_spec.rb
+++ b/nix/spec/dependabot/nix/channel_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe Dependabot::Nix::Channel do
       expect(described_class.channel_url?("https://example.com/archive/v1.0.0.tar.gz")).to be(false)
     end
 
+    it "recognises gzip and bzip2 channel tarballs" do
+      expect(described_class.channel_url?("https://channels.nixos.org/nixos-26.05/nixexprs.tar.gz")).to be(true)
+      expect(described_class.channel_url?("https://channels.nixos.org/nixos-26.05/nixexprs.tar.bz2")).to be(true)
+    end
+
     it "handles nil" do
       expect(described_class.channel_url?(nil)).to be(false)
     end
@@ -36,10 +41,27 @@ RSpec.describe Dependabot::Nix::Channel do
     end
   end
 
+  describe ".extension_from_url" do
+    it "extracts the compression suffix for each supported format" do
+      expect(described_class.extension_from_url("https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz")).to eq("xz")
+      expect(described_class.extension_from_url("https://channels.nixos.org/nixos-26.05/nixexprs.tar.gz")).to eq("gz")
+      expect(described_class.extension_from_url("https://channels.nixos.org/nixos-26.05/nixexprs.tar.bz2")).to eq("bz2")
+    end
+
+    it "returns nil for non-channel URLs" do
+      expect(described_class.extension_from_url("https://example.com/foo.tar.gz")).to be_nil
+    end
+  end
+
   describe ".url_for" do
-    it "builds the channel tarball URL" do
+    it "builds the channel tarball URL, defaulting to xz" do
       expect(described_class.url_for("nixos-26.05"))
         .to eq("https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz")
+    end
+
+    it "preserves a non-default compression suffix" do
+      expect(described_class.url_for("nixos-26.05", extension: "gz"))
+        .to eq("https://channels.nixos.org/nixos-26.05/nixexprs.tar.gz")
     end
   end
 

--- a/nix/spec/dependabot/nix/channel_spec.rb
+++ b/nix/spec/dependabot/nix/channel_spec.rb
@@ -1,0 +1,53 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/nix/channel"
+
+RSpec.describe Dependabot::Nix::Channel do
+  describe ".channel_url?" do
+    it "recognises NixOS channel tarball URLs" do
+      expect(described_class.channel_url?("https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"))
+        .to be(true)
+    end
+
+    it "rejects the resolved releases URL" do
+      url = "https://releases.nixos.org/nixos/26.05/nixos-26.05.1550.bd0ff2d3eac2/nixexprs.tar.xz"
+      expect(described_class.channel_url?(url)).to be(false)
+    end
+
+    it "rejects unrelated tarball URLs" do
+      expect(described_class.channel_url?("https://example.com/archive/v1.0.0.tar.gz")).to be(false)
+    end
+
+    it "handles nil" do
+      expect(described_class.channel_url?(nil)).to be(false)
+    end
+  end
+
+  describe ".channel_name_from_url" do
+    it "extracts the channel segment" do
+      expect(described_class.channel_name_from_url("https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"))
+        .to eq("nixos-26.05")
+    end
+
+    it "returns nil for non-channel URLs" do
+      expect(described_class.channel_name_from_url("https://example.com/foo.tar.gz")).to be_nil
+    end
+  end
+
+  describe ".url_for" do
+    it "builds the channel tarball URL" do
+      expect(described_class.url_for("nixos-26.05"))
+        .to eq("https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz")
+    end
+  end
+
+  describe "version parsing (inherited from VersionedName)" do
+    it "exposes the channel name's version and family via the shared base" do
+      channel = described_class.new("nixos-26.05")
+      expect(channel.versioned?).to be(true)
+      expect(channel.same_family?(described_class.new("nixos-25.05"))).to be(true)
+    end
+  end
+end

--- a/nix/spec/dependabot/nix/file_parser_spec.rb
+++ b/nix/spec/dependabot/nix/file_parser_spec.rb
@@ -157,5 +157,69 @@ RSpec.describe Dependabot::Nix::FileParser do
           .to eq("https://github.corp.example.com/myteam/internal-lib")
       end
     end
+
+    context "with a NixOS channel tarball input" do
+      let(:flake_lock_content) { fixture("flake_with_tarball.lock") }
+
+      it "parses the tarball channel input" do
+        nixpkgs = dependencies.find { |d| d.name == "nixpkgs" }
+        expect(nixpkgs).to be_a(Dependabot::Dependency)
+        expect(nixpkgs.version).to eq("bd0ff2d3eac24699c3664d5966b9ef36f388e2ca")
+        expect(nixpkgs.requirements).to eq(
+          [{
+            requirement: nil,
+            file: "flake.lock",
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-26.05"
+            },
+            groups: []
+          }]
+        )
+      end
+
+      it "still parses git-backed inputs alongside it" do
+        expect(dependencies.map(&:name)).to contain_exactly("nixpkgs", "flake-utils")
+        flake_utils = dependencies.find { |d| d.name == "flake-utils" }
+        expect(flake_utils.requirements.first[:source][:type]).to eq("git")
+      end
+    end
+
+    context "with a non-NixOS tarball input" do
+      let(:flake_lock_content) do
+        <<~JSON
+          {
+            "nodes": {
+              "some-tarball": {
+                "locked": {
+                  "lastModified": 1700000000,
+                  "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                  "rev": "1111111111111111111111111111111111111111",
+                  "type": "tarball",
+                  "url": "https://example.com/archive/v1.0.0.tar.gz"
+                },
+                "original": {
+                  "type": "tarball",
+                  "url": "https://example.com/archive/v1.0.0.tar.gz"
+                }
+              },
+              "root": {
+                "inputs": {
+                  "some-tarball": "some-tarball"
+                }
+              }
+            },
+            "root": "root",
+            "version": 7
+          }
+        JSON
+      end
+
+      it "skips tarball inputs that are not NixOS channels" do
+        expect(dependencies).to be_empty
+      end
+    end
   end
 end

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -262,5 +262,120 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         expect(nix_file.content).not_to include("nixos-24.11")
       end
     end
+
+    context "with a NixOS channel tarball input (channel bumped)" do
+      let(:flake_nix_content) do
+        <<~NIX
+          {
+            inputs = {
+              nixpkgs.url = "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz";
+            };
+            outputs = { self, nixpkgs }: { };
+          }
+        NIX
+      end
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "new_rev_bbb",
+          previous_version: "old_rev_aaa",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-26.05"
+            },
+            groups: []
+          }],
+          previous_requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-25.05"
+            },
+            groups: []
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      let(:updated_lock_content) { '{"updated": true}' }
+
+      it "returns both flake.nix and flake.lock" do
+        expect(updated_files.length).to eq(2)
+        expect(updated_files.map(&:name)).to contain_exactly("flake.nix", "flake.lock")
+      end
+
+      it "rewrites the channel in flake.nix" do
+        nix_file = updated_files.find { |f| f.name == "flake.nix" }
+        expect(nix_file.content).to include('"https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"')
+        expect(nix_file.content).not_to include("nixos-25.05")
+      end
+
+      it "runs nix flake update for the input" do
+        updated_files
+        expect(Dependabot::SharedHelpers)
+          .to have_received(:run_shell_command)
+          .with("nix flake update nixpkgs", fingerprint: "nix flake update <input_name>")
+      end
+    end
+
+    context "with a NixOS channel tarball input (lock refresh only)" do
+      let(:flake_nix_content) do
+        <<~NIX
+          {
+            inputs = {
+              nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
+            };
+            outputs = { self, nixpkgs }: { };
+          }
+        NIX
+      end
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "new_rev_bbb",
+          previous_version: "old_rev_aaa",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-26.05"
+            },
+            groups: []
+          }],
+          previous_requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-26.05"
+            },
+            groups: []
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      let(:updated_lock_content) { '{"updated": true}' }
+
+      it "returns only the updated flake.lock" do
+        expect(updated_files.length).to eq(1)
+        expect(updated_files.first.name).to eq("flake.lock")
+      end
+    end
   end
 end

--- a/nix/spec/dependabot/nix/fixtures/flake_with_tarball.lock
+++ b/nix/spec/dependabot/nix/fixtures/flake_with_tarball.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780902259,
+        "narHash": "sha256-YMnBf9lk/LYgvqfmSSJuOGigtRs5Lsy26pJHVlR9yMY=",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.1550.bd0ff2d3eac2/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/spec/dependabot/nix/fixtures/flake_with_tarball.nix
+++ b/nix/spec/dependabot/nix/fixtures/flake_with_tarball.nix
@@ -1,0 +1,15 @@
+{
+  inputs = {
+    nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    {
+    };
+}

--- a/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
+++ b/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
@@ -231,6 +231,26 @@ RSpec.describe Dependabot::Nix::FlakeNixParser do
         expect(result.ref).to eq("nixos-24.11")
       end
     end
+
+    context "with a NixOS channel tarball URL" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz";
+            outputs = { self, nixpkgs }: { };
+          }
+        NIX
+      end
+
+      it "parses the channel name as the ref" do
+        result = described_class.find_input_url(content, "nixpkgs")
+
+        expect(result).not_to be_nil
+        expect(result.scheme).to eq("tarball")
+        expect(result.ref).to eq("nixos-26.05")
+        expect(result.full_url).to eq("https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz")
+      end
+    end
   end
 
   describe ".update_input_ref" do
@@ -319,6 +339,24 @@ RSpec.describe Dependabot::Nix::FlakeNixParser do
 
         expect(updated).to include('"nixpkgs/nixos-25.05"')
         expect(updated).not_to include("nixos-24.11")
+      end
+    end
+
+    context "with a NixOS channel tarball URL" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.nixpkgs.url = "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz";
+            outputs = { self, nixpkgs }: { };
+          }
+        NIX
+      end
+
+      it "rewrites the channel segment in the URL" do
+        updated = described_class.update_input_ref(content, "nixpkgs", "nixos-26.05")
+
+        expect(updated).to include('"https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"')
+        expect(updated).not_to include("nixos-25.05")
       end
     end
   end

--- a/nix/spec/dependabot/nix/ignore_filter_spec.rb
+++ b/nix/spec/dependabot/nix/ignore_filter_spec.rb
@@ -1,0 +1,59 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/nix/ignore_filter"
+
+RSpec.describe Dependabot::Nix::IgnoreFilter do
+  subject(:filter) { described_class.new(ignored_versions) }
+
+  describe "#ignored?" do
+    context "with no ignore conditions" do
+      let(:ignored_versions) { [] }
+
+      it "treats every version as allowed" do
+        expect(filter.ignored?("26.05")).to be(false)
+      end
+    end
+
+    context "with a matching equality condition" do
+      let(:ignored_versions) { ["= 26.05"] }
+
+      it "ignores the matching version" do
+        expect(filter.ignored?("26.05")).to be(true)
+      end
+
+      it "allows non-matching versions" do
+        expect(filter.ignored?("25.05")).to be(false)
+      end
+    end
+
+    context "with a range condition" do
+      let(:ignored_versions) { [">= 24"] }
+
+      it "ignores versions in the range" do
+        expect(filter.ignored?("24.11")).to be(true)
+      end
+
+      it "allows versions below the range" do
+        expect(filter.ignored?("23.11")).to be(false)
+      end
+    end
+
+    context "with an invalid condition" do
+      let(:ignored_versions) { ["not a requirement"] }
+
+      it "skips the bad condition and allows the version" do
+        expect(filter.ignored?("26.05")).to be(false)
+      end
+    end
+
+    context "with a nil version" do
+      let(:ignored_versions) { ["= 26.05"] }
+
+      it "returns false" do
+        expect(filter.ignored?(nil)).to be(false)
+      end
+    end
+  end
+end

--- a/nix/spec/dependabot/nix/metadata_finder_spec.rb
+++ b/nix/spec/dependabot/nix/metadata_finder_spec.rb
@@ -65,5 +65,29 @@ RSpec.describe Dependabot::Nix::MetadataFinder do
 
       it { is_expected.to eq("https://gitlab.com/myorg/myrepo") }
     end
+
+    context "when the source is a NixOS channel tarball" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+          previous_version: "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-26.05"
+            }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      it { is_expected.to eq("https://github.com/NixOS/nixpkgs") }
+    end
   end
 end

--- a/nix/spec/dependabot/nix/update_checker/channel_version_finder_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker/channel_version_finder_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe Dependabot::Nix::UpdateChecker::ChannelVersionFinder do
     described_class.new(
       current_channel: current_channel,
       credentials: credentials,
-      ignored_versions: ignored_versions
+      ignored_versions: ignored_versions,
+      extension: extension
     )
   end
 
   let(:credentials) { [] }
   let(:ignored_versions) { [] }
+  let(:extension) { Dependabot::Nix::Channel::DEFAULT_EXTENSION }
   let(:listing_url) { "https://channels.nixos.org/" }
 
   let(:channel_listing) do
@@ -58,6 +60,24 @@ RSpec.describe Dependabot::Nix::UpdateChecker::ChannelVersionFinder do
         finder.latest_channel
         expect(WebMock)
           .not_to have_requested(:get, "https://channels.nixos.org/nixos-26.05-small/git-revision")
+      end
+    end
+
+    context "with a non-default tarball extension" do
+      let(:current_channel) { "nixos-25.05" }
+      let(:extension) { "gz" }
+
+      before do
+        stub_request(:get, listing_url)
+          .with(query: hash_including("prefix" => "nixos-"))
+          .to_return(status: 200, body: channel_listing)
+        stub_request(:get, "https://channels.nixos.org/nixos-26.05/git-revision")
+          .to_return(status: 200, body: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca")
+      end
+
+      it "preserves the extension in the channel URL" do
+        expect(finder.latest_channel)
+          .to include(url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.gz")
       end
     end
 

--- a/nix/spec/dependabot/nix/update_checker/channel_version_finder_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker/channel_version_finder_spec.rb
@@ -1,0 +1,156 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/nix/update_checker/channel_version_finder"
+
+RSpec.describe Dependabot::Nix::UpdateChecker::ChannelVersionFinder do
+  subject(:finder) do
+    described_class.new(
+      current_channel: current_channel,
+      credentials: credentials,
+      ignored_versions: ignored_versions
+    )
+  end
+
+  let(:credentials) { [] }
+  let(:ignored_versions) { [] }
+  let(:listing_url) { "https://channels.nixos.org/" }
+
+  let(:channel_listing) do
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <Name>nix-channels</Name>
+        <Prefix>nixos-</Prefix>
+        <Contents><Key>nixos-24.11</Key><LastModified>2025-07-01T03:39:48.000Z</LastModified></Contents>
+        <Contents><Key>nixos-24.11-small</Key><LastModified>2025-07-01T11:45:13.000Z</LastModified></Contents>
+        <Contents><Key>nixos-25.05</Key><LastModified>2026-01-06T15:37:21.000Z</LastModified></Contents>
+        <Contents><Key>nixos-25.05-small</Key><LastModified>2026-01-03T10:42:03.000Z</LastModified></Contents>
+        <Contents><Key>nixos-26.05</Key><LastModified>2026-06-22T23:44:27.000Z</LastModified></Contents>
+        <Contents><Key>nixos-26.05-small</Key><LastModified>2026-06-24T20:46:42.000Z</LastModified></Contents>
+        <Contents><Key>nixos-unstable</Key><LastModified>2026-06-16T15:10:41.000Z</LastModified></Contents>
+      </ListBucketResult>
+    XML
+  end
+
+  describe "#latest_channel" do
+    context "with a versioned channel that has newer releases" do
+      let(:current_channel) { "nixos-25.05" }
+
+      before do
+        stub_request(:get, listing_url)
+          .with(query: hash_including("prefix" => "nixos-"))
+          .to_return(status: 200, body: channel_listing)
+        stub_request(:get, "https://channels.nixos.org/nixos-26.05/git-revision")
+          .to_return(status: 200, body: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca")
+      end
+
+      it "returns the newest same-family channel and its revision" do
+        expect(finder.latest_channel).to eq(
+          channel: "nixos-26.05",
+          url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+          commit_sha: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca"
+        )
+      end
+
+      it "does not cross into the -small family" do
+        finder.latest_channel
+        expect(WebMock)
+          .not_to have_requested(:get, "https://channels.nixos.org/nixos-26.05-small/git-revision")
+      end
+    end
+
+    context "when already on the newest channel" do
+      let(:current_channel) { "nixos-26.05" }
+
+      before do
+        stub_request(:get, listing_url)
+          .with(query: hash_including("prefix" => "nixos-"))
+          .to_return(status: 200, body: channel_listing)
+      end
+
+      it "returns nil" do
+        expect(finder.latest_channel).to be_nil
+      end
+    end
+
+    context "with a rolling (unstable) channel" do
+      let(:current_channel) { "nixos-unstable" }
+
+      it "returns nil without listing channels" do
+        expect(finder.latest_channel).to be_nil
+        expect(WebMock).not_to have_requested(:get, listing_url)
+      end
+    end
+
+    context "when the only newer channel is ignored" do
+      let(:current_channel) { "nixos-25.05" }
+      let(:ignored_versions) { ["= 26.05"] }
+
+      before do
+        stub_request(:get, listing_url)
+          .with(query: hash_including("prefix" => "nixos-"))
+          .to_return(status: 200, body: channel_listing)
+      end
+
+      it "returns nil" do
+        expect(finder.latest_channel).to be_nil
+      end
+    end
+
+    context "when the candidate revision cannot be resolved" do
+      let(:current_channel) { "nixos-25.05" }
+
+      before do
+        stub_request(:get, listing_url)
+          .with(query: hash_including("prefix" => "nixos-"))
+          .to_return(status: 200, body: channel_listing)
+        stub_request(:get, "https://channels.nixos.org/nixos-26.05/git-revision")
+          .to_return(status: 404, body: "")
+      end
+
+      it "returns nil" do
+        expect(finder.latest_channel).to be_nil
+      end
+    end
+
+    context "when listing the channels fails" do
+      let(:current_channel) { "nixos-25.05" }
+
+      before do
+        stub_request(:get, listing_url)
+          .with(query: hash_including("prefix" => "nixos-"))
+          .to_return(status: 500, body: "")
+      end
+
+      it "returns nil" do
+        expect(finder.latest_channel).to be_nil
+      end
+    end
+  end
+
+  describe "#current_channel_revision" do
+    let(:current_channel) { "nixos-26.05" }
+
+    before do
+      stub_request(:get, "https://channels.nixos.org/nixos-26.05/git-revision")
+        .to_return(status: 200, body: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca\n")
+    end
+
+    it "resolves the current channel revision, trimming whitespace" do
+      expect(finder.current_channel_revision).to eq("bd0ff2d3eac24699c3664d5966b9ef36f388e2ca")
+    end
+
+    context "when the response is not a valid revision" do
+      before do
+        stub_request(:get, "https://channels.nixos.org/nixos-26.05/git-revision")
+          .to_return(status: 200, body: "not-a-sha")
+      end
+
+      it "returns nil" do
+        expect(finder.current_channel_revision).to be_nil
+      end
+    end
+  end
+end

--- a/nix/spec/dependabot/nix/update_checker_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker_spec.rb
@@ -284,6 +284,87 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
         expect(checker.latest_version).to eq(current_sha)
       end
     end
+
+    context "with a NixOS channel tarball input that has a newer channel" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-25.05"
+            }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        channel_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::ChannelVersionFinder,
+          latest_channel: {
+            channel: "nixos-26.05",
+            url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+            commit_sha: "34268251cf55aa3d8c4c5e6f7a8b9c0d1e2f3a4b"
+          }
+        )
+        allow(Dependabot::Nix::UpdateChecker::ChannelVersionFinder)
+          .to receive(:new).and_return(channel_finder)
+      end
+
+      it "returns the revision of the newest channel" do
+        expect(checker.latest_version).to eq("34268251cf55aa3d8c4c5e6f7a8b9c0d1e2f3a4b")
+      end
+
+      it "reports as updatable" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be true
+      end
+    end
+
+    context "with a NixOS channel tarball input on the newest channel" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-26.05"
+            }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        channel_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::ChannelVersionFinder,
+          latest_channel: nil,
+          current_channel_revision: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca"
+        )
+        allow(Dependabot::Nix::UpdateChecker::ChannelVersionFinder)
+          .to receive(:new).and_return(channel_finder)
+      end
+
+      it "falls back to refreshing the current channel revision" do
+        expect(checker.latest_version).to eq("bd0ff2d3eac24699c3664d5966b9ef36f388e2ca")
+      end
+
+      it "reports as not updatable when the revision is unchanged" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be false
+      end
+    end
   end
 
   describe "#updated_requirements" do
@@ -370,6 +451,84 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
         updated = checker.updated_requirements
         expect(updated.first[:source][:ref]).to eq("nixos-25.05")
         expect(updated.first[:source][:branch]).to be_nil
+      end
+    end
+
+    context "with a NixOS channel tarball input that has a newer channel" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "old_rev_aaa",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-25.05"
+            }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        channel_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::ChannelVersionFinder,
+          latest_channel: {
+            channel: "nixos-26.05",
+            url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+            commit_sha: "new_rev_bbb"
+          }
+        )
+        allow(Dependabot::Nix::UpdateChecker::ChannelVersionFinder)
+          .to receive(:new).and_return(channel_finder)
+      end
+
+      it "rewrites the channel ref and url" do
+        updated = checker.updated_requirements
+        expect(updated.first[:source][:ref]).to eq("nixos-26.05")
+        expect(updated.first[:source][:url])
+          .to eq("https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz")
+      end
+    end
+
+    context "with a NixOS channel tarball input being refreshed" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "current_rev_ccc",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+              branch: nil,
+              ref: "nixos-26.05"
+            }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        channel_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::ChannelVersionFinder,
+          latest_channel: nil
+        )
+        allow(Dependabot::Nix::UpdateChecker::ChannelVersionFinder)
+          .to receive(:new).and_return(channel_finder)
+      end
+
+      it "leaves the channel ref and url unchanged" do
+        updated = checker.updated_requirements
+        expect(updated.first[:source][:ref]).to eq("nixos-26.05")
+        expect(updated.first[:source][:url])
+          .to eq("https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz")
       end
     end
   end

--- a/nix/spec/dependabot/nix/update_checker_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker_spec.rb
@@ -365,6 +365,90 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
         expect(checker.can_update?(requirements_to_unlock: :own)).to be false
       end
     end
+
+    context "with a NixOS channel tarball input whose source omits the ref" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz",
+              branch: nil
+            }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        channel_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::ChannelVersionFinder,
+          latest_channel: {
+            channel: "nixos-26.05",
+            url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz",
+            commit_sha: "34268251cf55aa3d8c4c5e6f7a8b9c0d1e2f3a4b"
+          }
+        )
+        allow(Dependabot::Nix::UpdateChecker::ChannelVersionFinder)
+          .to receive(:new).and_return(channel_finder)
+      end
+
+      it "parses the channel from the URL instead of crashing" do
+        expect(checker.latest_version).to eq("34268251cf55aa3d8c4c5e6f7a8b9c0d1e2f3a4b")
+        expect(Dependabot::Nix::UpdateChecker::ChannelVersionFinder)
+          .to have_received(:new).with(hash_including(current_channel: "nixos-25.05"))
+      end
+    end
+
+    context "with a NixOS channel tarball input using a non-xz suffix" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "nixpkgs",
+          version: "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+          requirements: [{
+            file: "flake.lock",
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "tarball",
+              url: "https://channels.nixos.org/nixos-25.05/nixexprs.tar.gz",
+              branch: nil,
+              ref: "nixos-25.05"
+            }
+          }],
+          package_manager: "nix"
+        )
+      end
+
+      before do
+        channel_finder = instance_double(
+          Dependabot::Nix::UpdateChecker::ChannelVersionFinder,
+          latest_channel: {
+            channel: "nixos-26.05",
+            url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.gz",
+            commit_sha: "34268251cf55aa3d8c4c5e6f7a8b9c0d1e2f3a4b"
+          }
+        )
+        allow(Dependabot::Nix::UpdateChecker::ChannelVersionFinder)
+          .to receive(:new).and_return(channel_finder)
+      end
+
+      it "passes the original extension to the channel finder" do
+        checker.latest_version
+        expect(Dependabot::Nix::UpdateChecker::ChannelVersionFinder)
+          .to have_received(:new).with(hash_including(extension: "gz"))
+      end
+
+      it "updates the requirement URL preserving the suffix" do
+        expect(checker.updated_requirements.first[:source][:url])
+          .to eq("https://channels.nixos.org/nixos-26.05/nixexprs.tar.gz")
+      end
+    end
   end
 
   describe "#updated_requirements" do

--- a/nix/spec/dependabot/nix/versioned_name_spec.rb
+++ b/nix/spec/dependabot/nix/versioned_name_spec.rb
@@ -1,0 +1,102 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/nix/versioned_name"
+
+RSpec.describe Dependabot::Nix::VersionedName do
+  describe "#versioned?" do
+    it "is true for a YY.MM name" do
+      expect(described_class.new("nixos-26.05").versioned?).to be(true)
+    end
+
+    it "is true for a suffixed name" do
+      expect(described_class.new("nixpkgs-26.05-darwin").versioned?).to be(true)
+    end
+
+    it "is false for a rolling name" do
+      expect(described_class.new("nixos-unstable").versioned?).to be(false)
+    end
+
+    it "is false for a semver-like tag" do
+      expect(described_class.new("v0.5").versioned?).to be(false)
+    end
+  end
+
+  describe "#prefix, #suffix, #version_string" do
+    it "splits a plain versioned name" do
+      name = described_class.new("nixos-26.05")
+      expect(name.prefix).to eq("nixos-")
+      expect(name.suffix).to be_nil
+      expect(name.version_string).to eq("26.05")
+    end
+
+    it "captures the suffix" do
+      name = described_class.new("nixos-24.11-small")
+      expect(name.prefix).to eq("nixos-")
+      expect(name.suffix).to eq("-small")
+      expect(name.version_string).to eq("24.11")
+    end
+
+    it "returns nil parts for a rolling name" do
+      name = described_class.new("nixos-unstable")
+      expect(name.prefix).to be_nil
+      expect(name.suffix).to be_nil
+      expect(name.version_string).to be_nil
+    end
+  end
+
+  describe "#version" do
+    it "parses YY.MM into [year, month]" do
+      expect(described_class.new("nixos-26.05").version).to eq([26, 5])
+    end
+
+    it "rejects an invalid month" do
+      expect(described_class.new("nixos-26.13").version).to be_nil
+    end
+
+    it "returns nil for a rolling name" do
+      expect(described_class.new("nixos-unstable").version).to be_nil
+    end
+  end
+
+  describe "#same_family?" do
+    let(:current) { described_class.new("nixos-25.05") }
+
+    it "matches the same prefix and suffix" do
+      expect(described_class.new("nixos-26.05").same_family?(current)).to be(true)
+    end
+
+    it "rejects a different suffix" do
+      expect(described_class.new("nixos-26.05-small").same_family?(current)).to be(false)
+    end
+
+    it "rejects a different prefix" do
+      expect(described_class.new("release-26.05").same_family?(current)).to be(false)
+    end
+
+    it "rejects a rolling name" do
+      expect(described_class.new("nixos-unstable").same_family?(current)).to be(false)
+    end
+  end
+
+  describe "#newer_than?" do
+    let(:current) { described_class.new("nixos-25.05") }
+
+    it "is true for a later version in the same year" do
+      expect(described_class.new("nixos-25.11").newer_than?(current)).to be(true)
+    end
+
+    it "is true across a year boundary" do
+      expect(described_class.new("nixos-26.05").newer_than?(described_class.new("nixos-25.11"))).to be(true)
+    end
+
+    it "is false for an equal version" do
+      expect(described_class.new("nixos-25.05").newer_than?(current)).to be(false)
+    end
+
+    it "is false for an earlier version" do
+      expect(described_class.new("nixos-24.11").newer_than?(current)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Adds Nix support for updating NixOS channel tarball inputs (e.g. `inputs.nixpkgs.url = "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"`). Dependabot bumps to a newer stable channel when one exists (editing `flake.nix`), otherwise refreshes the locked revision.

### Anything you want to highlight for special attention from reviewers?

Channels come from the channels.nixos.org S3 listing; revisions from each channel's `git-revision` marker. Shared `VersionedName` and `IgnoreFilter` value objects de-duplicate logic between the branch and channel finders.

### How will you know you've accomplished your goal?

New specs cover the parser, `flake.nix` rewriting, channel finder, updater, and metadata. The nix suite (178 examples), RuboCop, and Sorbet all pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
