### PR TITLE
Fix vcpkg empty PRs for up-to-date baselines

### DIFF
--- a/vcpkg/lib/dependabot/vcpkg/update_checker.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker.rb
@@ -67,7 +67,7 @@ module Dependabot
       end
 
       # `latest_version` is a git tag but the baseline is a commit SHA, so the base check never
-      # matches and reports an up-to-date baseline as stale. Compare the release SHA instead.
+      # matches and reports an up-to-date baseline as stale. Match the release commit SHA by prefix.
       sig { returns(T::Boolean) }
       def sha1_version_up_to_date?
         return super unless registry_dependency?
@@ -75,7 +75,7 @@ module Dependabot
         latest_commit_sha = latest_version_finder.latest_release_info&.details&.dig("commit_sha")
         return super unless latest_commit_sha
 
-        latest_commit_sha == dependency.version
+        latest_commit_sha.start_with?(T.must(dependency.version))
       end
 
       # Vcpkg doesn't support full unlocking since dependencies are tracked via baselines

--- a/vcpkg/lib/dependabot/vcpkg/update_checker.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker.rb
@@ -66,6 +66,18 @@ module Dependabot
         !registry_dependency? && dependency.requirements.any? { |req| req[:requirement] }
       end
 
+      # `latest_version` is a git tag but the baseline is a commit SHA, so the base check never
+      # matches and reports an up-to-date baseline as stale. Compare the release SHA instead.
+      sig { returns(T::Boolean) }
+      def sha1_version_up_to_date?
+        return super unless registry_dependency?
+
+        latest_commit_sha = latest_version_finder.latest_release_info&.details&.dig("commit_sha")
+        return super unless latest_commit_sha
+
+        latest_commit_sha == dependency.version
+      end
+
       # Vcpkg doesn't support full unlocking since dependencies are tracked via baselines
       sig { override.returns(T::Boolean) }
       def latest_version_resolvable_with_full_unlock? = false

--- a/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
@@ -206,6 +206,15 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
       end
     end
 
+    context "when the baseline is an abbreviated SHA that prefixes the latest release commit" do
+      let(:dependency_version) { "9b75e78" }
+      let(:commit_sha) { "9b75e789ece3f942159b8500584e35aafe3979ff" }
+
+      it "is up to date" do
+        expect(up_to_date).to be(true)
+      end
+    end
+
     context "when there is no resolvable latest release" do
       let(:commit_sha) { dependency_version }
       let(:mock_latest_release_info) { nil }

--- a/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
@@ -148,6 +148,74 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
     end
   end
 
+  describe "#up_to_date?" do
+    subject(:up_to_date) { checker.up_to_date? }
+
+    let(:dependency_version) { "9b75e789ece3f942159b8500584e35aafe3979ff" }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: dependency_name,
+        version: dependency_version,
+        requirements: [{
+          requirement: nil,
+          groups: [],
+          source: {
+            type: "git",
+            url: "https://github.com/microsoft/vcpkg.git",
+            ref: "master"
+          },
+          file: "vcpkg.json"
+        }],
+        package_manager: "vcpkg"
+      )
+    end
+
+    let(:latest_version) { "2025.06.13" }
+    let(:latest_version_finder) { instance_double(Dependabot::Vcpkg::UpdateChecker::LatestVersionFinder) }
+    let(:mock_latest_release_info) do
+      instance_double(
+        Dependabot::Package::PackageRelease,
+        details: { "commit_sha" => commit_sha, "tag_sha" => "tag123" }
+      )
+    end
+
+    before do
+      allow(Dependabot::Vcpkg::UpdateChecker::LatestVersionFinder)
+        .to receive(:new)
+        .and_return(latest_version_finder)
+      allow(latest_version_finder)
+        .to receive_messages(
+          latest_version: latest_version,
+          latest_release_info: mock_latest_release_info
+        )
+    end
+
+    context "when the baseline already points at the latest release commit" do
+      let(:commit_sha) { dependency_version }
+
+      it "is up to date and does not propose an empty update" do
+        expect(up_to_date).to be(true)
+      end
+    end
+
+    context "when the baseline points at an older commit than the latest release" do
+      let(:commit_sha) { "1111111111111111111111111111111111111111" }
+
+      it "is not up to date" do
+        expect(up_to_date).to be(false)
+      end
+    end
+
+    context "when there is no resolvable latest release" do
+      let(:commit_sha) { dependency_version }
+      let(:mock_latest_release_info) { nil }
+
+      it "falls back to the base behaviour and is not up to date" do
+        expect(up_to_date).to be(false)
+      end
+    end
+  end
+
   describe "#updated_requirements" do
     subject(:updated_requirements) { checker.updated_requirements }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #13068. vcpkg opened empty PRs. A `builtin-baseline` (or registry `baseline`) is a commit SHA, but `latest_version` resolves to a git tag, so the base up-to-date check compared a tag name against a SHA and never matched. An already-current baseline looked stale and produced a no-op PR. This overrides `sha1_version_up_to_date?` to compare the latest release's commit SHA against the baseline.

### Anything you want to highlight for special attention from reviewers?

Mirrors the `pre_commit` ecosystem.

### How will you know you've accomplished your goal?

Added `#up_to_date?` specs for the at-latest, behind, and no-release cases.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
