### PR TITLE
Fix file updater failed to update for all support files sentry error

### DIFF
--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -168,6 +168,11 @@ module Dependabot
       @notices.concat(updater_notices)
 
       updated_files = all_files.reject(&:support_file?)
+
+      # If the file updater only produced support files, include them — they are the
+      # primary update targets (e.g. provider requirements in Terraform local modules,
+      # build-system deps in UV workspace members).
+      updated_files = all_files if updated_files.empty? && all_files.any?
       updated_files
     end
 

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -158,8 +158,11 @@ module Dependabot
       # Create file updater and collect notices from it
       file_updater = file_updater_for(relevant_dependencies)
 
-      # Collect regenerated files (including support files); we filter support files out of
-      # the returned updated files below since they are not manifests.
+      # Collect all regenerated files (including support files). When non-support
+      # files exist, we exclude support files since they are contextual (not manifests).
+      # When the updater only modified support files, they ARE the primary update targets
+      # (e.g. provider requirements in Terraform local modules, build-system deps in UV
+      # workspace members) and must be included.
       all_files = file_updater.updated_dependency_files
       @regenerated_dependency_files = all_files
 
@@ -168,10 +171,6 @@ module Dependabot
       @notices.concat(updater_notices)
 
       updated_files = all_files.reject(&:support_file?)
-
-      # If the file updater only produced support files, include them — they are the
-      # primary update targets (e.g. provider requirements in Terraform local modules,
-      # build-system deps in UV workspace members).
       updated_files = all_files if updated_files.empty? && all_files.any?
       updated_files
     end

--- a/updater/spec/dependabot/dependency_change_builder_spec.rb
+++ b/updater/spec/dependabot/dependency_change_builder_spec.rb
@@ -279,21 +279,16 @@ RSpec.describe Dependabot::DependencyChangeBuilder do
         stub_file_updater(updated_dependency_files: updated_support_files, notices: updater_notices)
       end
 
-      it "raises a generic no-files error" do
-        expect { create_change }
-          .to raise_error(
-            Dependabot::DependabotError,
-            "FileUpdater failed to update any files for: dummy-pkg-b (1.1.0 → 1.2.0)"
-          )
+      it "includes support files as primary update targets" do
+        dependency_change = create_change
+
+        expect(dependency_change).to be_a(Dependabot::DependencyChange)
+        expect(dependency_change.updated_dependency_files.map(&:name))
+          .to eq(updated_support_files.map(&:name))
       end
 
-      it "collects notices before raising" do
-        expect { create_change }
-          .to raise_error(
-            Dependabot::DependabotError,
-            "FileUpdater failed to update any files for: dummy-pkg-b (1.1.0 → 1.2.0)"
-          )
-
+      it "collects notices" do
+        create_change
         expect(notices).to eq(updater_notices)
       end
     end
@@ -313,12 +308,12 @@ RSpec.describe Dependabot::DependencyChangeBuilder do
         stub_file_updater(updated_dependency_files: support_files)
       end
 
-      it "raises a no-files error listing sorted and unique dependency names" do
-        expect { create_change }
-          .to raise_error(
-            Dependabot::DependabotError,
-            "FileUpdater failed to update any files for: dummy-pkg-a, dummy-pkg-b"
-          )
+      it "includes support files as primary update targets" do
+        dependency_change = create_change
+
+        expect(dependency_change).to be_a(Dependabot::DependencyChange)
+        expect(dependency_change.updated_dependency_files.map(&:name))
+          .to eq(support_files.map(&:name))
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?
Fix `Dependabot::DependabotError: FileUpdater failed to update any files` errors occurring across multiple ecosystems when the only files modified by a FileUpdater are marked as `support_file`.

PR #14198 introduced `all_files.reject(&:support_file?)` filtering in `DependencyChangeBuilder#generate_dependency_files`. This correctly excludes contextual support files when non-support files are also present, but causes a regression when the updated dependency lives *exclusively* in support files — e.g. Terraform provider requirements in local module `.tf` files, or UV build-system dependencies in workspace member `pyproject.toml` files. In those cases, filtering removes every updated file, producing an empty set that triggers the error.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
The fix is a single fallback in `DependencyChangeBuilder`: if `reject(&:support_file?)` yields an empty list but the file updater *did* produce updated files, we include all of them. This preserves the existing behavior of excluding support files when non-support files are present, while allowing support-file-only updates to succeed.

This is an ecosystem-agnostic fix — no per-ecosystem changes are needed. The alternative of clearing `support_file` flags inside each ecosystem's file updater would require changes in every affected ecosystem and is fragile against future additions.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- Some of the testes Sentry errors stop recurring
- Updated specs in `dependency_change_builder_spec.rb` confirm that support-file-only results produce a valid `DependencyChange` instead of raising.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
