### PR TITLE
Map additional NuGet feed errors to private_source_bad_response

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -489,7 +489,7 @@ public class MSBuildHelperTests : TestBase
             // output
             "The content at 'https://nuget.example.com/v3/some.package/index.json' is not a valid JSON object.",
             // expectedError
-            new PrivateSourceBadResponse(["http://localhost/test-feed"], "unused"),
+            new PrivateSourceBadResponse(["https://nuget.example.com/v3/some.package/index.json"], "unused"),
         ];
 
         yield return

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -478,6 +478,14 @@ public class MSBuildHelperTests : TestBase
 
         yield return
         [
+            // output
+            "error : End of Central Directory record could not be found.",
+            // expectedError
+            new PrivateSourceBadResponse(["http://localhost/test-feed"], "unused"),
+        ];
+
+        yield return
+        [
             // a generic 404 (e.g., a misconfigured credential in a `packages.config` scenario) is reported as a bad response
             // output
             "Failed to fetch results from V2 feed at 'https://nuget.example.com/FindPackagesById()?id='Some.Package'&semVerLevel=2.0.0' with following message : Response status code does not indicate success: 404 (Not Found)",

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -478,6 +478,14 @@ public class MSBuildHelperTests : TestBase
 
         yield return
         [
+            // a generic 404 (e.g., a misconfigured credential in a `packages.config` scenario) is reported as a bad response
+            // output
+            "Failed to fetch results from V2 feed at 'https://nuget.example.com/FindPackagesById()?id='Some.Package'&semVerLevel=2.0.0' with following message : Response status code does not indicate success: 404 (Not Found)",
+            // expectedError
+            new PrivateSourceBadResponse(["https://nuget.example.com"], "unused"),
+        ];
+        yield return
+        [
             // output
             "The file is not a valid nupkg.",
             // expectedError

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -486,6 +486,14 @@ public class MSBuildHelperTests : TestBase
 
         yield return
         [
+            // output
+            "The content at 'https://nuget.example.com/v3/some.package/index.json' is not a valid JSON object.",
+            // expectedError
+            new PrivateSourceBadResponse(["http://localhost/test-feed"], "unused"),
+        ];
+
+        yield return
+        [
             // a generic 404 (e.g., a misconfigured credential in a `packages.config` scenario) is reported as a bad response
             // output
             "Failed to fetch results from V2 feed at 'https://nuget.example.com/FindPackagesById()?id='Some.Package'&semVerLevel=2.0.0' with following message : Response status code does not indicate success: 404 (Not Found)",

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -726,6 +726,7 @@ internal static partial class MSBuildHelper
             new Regex(@"The file is not a valid nupkg"),
             new Regex(@"The response ended prematurely\. \(ResponseEnded\)"),
             new Regex(@"The content at '.*' is not valid XML\."),
+            new Regex(@"End of Central Directory record could not be found\."),
         };
         if (patterns.Any(p => p.IsMatch(stdout)))
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -726,6 +726,7 @@ internal static partial class MSBuildHelper
             new Regex(@"The file is not a valid nupkg"),
             new Regex(@"The response ended prematurely\. \(ResponseEnded\)"),
             new Regex(@"The content at '.*' is not valid XML\."),
+            new Regex(@"The content at '.*' is not a valid JSON object\."),
             new Regex(@"End of Central Directory record could not be found\."),
         };
         if (patterns.Any(p => p.IsMatch(stdout)))

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -667,6 +667,7 @@ internal static partial class MSBuildHelper
         ThrowOnRateLimitExceeded(output);
         ThrowOnTimeout(output);
         ThrowOnBadResponse(output);
+        ThrowOnNotFoundResponse(output);
         ThrowOnUnparseableFile(output);
         ThrowOnMultipleProjectsForPackagesConfig(output);
         ThrowOnCircularDependency(output);
@@ -729,6 +730,19 @@ internal static partial class MSBuildHelper
         if (patterns.Any(p => p.IsMatch(stdout)))
         {
             throw new HttpRequestException(message: stdout, inner: null, statusCode: System.Net.HttpStatusCode.InternalServerError);
+        }
+    }
+
+    private static void ThrowOnNotFoundResponse(string stdout)
+    {
+        // This commonly occurs in `packages.config` scenarios when a feed is misconfigured (e.g., a bad
+        // credential or URL); it's a user configuration error rather than an updater failure.  The URI is
+        // the portion before the `/FindPackagesById` path.
+        var pattern = new Regex(@"Failed to fetch results from V2 feed at '(?<Uri>.+?)/FindPackagesById.*Response status code does not indicate success: 404");
+        var match = pattern.Match(stdout);
+        if (match.Success)
+        {
+            throw new BadResponseException(stdout, uri: match.Groups["Uri"].Value);
         }
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -726,7 +726,6 @@ internal static partial class MSBuildHelper
             new Regex(@"The file is not a valid nupkg"),
             new Regex(@"The response ended prematurely\. \(ResponseEnded\)"),
             new Regex(@"The content at '.*' is not valid XML\."),
-            new Regex(@"The content at '.*' is not a valid JSON object\."),
             new Regex(@"End of Central Directory record could not be found\."),
         };
         if (patterns.Any(p => p.IsMatch(stdout)))
@@ -737,12 +736,18 @@ internal static partial class MSBuildHelper
 
     private static void ThrowOnNotFoundResponse(string stdout)
     {
-        // This commonly occurs in `packages.config` scenarios when a feed is misconfigured (e.g., a bad
-        // credential or URL); it's a user configuration error rather than an updater failure.  The URI is
-        // the portion before the `/FindPackagesById` path.
-        var pattern = new Regex(@"Failed to fetch results from V2 feed at '(?<Uri>.+?)/FindPackagesById.*Response status code does not indicate success: 404");
-        var match = pattern.Match(stdout);
-        if (match.Success)
+        // These commonly occur when a feed is misconfigured (e.g., a bad credential or URL); they're a user
+        // configuration error rather than an updater failure.  In each case a URI is extracted from the
+        // message and passed through to the reported error.
+        var patterns = new[]
+        {
+            // V2 feed 404; the URI is the portion before the `/FindPackagesById` path
+            new Regex(@"Failed to fetch results from V2 feed at '(?<Uri>.+?)/FindPackagesById.*Response status code does not indicate success: 404"),
+            // feed returned content that couldn't be parsed as a valid JSON object
+            new Regex(@"The content at '(?<Uri>[^']*)' is not a valid JSON object\."),
+        };
+        var match = patterns.Select(p => p.Match(stdout)).FirstOrDefault(m => m.Success);
+        if (match is not null)
         {
             throw new BadResponseException(stdout, uri: match.Groups["Uri"].Value);
         }


### PR DESCRIPTION
Several NuGet feed error messages (most common in packages.config scenarios) indicate a misconfigured or misbehaving private feed rather than an updater failure. This PR teaches MSBuildHelper.ThrowOnError to recognize them and surface a `private_source_bad_response` job error.

### New errors mapped to private_source_bad_response

- **V2 feed 404** — `Failed to fetch results from V2 feed at '...' ... Response status code does not indicate success: 404`. The feed URI (the portion before the `/FindPackagesById` path) is extracted and passed through to the reported error.
- **Invalid JSON object** — `The content at '...' is not a valid JSON object.`. The content URI is extracted and passed through to the reported error.
- **Corrupt/truncated nupkg** — `End of Central Directory record could not be found.`.

### Notes

- URI-extracting cases throw `BadResponseException` (carrying the extracted URI); the remaining case is handled by `ThrowOnBadResponse`. Both map to `PrivateSourceBadResponse`.
- The new 404 check is ordered after `ThrowOnMissingPackages` so the more specific 'package not found' V2 message still maps to `DependencyNotFound`.

Tests added/updated in `MSBuildHelperTests.GenerateErrorFromToolOutput` (30 passing).