### PR TITLE
[Update Graph] Report empty manifests as present but empty instead of omitting them

### DIFF
--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -165,7 +165,12 @@ module GithubApi
       returns(T::Hash[String, T.untyped])
     end
     def manifests
-      return {} if resolved_dependencies.empty?
+      # We only omit the manifest entry when there is no real manifest file to report, e.g. an empty
+      # submission representing a directory where no manifests were found or a failure occurred.
+      #
+      # A manifest file that genuinely resolves to no dependencies should still be submitted with an
+      # empty `resolved` collection so the snapshot reflects that the file was scanned.
+      return {} if manifest_file.name.empty?
 
       {
         manifest_file.path => {

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -517,8 +517,9 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
     end
   end
 
-  # This is mainly for documentation purposes, this is unlikely to happen in the real world.
-  context "with a set of empty dependency files" do
+  # A manifest file that resolves to no dependencies should still be reported so the snapshot
+  # records that the file was scanned, rather than being omitted from the manifest list.
+  context "with a set of dependency files that resolve to no dependencies" do
     let(:directories) { [directory] }
     let(:directory) { "/" }
     let(:repo_contents_path) { build_tmp_repo("bundler/original", path: "") }
@@ -538,12 +539,22 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       ]
     end
 
-    it "generates a snapshot with metadata and an empty manifest list" do
+    it "generates a snapshot reporting the manifest with an empty resolved collection" do
       expect(service).to receive(:create_dependency_submission) do |args|
         payload = args[:dependency_submission].payload
 
         expect(payload[:job][:correlator]).to eq("dependabot-bundler")
-        expect(payload[:manifests]).to be_empty
+
+        # The manifest is still reported, with no resolved dependencies
+        expect(payload[:manifests].length).to eq(1)
+
+        manifest = payload[:manifests].fetch("/Gemfile.lock")
+        expect(manifest[:name]).to eq("/Gemfile.lock")
+        expect(manifest[:resolved]).to be_empty
+
+        # The snapshot is a successful scan
+        expect(payload[:metadata][:status]).to eq(GithubApi::DependencySubmission::SnapshotStatus::SUCCESS.serialize)
+        expect(payload[:metadata][:scanned_manifest_path]).to eql("rubygems::/")
       end
 
       update_graph_processor.run

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -204,6 +204,41 @@ RSpec.describe GithubApi::DependencySubmission do
     it_behaves_like "dependency_submission", true
   end
 
+  context "with a manifest file but no resolved dependencies" do
+    include DependencyFileHelpers
+
+    subject(:dependency_submission) do
+      described_class.new(
+        job_id: "9999",
+        branch: "main",
+        sha: "fake-sha",
+        package_manager: "bundler",
+        manifest_file: lockfile,
+        resolved_dependencies: {}
+      )
+    end
+
+    let(:lockfile) do
+      Dependabot::DependencyFile.new(
+        name: "Gemfile.lock",
+        content: fixture("bundler/original/Gemfile.lock"),
+        directory: "/"
+      )
+    end
+
+    it "still reports the manifest with an empty resolved collection" do
+      payload = dependency_submission.payload
+
+      expect(payload[:manifests].length).to eq(1)
+
+      manifest = payload[:manifests].fetch("/Gemfile.lock")
+      expect(manifest[:name]).to eq("/Gemfile.lock")
+      expect(manifest[:file][:source_location]).to eq("Gemfile.lock")
+      expect(manifest[:metadata][:ecosystem]).to eq("rubygems")
+      expect(manifest[:resolved]).to be_empty
+    end
+  end
+
   context "when the commit SHA is 64 characters (SHA-256 repo)" do
     subject(:dependency_submission) do
       described_class.new(

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -205,8 +205,6 @@ RSpec.describe GithubApi::DependencySubmission do
   end
 
   context "with a manifest file but no resolved dependencies" do
-    include DependencyFileHelpers
-
     subject(:dependency_submission) do
       described_class.new(
         job_id: "9999",


### PR DESCRIPTION
### What are you trying to accomplish?

We've encountered a corner case where someone has a repository that contains a set of manifest/lockfiles that have no dependencies.

Our current behaviour is 'no dependencies? no manifest!' but this introduces a problem when we diff snapshots as we end up waiting for a snapshot that covers the empty manifest path that the evaluator can see in the repository file system.

### Anything you want to highlight for special attention from reviewers?

This is a fairly straightforward 'empty isn't nil' fix.

### How will you know you've accomplished your goal?

We will be able to verify a PR evaluates properly when comparing a change that empties a lockfile of dependencies without deleting it.

I have also prepared [a failing smoke test ](https://github.com/dependabot/smoke-tests/pull/540)I will check in once this fix is in place that acts as a clean repro.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
