### PR TITLE
Support `version` and `security` NuGet job commands

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
@@ -421,8 +421,10 @@ public class JobTests
     }
 
     [Theory]
+    [InlineData("version", JobCommand.Version)]
     [InlineData("update", JobCommand.Update)]
     [InlineData("recreate", JobCommand.Recreate)]
+    [InlineData("security", JobCommand.Security)]
     [InlineData("graph", JobCommand.Graph)]
     [InlineData("", JobCommand.None)]
     public void CommandDeserialization_KnownValues(string commandValue, JobCommand expectedCommand)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommand.cs
@@ -3,7 +3,9 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 public enum JobCommand
 {
     None,
+    Version,
     Update,
     Recreate,
+    Security,
     Graph,
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommandConverter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/JobCommandConverter.cs
@@ -30,8 +30,10 @@ public class JobCommandConverter : JsonConverter<JobCommand>
         return value switch
         {
             "" => JobCommand.None,
+            "version" => JobCommand.Version,
             "update" => JobCommand.Update,
             "recreate" => JobCommand.Recreate,
+            "security" => JobCommand.Security,
             "graph" => JobCommand.Graph,
             _ => LogAndDefault(value),
         };
@@ -47,8 +49,10 @@ public class JobCommandConverter : JsonConverter<JobCommand>
     {
         var str = value switch
         {
+            JobCommand.Version => "version",
             JobCommand.Update => "update",
             JobCommand.Recreate => "recreate",
+            JobCommand.Security => "security",
             JobCommand.Graph => "graph",
             _ => "",
         };


### PR DESCRIPTION
Support `version` and `security` NuGet job commands

## Summary
NuGet logs were reporting `Unknown job command value: "version"; defaulting to None.` The job command parser (`JobCommandConverter`) only recognized `update`, `recreate`, and `graph`, so valid `version` (and `security`) commands were logged as unknown and silently downgraded to `None`.

The authoritative set of job command values is defined by the `RunCommand` type in [dependabot/cli](https://github.com/dependabot/cli/blob/main/internal/model/smoke.go):

| Value | Constant |
|-------|----------|
| `update` | UpdateFilesCommand |
| `version` | VersionCommand |
| `recreate` | RecreateCommand |
| `security` | SecurityCommand |
| `graph` | UpdateGraphCommand |

This PR adds the two missing values (`version`, `security`) so all five are handled.

## Changes
- `JobCommand.cs` — add `Version` and `Security` enum members.
- `JobCommandConverter.cs` — parse and serialize `"version"` and `"security"`.
- `JobTests.cs` — extend the known-values theory with `version` and `security`.

## Testing
`JobTests.CommandDeserialization` tests pass (10/10).
