### PR TITLE
Register MSBuild before running the job so early NuGet errors are reported

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/RunWorker.cs
@@ -96,6 +96,13 @@ public class RunWorker
 
         try
         {
+            // Register MSBuild up front so that the `Microsoft.Build` assembly is loadable for
+            // the rest of the job.  This is required even on the error-handling path:
+            // `JobErrorBase.ErrorFromException` references `Microsoft.Build` exception types, so
+            // if a failure occurs before MSBuild is registered, JIT-compiling the error handler
+            // would itself throw `FileNotFoundException` for `Microsoft.Build` and mask the real
+            // error.
+            MSBuildHelper.RegisterMSBuild(repoContentsPath.FullName, repoContentsPath.FullName, _logger);
             await PatchNuGetConfigFilesAsync(repoContentsPath);
             var handler = GetUpdateHandler(job);
             _logger.Info($"Starting update job of type {handler.TagName}");


### PR DESCRIPTION
### Problem

If an error is encountered early in the NuGet updater—before MSBuild has been registered via `MSBuildLocator`—the updater crashes while trying to *report* that error, masking the real failure:

```
Unhandled exception: System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Build, Version=15.1.0.0, ...'
   at NuGetUpdater.Core.Run.ApiModel.JobErrorBase.ErrorFromException(...) JobErrorBase.cs:line 36
   at NuGetUpdater.Core.Run.RunWorker.RunScenarioHandlersWithErrorHandlingAsync(...) RunWorker.cs:line 106
```

### Root cause

`JobErrorBase.ErrorFromException` references `Microsoft.Build.Exceptions.InvalidProjectFileException`. The CLR loads referenced assemblies when JIT-compiling a method, and `Microsoft.Build` is only resolvable after `MSBuildLocator.RegisterInstance` installs its assembly resolver. When a failure occurs before MSBuild is registered, the `catch` block invokes `ErrorFromException`, whose JIT-compilation then throws `FileNotFoundException` for `Microsoft.Build`—replacing the original error with an unhandled crash.

### Fix

Register MSBuild as the first step inside the error-handled scope in `RunWorker.RunScenarioHandlersWithErrorHandlingAsync`, before any other job work. This ensures the `Microsoft.Build` assembly is loadable throughout the job, including the error-handling path, so early failures are reported correctly instead of crashing.