### PR TITLE
Add a baseline to vcpkg projects missing one

### DIFF
--- a/vcpkg/lib/dependabot/vcpkg.rb
+++ b/vcpkg/lib/dependabot/vcpkg.rb
@@ -38,6 +38,9 @@ module Dependabot
 
     VCPKG_DEFAULT_BASELINE_URL = "https://github.com/microsoft/vcpkg.git"
 
+    # Repository URL without the `.git` suffix, for generated `default-registry` blocks.
+    VCPKG_DEFAULT_REGISTRY_REPOSITORY = "https://github.com/microsoft/vcpkg"
+
     VCPKG_DEFAULT_BASELINE_DEFAULT_BRANCH = "master"
 
     VCPKG_SUPPORTED_REGISTRY_TYPES = %w(git builtin).freeze

--- a/vcpkg/lib/dependabot/vcpkg/file_parser.rb
+++ b/vcpkg/lib/dependabot/vcpkg/file_parser.rb
@@ -21,7 +21,10 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::Dependency]) }
       def parse
-        dependency_files.flat_map { |file| parse_dependency_file(file) }.compact
+        dependencies = dependency_files.flat_map { |file| parse_dependency_file(file) }.compact
+        baseline = missing_baseline_dependency
+        dependencies << baseline if baseline
+        dependencies
       end
 
       sig { override.returns(Ecosystem) }
@@ -234,6 +237,106 @@ module Dependabot
         else
           [version_string, nil]
         end
+      end
+
+      # A project relying on a global vcpkg install has no baseline to update.
+      # Synthesize one so the updater adds it to the manifest; later runs keep it
+      # current. See https://github.com/dependabot/dependabot-core/issues/13051
+      sig { returns(T.nilable(Dependabot::Dependency)) }
+      def missing_baseline_dependency
+        manifest = vcpkg_manifest_file
+        return nil unless manifest
+        return nil unless manifest_declares_dependencies?(manifest)
+        return nil if baseline_resolvable?
+
+        config = vcpkg_configuration_file
+        if config.nil?
+          synthetic_baseline_dependency(file_name: manifest.name)
+        elsif default_registry.nil?
+          synthetic_baseline_dependency(
+            file_name: config.name,
+            metadata: { default: true, create_default_registry: true }
+          )
+        end
+      end
+
+      sig do
+        params(file_name: String, metadata: T::Hash[Symbol, T.untyped]).returns(Dependabot::Dependency)
+      end
+      def synthetic_baseline_dependency(file_name:, metadata: {})
+        Dependabot::Dependency.new(
+          name: VCPKG_DEFAULT_BASELINE_DEPENDENCY_NAME,
+          version: nil,
+          package_manager: "vcpkg",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "git",
+              url: VCPKG_DEFAULT_BASELINE_URL,
+              ref: VCPKG_DEFAULT_BASELINE_DEFAULT_BRANCH
+            },
+            file: file_name
+          }],
+          metadata: metadata
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def baseline_resolvable?
+        manifest_baseline_present? || default_registry_baseline_present?
+      end
+
+      sig { returns(T::Boolean) }
+      def manifest_baseline_present?
+        manifest = vcpkg_manifest_file
+        return false unless manifest
+
+        parsed_json(manifest)&.dig("builtin-baseline").is_a?(String)
+      end
+
+      sig { returns(T::Boolean) }
+      def default_registry_baseline_present?
+        registry = default_registry
+        !!(registry && registry["baseline"].is_a?(String))
+      end
+
+      sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+      def default_registry
+        config = vcpkg_configuration_file
+        return nil unless config
+
+        registry = parsed_json(config)&.dig("default-registry")
+        registry.is_a?(Hash) ? registry : nil
+      end
+
+      sig { params(file: Dependabot::DependencyFile).returns(T::Boolean) }
+      def manifest_declares_dependencies?(file)
+        declared = parsed_json(file)&.dig("dependencies")
+        return false unless declared.is_a?(Array)
+
+        !declared.empty?
+      end
+
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
+      def vcpkg_manifest_file
+        dependency_files.find { |file| file.name == VCPKG_JSON_FILENAME }
+      end
+
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
+      def vcpkg_configuration_file
+        dependency_files.find { |file| file.name == VCPKG_CONFIGURATION_JSON_FILENAME }
+      end
+
+      sig { params(file: Dependabot::DependencyFile).returns(T.nilable(T::Hash[String, T.untyped])) }
+      def parsed_json(file)
+        content = file.content
+        return nil unless content
+
+        parsed = JSON.parse(content)
+        parsed.is_a?(Hash) ? parsed : nil
+      rescue JSON::ParserError
+        nil
       end
 
       sig { returns(Ecosystem::VersionManager) }

--- a/vcpkg/lib/dependabot/vcpkg/file_updater.rb
+++ b/vcpkg/lib/dependabot/vcpkg/file_updater.rb
@@ -117,9 +117,32 @@ module Dependabot
       sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency, filename: String).void }
       def update_default_registry(content, dependency, filename)
         default_registry = content["default-registry"]
-        return unless default_registry.is_a?(Hash)
+        if default_registry.is_a?(Hash)
+          update_baseline_field(default_registry, dependency, filename, "baseline")
+        elsif dependency.metadata[:create_default_registry]
+          created_registry = build_default_registry(dependency, filename)
+          content["default-registry"] = created_registry if created_registry
+        end
+      end
 
-        update_baseline_field(default_registry, dependency, filename, "baseline")
+      sig do
+        params(dependency: Dependabot::Dependency, filename: String)
+          .returns(T.nilable(T::Hash[String, String]))
+      end
+      def build_default_registry(dependency, filename)
+        requirement = dependency.requirements.find { |r| r[:file] == filename }
+        return unless requirement
+
+        case requirement[:source]
+        in { ref: String => baseline }
+          {
+            "kind" => "git",
+            "repository" => VCPKG_DEFAULT_REGISTRY_REPOSITORY,
+            "baseline" => baseline
+          }
+        else
+          nil
+        end
       end
 
       sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency, filename: String).void }

--- a/vcpkg/spec/dependabot/vcpkg/file_parser_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/file_parser_spec.rb
@@ -137,11 +137,10 @@ RSpec.describe Dependabot::Vcpkg::FileParser do
           JSON
         end
 
-        it "returns only the dependency with version constraint" do
-          expect(dependencies.length).to eq(1)
+        it "returns the dependency with version constraint and a synthesized baseline" do
+          expect(dependencies.length).to eq(2)
 
-          openssl_dep = dependencies.first
-          expect(openssl_dep.name).to eq("openssl")
+          openssl_dep = dependencies.find { |d| d.name == "openssl" }
           expect(openssl_dep.version).to eq("3.1")
           expect(openssl_dep.package_manager).to eq("vcpkg")
           expect(openssl_dep.requirements).to eq(
@@ -152,6 +151,9 @@ RSpec.describe Dependabot::Vcpkg::FileParser do
               source: nil
             }]
           )
+
+          baseline_dep = dependencies.find { |d| d.name == "github.com/microsoft/vcpkg" }
+          expect(baseline_dep.version).to be_nil
         end
       end
 
@@ -168,14 +170,15 @@ RSpec.describe Dependabot::Vcpkg::FileParser do
           JSON
         end
 
-        it "returns no dependencies and logs warnings" do
+        it "synthesizes a baseline dependency and logs warnings for the string dependencies" do
           expect(Dependabot.logger)
             .to receive(:warn)
             .with("Skipping vcpkg dependency 'curl' without version>= constraint")
           expect(Dependabot.logger)
             .to receive(:warn)
             .with("Skipping vcpkg dependency 'openssl' without version>= constraint")
-          expect(dependencies).to be_empty
+
+          expect(dependencies.map(&:name)).to contain_exactly("github.com/microsoft/vcpkg")
         end
       end
 
@@ -192,8 +195,25 @@ RSpec.describe Dependabot::Vcpkg::FileParser do
           JSON
         end
 
-        it "returns no dependencies" do
-          expect(dependencies).to be_empty
+        it "synthesizes a baseline dependency to be added to vcpkg.json" do
+          expect(dependencies.length).to eq(1)
+
+          baseline_dep = dependencies.first
+          expect(baseline_dep.name).to eq("github.com/microsoft/vcpkg")
+          expect(baseline_dep.version).to be_nil
+          expect(baseline_dep.requirements).to eq(
+            [{
+              requirement: nil,
+              groups: [],
+              source: {
+                type: "git",
+                url: "https://github.com/microsoft/vcpkg.git",
+                ref: "master"
+              },
+              file: "vcpkg.json"
+            }]
+          )
+          expect(baseline_dep.metadata).to eq({})
         end
       end
 
@@ -226,6 +246,101 @@ RSpec.describe Dependabot::Vcpkg::FileParser do
         it "returns no dependencies" do
           expect(dependencies).to be_empty
         end
+      end
+    end
+
+    context "when the manifest has dependencies but no resolvable baseline" do
+      let(:dependency_files) { [vcpkg_json, vcpkg_configuration_json].compact }
+      let(:vcpkg_json) do
+        Dependabot::DependencyFile.new(
+          name: "vcpkg.json",
+          content: <<~JSON
+            {
+              "dependencies": ["fmt"]
+            }
+          JSON
+        )
+      end
+
+      context "when there is no vcpkg-configuration.json" do
+        let(:vcpkg_configuration_json) { nil }
+
+        it "synthesizes a baseline targeting vcpkg.json" do
+          expect(dependencies.length).to eq(1)
+
+          baseline_dep = dependencies.first
+          expect(baseline_dep.name).to eq("github.com/microsoft/vcpkg")
+          expect(baseline_dep.version).to be_nil
+          expect(baseline_dep.requirements.first[:file]).to eq("vcpkg.json")
+          expect(baseline_dep.metadata).to eq({})
+        end
+      end
+
+      context "when a vcpkg-configuration.json has no default-registry" do
+        let(:vcpkg_configuration_json) do
+          Dependabot::DependencyFile.new(
+            name: "vcpkg-configuration.json",
+            content: <<~JSON
+              {
+                "registries": [
+                  {
+                    "kind": "git",
+                    "repository": "https://github.com/northwindtraders/vcpkg-registry",
+                    "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
+                    "packages": ["beicode", "beison"]
+                  }
+                ]
+              }
+            JSON
+          )
+        end
+
+        it "synthesizes a baseline that creates a default-registry in the configuration" do
+          baseline_dep = dependencies.find { |d| d.name == "github.com/microsoft/vcpkg" }
+          expect(baseline_dep).not_to be_nil
+          expect(baseline_dep.version).to be_nil
+          expect(baseline_dep.requirements.first[:file]).to eq("vcpkg-configuration.json")
+          expect(baseline_dep.metadata).to eq(default: true, create_default_registry: true)
+        end
+      end
+
+      context "when a vcpkg-configuration.json default-registry is missing its baseline" do
+        let(:vcpkg_configuration_json) do
+          Dependabot::DependencyFile.new(
+            name: "vcpkg-configuration.json",
+            content: <<~JSON
+              {
+                "default-registry": {
+                  "kind": "git",
+                  "repository": "https://github.com/northwindtraders/vcpkg-registry"
+                }
+              }
+            JSON
+          )
+        end
+
+        it "does not synthesize a baseline" do
+          expect(dependencies).to be_empty
+        end
+      end
+    end
+
+    context "when the manifest has no dependencies and no baseline" do
+      let(:dependency_files) { [vcpkg_json] }
+      let(:vcpkg_json) do
+        Dependabot::DependencyFile.new(
+          name: "vcpkg.json",
+          content: <<~JSON
+            {
+              "name": "my-port",
+              "version": "1.0.0"
+            }
+          JSON
+        )
+      end
+
+      it "does not synthesize a baseline" do
+        expect(dependencies).to be_empty
       end
     end
 

--- a/vcpkg/spec/dependabot/vcpkg/file_updater_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/file_updater_spec.rb
@@ -684,5 +684,127 @@ RSpec.describe Dependabot::Vcpkg::FileUpdater do
         expect(updated_content["registries"][1]["baseline"]).to eq("new-commit-sha-2")
       end
     end
+
+    context "when creating a default-registry in a configuration without one" do
+      let(:vcpkg_configuration_json_content) do
+        <<~JSON
+          {
+            "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+            "registries": [
+              {
+                "kind": "git",
+                "repository": "https://github.com/northwindtraders/vcpkg-registry",
+                "baseline": "dacf4de488094a384ca2c202b923ccc097956e0c",
+                "packages": ["beicode", "beison"]
+              }
+            ]
+          }
+        JSON
+      end
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "github.com/microsoft/vcpkg",
+          version: "2025.06.13",
+          previous_version: nil,
+          package_manager: "vcpkg",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "git",
+              url: "https://github.com/microsoft/vcpkg.git",
+              ref: "new-commit-sha"
+            },
+            file: "vcpkg-configuration.json"
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            source: {
+              type: "git",
+              url: "https://github.com/microsoft/vcpkg.git",
+              ref: "master"
+            },
+            file: "vcpkg-configuration.json"
+          }],
+          metadata: {
+            default: true,
+            create_default_registry: true
+          }
+        )
+      end
+
+      let(:dependencies) { [dependency] }
+
+      it "adds a git default-registry pointing at microsoft/vcpkg" do
+        expect(updated_dependency_files.length).to eq(1)
+
+        updated_content = JSON.parse(updated_dependency_files.first.content)
+        expect(updated_content["default-registry"]).to eq(
+          "kind" => "git",
+          "repository" => "https://github.com/microsoft/vcpkg",
+          "baseline" => "new-commit-sha"
+        )
+        expect(updated_content["registries"].length).to eq(1)
+      end
+    end
+  end
+
+  describe "#updated_dependency_files when adding a missing builtin-baseline" do
+    subject(:updated_dependency_files) { updater.updated_dependency_files }
+
+    let(:dependency_files) { [vcpkg_json] }
+    let(:vcpkg_json) do
+      Dependabot::DependencyFile.new(
+        name: "vcpkg.json",
+        content: <<~JSON
+          {
+            "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+            "dependencies": ["fmt"]
+          }
+        JSON
+      )
+    end
+
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "github.com/microsoft/vcpkg",
+        version: "2025.06.13",
+        previous_version: nil,
+        package_manager: "vcpkg",
+        requirements: [{
+          requirement: nil,
+          groups: [],
+          source: {
+            type: "git",
+            url: "https://github.com/microsoft/vcpkg.git",
+            ref: "new-commit-sha"
+          },
+          file: "vcpkg.json"
+        }],
+        previous_requirements: [{
+          requirement: nil,
+          groups: [],
+          source: {
+            type: "git",
+            url: "https://github.com/microsoft/vcpkg.git",
+            ref: "master"
+          },
+          file: "vcpkg.json"
+        }],
+        metadata: {}
+      )
+    end
+
+    let(:dependencies) { [dependency] }
+
+    it "adds the builtin-baseline to vcpkg.json" do
+      expect(updated_dependency_files.length).to eq(1)
+
+      updated_content = JSON.parse(updated_dependency_files.first.content)
+      expect(updated_content["builtin-baseline"]).to eq("new-commit-sha")
+      expect(updated_content["dependencies"]).to eq(["fmt"])
+    end
   end
 end

--- a/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
@@ -515,4 +515,77 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
       end
     end
   end
+
+  describe "with a synthesized missing-baseline (version-less) dependency" do
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: dependency_name,
+        version: nil,
+        requirements: [{
+          requirement: nil,
+          groups: [],
+          source: {
+            type: "git",
+            url: "https://github.com/microsoft/vcpkg.git",
+            ref: "master"
+          },
+          file: "vcpkg.json"
+        }],
+        package_manager: "vcpkg"
+      )
+    end
+
+    let(:dependency_files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "vcpkg.json",
+          content: '{"dependencies": ["fmt"]}',
+          directory: "/"
+        )
+      ]
+    end
+
+    let(:commit_sha) { "9b75e789ece3f942159b8500584e35aafe3979ff" }
+    let(:latest_version_finder) { instance_double(Dependabot::Vcpkg::UpdateChecker::LatestVersionFinder) }
+    let(:mock_latest_release_info) do
+      instance_double(
+        Dependabot::Package::PackageRelease,
+        details: { "commit_sha" => commit_sha, "tag_sha" => "tag123" }
+      )
+    end
+
+    before do
+      allow(Dependabot::Vcpkg::UpdateChecker::LatestVersionFinder)
+        .to receive(:new)
+        .and_return(latest_version_finder)
+      allow(latest_version_finder)
+        .to receive_messages(
+          latest_version: "2025.06.13",
+          latest_release_info: mock_latest_release_info
+        )
+    end
+
+    it "is not up to date" do
+      expect(checker.up_to_date?).to be(false)
+    end
+
+    it "can update via an own-requirement unlock" do
+      expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+    end
+
+    it "sets the baseline ref to the latest release commit SHA" do
+      expect(checker.updated_requirements).to eq(
+        [{
+          requirement: nil,
+          groups: [],
+          source: {
+            type: "git",
+            url: "https://github.com/microsoft/vcpkg.git",
+            ref: commit_sha
+          },
+          file: "vcpkg.json"
+        }]
+      )
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Closes #13051.

vcpkg projects that rely on a global vcpkg install have no baseline, so Dependabot parsed them to zero dependencies and couldn't update them. The parser now synthesizes a baseline pinned to the latest vcpkg release: it adds `builtin-baseline` to `vcpkg.json`, or a git `default-registry` to a `vcpkg-configuration.json` that has none. The existing flow maintains the baseline after that.

### Anything you want to highlight for special attention from reviewers?

The synthesized dependency has no current version, so it goes through the requirements-based update path. The update checker already writes the latest release SHA into the git ref, so it needed no change.

A `default-registry` that exists without a baseline is left alone, since that is invalid vcpkg and can't occur in a working repo.

### How will you know you've accomplished your goal?

New parser, updater, and checker specs cover the cases. The vcpkg suite passes (113 examples), with rubocop and Sorbet clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
