### PR TITLE
Show the vcpkg release tag instead of master in PR titles

### DIFF
--- a/vcpkg/lib/dependabot/vcpkg/update_checker.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker.rb
@@ -30,6 +30,16 @@ module Dependabot
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_resolvable_version_with_no_unlock = latest_version
 
+      # The release tag for the current baseline commit SHA (else the SHA), so the
+      # PR title's "from" shows the tag, not the "master" ref.
+      sig { params(_updated_version: String).returns(T.nilable(String)) }
+      def latest_resolvable_previous_version(_updated_version)
+        current_version = dependency.version
+        return current_version unless registry_dependency? && current_version&.match?(/\A[0-9a-f]{40}\z/)
+
+        latest_version_finder.tag_for_commit_sha(current_version) || current_version
+      end
+
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         return dependency.requirements unless latest_version

--- a/vcpkg/lib/dependabot/vcpkg/update_checker/latest_version_finder.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker/latest_version_finder.rb
@@ -50,6 +50,15 @@ module Dependabot
           )
         end
 
+        # The release tag for the given commit SHA, if any.
+        sig { params(commit_sha: String).returns(T.nilable(String)) }
+        def tag_for_commit_sha(commit_sha)
+          package_details
+            &.releases
+            &.find { |release| release.details["commit_sha"] == commit_sha }
+            &.tag
+        end
+
         private
 
         sig { returns(T::Boolean) }

--- a/vcpkg/spec/dependabot/vcpkg/update_checker/latest_version_finder_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker/latest_version_finder_spec.rb
@@ -188,4 +188,66 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker::LatestVersionFinder do
       end
     end
   end
+
+  describe "#tag_for_commit_sha" do
+    subject(:tag_for_commit_sha) { finder.tag_for_commit_sha(commit_sha) }
+
+    let(:package_details_fetcher) { instance_double(Dependabot::Vcpkg::Package::PackageDetailsFetcher) }
+    let(:mock_package_details) do
+      Dependabot::Package::PackageDetails.new(
+        dependency: dependency,
+        releases: [
+          Dependabot::Package::PackageRelease.new(
+            version: Dependabot::Vcpkg::Version.new("2025.06.13"),
+            tag: "2025.06.13",
+            url: "https://github.com/microsoft/vcpkg.git",
+            released_at: Time.new(2025, 6, 13),
+            details: { "commit_sha" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "tag_sha" => "t1" }
+          ),
+          Dependabot::Package::PackageRelease.new(
+            version: Dependabot::Vcpkg::Version.new("2025.04.09"),
+            tag: "2025.04.09",
+            url: "https://github.com/microsoft/vcpkg.git",
+            released_at: Time.new(2025, 4, 9),
+            details: { "commit_sha" => "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "tag_sha" => "t2" }
+          )
+        ]
+      )
+    end
+
+    before do
+      allow(Dependabot::Vcpkg::Package::PackageDetailsFetcher)
+        .to receive(:new)
+        .and_return(package_details_fetcher)
+      allow(package_details_fetcher).to receive(:fetch).and_return(mock_package_details)
+    end
+
+    context "when a release matches the commit SHA" do
+      let(:commit_sha) { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" }
+
+      it "returns the matching release tag" do
+        expect(tag_for_commit_sha).to eq("2025.04.09")
+      end
+    end
+
+    context "when no release matches the commit SHA" do
+      let(:commit_sha) { "cccccccccccccccccccccccccccccccccccccccc" }
+
+      it "returns nil" do
+        expect(tag_for_commit_sha).to be_nil
+      end
+    end
+
+    context "when no package details are available" do
+      let(:commit_sha) { "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" }
+
+      before do
+        allow(package_details_fetcher).to receive(:fetch).and_return(nil)
+      end
+
+      it "returns nil" do
+        expect(tag_for_commit_sha).to be_nil
+      end
+    end
+  end
 end

--- a/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
@@ -312,6 +312,62 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
     end
   end
 
+  describe "#latest_resolvable_previous_version" do
+    subject(:latest_resolvable_previous_version) do
+      checker.latest_resolvable_previous_version("2025.06.13")
+    end
+
+    let(:latest_version_finder) { instance_double(Dependabot::Vcpkg::UpdateChecker::LatestVersionFinder) }
+
+    before do
+      allow(Dependabot::Vcpkg::UpdateChecker::LatestVersionFinder)
+        .to receive(:new)
+        .and_return(latest_version_finder)
+    end
+
+    context "when the baseline is a commit SHA" do
+      let(:dependency_version) { "1111111111111111111111111111111111111111" }
+
+      before do
+        allow(latest_version_finder)
+          .to receive(:tag_for_commit_sha)
+          .with(dependency_version)
+          .and_return(previous_tag)
+      end
+
+      context "when the SHA maps to a release tag" do
+        let(:previous_tag) { "2025.04.09" }
+
+        it "returns the release tag" do
+          expect(latest_resolvable_previous_version).to eq("2025.04.09")
+        end
+      end
+
+      context "when the SHA has no matching release tag" do
+        let(:previous_tag) { nil }
+
+        it "falls back to the commit SHA" do
+          expect(latest_resolvable_previous_version).to eq(dependency_version)
+        end
+      end
+    end
+
+    context "when the version is not a commit SHA" do
+      let(:dependency_version) { "2025.04.09" }
+
+      before { allow(latest_version_finder).to receive(:tag_for_commit_sha) }
+
+      it "returns the current version unchanged" do
+        expect(latest_resolvable_previous_version).to eq("2025.04.09")
+      end
+
+      it "does not query the version finder" do
+        latest_resolvable_previous_version
+        expect(latest_version_finder).not_to have_received(:tag_for_commit_sha)
+      end
+    end
+  end
+
   describe "#latest_version_resolvable_with_full_unlock?" do
     subject(:latest_version_resolvable_with_full_unlock) do
       checker.send(:latest_version_resolvable_with_full_unlock?)


### PR DESCRIPTION
### What are you trying to accomplish?

vcpkg PR titles read "from master to 2026.06.01" because the baseline is a commit SHA that tracks the `master` branch. This shows the release tag for the previous baseline instead, so the title reads "from 2026.05.15 to 2026.06.01".

### Anything you want to highlight for special attention from reviewers?

The "to" side already showed the tag; only `previous_version` stayed a raw SHA. I set it the idiomatic way, by overriding `latest_resolvable_previous_version` (the hook npm_and_yarn and bun use), not the display layer. When the baseline SHA has no matching tag, the "from" falls back to `master`. It also drops the body's "previously tagged commit" note when both sides are tags.

### How will you know you've accomplished your goal?

New specs cover `latest_resolvable_previous_version` and `tag_for_commit_sha`. The full vcpkg suite, `srb tc`, and RuboCop pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.