### PR TITLE
Skip disabled Maven repositories

### DIFF
--- a/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
@@ -103,6 +103,11 @@ module Dependabot
         end
 
         sig { params(entry: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        def disabled_repo?(entry)
+          entry[:releases] == "false" && entry[:snapshots] == "false"
+        end
+
+        sig { params(entry: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
         def snapshot_repo(entry)
           entry[:releases] == "false" && (entry[:snapshots].nil? || entry[:snapshots] == "true")
         end
@@ -168,6 +173,7 @@ module Dependabot
 
           return if property_blocked?(entry)
           return unless http_url?(entry)
+          return if disabled_repo?(entry)
 
           serialize_urls(entry, pom)
         end

--- a/maven/spec/fixtures/poms/custom_repositories_pom.xml
+++ b/maven/spec/fixtures/poms/custom_repositories_pom.xml
@@ -108,6 +108,16 @@ url>http://github.com/davidB/${project.artifactId}</url
         <enabled>true</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>disabled-repository</id>
+      <url>https://example.com/disabled</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
### What are you trying to accomplish?

Skip Maven repositories which have both `releases` and `snapshots` disabled.  Such repository definitions exist in `pom.xml` to avoid using them.

Fixes #15442

### How will you know you've accomplished your goal?

Added a new custom repository in test fixtures with both `releases` and `snapshots` disabled.  Tests are otherwise not modified, since the output is expected to be unchanged: the new repo should not appear in result of `finder.repository_urls` calls in existing test cases.

```
$ bin/docker-dev-shell maven
...
[dependabot-core-dev] ~ $ cd maven
[dependabot-core-dev] ~/maven $ rspec spec
...
726 examples, 0 failures

[dependabot-core-dev] ~/maven $ rubocop 
Inspecting 60 files
............................................................

60 files inspected, no offenses detected
```

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
