### PR TITLE
Filter null entries from job directories

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ApiModel/JobTests.cs
@@ -420,6 +420,38 @@ public class JobTests
         AssertEx.Equal(expectedDirectories, actualDirectories);
     }
 
+    [Fact]
+    public void ExpandJobDirectoriesIgnoresNullEntries()
+    {
+        // arrange
+        using var tempDir = new TemporaryDirectory();
+        var json = """
+            {
+              "job": {
+                "package-manager": "nuget",
+                "source": {
+                  "provider": "github",
+                  "repo": "test/repo",
+                  "directories": [
+                    null
+                  ]
+                }
+              }
+            }
+            """;
+        var job = RunWorker.Deserialize(json).Job;
+
+        // act - the null entry should be ignored, not cause a NullReferenceException
+        var actualDirectories = job.GetAllDirectories(tempDir.DirectoryPath);
+
+        // assert - null entry was filtered out, falling back to the repo root
+        var expectedDirectories = new[]
+        {
+            "/",
+        }.ToImmutableArray();
+        AssertEx.Equal(expectedDirectories, actualDirectories);
+    }
+
     [Theory]
     [InlineData("version", JobCommand.Version)]
     [InlineData("update", JobCommand.Update)]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -53,7 +53,7 @@ public sealed record Job
             builder.Add(Source.Directory);
         }
 
-        builder.AddRange(Source.Directories ?? []);
+        builder.AddRange((Source.Directories ?? []).Where(d => d is not null));
         if (builder.Count == 0)
         {
             builder.Add("/");


### PR DESCRIPTION
Fixes a NullReferenceException when a job's `directories` array contains a `null` entry. `Job.GetRawDirectories` now filters out nulls.
