### PR TITLE
Type opaque hashes in common with T.anything

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1683
+# Offense count: 1665
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -296,10 +296,8 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/clients/codecommit.rb"
     - "common/lib/dependabot/clients/github_with_retries.rb"
     - "common/lib/dependabot/clients/gitlab_with_retries.rb"
-    - "common/lib/dependabot/command_helpers.rb"
     - "common/lib/dependabot/dependency.rb"
     - "common/lib/dependabot/errors.rb"
-    - "common/lib/dependabot/experiments.rb"
     - "common/lib/dependabot/file_fetchers/base.rb"
     - "common/lib/dependabot/file_parsers/base.rb"
     - "common/lib/dependabot/file_updaters/base.rb"
@@ -309,16 +307,13 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/metadata_finders/base/release_finder.rb"
     - "common/lib/dependabot/package/package_latest_version_finder.rb"
     - "common/lib/dependabot/package/package_release.rb"
-    - "common/lib/dependabot/pull_request_creator.rb"
     - "common/lib/dependabot/pull_request_creator/github.rb"
     - "common/lib/dependabot/pull_request_creator/message_builder.rb"
     - "common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb"
     - "common/lib/dependabot/pull_request_updater/azure.rb"
     - "common/lib/dependabot/pull_request_updater/github.rb"
     - "common/lib/dependabot/pull_request_updater/gitlab.rb"
-    - "common/lib/dependabot/registry_client.rb"
     - "common/lib/dependabot/shared_helpers.rb"
-    - "common/lib/dependabot/simple_instrumentor.rb"
     - "common/lib/dependabot/update_checkers/base.rb"
     - "composer/lib/dependabot/composer/file_fetcher.rb"
     - "composer/lib/dependabot/composer/file_fetcher/path_dependency_builder.rb"

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -20,13 +20,13 @@ module Dependabot
     end
 
     OutputObserver = T.type_alias do
-      T.nilable(T.proc.params(data: String).returns(T::Hash[Symbol, T.untyped]))
+      T.nilable(T.proc.params(data: String).returns(T::Hash[Symbol, T.anything]))
     end
 
     EnvCmdItem = T.type_alias do
       T.any(
         String,
-        T::Hash[T.any(String, Symbol), T.untyped]
+        T::Hash[T.any(String, Symbol), T.anything]
       )
     end
 

--- a/common/lib/dependabot/experiments.rb
+++ b/common/lib/dependabot/experiments.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -7,21 +7,21 @@ module Dependabot
   module Experiments
     extend T::Sig
 
-    @experiments = T.let({}, T::Hash[T.any(String, Symbol), T.untyped])
+    @experiments = T.let({}, T::Hash[T.any(String, Symbol), T.anything])
 
-    sig { returns(T::Hash[T.any(String, Symbol), T.untyped]) }
+    sig { returns(T::Hash[T.any(String, Symbol), T.anything]) }
     def self.reset!
       @experiments = {}
     end
 
-    sig { params(name: T.any(String, Symbol), value: T.untyped).void }
+    sig { params(name: T.any(String, Symbol), value: T.anything).void }
     def self.register(name, value)
       @experiments[name.to_sym] = value
     end
 
     sig { params(name: T.any(String, Symbol)).returns(T::Boolean) }
     def self.enabled?(name)
-      !!@experiments[name.to_sym]
+      @experiments[name.to_sym] ? true : false
     end
   end
 end

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -97,7 +97,7 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_reader :signature_key
 
-    sig { returns(T::Hash[Symbol, T.untyped]) }
+    sig { returns(T::Hash[Symbol, T.anything]) }
     attr_reader :commit_message_options
 
     sig { returns(T::Hash[String, String]) }
@@ -132,7 +132,7 @@ module Dependabot
     sig { returns(T.nilable(T::Hash[String, String])) }
     attr_reader :custom_headers
 
-    sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    sig { returns(T.nilable(T::Hash[Symbol, T.anything])) }
     attr_reader :provider_metadata
 
     sig { returns(T.nilable(Dependabot::DependencyGroup)) }
@@ -156,7 +156,7 @@ module Dependabot
         custom_labels: T.nilable(T::Array[String]),
         author_details: T.nilable(T::Hash[Symbol, String]),
         signature_key: T.nilable(String),
-        commit_message_options: T::Hash[Symbol, T.untyped],
+        commit_message_options: T::Hash[Symbol, T.anything],
         vulnerabilities_fixed: T::Hash[String, String],
         reviewers: Reviewers,
         assignees: T.nilable(T.any(T::Array[String], T::Array[Integer])),
@@ -169,7 +169,7 @@ module Dependabot
         github_redirection_service: String,
         custom_headers: T.nilable(T::Hash[String, String]),
         require_up_to_date_base: T::Boolean,
-        provider_metadata: T.nilable(T::Hash[Symbol, T.untyped]),
+        provider_metadata: T.nilable(T::Hash[Symbol, T.anything]),
         message: T.nilable(
           T.any(Dependabot::PullRequestCreator::Message, Dependabot::PullRequestCreator::MessageBuilder)
         ),
@@ -253,7 +253,7 @@ module Dependabot
     # TODO: This returns client-specific objects.
     # We should create a standard interface (`Dependabot::PullRequest`) and
     # then convert to that
-    sig { returns(T.untyped) }
+    sig { returns(T.anything) }
     def create
       case source.provider
       when "github" then github_creator.create

--- a/common/lib/dependabot/registry_client.rb
+++ b/common/lib/dependabot/registry_client.rb
@@ -21,8 +21,8 @@ module Dependabot
     sig do
       params(
         url: String,
-        headers: T::Hash[T.any(String, Symbol), T.untyped],
-        options: T::Hash[Symbol, T.untyped]
+        headers: T::Hash[T.any(String, Symbol), T.anything],
+        options: T::Hash[Symbol, T.anything]
       )
         .returns(Excon::Response)
     end
@@ -43,8 +43,8 @@ module Dependabot
     sig do
       params(
         url: String,
-        headers: T::Hash[T.any(String, Symbol), T.untyped],
-        options: T::Hash[Symbol, T.untyped]
+        headers: T::Hash[T.any(String, Symbol), T.anything],
+        options: T::Hash[Symbol, T.anything]
       )
         .returns(Excon::Response)
     end

--- a/common/lib/dependabot/simple_instrumentor.rb
+++ b/common/lib/dependabot/simple_instrumentor.rb
@@ -9,14 +9,14 @@ module Dependabot
       extend T::Sig
       extend T::Generic
 
-      sig { returns(T.nilable(T::Array[T.proc.params(name: String, params: T::Hash[Symbol, T.untyped]).void])) }
+      sig { returns(T.nilable(T::Array[T.proc.params(name: String, params: T::Hash[Symbol, T.anything]).void])) }
       attr_accessor :subscribers
 
-      sig { params(block: T.proc.params(name: String, params: T::Hash[Symbol, T.untyped]).void).void }
+      sig { params(block: T.proc.params(name: String, params: T::Hash[Symbol, T.anything]).void).void }
       def subscribe(&block)
         @subscribers ||= T.let(
           [],
-          T.nilable(T::Array[T.proc.params(name: String, params: T::Hash[Symbol, T.untyped]).void])
+          T.nilable(T::Array[T.proc.params(name: String, params: T::Hash[Symbol, T.anything]).void])
         )
         @subscribers << block
       end
@@ -25,7 +25,7 @@ module Dependabot
         type_parameters(:T)
           .params(
             name: String,
-            params: T::Hash[Symbol, T.untyped],
+            params: T::Hash[Symbol, T.anything],
             block: T.proc.returns(T.type_parameter(:T))
           )
           .returns(T.nilable(T.type_parameter(:T)))


### PR DESCRIPTION
### What are you trying to accomplish?

Five common utilities typed their pass-through hashes as `T.untyped`: experiments, the instrumentor, command helpers, the pull request creator, and the registry client. The values are genuinely opaque there, so this switches them to `T.anything`, which still accepts any value but makes callers narrow it before use.

This is the first slice of burning down `Sorbet/ForbidTUntyped` in `common/`. It clears all five files: 323 to 318 on the list, 1683 to 1665 offenses.

### Anything you want to highlight for special attention from reviewers?

`T.anything` only fits where a value never gets used as a concrete type. I picked the files where that already holds, so there are no call-site changes and `srb tc` confirms nothing downstream had to narrow. Heavier files and value-object refactors come in later slices of the stack.

### How will you know you've accomplished your goal?

- `bundle exec srb tc` is green
- `bundle exec rubocop` is clean on the changed files
- `script/sorbet-untyped-ratchet` reports the burndown shrank (-5 files, -18 offenses)
- common specs pass (88 examples)

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.