### PR TITLE
Select group update handler for multi-ecosystem NuGet jobs

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlerSelectionTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/UpdateHandlerSelectionTests.cs
@@ -71,6 +71,24 @@ public class UpdateHandlerSelectionTests : UpdateHandlersTestsBase
             GroupUpdateAllVersionsHandler.Instance,
         ];
 
+        // multi-ecosystem update; this short-circuits to `group_update_all_versions` even when
+        // `UpdatingAPullRequest` is true, no top-level dependencies are listed, and a group is
+        // being refreshed (regression test for "Unable to find appropriate update handler.")
+        yield return
+        [
+            new Job()
+            {
+                Source = CreateJobSource("/"),
+                Dependencies = [],
+                DependencyGroups = [new() { Name = "some-group" }],
+                DependencyGroupToRefresh = "some-group",
+                SecurityUpdatesOnly = false,
+                UpdatingAPullRequest = true,
+                MultiEcosystemUpdate = true,
+            },
+            GroupUpdateAllVersionsHandler.Instance,
+        ];
+
         //
         // update_version_group_pr
         //

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -37,6 +37,7 @@ public sealed record Job
     public required JobSource Source { get; init; }
     public bool UpdateSubdependencies { get; init; } = false;
     public bool UpdatingAPullRequest { get; init; } = false;
+    public bool MultiEcosystemUpdate { get; init; } = false;
     public bool VendorDependencies { get; init; } = false;
     public bool RejectExternalCode { get; init; } = false;
     public bool RepoPrivate { get; init; } = false;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -17,6 +17,11 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
 
     public bool CanHandle(Job job)
     {
+        if (job.MultiEcosystemUpdate)
+        {
+            return true;
+        }
+
         if (job.UpdatingAPullRequest)
         {
             return false;


### PR DESCRIPTION
## Problem

A NuGet job failed early with `Unable to find appropriate update handler.` The job had `multi-ecosystem-update: true`, `updating-a-pull-request: true`, an empty `dependencies` list, and a `dependency-group-to-refresh`. None of the C# update handlers matched, so `RunWorker.GetUpdateHandler` threw.

## Cause

The Ruby updater selects `GroupUpdateAllVersions` for these jobs because `applies_to?` short-circuits to `true` when `multi_ecosystem_update?` is set, before the `updating_a_pull_request?` check. The C# `GroupUpdateAllVersionsHandler` was missing this short-circuit, and the C# `Job` model had no `MultiEcosystemUpdate` property at all, so the flag was ignored.

The multi-ecosystem handling was added to the Ruby code in #12339.

## Changes

- Add `MultiEcosystemUpdate` to the C# `Job` model (deserialized from `multi-ecosystem-update`).
- In `GroupUpdateAllVersionsHandler.CanHandle`, return `true` first when `MultiEcosystemUpdate` is set, matching the Ruby logic.
- Add a handler-selection test for a multi-ecosystem job that previously failed to resolve a handler.