### PR TITLE
Type requirement helpers in the update-checker base class

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1657
+# Offense count: 1655
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -312,7 +312,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/pull_request_updater/github.rb"
     - "common/lib/dependabot/pull_request_updater/gitlab.rb"
     - "common/lib/dependabot/shared_helpers.rb"
-    - "common/lib/dependabot/update_checkers/base.rb"
     - "composer/lib/dependabot/composer/file_fetcher.rb"
     - "composer/lib/dependabot/composer/file_fetcher/path_dependency_builder.rb"
     - "composer/lib/dependabot/composer/file_parser.rb"

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -233,7 +233,7 @@ module Dependabot
       # instances are returned as-is; plain hashes are wrapped. Re-wrapping
       # would produce a value-equal copy, so skipping it avoids needless
       # allocations.
-      sig { params(requirements: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Array[Dependabot::DependencyRequirement]) }
+      sig { params(requirements: T::Array[T::Hash[Symbol, T.anything]]).returns(T::Array[Dependabot::DependencyRequirement]) }
       def wrap_requirements(requirements)
         requirements.map do |requirement|
           requirement.is_a?(Dependabot::DependencyRequirement) ? requirement : Dependabot::DependencyRequirement.create(requirement)
@@ -406,7 +406,7 @@ module Dependabot
           version_class.correct?(latest_version.to_s)) || false
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def changed_requirements
         (updated_requirements - dependency.requirements)
       end


### PR DESCRIPTION
`wrap_requirements` and `changed_requirements` were typed as `T::Array[T::Hash[Symbol, T.untyped]]`, but both already work in terms of `DependencyRequirement`.

`changed_requirements` returns the difference of two `DependencyRequirement` arrays, so it now returns `T::Array[Dependabot::DependencyRequirement]`. `wrap_requirements` wraps raw requirement hashes, so its parameter is now `T::Array[T::Hash[Symbol, T.anything]]`.

That removes the last `T.untyped` from the file, so it comes off the `Sorbet/ForbidTUntyped` burndown list. It stays `# typed: strict` because other call sites still surface untyped values.
