### PR TITLE
Type error-detail payloads across common and the updater

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1655
+# Offense count: 1649
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -297,13 +297,11 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/clients/github_with_retries.rb"
     - "common/lib/dependabot/clients/gitlab_with_retries.rb"
     - "common/lib/dependabot/dependency.rb"
-    - "common/lib/dependabot/errors.rb"
     - "common/lib/dependabot/file_fetchers/base.rb"
     - "common/lib/dependabot/git_commit_checker.rb"
     - "common/lib/dependabot/git_metadata_fetcher.rb"
     - "common/lib/dependabot/metadata_finders/base/changelog_finder.rb"
     - "common/lib/dependabot/metadata_finders/base/release_finder.rb"
-    - "common/lib/dependabot/package/package_latest_version_finder.rb"
     - "common/lib/dependabot/package/package_release.rb"
     - "common/lib/dependabot/pull_request_creator/github.rb"
     - "common/lib/dependabot/pull_request_creator/message_builder.rb"

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -23,7 +23,7 @@ module Dependabot
 
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/CyclomaticComplexity
-  sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+  sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.anything])) }
   def self.fetcher_error_details(error)
     case error
     when Dependabot::ToolVersionNotSupported
@@ -142,7 +142,7 @@ module Dependabot
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
-  sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+  sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.anything])) }
   def self.parser_error_details(error)
     case error
     when Dependabot::ToolFeatureNotSupported
@@ -226,7 +226,7 @@ module Dependabot
   # rubocop:disable Lint/RedundantCopDisableDirective
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/AbcSize
-  sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+  sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.anything])) }
   def self.updater_error_details(error)
     case error
     when Dependabot::ToolFeatureNotSupported
@@ -416,7 +416,7 @@ module Dependabot
 
     interface!
 
-    sig { abstract.returns(T::Hash[Symbol, T.untyped]) }
+    sig { abstract.returns(T::Hash[Symbol, T.anything]) }
     def sentry_context; end
   end
 
@@ -484,7 +484,7 @@ module Dependabot
       super(message || error_type)
     end
 
-    sig { params(hash: T.nilable(T::Hash[Symbol, T.untyped])).returns(T::Hash[Symbol, T.untyped]) }
+    sig { params(hash: T.nilable(T::Hash[Symbol, T.anything])).returns(T::Hash[Symbol, T.anything]) }
     def detail(hash = nil)
       {
         "error-type": error_type,

--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -335,7 +335,7 @@ module Dependabot
         end
       end
 
-      sig { returns(T::Array[T.untyped]) }
+      sig { returns(T::Array[Dependabot::Requirement]) }
       def ignore_requirements
         ignored_versions.flat_map { |req| requirement_class.requirements_array(req) }
       end

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -143,34 +143,39 @@ module Dependabot
           }
         end
 
+      error_type = T.cast(error_details.fetch(:"error-type"), T.any(String, Symbol))
+      error_detail = T.cast(error_details[:"error-detail"], T.nilable(T::Hash[Symbol, T.anything]))
+
       service.record_update_job_error(
-        error_type: error_details.fetch(:"error-type"),
-        error_details: error_details[:"error-detail"]
+        error_type: error_type,
+        error_details: error_detail
       )
       # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
       return unless Experiments.enabled?(:record_update_job_unknown_error)
-      return unless error_details.fetch(:"error-type") == "update_files_error"
+      return unless error_type == "update_files_error"
 
       service.record_update_job_unknown_error(
-        error_type: error_details.fetch(:"error-type"),
-        error_details: error_details[:"error-detail"]
+        error_type: error_type,
+        error_details: error_detail
       )
     end
     # rubocop:enable Metrics/AbcSize, Layout/LineLength, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     sig { params(error: Dependabot::DependencyFileNotParseable).void }
     def handle_dependency_file_not_parseable_error(error)
-      error_details = Dependabot.updater_error_details(error)
+      error_details = T.must(Dependabot.updater_error_details(error))
+      error_type = T.cast(error_details.fetch(:"error-type"), T.any(String, Symbol))
+      error_detail = T.cast(error_details[:"error-detail"], T.nilable(T::Hash[Symbol, T.anything]))
 
       service.record_update_job_error(
-        error_type: T.must(error_details).fetch(:"error-type"),
-        error_details: T.must(error_details)[:"error-detail"]
+        error_type: error_type,
+        error_details: error_detail
       )
       return unless Experiments.enabled?(:record_update_job_unknown_error)
 
       service.record_update_job_unknown_error(
-        error_type: T.must(error_details).fetch(:"error-type"),
-        error_details: T.must(error_details)[:"error-detail"]
+        error_type: error_type,
+        error_details: error_detail
       )
     end
   end

--- a/updater/lib/dependabot/update_graph_command.rb
+++ b/updater/lib/dependabot/update_graph_command.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "json"
@@ -98,17 +98,20 @@ module Dependabot
           }
         end
 
+      error_type = T.cast(error_details.fetch(:"error-type"), T.any(String, Symbol))
+      error_detail = T.cast(error_details[:"error-detail"], T.nilable(T::Hash[Symbol, T.anything]))
+
       service.record_update_job_error(
-        error_type: error_details.fetch(:"error-type"),
-        error_details: error_details[:"error-detail"]
+        error_type: error_type,
+        error_details: error_detail
       )
       # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
       return unless Experiments.enabled?(:record_update_job_unknown_error)
-      return unless error_details.fetch(:"error-type") == ERROR_TYPE_LABEL
+      return unless error_type == ERROR_TYPE_LABEL
 
       service.record_update_job_unknown_error(
-        error_type: error_details.fetch(:"error-type"),
-        error_details: error_details[:"error-detail"]
+        error_type: error_type,
+        error_details: error_detail
       )
     end
   end

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -166,7 +166,8 @@ module Dependabot
       return unless Dependabot::Environment.github_actions?
 
       error_details = Dependabot.updater_error_details(e) || { "error-type": "unknown_error" }
-      detail_message = error_details.dig(:"error-detail", :message)
+      error_detail = T.cast(error_details[:"error-detail"], T.nilable(T::Hash[Symbol, T.anything]))
+      detail_message = T.cast(error_detail&.dig(:message), T.nilable(Object))
       record_workflow_result(
         directory,
         GithubApi::DependencySubmission::SnapshotStatus::FAILED,
@@ -178,7 +179,7 @@ module Dependabot
         branch,
         T.must(directory_source),
         GithubApi::DependencySubmission::SnapshotStatus::FAILED,
-        error_details.fetch(:"error-type")
+        T.cast(error_details.fetch(:"error-type"), String)
       )
       service.create_dependency_submission(dependency_submission: empty_submission)
     end


### PR DESCRIPTION
The error-detail payloads from `Dependabot.fetcher_error_details`, `parser_error_details`, and `updater_error_details` (plus `sentry_context` and `detail`) were `T::Hash[Symbol, T.untyped]`. Their values are genuinely heterogeneous, so they are now `T::Hash[Symbol, T.anything]`.

The updater reads two known keys off that payload, so the three command classes narrow `error-type` and `error-detail` once with `T.cast` before passing them to the service.

Separately, `ignore_requirements` in `package_latest_version_finder` now returns `T::Array[Dependabot::Requirement]`, which is what `requirements_array` already produces.

Removes three files from the `Sorbet/ForbidTUntyped` burndown list.

Stacked on #15461.
