### PR TITLE
Type package release details with T.anything

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1649
+# Offense count: 1646
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -302,7 +302,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/git_metadata_fetcher.rb"
     - "common/lib/dependabot/metadata_finders/base/changelog_finder.rb"
     - "common/lib/dependabot/metadata_finders/base/release_finder.rb"
-    - "common/lib/dependabot/package/package_release.rb"
     - "common/lib/dependabot/pull_request_creator/github.rb"
     - "common/lib/dependabot/pull_request_creator/message_builder.rb"
     - "common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb"

--- a/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
+++ b/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
@@ -242,7 +242,7 @@ module Dependabot
             .sort_by(&:version).reverse
         end
 
-        sig { returns(T::Array[[Dependabot::Version, T::Hash[String, T.nilable(String)]]]) }
+        sig { returns(T::Array[[Dependabot::Version, T::Hash[String, T.anything]]]) }
         def possible_previous_versions_with_details
           possible_previous_releases.map do |r|
             [r.version, r.details]

--- a/common/lib/dependabot/package/package_release.rb
+++ b/common/lib/dependabot/package/package_release.rb
@@ -24,7 +24,7 @@ module Dependabot
           package_type: T.nilable(String),
           language: T.nilable(Dependabot::Package::PackageLanguage),
           tag: T.nilable(String),
-          details: T::Hash[String, T.untyped]
+          details: T::Hash[String, T.anything]
         ).void
       end
       def initialize(
@@ -50,7 +50,7 @@ module Dependabot
         @package_type = T.let(package_type, T.nilable(String))
         @language = T.let(language, T.nilable(Dependabot::Package::PackageLanguage))
         @tag = T.let(tag, T.nilable(String))
-        @details = T.let(details, T::Hash[String, T.untyped])
+        @details = T.let(details, T::Hash[String, T.anything])
       end
 
       sig { returns(Dependabot::Version) }
@@ -83,7 +83,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       attr_reader :tag
 
-      sig { returns(T::Hash[String, T.untyped]) }
+      sig { returns(T::Hash[String, T.anything]) }
       attr_reader :details
 
       sig { returns(T::Boolean) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -242,7 +242,7 @@ module Dependabot
             .sort_by(&:version).reverse
         end
 
-        sig { returns(T::Array[[Dependabot::Version, T::Hash[String, T.nilable(String)]]]) }
+        sig { returns(T::Array[[Dependabot::Version, T::Hash[String, T.anything]]]) }
         def possible_previous_versions_with_details
           possible_previous_releases.map do |r|
             [r.version, r.details]

--- a/vcpkg/lib/dependabot/vcpkg/update_checker.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker.rb
@@ -82,7 +82,10 @@ module Dependabot
       def sha1_version_up_to_date?
         return super unless registry_dependency?
 
-        latest_commit_sha = latest_version_finder.latest_release_info&.details&.dig("commit_sha")
+        latest_commit_sha = T.cast(
+          latest_version_finder.latest_release_info&.details&.dig("commit_sha"),
+          T.nilable(String)
+        )
         return super unless latest_commit_sha
 
         latest_commit_sha.start_with?(T.must(dependency.version))

--- a/vcpkg/lib/dependabot/vcpkg/update_checker/latest_version_finder.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker/latest_version_finder.rb
@@ -55,7 +55,7 @@ module Dependabot
         def tag_for_commit_sha(commit_sha)
           package_details
             &.releases
-            &.find { |release| release.details["commit_sha"] == commit_sha }
+            &.find { |release| T.cast(release.details["commit_sha"], T.nilable(String)) == commit_sha }
             &.tag
         end
 


### PR DESCRIPTION
`Package::PackageRelease#details` holds ecosystem-specific registry data with heterogeneous values, so `T::Hash[String, T.untyped]` becomes `T::Hash[String, T.anything]`.

Consumers that read individual values now narrow them: vcpkg casts `commit_sha` to `T.nilable(String)` before comparing and prefix-matching, and npm/bun widen the return type of `possible_previous_versions_with_details` to match (its only caller uses `.map(&:first)` and ignores the details).

Removes `package_release.rb` from the `Sorbet/ForbidTUntyped` burndown list.

Stacked on #15462.
