### PR TITLE
Type message builder commit options and vulnerabilities-fixed

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1646
+# Offense count: 1642
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -303,7 +303,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/metadata_finders/base/changelog_finder.rb"
     - "common/lib/dependabot/metadata_finders/base/release_finder.rb"
     - "common/lib/dependabot/pull_request_creator/github.rb"
-    - "common/lib/dependabot/pull_request_creator/message_builder.rb"
     - "common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb"
     - "common/lib/dependabot/pull_request_updater/azure.rb"
     - "common/lib/dependabot/pull_request_updater/github.rb"

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -100,7 +100,7 @@ module Dependabot
     sig { returns(T::Hash[Symbol, T.anything]) }
     attr_reader :commit_message_options
 
-    sig { returns(T::Hash[String, String]) }
+    sig { returns(T::Hash[String, T::Array[T::Hash[String, String]]]) }
     attr_reader :vulnerabilities_fixed
 
     AzureReviewers = T.type_alias { T.nilable(T::Array[String]) }
@@ -157,7 +157,7 @@ module Dependabot
         author_details: T.nilable(T::Hash[Symbol, String]),
         signature_key: T.nilable(String),
         commit_message_options: T::Hash[Symbol, T.anything],
-        vulnerabilities_fixed: T::Hash[String, String],
+        vulnerabilities_fixed: T::Hash[String, T::Array[T::Hash[String, String]]],
         reviewers: Reviewers,
         assignees: T.nilable(T.any(T::Array[String], T::Array[Integer])),
         milestone: T.nilable(T.any(T::Array[String], Integer)),

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -45,10 +45,10 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       attr_reader :pr_message_footer
 
-      sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { returns(T.nilable(T::Hash[Symbol, T.anything])) }
       attr_reader :commit_message_options
 
-      sig { returns(T::Hash[String, T.untyped]) }
+      sig { returns(T::Hash[String, T::Array[T::Hash[String, String]]]) }
       attr_reader :vulnerabilities_fixed
 
       sig { returns(T.nilable(String)) }
@@ -79,8 +79,8 @@ module Dependabot
           credentials: T::Array[Dependabot::Credential],
           pr_message_header: T.nilable(String),
           pr_message_footer: T.nilable(String),
-          commit_message_options: T.nilable(T::Hash[Symbol, T.untyped]),
-          vulnerabilities_fixed: T::Hash[String, T.untyped],
+          commit_message_options: T.nilable(T::Hash[Symbol, T.anything]),
+          vulnerabilities_fixed: T::Hash[String, T::Array[T::Hash[String, String]]],
           github_redirection_service: T.nilable(String),
           dependency_group: T.nilable(Dependabot::DependencyGroup),
           pr_message_max_length: T.nilable(Integer),
@@ -379,7 +379,7 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def custom_trailers
-        trailers = commit_message_options&.dig(:trailers)
+        trailers = T.cast(commit_message_options&.dig(:trailers), T.nilable(Object))
         return if trailers.nil?
         raise("Commit trailers must be a Hash object") unless trailers.is_a?(Hash)
 
@@ -395,7 +395,7 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def signoff_message
-        signoff_details = commit_message_options&.dig(:signoff_details)
+        signoff_details = T.cast(commit_message_options&.dig(:signoff_details), T.nilable(Object))
         return unless signoff_details.is_a?(Hash)
         return unless signoff_details[:name] && signoff_details[:email]
 
@@ -404,7 +404,7 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def on_behalf_of_message
-        signoff_details = commit_message_options&.dig(:signoff_details)
+        signoff_details = T.cast(commit_message_options&.dig(:signoff_details), T.nilable(Object))
         return unless signoff_details.is_a?(Hash)
         return unless signoff_details[:org_name] && signoff_details[:org_email]
 


### PR DESCRIPTION
`MessageBuilder`'s two loosely-typed inputs are now typed.

`vulnerabilities_fixed` maps a dependency name to an array of fixed-vulnerability hashes, so `T::Hash[String, T.untyped]` becomes `T::Hash[String, T::Array[T::Hash[String, String]]]`, the shape `MetadataPresenter` already expects. The same type flows up through `PullRequestCreator`.

`commit_message_options` holds heterogeneous values, so it becomes `T::Hash[Symbol, T.anything]`. The two `dig` reads for `:trailers` and `:signoff_details` cast to `Object` and keep their existing `is_a?(Hash)` checks.

Removes `message_builder.rb` from the `Sorbet/ForbidTUntyped` burndown list.

Stacked on #15463.
