### PR TITLE
Use shared git-tag cooldown in opentofu

### DIFF
--- a/opentofu/lib/dependabot/opentofu/package/package_details_fetcher.rb
+++ b/opentofu/lib/dependabot/opentofu/package/package_details_fetcher.rb
@@ -13,7 +13,6 @@ module Dependabot
       class PackageDetailsFetcher
         extend T::Sig
 
-        RELEASES_URL_GIT = "https://api.github.com/repos/"
         RELEASE_URL_FOR_PROVIDER = "https://api.opentofu.org/registry/docs/providers/"
         RELEASE_URL_FOR_MODULE = "https://api.opentofu.org/registry/docs/modules/"
         APPLICATION_JSON = "JSON"
@@ -43,38 +42,6 @@ module Dependabot
 
         sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
-
-        sig { returns(T::Array[GitTagWithDetail]) }
-        def fetch_tag_and_release_date
-          truncate_github_url = @dependency.name.gsub("github.com/", "")
-          url = RELEASES_URL_GIT + "#{truncate_github_url}/releases"
-          result_lines = T.let([], T::Array[GitTagWithDetail])
-          # Fetch the releases from the GitHub API
-          response = Excon.get(
-            url,
-            headers: { "User-Agent" => "Dependabot (dependabot.com)",
-                       "Accept" => "application/vnd.github.v3+json" }
-          )
-          Dependabot.logger.error("Failed call details: #{response.body}") unless response.status == 200
-          return result_lines unless response.status == 200
-
-          # Parse the JSON response
-          releases = JSON.parse(response.body)
-
-          # Extract version names and release dates into a hash
-          releases.map do |release|
-            result_lines << GitTagWithDetail.new(
-              tag: release["tag_name"],
-              release_date: release["published_at"]
-            )
-          end
-
-          # sort the result lines by tag in descending order
-          result_lines = result_lines.sort_by(&:tag).reverse
-          # Log the extracted details for debugging
-          Dependabot.logger.info("Extracted release details: #{result_lines}")
-          result_lines
-        end
 
         sig { returns(T::Array[GitTagWithDetail]) }
         def fetch_tag_and_release_date_from_provider

--- a/opentofu/lib/dependabot/opentofu/update_checker.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker.rb
@@ -161,31 +161,26 @@ module Dependabot
 
         # If the dependency is pinned to a tag that looks like a version then
         # we want to update that tag. Because we don't have a lockfile, the
-        # latest version is the tag itself.
-        if git_commit_checker.pinned_ref_looks_like_version?
-          # Filter version tags that are in cooldown period
-          latest_tag =  latest_version_resolver.latest_version_tag&.fetch(:tag)
-          version_rgx = GitCommitChecker::VERSION_REGEX
-          return unless latest_tag.match(version_rgx)
+        # latest version is the tag itself. Tags within their cooldown window
+        # are filtered out by the shared GitCommitChecker.
+        latest_tag = git_commit_checker.local_tag_for_pinned_version_ref(update_cooldown)&.fetch(:tag)
+        return unless latest_tag
 
-          version = latest_tag.match(version_rgx)
-                              .named_captures.fetch("version")
-          return version_class.new(version)
-        end
+        version_rgx = GitCommitChecker::VERSION_REGEX
+        return unless latest_tag.match(version_rgx)
 
-        # If the dependency is pinned to a tag that doesn't look like a
-        # version then there's nothing we can do.
-        nil
+        version = latest_tag.match(version_rgx)
+                            .named_captures.fetch("version")
+        version_class.new(version)
       end
 
       sig { returns(T.nilable(String)) }
       def tag_for_latest_version
         return unless git_commit_checker.git_dependency?
-        return unless git_commit_checker.pinned?
-        return unless git_commit_checker.pinned_ref_looks_like_version?
 
-        latest_tag = git_commit_checker.local_tag_for_latest_version
+        latest_tag = git_commit_checker.local_tag_for_pinned_version_ref(update_cooldown)
                                        &.fetch(:tag)
+        return unless latest_tag
 
         version_rgx = GitCommitChecker::VERSION_REGEX
         return unless latest_tag.match(version_rgx)

--- a/opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb
@@ -35,34 +35,6 @@ module Dependabot
         sig { returns(Dependabot::Dependency) }
         attr_reader :dependency
 
-        # Return latest version tag for the dependency, it removes tags that are in cooldown period
-        # and returns the latest version tag that is not in cooldown period. If exception occurs
-        # it will return the latest version tag from the git_commit_checker. as it was before
-        sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
-        def latest_version_tag
-          # step one fetch allowed version tags and
-          allowed_version_tags = git_commit_checker.allowed_version_tags
-          begin
-            if cooldown_enabled?
-              # sort the allowed version tags by name in descending order
-              select_version_tags_in_cooldown_period&.each do |tag_name|
-                # filter out if name is not in cooldown period
-                allowed_version_tags.reject! do |gitref_filtered|
-                  true if gitref_filtered.name == tag_name
-                end
-              end
-            end
-            Dependabot.logger.info(
-              "Allowed version tags after filtering versions in cooldown:
-              #{allowed_version_tags.map(&:name).join(', ')}"
-            )
-            git_commit_checker.max_local_tag(allowed_version_tags)
-          rescue StandardError => e
-            Dependabot.logger.error("Error fetching latest version tag: #{e.message}")
-            git_commit_checker.local_tag_for_latest_version
-          end
-        end
-
         # To filter versions in cooldown period based on version tags from registry call
         sig do
           params(versions: T::Array[Dependabot::Opentofu::Version])
@@ -113,21 +85,6 @@ module Dependabot
         rescue StandardError => e
           Dependabot.logger.error("Error fetching latest version tag: #{e.message}")
           versions
-        end
-
-        sig { returns(T.nilable(T::Array[String])) }
-        def select_version_tags_in_cooldown_period
-          version_tags_in_cooldown_period = T.let([], T::Array[String])
-
-          package_details_fetcher.fetch_tag_and_release_date.each do |git_tag_with_detail|
-            if check_if_version_in_cooldown_period?(T.must(git_tag_with_detail.release_date))
-              version_tags_in_cooldown_period << git_tag_with_detail.tag
-            end
-          end
-          version_tags_in_cooldown_period
-        rescue StandardError => e
-          Dependabot.logger.error("Error checking if version is in cooldown: #{e.message}")
-          version_tags_in_cooldown_period
         end
 
         sig { params(release_date: String).returns(T::Boolean) }

--- a/opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb
@@ -152,17 +152,6 @@ module Dependabot
           )
         end
 
-        sig { returns(T::Boolean) }
-        def cooldown_enabled?
-          # This is a simple check to see if user has put cooldown days.
-          # If not set, then we aassume user does not want cooldown.
-          # Since OpenTofu does not support Semver versioning, So option left
-          # for the user is to set cooldown default days.
-          return false if @cooldown_options.nil?
-
-          @cooldown_options.default_days.positive?
-        end
-
         sig { returns(Dependabot::GitCommitChecker) }
         attr_reader :git_commit_checker
 

--- a/opentofu/spec/dependabot/opentofu/package/package_details_fetcher_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/package/package_details_fetcher_spec.rb
@@ -51,15 +51,6 @@ RSpec.describe Dependabot::Opentofu::Package::PackageDetailsFetcher do
     described_class.new(dependency: dependency, credentials: credentials, git_commit_checker: git_commit_checker)
   end
 
-  describe "#fetch_tag_and_release_date" do
-    it "fetches and parses release tags and dates", :vcr do
-      result = fetcher.fetch_tag_and_release_date
-      expect(result).to include(
-        an_object_having_attributes(tag: "v6.5.0", release_date: "2025-01-17T01:19:11Z")
-      )
-    end
-  end
-
   describe "#fetch_tag_and_release_date_from_provider" do
     it "fetches and parses provider release tags and dates", :vcr do
       result = fetcher.fetch_tag_and_release_date_from_provider

--- a/opentofu/spec/dependabot/opentofu/update_checker_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/update_checker_spec.rb
@@ -3,6 +3,9 @@
 
 require "spec_helper"
 require "dependabot/dependency"
+require "dependabot/git_commit_checker"
+require "dependabot/git_tag_details"
+require "dependabot/package/release_cooldown_options"
 require "dependabot/opentofu"
 require "dependabot/opentofu/update_checker"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
@@ -31,6 +34,7 @@ RSpec.describe Dependabot::Opentofu::UpdateChecker do
     )
   end
   let(:ignored_versions) { [] }
+  let(:update_cooldown) { nil }
   let(:credentials) do
     [{
       "type" => "git_source",
@@ -44,7 +48,8 @@ RSpec.describe Dependabot::Opentofu::UpdateChecker do
       dependency: dependency,
       dependency_files: [],
       credentials: credentials,
-      ignored_versions: ignored_versions
+      ignored_versions: ignored_versions,
+      update_cooldown: update_cooldown
     )
   end
 
@@ -90,6 +95,40 @@ RSpec.describe Dependabot::Opentofu::UpdateChecker do
       end
 
       it { is_expected.to eq(Gem::Version.new("0.4.1")) }
+
+      context "when the newest tags are within their cooldown window" do
+        let(:update_cooldown) do
+          Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          # Cooldown filtering itself is covered in git_commit_checker_spec; here we
+          # assert opentofu resolves the git tag through the shared cooldown-aware
+          # helper, which has filtered the brand-new 0.4.x tags back to 0.3.8.
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive_messages(
+            git_dependency?: true,
+            pinned?: true,
+            local_tag_for_pinned_version_ref: Dependabot::GitTagDetails.new(
+              tag: "0.3.8",
+              version: Dependabot::Opentofu::Version.new("0.3.8"),
+              commit_sha: "abc123",
+              tag_sha: "def456"
+            )
+          )
+        end
+
+        it "returns the latest tag left after cooldown filtering" do
+          expect(latest_version).to eq(Gem::Version.new("0.3.8"))
+        end
+
+        it "forwards the configured cooldown window to the git commit checker" do
+          latest_version
+          expect(git_checker).to have_received(:local_tag_for_pinned_version_ref)
+            .with(update_cooldown).at_least(:once)
+        end
+      end
     end
 
     context "with a registry dependency" do


### PR DESCRIPTION
### What are you trying to accomplish?

Now that git-tag cooldown is generalized in `common` (`GitCommitChecker#local_tag_for_latest_version(cooldown_options)` and `#local_tag_for_pinned_version_ref`), migrate **opentofu** off its own duplicated git-tag cooldown implementation onto the shared one. opentofu mirrored terraform, so this is the same treatment as the terraform migration.

Part of the git-tag cooldown generalization spike (github/dependabot-updates#13901), batch github/dependabot-updates#13952 (issue #13954).

Changes:
- `update_checker.rb`: `latest_version_for_git_dependency` and `tag_for_latest_version` resolve via `git_commit_checker.local_tag_for_pinned_version_ref(update_cooldown)` (folds in the pinned-ref precondition and applies cooldown). This also fixes an inconsistency where `tag_for_latest_version` ignored cooldown while `latest_version_for_git_dependency` applied it.
- `update_checker/latest_version_resolver.rb`: drop the bespoke git-tag `latest_version_tag` and `select_version_tags_in_cooldown_period`. Registry provider/module cooldown filtering is unchanged.
- `package/package_details_fetcher.rb`: drop the now-unused git `fetch_tag_and_release_date` (unauthenticated GitHub `/releases` call) and `RELEASES_URL_GIT`.

### Anything you want to highlight for special attention from reviewers?

- **Never applies to security updates** — `update_cooldown` is `nil` for security jobs and the shared method short-circuits via `CooldownCalculation.skip_cooldown?`.
- **Registry cooldown untouched** — only the git-tag path is migrated; the provider/module registry cooldown (`filter_versions_in_cooldown_period_from_provider/_module`) stays.
- Behaviour is a slight improvement: release dates now come from the shared GitCommitChecker (GitHub Release `published_at` → tag creation date) rather than an unauthenticated `/releases` call, and the git path is semver-aware via the shared primitives.

### How will you know you've accomplished your goal?

Refactor is functionally equivalent, verified in Docker:

- Existing git-dependency tests (`#latest_version`, `#latest_resolvable_version`, `#can_update?`, `#updated_requirements`) exercise the migrated path via a real upload-pack fixture and pass.
- Added a git-tag cooldown test to `update_checker_spec` (cooldown filters the newest tags); cooldown filtering itself remains covered by `git_commit_checker_spec`.
- Removed the spec for the deleted git fetcher method.

Results:
- rubocop: clean (5 files)
- sorbet `srb tc`: no errors (whole repo)
- affected specs (`update_checker`, `latest_version_resolver`, `package_details_fetcher`): 36 examples, 0 failures
- full `opentofu` suite: 293 examples, **0 related failures** (1 pre-existing environmental failure in `file_updater_spec.rb:1496`, a `tofu` CLI module-install path that is byte-identical to `main` and unrelated to this change)

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
