### PR TITLE
Detect cargo registries across hierarchical .cargo/config.toml files

### DIFF
--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -47,7 +47,7 @@ module Dependabot
       def fetch_files
         fetched_files = T.let([cargo_toml], T::Array[DependencyFile])
         fetched_files << T.must(cargo_lock) if cargo_lock
-        fetched_files << T.must(cargo_config) if cargo_config
+        fetched_files.concat(cargo_configs)
         fetched_files << T.must(rust_toolchain) if rust_toolchain
         fetched_files += fetch_path_dependency_and_workspace_files
         parsed_manifest = parsed_file(cargo_toml)
@@ -428,17 +428,51 @@ module Dependabot
         @cargo_lock ||= T.let(fetch_file_if_present("Cargo.lock"), T.nilable(Dependabot::DependencyFile))
       end
 
+      # Cargo merges configuration hierarchically: it reads `.cargo/config.toml`
+      # from the package directory *and* every ancestor directory up to the repo
+      # root, combining them. We therefore collect all of them so that registries
+      # (and other settings) defined higher up the tree are not dropped.
+      #
+      # The package-directory config keeps the canonical name `.cargo/config.toml`
+      # (single-config consumers rely on this). Ancestor configs keep their
+      # relative `../` paths so they are written to the correct location and can
+      # be merged by Cargo. When the package directory has no config of its own,
+      # the nearest ancestor is promoted to the canonical name to preserve the
+      # historical behaviour that downstream consumers depend on.
+      sig { returns(T::Array[Dependabot::DependencyFile]) }
+      def cargo_configs
+        return T.must(@cargo_configs) if defined?(@cargo_configs)
+
+        configs = T.let([], T::Array[Dependabot::DependencyFile])
+        local = local_cargo_config
+        parents = parent_dir_cargo_configs
+
+        if local
+          configs << local
+          configs.concat(parents)
+        elsif parents.any?
+          effective = T.must(parents.first)
+          effective.name = ".cargo/config.toml"
+          configs << effective
+          configs.concat(parents.drop(1))
+        end
+
+        @cargo_configs = T.let(configs, T.nilable(T::Array[Dependabot::DependencyFile]))
+        configs
+      end
+
       sig { returns(T.nilable(Dependabot::DependencyFile)) }
       def cargo_config
-        return @cargo_config if defined?(@cargo_config)
+        cargo_configs.find { |f| f.name == ".cargo/config.toml" }
+      end
 
-        @cargo_config = fetch_support_file(".cargo/config.toml")
-        @cargo_config ||= T.let(
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
+      def local_cargo_config
+        return @local_cargo_config if defined?(@local_cargo_config)
+
+        @local_cargo_config = fetch_support_file(".cargo/config.toml")
+        @local_cargo_config ||= T.let(
           fetch_support_file(".cargo/config")&.tap { |f| f.name = ".cargo/config.toml" },
-          T.nilable(Dependabot::DependencyFile)
-        )
-        @cargo_config ||= T.let(
-          fetch_cargo_config_from_parent_dirs,
           T.nilable(Dependabot::DependencyFile)
         )
       end
@@ -470,22 +504,26 @@ module Dependabot
         super.tap { |f| f.name = Pathname.new(f.name).cleanpath.to_s.gsub(%r{^/+}, "") }
       end
 
-      sig { returns(T.nilable(Dependabot::DependencyFile)) }
-      def fetch_cargo_config_from_parent_dirs
-        return nil if directory.empty?
+      sig { returns(T::Array[Dependabot::DependencyFile]) }
+      def parent_dir_cargo_configs
+        return T.must(@parent_dir_cargo_configs) if defined?(@parent_dir_cargo_configs)
+
+        configs = T.let([], T::Array[Dependabot::DependencyFile])
+        @parent_dir_cargo_configs = T.let(configs, T.nilable(T::Array[Dependabot::DependencyFile]))
+        return configs if directory.empty?
 
         # Count directory depth to determine how many levels to search up
         depth = directory.split("/").count { |s| !s.empty? }
-        return nil if depth.zero?
+        return configs if depth.zero?
 
-        # Try each parent directory level
+        # Collect a config from every ancestor directory that has one, nearest first
         depth.times do |i|
           parent_path = ([".."] * (i + 1)).join("/")
           config = try_fetch_config_at_path(parent_path)
-          return config if config
+          configs << config if config
         end
 
-        nil
+        configs
       end
 
       sig { params(parent_path: String).returns(T.nilable(Dependabot::DependencyFile)) }
@@ -499,7 +537,9 @@ module Dependabot
           )
           Dependabot.logger.debug("Successfully fetched config from: #{full_path}")
           config.support_file = true
-          config.name = ".cargo/config.toml"
+          # Normalise `.cargo/config` to `.cargo/config.toml` while preserving the
+          # relative `../` path so the file is written to the right location.
+          config.name = Pathname.new(File.join(parent_path, ".cargo/config.toml")).cleanpath.to_s
           return config
         rescue Dependabot::DependencyFileNotFound
           Dependabot.logger.debug("No config found at: #{full_path}")

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -332,10 +332,15 @@ module Dependabot
 
       sig { params(key_name: String).returns(T.nilable(String)) }
       def cargo_config_from_file(key_name)
-        config_file = cargo_config
-        return nil unless config_file
+        # Cargo merges `.cargo/config.toml` hierarchically, with nearer configs
+        # taking precedence over ancestors. Search the package-directory config
+        # first, then each ancestor config, returning the first match.
+        cargo_config_files.each do |config_file|
+          value = parsed_file(config_file).dig(*key_name.split("."))
+          return value if value
+        end
 
-        parsed_file(config_file).dig(*key_name.split("."))
+        nil
       end
 
       sig { params(name: String, declaration: T.any(String, T::Hash[String, String])).returns(T.nilable(String)) }
@@ -422,9 +427,18 @@ module Dependabot
         @lockfile ||= T.let(get_original_file("Cargo.lock"), T.nilable(Dependabot::DependencyFile))
       end
 
-      sig { returns(T.nilable(Dependabot::DependencyFile)) }
-      def cargo_config
-        @cargo_config ||= T.let(get_original_file(".cargo/config.toml"), T.nilable(Dependabot::DependencyFile))
+      # All `.cargo/config.toml` files in the fetched set, ordered nearest-first
+      # (package directory config, then successive ancestors). Ancestor configs
+      # carry relative `../` names, so we order by `../` depth to reflect Cargo's
+      # nearest-wins precedence.
+      sig { returns(T::Array[Dependabot::DependencyFile]) }
+      def cargo_config_files
+        @cargo_config_files ||= T.let(
+          dependency_files
+            .select { |f| f.name.end_with?(".cargo/config.toml") }
+            .sort_by { |f| f.name.scan("../").count },
+          T.nilable(T::Array[Dependabot::DependencyFile])
+        )
       end
 
       sig { returns(T.class_of(Dependabot::Version)) }

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -307,7 +307,10 @@ module Dependabot
           File.write(T.must(toolchain).name, T.must(toolchain).content) if toolchain
           config_files.each do |config_file|
             FileUtils.mkdir_p(File.dirname(config_file.name))
-            File.write(config_file.name, Helpers.sanitize_cargo_config(T.must(config_file.content)))
+            File.write(
+              config_file.name,
+              Helpers.sanitize_cargo_config(T.must(config_file.content), file_name: config_file.name)
+            )
           end
         end
 

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -41,7 +41,7 @@ module Dependabot
           @path_dependency_files = T.let(nil, T.nilable(T::Array[Dependabot::DependencyFile]))
           @lockfile = T.let(nil, T.nilable(Dependabot::DependencyFile))
           @toolchain = T.let(nil, T.nilable(Dependabot::DependencyFile))
-          @config = T.let(nil, T.nilable(Dependabot::DependencyFile))
+          @config_files = T.let(nil, T.nilable(T::Array[Dependabot::DependencyFile]))
         end
 
         sig { returns(T.any(String, T.noreturn)) }
@@ -305,11 +305,10 @@ module Dependabot
 
           File.write(lockfile.name, replace_ssh_urls(T.must(lockfile.content)))
           File.write(T.must(toolchain).name, T.must(toolchain).content) if toolchain
-          config_file = config
-          return unless config_file
-
-          FileUtils.mkdir_p(File.dirname(config_file.name))
-          File.write(config_file.name, Helpers.sanitize_cargo_config(T.must(config_file.content)))
+          config_files.each do |config_file|
+            FileUtils.mkdir_p(File.dirname(config_file.name))
+            File.write(config_file.name, Helpers.sanitize_cargo_config(T.must(config_file.content)))
+          end
         end
 
         sig { void }
@@ -537,9 +536,12 @@ module Dependabot
             dependency_files.find { |f| f.name == "rust-toolchain" }
         end
 
-        sig { returns(T.nilable(Dependabot::DependencyFile)) }
-        def config
-          @config ||= dependency_files.find { |f| f.name == ".cargo/config.toml" }
+        # Cargo merges `.cargo/config.toml` hierarchically (package directory plus
+        # every ancestor up to the repo root), so we materialise all of them and
+        # let Cargo perform the merge with its own precedence rules.
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        def config_files
+          @config_files ||= dependency_files.select { |f| f.name.end_with?(".cargo/config.toml") }
         end
 
         sig { params(file: Dependabot::DependencyFile).returns(T::Boolean) }

--- a/cargo/lib/dependabot/cargo/helpers.rb
+++ b/cargo/lib/dependabot/cargo/helpers.rb
@@ -109,10 +109,12 @@ module Dependabot
         ).returns(T::Hash[String, String])
       end
       def self.registry_token_env_from_files(dependency_files, credentials)
-        config_file = dependency_files.find { |f| f.name == ".cargo/config.toml" }
-        return {} unless config_file
+        config_files = dependency_files.select { |f| f.name.end_with?(".cargo/config.toml") }
+        return {} if config_files.empty?
 
-        registry_token_env(T.must(config_file.content), credentials)
+        config_files.each_with_object({}) do |config_file, env|
+          env.merge!(registry_token_env(T.must(config_file.content), credentials))
+        end
       end
 
       # Builds the complete environment variable hash for running cargo commands:

--- a/cargo/lib/dependabot/cargo/helpers.rb
+++ b/cargo/lib/dependabot/cargo/helpers.rb
@@ -19,8 +19,8 @@ module Dependabot
       # These per-registry settings override the global CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS env var,
       # causing Cargo to look up tokens locally. Since the dependabot proxy handles all registry authentication
       # transparently, we remove these so Cargo makes plain unauthenticated requests that the proxy can intercept.
-      sig { params(config_content: String).returns(String) }
-      def self.sanitize_cargo_config(config_content)
+      sig { params(config_content: String, file_name: String).returns(String) }
+      def self.sanitize_cargo_config(config_content, file_name: ".cargo/config.toml")
         parsed = TomlRB.parse(config_content)
         return config_content unless parsed.is_a?(Hash)
 
@@ -40,7 +40,7 @@ module Dependabot
         TomlRB.dump(parsed)
       rescue TomlRB::Error => e
         raise Dependabot::DependencyFileNotParseable.new(
-          ".cargo/config.toml",
+          file_name,
           "Failed to parse Cargo config file: #{e.message}"
         )
       end
@@ -112,7 +112,12 @@ module Dependabot
         config_files = dependency_files.select { |f| f.name.end_with?(".cargo/config.toml") }
         return {} if config_files.empty?
 
-        config_files.each_with_object({}) do |config_file, env|
+        # Cargo gives nearer configs precedence over ancestors on key collisions.
+        # A config's `../` depth (how many parent hops appear in its name)
+        # indicates how far up the tree it lives, so merge farthest-first and let
+        # the nearest config (fewest `../`) win.
+        ordered = config_files.sort_by { |f| -f.name.scan("../").count }
+        ordered.each_with_object({}) do |config_file, env|
           env.merge!(registry_token_env(T.must(config_file.content), credentials))
         end
       end

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -215,7 +215,10 @@ module Dependabot
           File.write(T.must(toolchain).name, T.must(toolchain).content) if toolchain
           config_files.each do |config_file|
             FileUtils.mkdir_p(File.dirname(config_file.name))
-            File.write(config_file.name, Helpers.sanitize_cargo_config(T.must(config_file.content)))
+            File.write(
+              config_file.name,
+              Helpers.sanitize_cargo_config(T.must(config_file.content), file_name: config_file.name)
+            )
           end
         end
 

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -207,17 +207,16 @@ module Dependabot
           )
         end
 
-        sig { params(prepared: T::Boolean).returns(T.nilable(Integer)) }
+        sig { params(prepared: T::Boolean).void }
         def write_temporary_dependency_files(prepared: true)
           write_manifest_files(prepared: prepared)
 
           File.write(T.must(lockfile).name, T.must(lockfile).content) if lockfile
           File.write(T.must(toolchain).name, T.must(toolchain).content) if toolchain
-          config_file = config
-          return unless config_file
-
-          FileUtils.mkdir_p(File.dirname(config_file.name))
-          File.write(config_file.name, Helpers.sanitize_cargo_config(T.must(config_file.content)))
+          config_files.each do |config_file|
+            FileUtils.mkdir_p(File.dirname(config_file.name))
+            File.write(config_file.name, Helpers.sanitize_cargo_config(T.must(config_file.content)))
+          end
         end
 
         sig { void }
@@ -554,13 +553,18 @@ module Dependabot
           )
         end
 
-        sig { returns(T.nilable(DependencyFile)) }
-        def config
-          @config ||= T.let(
-            original_dependency_files.find do |f|
-              f.name == ".cargo/config.toml"
+        # Cargo merges `.cargo/config.toml` hierarchically (package directory plus
+        # every ancestor up to the repo root), so we materialise all of them and
+        # let Cargo perform the merge with its own precedence rules. Ancestor
+        # configs carry relative `../` names and are written to the matching
+        # location within the temporary tree.
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        def config_files
+          @config_files ||= T.let(
+            original_dependency_files.select do |f|
+              f.name.end_with?(".cargo/config.toml")
             end,
-            T.nilable(Dependabot::DependencyFile)
+            T.nilable(T::Array[Dependabot::DependencyFile])
           )
         end
 

--- a/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_fetcher_spec.rb
@@ -226,6 +226,139 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
     end
   end
 
+  context "with a config file at repository root and Cargo.toml in a deeply nested directory" do
+    let(:source) do
+      Dependabot::Source.new(
+        provider: "github",
+        repo: "gocardless/bump",
+        directory: "a/b/c"
+      )
+    end
+
+    let(:url) do
+      "https://api.github.com/repos/gocardless/bump/contents/a/b/c/"
+    end
+
+    before do
+      # Mock the nested directory listing (includes Cargo.toml and Cargo.lock)
+      stub_request(:get, "https://api.github.com/repos/gocardless/bump/contents/a/b/c?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_cargo_with_lockfile.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, url + "Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_cargo_manifest.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, url + "Cargo.lock?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_cargo_lockfile.json"),
+          headers: json_header
+        )
+
+      # No config anywhere between the nested directory and the repository root
+      %w(a/b/c a/b a).each do |dir|
+        base = "https://api.github.com/repos/gocardless/bump/contents/#{dir}"
+        stub_request(:get, "#{base}/.cargo?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 404, headers: json_header)
+        stub_request(:get, "#{base}/.cargo/config.toml?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 404, headers: json_header)
+        stub_request(:get, "#{base}/.cargo/config?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 404, headers: json_header)
+      end
+
+      # Config at repository root, reachable only by walking up multiple parent dirs
+      stub_request(:get, "https://api.github.com/repos/gocardless/bump/contents/.cargo?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_cargo_dir.json"),
+          headers: json_header
+        )
+
+      stub_request(:get, "https://api.github.com/repos/gocardless/bump/contents/.cargo/config.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_cargo_config.json"),
+          headers: json_header
+        )
+    end
+
+    it "names the config file exactly '.cargo/config.toml' regardless of nesting depth" do
+      config = file_fetcher_instance.files.find { |f| f.name.end_with?("config.toml") }
+
+      expect(config.name).to eq(".cargo/config.toml")
+      # Depth is captured in the directory / path, never in the name.
+      expect(config.path).to eq("/a/b/c/.cargo/config.toml")
+    end
+  end
+
+  context "with cargo config files in both the package directory and the repository root" do
+    let(:source) do
+      Dependabot::Source.new(
+        provider: "github",
+        repo: "gocardless/bump",
+        directory: "my_dir"
+      )
+    end
+
+    let(:url) do
+      "https://api.github.com/repos/gocardless/bump/contents/my_dir/"
+    end
+
+    before do
+      stub_request(:get, "https://api.github.com/repos/gocardless/bump/contents/my_dir?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: fixture("github", "contents_cargo_with_lockfile.json"), headers: json_header)
+
+      stub_request(:get, url + "Cargo.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: fixture("github", "contents_cargo_manifest.json"), headers: json_header)
+
+      stub_request(:get, url + "Cargo.lock?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: fixture("github", "contents_cargo_lockfile.json"), headers: json_header)
+
+      # Local config in the package directory
+      stub_request(:get, url + ".cargo?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: fixture("github", "contents_cargo_dir.json"), headers: json_header)
+      stub_request(:get, url + ".cargo/config.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: fixture("github", "contents_cargo_config.json"), headers: json_header)
+
+      # Config also present at the repository root (an ancestor directory)
+      stub_request(:get, "https://api.github.com/repos/gocardless/bump/contents/.cargo/config.toml?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 200, body: fixture("github", "contents_cargo_config.json"), headers: json_header)
+    end
+
+    it "fetches both the package-directory and ancestor cargo configs" do
+      config_files = file_fetcher_instance.files.select { |f| f.name.end_with?(".cargo/config.toml") }
+
+      expect(config_files.map(&:name))
+        .to match_array(%w(.cargo/config.toml ../.cargo/config.toml))
+      # The ancestor config keeps its relative path so Cargo can merge it,
+      # while the package-directory config keeps the canonical name.
+      expect(config_files.map(&:path))
+        .to match_array(%w(/my_dir/.cargo/config.toml /.cargo/config.toml))
+      expect(config_files).to all(be_support_file)
+    end
+  end
+
   context "without a lockfile" do
     before do
       stub_request(:get, url + "?ref=sha")
@@ -458,6 +591,14 @@ RSpec.describe Dependabot::Cargo::FileFetcher do
               body: fixture("github", "contents_cargo_without_lockfile.json"),
               headers: json_header
             )
+
+          # No cargo config in the parent (repository root) directory
+          stub_request(:get, "https://api.github.com/repos/gocardless/bump/contents/.cargo/config.toml?ref=sha")
+            .with(headers: { "Authorization" => "token token" })
+            .to_return(status: 404, headers: json_header)
+          stub_request(:get, "https://api.github.com/repos/gocardless/bump/contents/.cargo/config?ref=sha")
+            .with(headers: { "Authorization" => "token token" })
+            .to_return(status: 404, headers: json_header)
         end
 
         it "fetches the path dependency's Cargo.toml" do

--- a/cargo/spec/dependabot/cargo/file_parser_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_parser_spec.rb
@@ -516,6 +516,54 @@ RSpec.describe Dependabot::Cargo::FileParser do
         end
       end
 
+      context "with a registry defined only in an ancestor .cargo/config.toml" do
+        let(:manifest) do
+          Dependabot::DependencyFile.new(
+            name: "Cargo.toml",
+            content: <<~TOML
+              [package]
+              name = "test"
+              version = "0.1.0"
+
+              [dependencies]
+              private-dep = { version = "0.1.0", registry = "my-registry" }
+            TOML
+          )
+        end
+        let(:ancestor_config) do
+          Dependabot::DependencyFile.new(
+            name: "../.cargo/config.toml",
+            support_file: true,
+            content: <<~TOML
+              [registries.my-registry]
+              index = "sparse+https://private.example.com/index/"
+            TOML
+          )
+        end
+        let(:files) { [manifest, ancestor_config] }
+
+        before do
+          stub_request(:get, "https://private.example.com/index/config.json")
+            .to_return(
+              status: 200,
+              body: {
+                "dl" => "https://private.example.com/api/v1/crates",
+                "api" => "https://private.example.com"
+              }.to_json
+            )
+        end
+
+        it "resolves the registry from the ancestor config" do
+          dependency = dependencies.find { |dep| dep.name == "private-dep" }
+          expect(dependency).to be_a(Dependabot::Dependency)
+          expect(dependency.requirements.first[:source]).to include(
+            type: "registry",
+            name: "my-registry",
+            index: "sparse+https://private.example.com/index/"
+          )
+        end
+      end
+
       context "when the input is unparseable" do
         let(:manifest_fixture_name) { "unparseable" }
 

--- a/cargo/spec/dependabot/cargo/helpers_spec.rb
+++ b/cargo/spec/dependabot/cargo/helpers_spec.rb
@@ -327,12 +327,12 @@ RSpec.describe Dependabot::Cargo::Helpers do
         [
           Dependabot::DependencyFile.new(
             name: ".cargo/config.toml",
-            content: root_config_content,
-            directory: "/"
+            content: nested_config_content,
+            directory: "/subcrate"
           ),
           Dependabot::DependencyFile.new(
-            name: ".cargo/config.toml",
-            content: nested_config_content,
+            name: "../.cargo/config.toml",
+            content: root_config_content,
             directory: "/subcrate"
           )
         ]

--- a/cargo/spec/dependabot/cargo/helpers_spec.rb
+++ b/cargo/spec/dependabot/cargo/helpers_spec.rb
@@ -302,6 +302,52 @@ RSpec.describe Dependabot::Cargo::Helpers do
     end
   end
 
+  describe ".registry_token_env_from_files" do
+    let(:creds) do
+      [
+        { "host" => "private.example.com" },
+        { "host" => "another.example.com" }
+      ]
+    end
+
+    context "when multiple .cargo/config.toml files each define a registry" do
+      let(:root_config_content) do
+        <<~TOML
+          [registries.my-private-registry]
+          index = "sparse+https://private.example.com/index/"
+        TOML
+      end
+      let(:nested_config_content) do
+        <<~TOML
+          [registries.another-registry]
+          index = "sparse+https://another.example.com/index/"
+        TOML
+      end
+      let(:dependency_files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: ".cargo/config.toml",
+            content: root_config_content,
+            directory: "/"
+          ),
+          Dependabot::DependencyFile.new(
+            name: ".cargo/config.toml",
+            content: nested_config_content,
+            directory: "/subcrate"
+          )
+        ]
+      end
+
+      it "returns token env vars for registries defined across all config files" do
+        env = described_class.registry_token_env_from_files(dependency_files, creds)
+        expect(env).to eq(
+          "CARGO_REGISTRIES_MY_PRIVATE_REGISTRY_TOKEN" => "garbage_token",
+          "CARGO_REGISTRIES_ANOTHER_REGISTRY_TOKEN" => "garbage_token"
+        )
+      end
+    end
+  end
+
   describe ".cargo_command_env" do
     let(:config_content) do
       <<~TOML


### PR DESCRIPTION
## Summary

Cargo merges configuration **hierarchically** — it reads `.cargo/config.toml` from the package directory *and* every ancestor directory up to the repo root. Dependabot only ever surfaced/used a single config file, so anything defined in ancestor configs was dropped: registries' `CARGO_REGISTRIES_<NAME>_TOKEN` env vars were never set **and** their `index`/`[source]` settings were never applied during resolution.

## Root cause

Three gaps, all fixed here:

1. **File fetcher** (`cargo/lib/dependabot/cargo/file_fetcher.rb`): `cargo_config` returned a single `.cargo/config.toml` — the package-dir config, or the *nearest* ancestor only when the package dir had none. Configs from other ancestor levels were never fetched.
2. **Helpers** (`cargo/lib/dependabot/cargo/helpers.rb`): `registry_token_env_from_files` used `Array#find`, so even when multiple config files were present it only read the first.
3. **Resolution writers** (`update_checker/version_resolver.rb`, `file_updater/lockfile_updater.rb`): when materialising files into the temporary working tree they wrote only the single canonical `.cargo/config.toml`, so ancestor configs never reached disk and Cargo couldn't merge them.

## Changes

- The fetcher now collects the whole config hierarchy. The package-directory config keeps the canonical name `.cargo/config.toml` (single-config consumers rely on it); ancestor configs keep their relative `../` paths so they're written to the correct location and can be merged by Cargo. When the package dir has no config, the nearest ancestor is promoted to the canonical name, preserving prior behaviour.
- `registry_token_env_from_files` now `select`s every `*.cargo/config.toml` file and merges their registry token env vars.
- `version_resolver` and `lockfile_updater` now write **every** config file in the hierarchy into the temp tree. `SharedHelpers.in_a_temporary_directory` roots the temp dir at the repo and chdirs into the package directory, so `../`-named ancestor configs land at their real relative locations (always inside the temp tree, since `../` configs only exist for nested directories). Cargo then performs the hierarchical merge — tokens **and** index/source — natively.

## Tests

- `file_fetcher_spec`: config in a deeply nested directory (name stays `.cargo/config.toml`, depth lives in the path); config present in **both** the package dir and the repo root (both fetched, ancestor keeps its `../` path).
- `helpers_spec`: multiple `.cargo/config.toml` files each defining a distinct registry.

## Verification

- `bundle exec rspec spec/dependabot/cargo/helpers_spec.rb spec/dependabot/cargo/file_fetcher_spec.rb` — 96 examples, 0 failures
- `bundle exec rspec spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb` — 31/33; the 2 failures are pre-existing sandbox/network `SIGTERM`s (old-toolchain download, SSH git fetch) that also fail on `main` unchanged
- `bundle exec srb tc` — clean
- `bundle exec rubocop` on changed files — no offenses
