### PR TITLE
Fail open when git-tag cooldown date fetch errors

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -849,6 +849,10 @@ module Dependabot
       )
     end
 
+    # Fails open: if the tag-detail fetch is unavailable (e.g. a network or
+    # registry error while resolving tag dates), return no dates so cooldown
+    # treats every tag as outside its window and the latest tag is still
+    # proposed, rather than failing the whole update check.
     sig { returns(T::Hash[String, Time]) }
     def build_release_dates_by_tag_name
       dates = T.let({}, T::Hash[String, Time])
@@ -857,6 +861,11 @@ module Dependabot
         dates[detail.tag] = released_at if released_at
       end
       dates
+    rescue StandardError => e
+      Dependabot.logger.error(
+        "Error fetching git tag release dates for #{dependency.name}: #{e.message}"
+      )
+      {}
     end
 
     sig { params(release_date: T.nilable(String)).returns(T.nilable(Time)) }

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -849,10 +849,10 @@ module Dependabot
       )
     end
 
-    # Fails open: if the tag-detail fetch is unavailable (e.g. a network or
-    # registry error while resolving tag dates), return no dates so cooldown
-    # treats every tag as outside its window and the latest tag is still
-    # proposed, rather than failing the whole update check.
+    # Fails open: if the tag-detail fetch is unavailable (e.g. a network error
+    # or an error from the git host / GitHub API while resolving tag dates),
+    # return no dates so cooldown treats every tag as outside its window and the
+    # latest tag is still proposed, rather than failing the whole update check.
     sig { returns(T::Hash[String, Time]) }
     def build_release_dates_by_tag_name
       dates = T.let({}, T::Hash[String, Time])
@@ -862,8 +862,9 @@ module Dependabot
       end
       dates
     rescue StandardError => e
-      Dependabot.logger.error(
-        "Error fetching git tag release dates for #{dependency.name}: #{e.message}"
+      Dependabot.logger.warn(
+        "Skipping git tag cooldown for #{dependency.name}: could not resolve tag release dates " \
+        "(#{e.class}: #{e.message})"
       )
       {}
     end

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -1339,6 +1339,20 @@ RSpec.describe Dependabot::GitCommitChecker do
         end
       end
 
+      context "when fetching tag release dates raises" do
+        let(:refs_with_detail) { [] }
+
+        before do
+          allow(checker)
+            .to receive(:refs_for_tag_with_detail)
+            .and_raise(Dependabot::GitDependenciesNotReachable.new(["https://github.com/gocardless/business"]))
+        end
+
+        it "fails open and returns the latest version tag" do
+          expect(latest_tag[:tag]).to eq("v1.13.0")
+        end
+      end
+
       context "when the dependency is excluded from cooldown" do
         let(:cooldown_options) do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90, exclude: ["business"])


### PR DESCRIPTION
### What are you trying to accomplish?

Make git-tag cooldown **fail open** in the shared `GitCommitChecker` so a failure while fetching tag release dates can't fail an otherwise-successful update check.

`GitCommitChecker#local_tag_for_latest_version(cooldown_options)` resolves each candidate tag's release date via `refs_for_tag_with_detail`, which performs a separate tag-detail fetch that can raise (e.g. `GitDependenciesNotReachable`, `Octokit::Error`) independently of the main tag listing. Before the git-tag cooldown generalization, several ecosystems (python, terraform, opentofu, …) wrapped their own cooldown logic in a `rescue` that fell back to the non-cooldown latest tag. That fault-tolerance was lost when they moved onto the shared method.

This rescues in `build_release_dates_by_tag_name` so a date-fetch failure yields no dates: cooldown then treats every tag as outside its window and the latest tag is still proposed, rather than raising and failing the whole update check. It restores the prior fallback for every ecosystem in one place, keeping the de-duplication intact.

Raised by a Copilot review on #15470 (python migration).

### Anything you want to highlight for special attention from reviewers?

- The method already fails open for the two most common cases — `github_release_published_at` and `parse_release_date` both rescue to `nil`. This closes the remaining gap: an exception from the tag-detail fetch itself.
- The rescue is scoped to `build_release_dates_by_tag_name` (the cooldown consumer), not `refs_for_tag_with_detail`, so direct callers of `refs_for_tag_with_detail` (github_actions, pre_commit) keep their existing error semantics.
- No behaviour change on the happy path or for the "repo unreachable while listing tags" case (that still raises for cooldown and non-cooldown alike, as before).

### How will you know you've accomplished your goal?

- Added a `git_commit_checker_spec` context: when `refs_for_tag_with_detail` raises, `local_tag_for_latest_version(cooldown_options)` returns the latest tag instead of propagating the error.
- sorbet `srb tc`: no errors (whole repo)
- rubocop: clean
- `git_commit_checker_spec`: 140 examples, 0 failures

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
