### PR TITLE
Add word-separator and lowercase formatting for branch name

### DIFF
--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -129,8 +129,8 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_reader :branch_name_word_separator
 
-    sig { returns(T::Boolean) }
-    attr_reader :branch_name_lowercase
+    sig { returns(T.nilable(String)) }
+    attr_reader :branch_name_case
 
     sig { returns(String) }
     attr_reader :github_redirection_service
@@ -171,7 +171,7 @@ module Dependabot
         branch_name_prefix: String,
         branch_name_max_length: T.nilable(Integer),
         branch_name_word_separator: T.nilable(String),
-        branch_name_lowercase: T::Boolean,
+        branch_name_case: T.nilable(String),
         label_language: T::Boolean,
         automerge_candidate: T::Boolean,
         github_redirection_service: String,
@@ -207,7 +207,7 @@ module Dependabot
       branch_name_prefix: "dependabot",
       branch_name_max_length: 100,
       branch_name_word_separator: nil,
-      branch_name_lowercase: false,
+      branch_name_case: nil,
       label_language: false,
       automerge_candidate: false,
       github_redirection_service: DEFAULT_GITHUB_REDIRECTION_SERVICE,
@@ -238,7 +238,7 @@ module Dependabot
       @branch_name_prefix         = branch_name_prefix
       @branch_name_max_length     = branch_name_max_length
       @branch_name_word_separator = branch_name_word_separator
-      @branch_name_lowercase      = branch_name_lowercase
+      @branch_name_case = branch_name_case
       @label_language             = label_language
       @automerge_candidate        = automerge_candidate
       @github_redirection_service = github_redirection_service
@@ -433,7 +433,7 @@ module Dependabot
           prefix: branch_name_prefix,
           max_length: branch_name_max_length,
           word_separator: branch_name_word_separator,
-          lowercase: branch_name_lowercase,
+          branch_name_case: branch_name_case,
           includes_security_fixes: includes_security_fixes?
         ),
         T.nilable(Dependabot::PullRequestCreator::BranchNamer)

--- a/common/lib/dependabot/pull_request_creator.rb
+++ b/common/lib/dependabot/pull_request_creator.rb
@@ -126,6 +126,12 @@ module Dependabot
     sig { returns(T.nilable(Integer)) }
     attr_reader :branch_name_max_length
 
+    sig { returns(T.nilable(String)) }
+    attr_reader :branch_name_word_separator
+
+    sig { returns(T::Boolean) }
+    attr_reader :branch_name_lowercase
+
     sig { returns(String) }
     attr_reader :github_redirection_service
 
@@ -164,6 +170,8 @@ module Dependabot
         branch_name_separator: String,
         branch_name_prefix: String,
         branch_name_max_length: T.nilable(Integer),
+        branch_name_word_separator: T.nilable(String),
+        branch_name_lowercase: T::Boolean,
         label_language: T::Boolean,
         automerge_candidate: T::Boolean,
         github_redirection_service: String,
@@ -198,6 +206,8 @@ module Dependabot
       branch_name_separator: "/",
       branch_name_prefix: "dependabot",
       branch_name_max_length: 100,
+      branch_name_word_separator: nil,
+      branch_name_lowercase: false,
       label_language: false,
       automerge_candidate: false,
       github_redirection_service: DEFAULT_GITHUB_REDIRECTION_SERVICE,
@@ -227,6 +237,8 @@ module Dependabot
       @branch_name_separator      = branch_name_separator
       @branch_name_prefix         = branch_name_prefix
       @branch_name_max_length     = branch_name_max_length
+      @branch_name_word_separator = branch_name_word_separator
+      @branch_name_lowercase      = branch_name_lowercase
       @label_language             = label_language
       @automerge_candidate        = automerge_candidate
       @github_redirection_service = github_redirection_service
@@ -420,6 +432,8 @@ module Dependabot
           separator: branch_name_separator,
           prefix: branch_name_prefix,
           max_length: branch_name_max_length,
+          word_separator: branch_name_word_separator,
+          lowercase: branch_name_lowercase,
           includes_security_fixes: includes_security_fixes?
         ),
         T.nilable(Dependabot::PullRequestCreator::BranchNamer)

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -33,6 +33,12 @@ module Dependabot
       sig { returns(T.nilable(Integer)) }
       attr_reader :max_length
 
+      sig { returns(T.nilable(String)) }
+      attr_reader :word_separator
+
+      sig { returns(T::Boolean) }
+      attr_reader :lowercase
+
       sig { returns(T.nilable(Dependabot::DependencyGroup)) }
       attr_reader :dependency_group
 
@@ -51,6 +57,8 @@ module Dependabot
           separator: String,
           prefix: String,
           max_length: T.nilable(Integer),
+          word_separator: T.nilable(String),
+          lowercase: T::Boolean,
           includes_security_fixes: T::Boolean,
           multi_ecosystem_name: T.nilable(String)
         )
@@ -64,6 +72,8 @@ module Dependabot
         separator: "/",
         prefix: "dependabot",
         max_length: nil,
+        word_separator: nil,
+        lowercase: false,
         includes_security_fixes: false,
         multi_ecosystem_name: nil
       )
@@ -74,6 +84,8 @@ module Dependabot
         @separator     = separator
         @prefix        = prefix
         @max_length    = max_length
+        @word_separator = word_separator
+        @lowercase = lowercase
         @includes_security_fixes = includes_security_fixes
         @multi_ecosystem_name = multi_ecosystem_name
       end
@@ -109,6 +121,8 @@ module Dependabot
           separator: separator,
           prefix: prefix,
           max_length: max_length,
+          word_separator: word_separator,
+          lowercase: lowercase,
           multi_ecosystem_name: T.must(multi_ecosystem_name)
         )
       end
@@ -121,7 +135,9 @@ module Dependabot
           target_branch: target_branch,
           separator: separator,
           prefix: prefix,
-          max_length: max_length
+          max_length: max_length,
+          word_separator: word_separator,
+          lowercase: lowercase
         )
       end
 
@@ -135,7 +151,9 @@ module Dependabot
           includes_security_fixes: includes_security_fixes,
           separator: separator,
           prefix: prefix,
-          max_length: max_length
+          max_length: max_length,
+          word_separator: word_separator,
+          lowercase: lowercase
         )
       end
     end

--- a/common/lib/dependabot/pull_request_creator/branch_namer.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer.rb
@@ -36,8 +36,8 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       attr_reader :word_separator
 
-      sig { returns(T::Boolean) }
-      attr_reader :lowercase
+      sig { returns(T.nilable(String)) }
+      attr_reader :branch_name_case
 
       sig { returns(T.nilable(Dependabot::DependencyGroup)) }
       attr_reader :dependency_group
@@ -58,7 +58,7 @@ module Dependabot
           prefix: String,
           max_length: T.nilable(Integer),
           word_separator: T.nilable(String),
-          lowercase: T::Boolean,
+          branch_name_case: T.nilable(String),
           includes_security_fixes: T::Boolean,
           multi_ecosystem_name: T.nilable(String)
         )
@@ -73,7 +73,7 @@ module Dependabot
         prefix: "dependabot",
         max_length: nil,
         word_separator: nil,
-        lowercase: false,
+        branch_name_case: nil,
         includes_security_fixes: false,
         multi_ecosystem_name: nil
       )
@@ -85,7 +85,7 @@ module Dependabot
         @prefix        = prefix
         @max_length    = max_length
         @word_separator = word_separator
-        @lowercase = lowercase
+        @branch_name_case = branch_name_case
         @includes_security_fixes = includes_security_fixes
         @multi_ecosystem_name = multi_ecosystem_name
       end
@@ -122,7 +122,7 @@ module Dependabot
           prefix: prefix,
           max_length: max_length,
           word_separator: word_separator,
-          lowercase: lowercase,
+          branch_name_case: branch_name_case,
           multi_ecosystem_name: T.must(multi_ecosystem_name)
         )
       end
@@ -137,7 +137,7 @@ module Dependabot
           prefix: prefix,
           max_length: max_length,
           word_separator: word_separator,
-          lowercase: lowercase
+          branch_name_case: branch_name_case
         )
       end
 
@@ -153,7 +153,7 @@ module Dependabot
           prefix: prefix,
           max_length: max_length,
           word_separator: word_separator,
-          lowercase: lowercase
+          branch_name_case: branch_name_case
         )
       end
     end

--- a/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
@@ -28,6 +28,12 @@ module Dependabot
         sig { returns(T.nilable(Integer)) }
         attr_reader :max_length
 
+        sig { returns(T.nilable(String)) }
+        attr_reader :word_separator
+
+        sig { returns(T::Boolean) }
+        attr_reader :lowercase
+
         sig do
           params(
             dependencies: T::Array[Dependency],
@@ -35,7 +41,9 @@ module Dependabot
             target_branch: T.nilable(String),
             separator: String,
             prefix: String,
-            max_length: T.nilable(Integer)
+            max_length: T.nilable(Integer),
+            word_separator: T.nilable(String),
+            lowercase: T::Boolean
           )
             .void
         end
@@ -45,7 +53,9 @@ module Dependabot
           target_branch:,
           separator: "/",
           prefix: "dependabot",
-          max_length: nil
+          max_length: nil,
+          word_separator: nil,
+          lowercase: false
         )
           @dependencies      = dependencies
           @files             = files
@@ -53,6 +63,8 @@ module Dependabot
           @separator         = separator
           @prefix            = prefix
           @max_length        = max_length
+          @word_separator    = word_separator
+          @lowercase         = lowercase
         end
 
         sig { overridable.returns(String) }
@@ -69,6 +81,27 @@ module Dependabot
 
           # Some users need branch names without slashes
           sanitized_name = sanitized_name.gsub("/", separator)
+
+          # Apply word_separator and lowercase only to content after the prefix,
+          # preserving the user-configured prefix as-is.
+          if word_separator || lowercase
+            prefix_with_sep = "#{prefix}#{separator}"
+            if sanitized_name.start_with?(prefix_with_sep)
+              prefix_part = prefix_with_sep
+              content = sanitized_name[prefix_with_sep.length..]
+            else
+              prefix_part = ""
+              content = sanitized_name
+            end
+
+            # Replace underscores with word_separator in the content after prefix
+            content = T.must(content).gsub("_", T.must(word_separator)) if word_separator
+
+            # Downcase content after prefix for ACR/K8s compatibility
+            content = T.must(content).downcase if lowercase
+
+            sanitized_name = "#{prefix_part}#{content}"
+          end
 
           # Shorten the ref in case users refs have length limits
           branch_name_max_length = max_length

--- a/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/base.rb
@@ -31,8 +31,8 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         attr_reader :word_separator
 
-        sig { returns(T::Boolean) }
-        attr_reader :lowercase
+        sig { returns(T.nilable(String)) }
+        attr_reader :branch_name_case
 
         sig do
           params(
@@ -43,7 +43,7 @@ module Dependabot
             prefix: String,
             max_length: T.nilable(Integer),
             word_separator: T.nilable(String),
-            lowercase: T::Boolean
+            branch_name_case: T.nilable(String)
           )
             .void
         end
@@ -55,7 +55,7 @@ module Dependabot
           prefix: "dependabot",
           max_length: nil,
           word_separator: nil,
-          lowercase: false
+          branch_name_case: nil
         )
           @dependencies      = dependencies
           @files             = files
@@ -64,7 +64,7 @@ module Dependabot
           @prefix            = prefix
           @max_length        = max_length
           @word_separator    = word_separator
-          @lowercase         = lowercase
+          @branch_name_case  = branch_name_case
         end
 
         sig { overridable.returns(String) }
@@ -82,9 +82,9 @@ module Dependabot
           # Some users need branch names without slashes
           sanitized_name = sanitized_name.gsub("/", separator)
 
-          # Apply word_separator and lowercase only to content after the prefix,
+          # Apply word_separator and case transformation only to content after the prefix,
           # preserving the user-configured prefix as-is.
-          if word_separator || lowercase
+          if word_separator || branch_name_case
             prefix_with_sep = "#{prefix}#{separator}"
             if sanitized_name.start_with?(prefix_with_sep)
               prefix_part = prefix_with_sep
@@ -97,8 +97,13 @@ module Dependabot
             # Replace underscores with word_separator in the content after prefix
             content = T.must(content).gsub("_", T.must(word_separator)) if word_separator
 
-            # Downcase content after prefix for ACR/K8s compatibility
-            content = T.must(content).downcase if lowercase
+            # Apply case transformation to content after prefix
+            case branch_name_case
+            when "lower"
+              content = T.must(content).downcase
+            when "upper"
+              content = T.must(content).upcase
+            end
 
             sanitized_name = "#{prefix_part}#{content}"
           end

--- a/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
@@ -19,7 +19,9 @@ module Dependabot
             includes_security_fixes: T::Boolean,
             separator: String,
             prefix: String,
-            max_length: T.nilable(Integer)
+            max_length: T.nilable(Integer),
+            word_separator: T.nilable(String),
+            lowercase: T::Boolean
           )
             .void
         end
@@ -31,7 +33,9 @@ module Dependabot
           includes_security_fixes:,
           separator: "/",
           prefix: "dependabot",
-          max_length: nil
+          max_length: nil,
+          word_separator: nil,
+          lowercase: false
         )
           super(
             dependencies: dependencies,
@@ -40,6 +44,8 @@ module Dependabot
             separator: separator,
             prefix: prefix,
             max_length: max_length,
+            word_separator: word_separator,
+            lowercase: lowercase,
           )
 
           @dependency_group = dependency_group

--- a/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/dependency_group_strategy.rb
@@ -21,7 +21,7 @@ module Dependabot
             prefix: String,
             max_length: T.nilable(Integer),
             word_separator: T.nilable(String),
-            lowercase: T::Boolean
+            branch_name_case: T.nilable(String)
           )
             .void
         end
@@ -35,7 +35,7 @@ module Dependabot
           prefix: "dependabot",
           max_length: nil,
           word_separator: nil,
-          lowercase: false
+          branch_name_case: nil
         )
           super(
             dependencies: dependencies,
@@ -45,7 +45,7 @@ module Dependabot
             prefix: prefix,
             max_length: max_length,
             word_separator: word_separator,
-            lowercase: lowercase,
+            branch_name_case: branch_name_case,
           )
 
           @dependency_group = dependency_group

--- a/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
@@ -19,7 +19,9 @@ module Dependabot
             multi_ecosystem_name: String,
             separator: String,
             prefix: String,
-            max_length: T.nilable(Integer)
+            max_length: T.nilable(Integer),
+            word_separator: T.nilable(String),
+            lowercase: T::Boolean
           )
             .void
         end
@@ -31,7 +33,9 @@ module Dependabot
           multi_ecosystem_name:,
           separator: "/",
           prefix: "dependabot",
-          max_length: nil
+          max_length: nil,
+          word_separator: nil,
+          lowercase: false
         )
           super(
             dependencies: dependencies,
@@ -40,6 +44,8 @@ module Dependabot
             separator: separator,
             prefix: prefix,
             max_length: max_length,
+            word_separator: word_separator,
+            lowercase: lowercase,
           )
 
           @multi_ecosystem_name = multi_ecosystem_name

--- a/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/multi_ecosystem_strategy.rb
@@ -21,7 +21,7 @@ module Dependabot
             prefix: String,
             max_length: T.nilable(Integer),
             word_separator: T.nilable(String),
-            lowercase: T::Boolean
+            branch_name_case: T.nilable(String)
           )
             .void
         end
@@ -35,7 +35,7 @@ module Dependabot
           prefix: "dependabot",
           max_length: nil,
           word_separator: nil,
-          lowercase: false
+          branch_name_case: nil
         )
           super(
             dependencies: dependencies,
@@ -45,7 +45,7 @@ module Dependabot
             prefix: prefix,
             max_length: max_length,
             word_separator: word_separator,
-            lowercase: lowercase,
+            branch_name_case: branch_name_case,
           )
 
           @multi_ecosystem_name = multi_ecosystem_name

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -838,13 +838,13 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
       end
     end
 
-    context "with lowercase enabled" do
+    context "with branch_name_case set to lower" do
       let(:namer) do
         described_class.new(
           dependencies: dependencies,
           files: files,
           target_branch: target_branch,
-          lowercase: true
+          branch_name_case: "lower"
         )
       end
 
@@ -857,14 +857,14 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
         end
       end
 
-      context "when the prefix has uppercase and lowercase is true" do
+      context "when the prefix has uppercase" do
         let(:namer) do
           described_class.new(
             dependencies: dependencies,
             files: files,
             target_branch: target_branch,
             prefix: "MyProject",
-            lowercase: true
+            branch_name_case: "lower"
           )
         end
         let(:dependency_name) { "MyPackage" }
@@ -874,26 +874,64 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
             .to eq("MyProject/dummy/mypackage-1.5.0")
         end
       end
+    end
 
-      context "when lowercase is false (default)" do
-        let(:dependency_name) { "MyPackage" }
+    context "with branch_name_case set to upper" do
+      let(:namer) do
+        described_class.new(
+          dependencies: dependencies,
+          files: files,
+          target_branch: target_branch,
+          branch_name_case: "upper"
+        )
+      end
 
+      context "when the dependency name has lowercase characters" do
+        let(:dependency_name) { "business" }
+
+        it "upcases content after the prefix" do
+          expect(namer.new_branch_name)
+            .to eq("dependabot/DUMMY/BUSINESS-1.5.0")
+        end
+      end
+
+      context "when the prefix has lowercase" do
         let(:namer) do
           described_class.new(
             dependencies: dependencies,
             files: files,
-            target_branch: target_branch
+            target_branch: target_branch,
+            prefix: "myPrefix",
+            branch_name_case: "upper"
           )
         end
+        let(:dependency_name) { "business" }
 
-        it "preserves original casing" do
+        it "preserves prefix casing but upcases content" do
           expect(namer.new_branch_name)
-            .to eq("dependabot/dummy/MyPackage-1.5.0")
+            .to eq("myPrefix/DUMMY/BUSINESS-1.5.0")
         end
       end
     end
 
-    context "with word_separator, lowercase, and custom separator combined" do
+    context "with branch_name_case nil (default)" do
+      let(:dependency_name) { "MyPackage" }
+
+      let(:namer) do
+        described_class.new(
+          dependencies: dependencies,
+          files: files,
+          target_branch: target_branch
+        )
+      end
+
+      it "preserves original casing" do
+        expect(namer.new_branch_name)
+          .to eq("dependabot/dummy/MyPackage-1.5.0")
+      end
+    end
+
+    context "with word_separator, branch_name_case, and custom separator combined" do
       let(:namer) do
         described_class.new(
           dependencies: dependencies,
@@ -901,7 +939,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
           target_branch: target_branch,
           separator: "-",
           word_separator: "-",
-          lowercase: true
+          branch_name_case: "lower"
         )
       end
 
@@ -939,7 +977,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
             target_branch: target_branch,
             separator: "-",
             word_separator: "-",
-            lowercase: true,
+            branch_name_case: "lower",
             prefix: "MyProject-Deps"
           )
         end
@@ -958,7 +996,7 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
             target_branch: target_branch,
             separator: "-",
             word_separator: "-",
-            lowercase: true,
+            branch_name_case: "lower",
             max_length: 30
           )
         end

--- a/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_namer_spec.rb
@@ -715,5 +715,259 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNamer do
         expect(branch_namer.new_branch_name).to eq("dependabot/multi_ecosystem")
       end
     end
+
+    context "with a word separator" do
+      let(:namer) do
+        described_class.new(
+          dependencies: dependencies,
+          files: files,
+          target_branch: target_branch,
+          word_separator: "-"
+        )
+      end
+
+      context "when the package manager has underscores" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "lodash",
+            version: "4.17.21",
+            previous_version: "4.17.20",
+            package_manager: "npm_and_yarn",
+            requirements: [{
+              file: "package.json",
+              requirement: "^4.17.21",
+              groups: [],
+              source: nil
+            }],
+            previous_requirements: [{
+              file: "package.json",
+              requirement: "^4.17.20",
+              groups: [],
+              source: nil
+            }]
+          )
+        end
+
+        it "replaces underscores with the word separator" do
+          expect(namer.new_branch_name)
+            .to eq("dependabot/npm-and-yarn/lodash-4.17.21")
+        end
+      end
+
+      context "when the dependency name has underscores" do
+        let(:dependency_name) { "my_gem" }
+
+        it "replaces underscores in dependency names too" do
+          expect(namer.new_branch_name)
+            .to eq("dependabot/dummy/my-gem-1.5.0")
+        end
+      end
+
+      context "when word_separator is nil (default)" do
+        let(:namer) do
+          described_class.new(
+            dependencies: dependencies,
+            files: files,
+            target_branch: target_branch
+          )
+        end
+
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "lodash",
+            version: "4.17.21",
+            previous_version: "4.17.20",
+            package_manager: "npm_and_yarn",
+            requirements: [{
+              file: "package.json",
+              requirement: "^4.17.21",
+              groups: [],
+              source: nil
+            }],
+            previous_requirements: [{
+              file: "package.json",
+              requirement: "^4.17.20",
+              groups: [],
+              source: nil
+            }]
+          )
+        end
+
+        it "preserves underscores" do
+          expect(namer.new_branch_name)
+            .to eq("dependabot/npm_and_yarn/lodash-4.17.21")
+        end
+      end
+
+      context "when combined with a custom separator" do
+        let(:namer) do
+          described_class.new(
+            dependencies: dependencies,
+            files: files,
+            target_branch: target_branch,
+            separator: "-",
+            word_separator: "-"
+          )
+        end
+
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "lodash",
+            version: "4.17.21",
+            previous_version: "4.17.20",
+            package_manager: "npm_and_yarn",
+            requirements: [{
+              file: "package.json",
+              requirement: "^4.17.21",
+              groups: [],
+              source: nil
+            }],
+            previous_requirements: [{
+              file: "package.json",
+              requirement: "^4.17.20",
+              groups: [],
+              source: nil
+            }]
+          )
+        end
+
+        it "replaces both slashes and underscores" do
+          expect(namer.new_branch_name)
+            .to eq("dependabot-npm-and-yarn-lodash-4.17.21")
+        end
+      end
+    end
+
+    context "with lowercase enabled" do
+      let(:namer) do
+        described_class.new(
+          dependencies: dependencies,
+          files: files,
+          target_branch: target_branch,
+          lowercase: true
+        )
+      end
+
+      context "when the dependency name has uppercase characters" do
+        let(:dependency_name) { "MyPackage" }
+
+        it "downcases content after the prefix" do
+          expect(namer.new_branch_name)
+            .to eq("dependabot/dummy/mypackage-1.5.0")
+        end
+      end
+
+      context "when the prefix has uppercase and lowercase is true" do
+        let(:namer) do
+          described_class.new(
+            dependencies: dependencies,
+            files: files,
+            target_branch: target_branch,
+            prefix: "MyProject",
+            lowercase: true
+          )
+        end
+        let(:dependency_name) { "MyPackage" }
+
+        it "preserves prefix casing but downcases content" do
+          expect(namer.new_branch_name)
+            .to eq("MyProject/dummy/mypackage-1.5.0")
+        end
+      end
+
+      context "when lowercase is false (default)" do
+        let(:dependency_name) { "MyPackage" }
+
+        let(:namer) do
+          described_class.new(
+            dependencies: dependencies,
+            files: files,
+            target_branch: target_branch
+          )
+        end
+
+        it "preserves original casing" do
+          expect(namer.new_branch_name)
+            .to eq("dependabot/dummy/MyPackage-1.5.0")
+        end
+      end
+    end
+
+    context "with word_separator, lowercase, and custom separator combined" do
+      let(:namer) do
+        described_class.new(
+          dependencies: dependencies,
+          files: files,
+          target_branch: target_branch,
+          separator: "-",
+          word_separator: "-",
+          lowercase: true
+        )
+      end
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "MyPackage",
+          version: "4.17.21",
+          previous_version: "4.17.20",
+          package_manager: "npm_and_yarn",
+          requirements: [{
+            file: "package.json",
+            requirement: "^4.17.21",
+            groups: [],
+            source: nil
+          }],
+          previous_requirements: [{
+            file: "package.json",
+            requirement: "^4.17.20",
+            groups: [],
+            source: nil
+          }]
+        )
+      end
+
+      it "applies all transformations (ACR-compliant)" do
+        expect(namer.new_branch_name)
+          .to eq("dependabot-npm-and-yarn-mypackage-4.17.21")
+      end
+
+      context "with a custom prefix" do
+        let(:namer) do
+          described_class.new(
+            dependencies: dependencies,
+            files: files,
+            target_branch: target_branch,
+            separator: "-",
+            word_separator: "-",
+            lowercase: true,
+            prefix: "MyProject-Deps"
+          )
+        end
+
+        it "preserves the prefix as-is" do
+          expect(namer.new_branch_name)
+            .to eq("MyProject-Deps-npm-and-yarn-mypackage-4.17.21")
+        end
+      end
+
+      context "with max_length truncation" do
+        let(:namer) do
+          described_class.new(
+            dependencies: dependencies,
+            files: files,
+            target_branch: target_branch,
+            separator: "-",
+            word_separator: "-",
+            lowercase: true,
+            max_length: 30
+          )
+        end
+
+        it "truncates with SHA after applying transformations" do
+          branch_name = namer.new_branch_name
+          expect(branch_name.length).to eq(30)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Add `word_separator` and `branch_name_case` parameters to the `BranchNamer` class hierarchy to support user-configurable branch name formatting.

**What:** Two new optional parameters flow through `PullRequestCreator` → `BranchNamer` → all strategies → `Base#sanitize_branch_name`:
- `word_separator` (String?, default: `nil`) — replaces underscores (`_`) in branch name content after the prefix (e.g., `npm_and_yarn` → `npm-and-yarn`)
- `branch_name_case` (String?, default: `nil`) — transforms casing of branch name content after the prefix. Supported values: `"lower"`, `"upper"`, or `nil` (no change)

<!-- Provide both a what and a _why_ for the change. -->
**Why:** Addresses [issue #396](https://github.com/dependabot/dependabot-core/issues/396). Users need branch names compatible with Docker tags, ACR (Azure Container Registry), Tekton PVCs, and K8s naming rules — all of which reject underscores or mixed-case characters.

**Key design choices:**
- The user-configured `prefix` is preserved as-is — `word_separator` and `branch_name_case` transformations only apply to the content *after* the prefix. This allows branded prefixes like `"MyProject-Deps"` without mangling.
- `branch_name_case` is a `String?` rather than a boolean, supporting both `"lower"` (for ACR) and `"upper"` (for future use cases) with minimal additional cost.

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
1. **Prefix preservation logic** in `Base#sanitize_branch_name` — the method splits on `"#{prefix}#{separator}"` to isolate the prefix from transformable content. If the branch name doesn't start with the expected prefix pattern, the entire name is treated as content (safe fallback).

2. **`branch_name_case` uses a case/when** — chosen over a boolean to be extensible. Currently supports `"lower"` and `"upper"`. `nil` (default) means no transformation. Invalid values are silently ignored (no transformation applied).

3. **No behavior change when params are at defaults** — the `if word_separator || branch_name_case` guard means the entire new code path is skipped when neither option is configured. Zero performance impact on existing users.

4. **Subclass constructors updated** — `DependencyGroupStrategy` and `MultiEcosystemStrategy` accept and pass through the new params via `super()`. `SoloStrategy` inherits `Base#initialize` directly (no override), so it needed no changes.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
All 47 tests pass (`bundle exec rspec spec/dependabot/pull_request_creator/branch_namer_spec.rb` — 0 failures):
- 35 existing tests pass unchanged (no regression)
- 12 new tests cover:
  - `word_separator: "-"` replaces underscores in package manager names (`npm_and_yarn` → `npm-and-yarn`)
  - `word_separator: "-"` replaces underscores in dependency names (`my_gem` → `my-gem`)
  - `word_separator: nil` (default) preserves underscores
  - `word_separator` + custom `separator` applies both replacements
  - `branch_name_case: "lower"` downcases content after prefix (`MyPackage` → `mypackage`)
  - `branch_name_case: "lower"` with uppercase prefix preserves prefix casing
  - `branch_name_case: "upper"` upcases content after prefix (`business` → `BUSINESS`)
  - `branch_name_case: "upper"` with lowercase prefix preserves prefix casing
  - `branch_name_case: nil` (default) preserves original casing
  - All options combined produces ACR-compliant output
  - Custom prefix preserved as-is with all transformations active
  - `max_length` truncation still works correctly after transformations
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
