### PR TITLE
Apply cooldown to transitive npm/pnpm/yarn deps via native release-age gates

### DIFF
--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -779,7 +779,10 @@ begin
       dependency_files: $files,
       repo_contents_path: $repo_contents_path,
       credentials: $options[:credentials],
-      options: $options[:updater_options]
+      options: $options[:updater_options].merge(
+        security_updates_only: $options[:security_updates_only],
+        update_cooldown: $options[:security_updates_only] ? nil : update_cooldown
+      )
     )
   end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -435,6 +435,25 @@ module Dependabot
           )
       end
 
+      # The number of days from the dependabot.yml `cooldown` config to apply as
+      # a release-age floor for *transitive* dependencies. npm, pnpm and yarn each
+      # enforce this natively at install time, which is the only point at which
+      # Dependabot can constrain the versions the package manager resolves for the
+      # transitive tree. Returns nil for security updates (which must never be
+      # blocked by a release-age gate) or when no positive cooldown is configured.
+      # `default_days` is used because the native gates are a single global value
+      # and cannot express per-semver-type days or include/exclude patterns.
+      sig { returns(T.nilable(Integer)) }
+      def cooldown_release_age_days
+        return nil if options.fetch(:security_updates_only, false)
+
+        cooldown = options[:update_cooldown]
+        return nil if cooldown.nil?
+
+        days = cooldown.default_days
+        days.positive? ? days : nil
+      end
+
       sig { returns(Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater) }
       def yarn_lockfile_updater
         @yarn_lockfile_updater ||= T.let(
@@ -443,7 +462,8 @@ module Dependabot
             dependency_files: dependency_files,
             repo_contents_path: repo_contents_path,
             credentials: credentials,
-            security_updates_only: options.fetch(:security_updates_only, false)
+            security_updates_only: options.fetch(:security_updates_only, false),
+            release_age_days: cooldown_release_age_days
           ),
           T.nilable(Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater)
         )
@@ -457,7 +477,8 @@ module Dependabot
             dependency_files: dependency_files,
             repo_contents_path: repo_contents_path,
             credentials: credentials,
-            security_updates_only: options.fetch(:security_updates_only, false)
+            security_updates_only: options.fetch(:security_updates_only, false),
+            release_age_days: cooldown_release_age_days
           ),
           T.nilable(Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater)
         )
@@ -474,7 +495,8 @@ module Dependabot
           dependencies: dependencies,
           dependency_files: dependency_files,
           credentials: credentials,
-          security_updates_only: options.fetch(:security_updates_only, false)
+          security_updates_only: options.fetch(:security_updates_only, false),
+          release_age_days: cooldown_release_age_days
         )
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -30,16 +30,25 @@ module Dependabot
             dependencies: T::Array[Dependabot::Dependency],
             dependency_files: T::Array[Dependabot::DependencyFile],
             credentials: T::Array[Credential],
-            security_updates_only: T::Boolean
+            security_updates_only: T::Boolean,
+            release_age_days: T.nilable(Integer)
           )
             .void
         end
-        def initialize(lockfile:, dependencies:, dependency_files:, credentials:, security_updates_only: false)
+        def initialize(
+          lockfile:,
+          dependencies:,
+          dependency_files:,
+          credentials:,
+          security_updates_only: false,
+          release_age_days: nil
+        )
           @lockfile = lockfile
           @dependencies = dependencies
           @dependency_files = dependency_files
           @credentials = credentials
           @security_updates_only = T.let(security_updates_only, T::Boolean)
+          @release_age_days = T.let(release_age_days, T.nilable(Integer))
         end
 
         sig { returns(Dependabot::DependencyFile) }
@@ -404,9 +413,8 @@ module Dependabot
           ]
 
           command_args << "--save-optional" if has_optional_dependencies
-          # Override any min-release-age set in .npmrc: security fixes must not be
-          # blocked by a release-age gate the user configured for regular updates.
-          command_args << "--min-release-age=0" if security_updates_only?
+          min_release_age_arg = min_release_age_install_arg
+          command_args << min_release_age_arg if min_release_age_arg
 
           command = command_args.join(" ")
 
@@ -419,11 +427,41 @@ module Dependabot
           ]
 
           fingerprint_args << "--save-optional" if has_optional_dependencies
-          fingerprint_args << "--min-release-age=0" if security_updates_only?
+          # The cooldown day value varies per job, so keep it out of the fingerprint.
+          fingerprint_args << fingerprint_min_release_age_arg(min_release_age_arg) if min_release_age_arg
 
           fingerprint = fingerprint_args.join(" ")
 
           Helpers.run_npm_command(command, fingerprint: fingerprint)
+        end
+
+        # Returns the `--min-release-age` argument for `npm install`, or nil when
+        # none applies. Security updates pass `=0` so a release-age gate never
+        # blocks a fix. Regular updates pass the dependabot.yml cooldown floor (in
+        # days) so npm holds transitive dependencies back to versions at least that
+        # old. Requires npm >= 11.10 (the updater image ships a supporting version).
+        # An explicit `.npmrc` `min-release-age` always wins, so it is left
+        # untouched when present.
+        sig { returns(T.nilable(String)) }
+        def min_release_age_install_arg
+          return "--min-release-age=0" if security_updates_only?
+          return nil unless @release_age_days
+          return nil if npmrc_sets_min_release_age?
+
+          "--min-release-age=#{@release_age_days}"
+        end
+
+        sig { params(arg: String).returns(String) }
+        def fingerprint_min_release_age_arg(arg)
+          arg == "--min-release-age=0" ? arg : "--min-release-age=<days>"
+        end
+
+        sig { returns(T::Boolean) }
+        def npmrc_sets_min_release_age?
+          dependency_files.any? do |file|
+            File.basename(file.name) == ".npmrc" &&
+              file.content.to_s.match?(/^\s*min-release-age\s*=/)
+          end
         end
 
         sig { params(dependency: Dependabot::Dependency).returns(String) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -22,7 +22,8 @@ module Dependabot
             dependency_files: T::Array[Dependabot::DependencyFile],
             repo_contents_path: T.nilable(String),
             credentials: T::Array[Dependabot::Credential],
-            security_updates_only: T::Boolean
+            security_updates_only: T::Boolean,
+            release_age_days: T.nilable(Integer)
           ).void
         end
         def initialize(
@@ -30,13 +31,15 @@ module Dependabot
           dependency_files:,
           repo_contents_path:,
           credentials:,
-          security_updates_only: false
+          security_updates_only: false,
+          release_age_days: nil
         )
           @dependencies = dependencies
           @dependency_files = dependency_files
           @repo_contents_path = repo_contents_path
           @credentials = credentials
           @security_updates_only = T.let(security_updates_only, T::Boolean)
+          @release_age_days = T.let(release_age_days, T.nilable(Integer))
           @error_handler = T.let(
             PnpmErrorHandler.new(
               dependencies: dependencies,
@@ -207,24 +210,93 @@ module Dependabot
 
           cmd = "update #{dependency_updates}  --lockfile-only --no-save -r"
           fingerprint = "update <dependency_updates>  --lockfile-only --no-save -r"
-          if security_updates_only?
-            # Override any minimumReleaseAge set in pnpm-workspace.yaml: security fixes must not be
-            # blocked by a release-age gate the user configured for regular updates.
-            cmd += " --config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false"
-            fingerprint += " --config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false"
-          end
-          Helpers.run_pnpm_command(cmd, fingerprint: fingerprint)
+          run_pnpm_command_with_release_age_gate(cmd, fingerprint)
         end
 
         sig { returns(T.nilable(String)) }
         def run_pnpm_install
-          cmd = "install --lockfile-only"
+          run_pnpm_command_with_release_age_gate("install --lockfile-only")
+        end
+
+        # pnpm's `minimumReleaseAge` needs the registry `time` field, which is
+        # absent from the abbreviated metadata pnpm uses for some packages during
+        # `pnpm update`, raising ERR_PNPM_MISSING_TIME. When that happens for a
+        # cooldown-derived gate we retry without it so the update still succeeds,
+        # rather than failing the whole job. Security bypass (`=0`) never triggers
+        # this because it disables the age lookup entirely.
+        sig { params(cmd: String, fingerprint: T.nilable(String)).returns(T.nilable(String)) }
+        def run_pnpm_command_with_release_age_gate(cmd, fingerprint = nil)
+          gate = release_age_gate_config
+          return execute_pnpm_command(cmd, fingerprint) unless gate
+
+          gate_fingerprint = security_updates_only? ? gate : fingerprint_minimum_release_age_config
+          gated_fingerprint = fingerprint ? "#{fingerprint} #{gate_fingerprint}" : nil
+          begin
+            execute_pnpm_command("#{cmd} #{gate}", gated_fingerprint)
+          rescue SharedHelpers::HelperSubprocessFailed => e
+            raise if security_updates_only? || !e.message.include?("ERR_PNPM_MISSING_TIME")
+
+            Dependabot.logger.warn(
+              "pnpm could not apply the cooldown release-age gate because the registry metadata " \
+              "is missing the \"time\" field (ERR_PNPM_MISSING_TIME); retrying without the " \
+              "transitive cooldown gate so the update is not blocked."
+            )
+            execute_pnpm_command(cmd, fingerprint)
+          end
+        end
+
+        sig { params(cmd: String, fingerprint: T.nilable(String)).returns(T.nilable(String)) }
+        def execute_pnpm_command(cmd, fingerprint)
+          if fingerprint
+            Helpers.run_pnpm_command(cmd, fingerprint: fingerprint)
+          else
+            Helpers.run_pnpm_command(cmd)
+          end
+        end
+
+        # Returns the pnpm `--config.minimumReleaseAge` arguments to apply, or nil.
+        # Security updates disable the gate (`=0`); regular updates apply the
+        # dependabot.yml cooldown floor (in minutes).
+        sig { returns(T.nilable(String)) }
+        def release_age_gate_config
           if security_updates_only?
             # Override any minimumReleaseAge set in pnpm-workspace.yaml: security fixes must not be
             # blocked by a release-age gate the user configured for regular updates.
-            cmd += " --config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false"
+            return "--config.minimumReleaseAge=0 --config.minimumReleaseAgeStrict=false"
           end
-          Helpers.run_pnpm_command(cmd)
+
+          minimum_release_age_config
+        end
+
+        # Applies the dependabot.yml cooldown floor as pnpm's `minimumReleaseAge`
+        # (in minutes) so transitive dependencies are held back to versions at
+        # least that old. `minimumReleaseAgeStrict=false` lets pnpm fall back to
+        # the newest available version rather than erroring when nothing satisfies
+        # the window, and avoids gating the exact direct version Dependabot pins.
+        # An explicit `minimumReleaseAge` in pnpm-workspace.yaml (or `.npmrc`)
+        # always wins, so it is left untouched when present.
+        sig { returns(T.nilable(String)) }
+        def minimum_release_age_config
+          return nil unless @release_age_days
+          return nil if pnpm_config_sets_minimum_release_age?
+
+          minutes = @release_age_days * Helpers::MINUTES_PER_DAY
+          "--config.minimumReleaseAge=#{minutes} --config.minimumReleaseAgeStrict=false"
+        end
+
+        sig { returns(String) }
+        def fingerprint_minimum_release_age_config
+          "--config.minimumReleaseAge=<minutes> --config.minimumReleaseAgeStrict=false"
+        end
+
+        sig { returns(T::Boolean) }
+        def pnpm_config_sets_minimum_release_age?
+          dependency_files.any? do |file|
+            basename = File.basename(file.name)
+            content = file.content.to_s
+            (basename == "pnpm-workspace.yaml" && content.match?(/^\s*minimumReleaseAge\s*:/)) ||
+              (basename == ".npmrc" && content.match?(/^\s*minimum-release-age\s*=/))
+          end
         end
 
         # Tries `pnpm update --depth Infinity <dep>` for each dependency as a

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -31,7 +31,8 @@ module Dependabot
             dependency_files: T::Array[Dependabot::DependencyFile],
             repo_contents_path: T.nilable(String),
             credentials: T::Array[Dependabot::Credential],
-            security_updates_only: T::Boolean
+            security_updates_only: T::Boolean,
+            release_age_days: T.nilable(Integer)
           )
             .void
         end
@@ -40,13 +41,15 @@ module Dependabot
           dependency_files:,
           repo_contents_path:,
           credentials:,
-          security_updates_only: false
+          security_updates_only: false,
+          release_age_days: nil
         )
           @dependencies = dependencies
           @dependency_files = dependency_files
           @repo_contents_path = repo_contents_path
           @credentials = credentials
           @security_updates_only = T.let(security_updates_only, T::Boolean)
+          @release_age_days = T.let(release_age_days, T.nilable(Integer))
           @error_handler = T.let(
             YarnErrorHandler.new(
               dependencies: dependencies,
@@ -368,17 +371,41 @@ module Dependabot
           @security_updates_only
         end
 
-        # Returns an env hash that disables Yarn Berry's npmMinimalAgeGate for security updates.
-        # npmMinimalAgeGate was introduced in Yarn 4.10.0. Setting the corresponding
-        # YARN_NPM_MINIMAL_AGE_GATE env var on older Yarn Berry releases (or Yarn classic) raises
-        # "Unrecognized or legacy configuration settings found: npmMinimalAgeGate" and aborts the
-        # install, so we gate on a version check.
+        # Returns an env hash that sets Yarn Berry's YARN_NPM_MINIMAL_AGE_GATE.
+        # Security updates set it to 0 so a release-age gate never blocks a fix.
+        # Regular updates set it to the dependabot.yml cooldown floor (in minutes)
+        # so yarn holds transitive dependencies back to versions at least that old.
+        # An explicit `npmMinimalAgeGate` in .yarnrc.yml always wins, so it is left
+        # untouched when present.
+        #
+        # npmMinimalAgeGate was introduced in Yarn 4.10.0. Setting the env var on
+        # older Yarn Berry releases (or Yarn classic) raises "Unrecognized or legacy
+        # configuration settings found: npmMinimalAgeGate" and aborts the install,
+        # so we gate on a version check.
         sig { returns(T.nilable(T::Hash[String, String])) }
         def yarn_time_gate_env
-          return nil unless security_updates_only?
+          gate_value = yarn_minimal_age_gate_value
+          return nil unless gate_value
           return nil unless Helpers.yarn_berry_supports_minimal_age_gate?
 
-          { "YARN_NPM_MINIMAL_AGE_GATE" => "0" }
+          { "YARN_NPM_MINIMAL_AGE_GATE" => gate_value }
+        end
+
+        sig { returns(T.nilable(String)) }
+        def yarn_minimal_age_gate_value
+          return "0" if security_updates_only?
+          return nil unless @release_age_days
+          return nil if yarnrc_sets_minimal_age_gate?
+
+          (@release_age_days * Helpers::MINUTES_PER_DAY).to_s
+        end
+
+        sig { returns(T::Boolean) }
+        def yarnrc_sets_minimal_age_gate?
+          dependency_files.any? do |file|
+            File.basename(file.name) == ".yarnrc.yml" &&
+              file.content.to_s.match?(/^\s*npmMinimalAgeGate\s*:/)
+          end
         end
 
         sig { returns(String) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -69,6 +69,12 @@ module Dependabot
       # corepack supported package managers
       SUPPORTED_COREPACK_PACKAGE_MANAGERS = %w(npm yarn pnpm).freeze
 
+      # pnpm's `minimumReleaseAge` and yarn's `npmMinimalAgeGate` are expressed in
+      # minutes, whereas dependabot.yml cooldown and npm's `min-release-age` use
+      # days. Used to convert a cooldown floor (days) into the minutes those gates
+      # expect.
+      MINUTES_PER_DAY = 1440
+
       sig { params(lockfile: T.nilable(DependencyFile)).returns(Integer) }
       def self.npm_version_numeric(lockfile)
         detected_npm_version = detect_npm_version(lockfile)
@@ -253,10 +259,7 @@ module Dependabot
         version = Version.new(run_single_yarn_command("--version"))
         supported = version >= Version.new("4.10.0")
         if supported
-          Dependabot.logger.info(
-            "Yarn #{version} supports npmMinimalAgeGate. " \
-            "Setting YARN_NPM_MINIMAL_AGE_GATE=0 to bypass the release-age gate for security updates."
-          )
+          Dependabot.logger.info("Yarn #{version} supports npmMinimalAgeGate.")
         else
           Dependabot.logger.info(
             "Yarn #{version} does not support npmMinimalAgeGate (requires 4.10.0+). " \
@@ -268,7 +271,7 @@ module Dependabot
         Dependabot.logger.warn(
           "Could not determine Yarn version to check npmMinimalAgeGate support: #{e.message}. " \
           "Assuming unsupported (returning false). YARN_NPM_MINIMAL_AGE_GATE will not be set, " \
-          "so the registry's release-age gate may still block security updates."
+          "so any release-age gate must be enforced by the registry or .yarnrc.yml instead."
         )
         false
       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater_spec.rb
@@ -1398,6 +1398,44 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::NpmLockfileUpdater do
           updater.send(:run_npm_install_lockfile_only, install_args)
         end
       end
+
+      context "when update_cooldown sets a release-age floor (regular update)" do
+        let(:updater) do
+          described_class.new(
+            lockfile: package_lock,
+            dependency_files: files,
+            dependencies: dependencies,
+            credentials: credentials,
+            release_age_days: 7
+          )
+        end
+
+        it "passes --min-release-age with the cooldown day count" do
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command) do |command, _options|
+            expect(command).to include("--min-release-age=7")
+            expect(command).to include("--package-lock-only")
+            ""
+          end
+
+          updater.send(:run_npm_install_lockfile_only, install_args)
+        end
+
+        context "when the .npmrc already sets min-release-age" do
+          let(:files) do
+            project_dependency_files("npm8/simple") +
+              [Dependabot::DependencyFile.new(name: ".npmrc", content: "min-release-age=30")]
+          end
+
+          it "leaves the explicit .npmrc value untouched" do
+            expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command) do |command, _options|
+              expect(command).not_to include("--min-release-age")
+              ""
+            end
+
+            updater.send(:run_npm_install_lockfile_only, install_args)
+          end
+        end
+      end
     end
 
     describe "#run_npm8_subdependency_updater" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -872,5 +872,62 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         updater.send(:run_pnpm_install)
       end
     end
+
+    context "when update_cooldown sets a release-age floor (regular update)" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: files,
+          dependencies: dependencies,
+          credentials: credentials,
+          repo_contents_path: repo_contents_path,
+          release_age_days: 7
+        )
+      end
+
+      it "passes minimumReleaseAge in minutes (days * 1440) to pnpm update" do
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          expect(cmd).to include("--config.minimumReleaseAge=10080")
+          expect(cmd).to include("--config.minimumReleaseAgeStrict=false")
+          ""
+        end.at_least(:once)
+
+        updater.send(:run_pnpm_update_packages)
+      end
+
+      it "retries without the gate when pnpm raises ERR_PNPM_MISSING_TIME" do
+        call_count = 0
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          call_count += 1
+          if call_count == 1
+            expect(cmd).to include("--config.minimumReleaseAge=10080")
+            raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "ERR_PNPM_MISSING_TIME  The metadata of etag is missing the \"time\" field",
+              error_context: {}
+            )
+          end
+          expect(cmd).not_to include("--config.minimumReleaseAge")
+          ""
+        end
+
+        updater.send(:run_pnpm_update_packages)
+        expect(call_count).to eq(2)
+      end
+
+      context "when pnpm-workspace.yaml already sets minimumReleaseAge" do
+        let(:files) do
+          project_dependency_files(project_name) +
+            [Dependabot::DependencyFile.new(name: "pnpm-workspace.yaml", content: "minimumReleaseAge: 20160\n")]
+        end
+
+        it "leaves the explicit pnpm-workspace.yaml value untouched" do
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+            expect(cmd).not_to include("--config.minimumReleaseAge")
+            ""
+          end.at_least(:once)
+
+          updater.send(:run_pnpm_update_packages)
+        end
+      end
+    end
   end
 end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
@@ -527,5 +527,48 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
         )
       end
     end
+
+    context "when update_cooldown sets a release-age floor (regular update)" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: files,
+          dependencies: dependencies,
+          credentials: credentials,
+          repo_contents_path: nil,
+          release_age_days: 7
+        )
+      end
+
+      context "when Yarn supports npmMinimalAgeGate (>= 4.10.0)" do
+        before do
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:yarn_berry_supports_minimal_age_gate?).and_return(true)
+        end
+
+        it "sets YARN_NPM_MINIMAL_AGE_GATE to the cooldown floor in minutes (days * 1440)" do
+          expect(updater.send(:yarn_time_gate_env)).to eq({ "YARN_NPM_MINIMAL_AGE_GATE" => "10080" })
+        end
+
+        context "when .yarnrc.yml already sets npmMinimalAgeGate" do
+          let(:files) do
+            project_dependency_files("yarn_berry/workspace_subdependency_update") +
+              [Dependabot::DependencyFile.new(name: ".yarnrc.yml", content: "npmMinimalAgeGate: 20160\n")]
+          end
+
+          it "leaves the explicit .yarnrc.yml value untouched" do
+            expect(updater.send(:yarn_time_gate_env)).to be_nil
+          end
+        end
+      end
+
+      context "when Yarn does not support npmMinimalAgeGate (< 4.10.0)" do
+        before do
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:yarn_berry_supports_minimal_age_gate?).and_return(false)
+        end
+
+        it "returns nil from yarn_time_gate_env" do
+          expect(updater.send(:yarn_time_gate_env)).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes the transitive half of dependabot/dependabot-core#14683: `cooldown` only gated the **direct** dependency being updated. Transitive dependencies were resolved by the package manager to whatever latest version satisfied the parent's range — even a version published minutes ago — so a 7‑day cooldown could still pull in a same‑day transitive release.

Each JavaScript package manager can enforce a release‑age floor at install time, and that install step is the only point where Dependabot can constrain the transitive tree. The `FileUpdater` already receives `update_cooldown` via `options`, so the lockfile updaters now translate `cooldown.default_days` into the native gate on **regular** (non‑security) updates:

| Package manager | Applied on regular updates | Unit |
| --- | --- | --- |
| npm (≥ 11.10) | `--min-release-age=<days>` | days |
| pnpm (≥ 8.13) | `--config.minimumReleaseAge=<minutes> --config.minimumReleaseAgeStrict=false` | minutes |
| yarn berry (≥ 4.10) | `YARN_NPM_MINIMAL_AGE_GATE=<minutes>` env | minutes |

Behavioural guarantees:

- **Explicit native config always wins.** If the repo already sets `min-release-age` (`.npmrc`), `minimumReleaseAge` (`pnpm-workspace.yaml`/`.npmrc`) or `npmMinimalAgeGate` (`.yarnrc.yml`), Dependabot leaves it untouched — no lowering of a user's chosen value.
- **Security updates are never gated** — they still pass the existing `=0` bypass.
- **`default_days` is used** as the global floor because the native gates are a single value and cannot express per‑semver‑type days or include/exclude patterns.

### Anything you want to highlight for special attention from reviewers?

- **pnpm + `pnpm update` limitation.** pnpm's `minimumReleaseAge` needs the registry `time` field, which is absent from the abbreviated metadata pnpm uses for some packages during `pnpm update` (raising `ERR_PNPM_MISSING_TIME`). To avoid failing otherwise‑valid updates, the pnpm path retries **without** the gate when it hits this error (logged as a warning). In production the proxy supplies full metadata, so the gate applies; the fallback is a safety net.
- **yarn version requirement.** `npmMinimalAgeGate` requires **yarn ≥ 4.10** (the updater image currently ships 4.9.2). The gate is only set when `Helpers.yarn_berry_supports_minimal_age_gate?` is true, so older yarn is unaffected. Repos need a `packageManager: yarn@4.10+` pin (+ Corepack) to benefit — worth deciding whether to bump the image's yarn.
- **`bin/dry-run.rb`** now forwards `update_cooldown`/`security_updates_only` to the `FileUpdater`, mirroring `DependencyChangeBuilder#file_updater_for`, so transitive cooldown can be exercised locally.

### How will you know you've accomplished your goal?

Reproduced against a test repo (`aws-cdk-lib 2.249.0 → 2.260.0`, which moves `@aws-cdk/cloud-assembly-schema` from `^53` to `^54`; the newest `54.x` was ~1 day old while older in‑range versions existed). With `cooldown: default-days: 7` and **no** native config file, `bin/dry-run.rb`:

- **npm** control dir: transitive resolved to `54.5.0` (~10 days old) instead of `54.8.0` (~1 day old).
- **yarn** control dir: transitive resolved to `54.5.0`.
- **pnpm** control dir: gate attempted, `ERR_PNPM_MISSING_TIME` locally (no proxy) → graceful fallback, update still succeeds.

Tests added to `npm/pnpm/yarn` lockfile updater specs covering: flag applied with the cooldown floor (correct unit), explicit native config left untouched, security bypass preserved, and the pnpm `ERR_PNPM_MISSING_TIME` retry.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
