### PR TITLE
Use shared git-tag cooldown in pre_commit

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -867,10 +867,10 @@ module Dependabot
       )
     end
 
-    # Fails open: if the tag-detail fetch is unavailable (e.g. a network or
-    # registry error while resolving tag dates), return no dates so cooldown
-    # treats every tag as outside its window and the latest tag is still
-    # proposed, rather than failing the whole update check.
+    # Fails open: if the tag-detail fetch is unavailable (e.g. a network error
+    # or an error from the git host / GitHub API while resolving tag dates),
+    # return no dates so cooldown treats every tag as outside its window and the
+    # latest tag is still proposed, rather than failing the whole update check.
     sig { returns(T::Hash[String, Time]) }
     def build_release_dates_by_tag_name
       dates = T.let({}, T::Hash[String, Time])
@@ -880,8 +880,9 @@ module Dependabot
       end
       dates
     rescue StandardError => e
-      Dependabot.logger.error(
-        "Error fetching git tag release dates for #{dependency.name}: #{e.message}"
+      Dependabot.logger.warn(
+        "Skipping git tag cooldown for #{dependency.name}: could not resolve tag release dates " \
+        "(#{e.class}: #{e.message})"
       )
       {}
     end

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -851,6 +851,10 @@ module Dependabot
       )
     end
 
+    # Fails open: if the tag-detail fetch is unavailable (e.g. a network or
+    # registry error while resolving tag dates), return no dates so cooldown
+    # treats every tag as outside its window and the latest tag is still
+    # proposed, rather than failing the whole update check.
     sig { returns(T::Hash[String, Time]) }
     def build_release_dates_by_tag_name
       dates = T.let({}, T::Hash[String, Time])
@@ -859,6 +863,11 @@ module Dependabot
         dates[detail.tag] = released_at if released_at
       end
       dates
+    rescue StandardError => e
+      Dependabot.logger.error(
+        "Error fetching git tag release dates for #{dependency.name}: #{e.message}"
+      )
+      {}
     end
 
     sig { params(release_date: T.nilable(String)).returns(T.nilable(Time)) }

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -211,6 +211,22 @@ module Dependabot
       local_tag_for_latest_version(cooldown_options)
     end
 
+    # Like #local_tag_for_latest_version, but only considers tags whose version
+    # precision matches the currently pinned ref (e.g. a dep pinned to "v1.2"
+    # stays on two-part tags). Tags still within their cooldown window are
+    # filtered out, and nil is returned when every precision-matched candidate
+    # is still cooling down.
+    sig do
+      params(cooldown_options: T.nilable(Dependabot::Package::ReleaseCooldownOptions))
+        .returns(T.nilable(Dependabot::GitTagDetails))
+    end
+    def local_tag_for_latest_version_matching_existing_precision(cooldown_options = nil)
+      filtered_tags = apply_cooldown(select_matching_existing_precision(allowed_version_tags), cooldown_options)
+      return nil if filtered_tags.nil?
+
+      max_local_tag(filtered_tags)
+    end
+
     sig { returns(T::Array[Dependabot::GitTagDetails]) }
     def local_tags_for_allowed_versions_matching_existing_precision
       select_matching_existing_precision(allowed_version_tags).filter_map { |t| to_local_tag(t) }

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -1339,6 +1339,20 @@ RSpec.describe Dependabot::GitCommitChecker do
         end
       end
 
+      context "when fetching tag release dates raises" do
+        let(:refs_with_detail) { [] }
+
+        before do
+          allow(checker)
+            .to receive(:refs_for_tag_with_detail)
+            .and_raise(Dependabot::GitDependenciesNotReachable.new(["https://github.com/gocardless/business"]))
+        end
+
+        it "fails open and returns the latest version tag" do
+          expect(latest_tag[:tag]).to eq("v1.13.0")
+        end
+      end
+
       context "when the dependency is excluded from cooldown" do
         let(:cooldown_options) do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90, exclude: ["business"])

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -1370,6 +1370,59 @@ RSpec.describe Dependabot::GitCommitChecker do
     end
   end
 
+  describe "#local_tag_for_latest_version_matching_existing_precision" do
+    subject(:latest_tag) { checker.local_tag_for_latest_version_matching_existing_precision(cooldown_options) }
+
+    let(:repo_url) { "https://github.com/gocardless/business.git" }
+    let(:service_pack_url) { repo_url + "/info/refs?service=git-upload-pack" }
+    let(:upload_pack_fixture) { "business" }
+    let(:cooldown_options) { nil }
+
+    before do
+      stub_request(:get, service_pack_url)
+        .to_return(
+          status: 200,
+          body: fixture("git", "upload_packs", upload_pack_fixture),
+          headers: { "content-type" => "application/x-git-upload-pack-advertisement" }
+        )
+    end
+
+    context "when pinned to a full-precision version" do
+      let(:version) { "1.0.0" }
+      let(:source) do
+        {
+          type: "git",
+          url: "https://github.com/gocardless/business",
+          branch: "master",
+          ref: "v1.0.0"
+        }
+      end
+
+      it "returns the latest precision-matched tag" do
+        expect(latest_tag[:tag]).to eq("v1.13.0")
+      end
+
+      context "when the latest matching tag is within its cooldown window" do
+        let(:cooldown_options) do
+          Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
+        end
+
+        before do
+          allow(checker).to receive(:refs_for_tag_with_detail).and_return(
+            [
+              Dependabot::GitTagWithDetail.new(tag: "v1.11.1", release_date: "2018-01-02"),
+              Dependabot::GitTagWithDetail.new(tag: "v1.13.0", release_date: Time.now.strftime("%Y-%m-%d"))
+            ]
+          )
+        end
+
+        it "skips the cooled-down tag and returns the next newest matching tag" do
+          expect(latest_tag[:tag]).to eq("v1.11.1")
+        end
+      end
+    end
+  end
+
   describe "#local_ref_for_latest_version_matching_existing_precision" do
     subject { checker.local_ref_for_latest_version_matching_existing_precision }
 

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -2,9 +2,6 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
-require "dependabot/clients/github_with_retries"
-require "dependabot/errors"
-require "dependabot/git_cooldown_date_resolver"
 require "dependabot/pre_commit/comment_version_helper"
 require "dependabot/pre_commit/file_parser"
 require "dependabot/pre_commit/package/package_details_fetcher"
@@ -12,16 +9,12 @@ require "dependabot/pre_commit/requirement"
 require "dependabot/pre_commit/update_checker"
 require "dependabot/pre_commit/helpers"
 require "dependabot/package/package_latest_version_finder"
-require "dependabot/shared_helpers"
-require "dependabot/update_checkers/cooldown_calculation"
-require "dependabot/update_checkers/version_filters"
 
 module Dependabot
   module PreCommit
     class UpdateChecker
       class LatestVersionFinder < Dependabot::Package::PackageLatestVersionFinder
         extend T::Sig
-        include Dependabot::GitCooldownDateResolver
 
         sig do
           params(
@@ -50,8 +43,6 @@ module Dependabot
           @raise_on_ignored    = raise_on_ignored
           @options             = options
           @cooldown_options = cooldown_options
-          @cooldown_selected_tag = T.let(nil, T.nilable(T::Hash[Symbol, T.untyped]))
-          @cooldown_rejected_all = T.let(false, T::Boolean)
 
           @git_helper = T.let(git_helper, Dependabot::PreCommit::Helpers::Githelper)
           super(
@@ -91,46 +82,69 @@ module Dependabot
 
           Dependabot.logger.info("Available release version/ref is #{release}")
 
-          filter_release_with_cooldown(release)
+          # Commit SHA releases have no version ordering to apply cooldown against.
+          return release if release_type_sha?
+          return release unless cooldown_active?
+
+          selected = cooldown_selected_tag
+          return T.cast(selected.fetch(:version), Dependabot::Version) if selected
+
+          # Every candidate version is still within its cooldown window.
+          Dependabot.logger.info("All candidate versions are in cooldown, keeping current version #{current_version}")
+          current_version
         end
 
         sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
         def latest_version_tag
-          return nil if @cooldown_rejected_all
+          return available_latest_version_tag unless cooldown_active? && !release_type_sha?
 
-          @cooldown_selected_tag || available_latest_version_tag
-        end
-
-        sig { override.returns(T.nilable(String)) }
-        def cooldown_source_url
-          @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
-        end
-
-        sig { override.returns(T::Array[Dependabot::Credential]) }
-        def cooldown_credentials
-          @credentials
+          cooldown_selected_tag
         end
 
         private
 
-        sig do
-          params(release: T.any(Dependabot::Version, String))
-            .returns(T.nilable(T.any(Dependabot::Version, String)))
+        # Resolves the newest version tag outside its cooldown window by
+        # delegating to the shared GitCommitChecker cooldown (which handles
+        # release-date resolution and is semver-aware). Version-pinned deps keep
+        # their existing tag precision; a SHA pinned with a version comment has
+        # no precision to match against, so all allowed tags are considered.
+        # Tags that aren't newer than the current pinned version are ignored, so
+        # cooldown never proposes moving backwards.
+        sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+        def cooldown_selected_tag
+          return @cooldown_selected_tag if defined?(@cooldown_selected_tag)
+
+          checker = @git_helper.git_commit_checker
+          tag = if sha_pinned_with_version_comment?
+                  checker.local_tag_for_latest_version(cooldown_options)
+                else
+                  checker.local_tag_for_latest_version_matching_existing_precision(cooldown_options)
+                end
+
+          @cooldown_selected_tag = T.let(
+            tag && newer_than_current?(tag) ? tag : nil,
+            T.nilable(T::Hash[Symbol, T.untyped])
+          )
         end
-        def filter_release_with_cooldown(release)
-          return release unless cooldown_enabled?
-          return release unless cooldown_options
-          # Commit SHA releases have no version ordering to fall back through
-          return release if release_type_sha?
 
-          Dependabot.logger.info("Applying cooldown filter for #{dependency.name}")
+        # The shared cooldown returns the highest allowed tag left after
+        # filtering; guard against it being the current version (or older) so a
+        # cooled-down latest never falls back to a same-or-older tag.
+        sig { params(tag: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        def newer_than_current?(tag)
+          cur = current_version
+          return true unless cur.is_a?(Dependabot::Version)
 
-          result = find_latest_version_outside_cooldown
-          return result if result
+          tag_version = tag[:version]
+          return false unless tag_version.is_a?(Gem::Version)
 
-          Dependabot.logger.info("All candidate versions are in cooldown, keeping current version #{current_version}")
-          @cooldown_rejected_all = true
-          current_version
+          comparison = tag_version <=> cur
+          !comparison.nil? && comparison.positive?
+        end
+
+        sig { returns(T::Boolean) }
+        def cooldown_active?
+          cooldown_enabled? && !cooldown_options.nil?
         end
 
         sig { returns(T.nilable(Dependabot::PreCommit::Package::PackageDetailsFetcher)) }
@@ -166,172 +180,6 @@ module Dependabot
         sig { override.returns(T::Boolean) }
         def cooldown_enabled?
           true
-        end
-
-        # Checks versions from latest downward (among versions > current_version).
-        # First attempts to use GitHub Release published_at dates (no clone needed).
-        # Falls back to a bare clone for git-based date detection.
-        sig { returns(T.nilable(Dependabot::Version)) }
-        def find_latest_version_outside_cooldown
-          candidates = version_candidates_descending
-          return nil if candidates.empty?
-
-          # Try GitHub Release dates first (avoids clone)
-          result = check_candidates_via_github_releases(candidates)
-          return result if result
-
-          # Fallback: clone and check tag/commit dates
-          check_candidates_via_git_clone(candidates)
-        rescue StandardError => e
-          Dependabot.logger.error("Error checking cooldown for #{dependency.name}: #{e.message}")
-          nil
-        end
-
-        # Attempts to resolve cooldown using GitHub Release published_at dates.
-        # Returns:
-        # - A version outside cooldown (first eligible candidate)
-        # - current_version when ALL candidates have releases and all are in cooldown
-        # - nil when no releases exist or some candidates lack releases (triggers git fallback)
-        sig do
-          params(candidates: T::Array[T::Hash[Symbol, T.untyped]])
-            .returns(T.nilable(Dependabot::Version))
-        end
-        def check_candidates_via_github_releases(candidates)
-          releases = cached_github_releases
-          return nil if releases.empty?
-
-          filtered_count = 0
-          all_have_releases = T.let(true, T::Boolean)
-
-          candidates.each do |tag|
-            tag_name = normalize_tag_name(tag[:tag] || "v#{tag[:version]}")
-            release = releases.find { |r| r.tag_name == tag_name }
-
-            unless release&.published_at
-              all_have_releases = false
-              next
-            end
-
-            unless release_in_cooldown_period?(release.published_at)
-              log_cooldown_result(filtered_count, tag[:version], release.published_at)
-              @cooldown_selected_tag = tag
-              return T.cast(tag[:version], Dependabot::Version)
-            end
-
-            filtered_count += 1
-          end
-
-          return nil if filtered_count.zero?
-
-          # Some candidates lacked releases — fall back to git clone for those
-          return nil unless all_have_releases
-
-          # Every candidate had a release and all were in cooldown
-          Dependabot.logger.info(
-            "Filtered #{filtered_count} version(s) due to cooldown for #{dependency.name}, " \
-            "no eligible version found (via GitHub Releases)"
-          )
-          @cooldown_rejected_all = true
-          T.cast(current_version, T.nilable(Dependabot::Version))
-        end
-
-        # Checks candidate tags inside a bare clone directory, returning the first
-        # version whose tag creation date falls outside the cooldown window.
-        sig do
-          params(candidates: T::Array[T::Hash[Symbol, T.untyped]])
-            .returns(T.nilable(Dependabot::Version))
-        end
-        def check_candidates_via_git_clone(candidates)
-          url = cooldown_source_url
-          source = T.must(Source.from_url(url))
-
-          SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
-            repo_contents_path = File.join(temp_dir, File.basename(source.repo))
-            SharedHelpers.run_shell_command("git clone --bare --no-recurse-submodules #{url} #{repo_contents_path}")
-
-            Dir.chdir(repo_contents_path) do
-              return check_candidates_cooldown(candidates)
-            end
-          end
-        end
-
-        # Iterates candidate tags inside a bare clone directory, returning the first
-        # version whose release date falls outside the cooldown window.
-        # Prefers GitHub Release published_at when available for a candidate,
-        # falling back to tag creation date from the cloned repo.
-        sig do
-          params(candidates: T::Array[T::Hash[Symbol, T.untyped]])
-            .returns(T.nilable(Dependabot::Version))
-        end
-        def check_candidates_cooldown(candidates)
-          filtered_count = 0
-
-          candidates.each do |tag|
-            commit_sha = tag[:commit_sha]
-            next unless commit_sha
-
-            tag_name = normalize_tag_name(tag[:tag] || "v#{tag[:version]}")
-            release_date = resolve_candidate_date(tag_name, commit_sha)
-
-            if release_in_cooldown_period?(release_date)
-              filtered_count += 1
-            else
-              log_cooldown_result(filtered_count, tag[:version], release_date)
-              @cooldown_selected_tag = tag
-              return T.cast(tag[:version], Dependabot::Version)
-            end
-          end
-
-          Dependabot.logger.info(
-            "Filtered #{filtered_count} version(s) due to cooldown for #{dependency.name}, " \
-            "no eligible version found"
-          )
-          nil
-        end
-
-        sig do
-          params(filtered_count: Integer, version: T.untyped, release_date: Time).void
-        end
-        def log_cooldown_result(filtered_count, version, release_date)
-          if filtered_count.positive?
-            Dependabot.logger.info(
-              "Filtered #{filtered_count} version(s) due to cooldown for #{dependency.name}"
-            )
-          end
-          Dependabot.logger.info("Selected version #{version} (released #{release_date})")
-        end
-
-        # Returns all version tags > current_version, sorted descending (latest first).
-        # This ensures we evaluate from the newest candidate downward.
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
-        def version_candidates_descending
-          # When pinned to a SHA, precision matching against the SHA is meaningless
-          # (a SHA has no dots, so precision=1 matches nothing useful).
-          # Use the unfiltered allowed version tags instead.
-          all_tags = if sha_pinned_with_version_comment?
-                       @git_helper.git_commit_checker.local_tags_for_allowed_versions
-                     else
-                       @git_helper.git_commit_checker.local_tags_for_allowed_versions_matching_existing_precision
-                     end
-          cur_version = current_version
-
-          all_tags
-            .select { |tag| tag[:version].is_a?(Gem::Version) }
-            .select { |tag| cur_version.nil? || tag[:version] > cur_version }
-            .sort_by { |tag| tag[:version] }
-            .reverse
-        end
-
-        sig { params(release_date: Time).returns(T::Boolean) }
-        def release_in_cooldown_period?(release_date)
-          cooldown = @cooldown_options
-
-          return false unless T.must(cooldown).included?(dependency.name)
-
-          days = T.must(cooldown).default_days
-
-          Dependabot::UpdateCheckers::CooldownCalculation
-            .within_cooldown_window?(release_date, days)
         end
 
         sig { returns(T.nilable(T.any(Dependabot::Version, String))) }

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -89,8 +89,10 @@ module Dependabot
           selected = cooldown_selected_tag
           return T.cast(selected.fetch(:version), Dependabot::Version) if selected
 
-          # Every candidate version is still within its cooldown window.
-          Dependabot.logger.info("All candidate versions are in cooldown, keeping current version #{current_version}")
+          # No newer version is available outside its cooldown window — either
+          # every candidate is still cooling down, or the only remaining tags
+          # aren't newer than the current pin — so keep the current version.
+          Dependabot.logger.info("No newer version outside cooldown; keeping #{current_version}")
           current_version
         end
 

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -192,173 +192,68 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
       end
     end
 
-    context "when latest version is in cooldown" do
+    context "when the latest version is in cooldown" do
       let(:update_cooldown) do
-        Dependabot::Package::ReleaseCooldownOptions.new(
-          default_days: 7
-        )
+        Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
       end
 
-      it "falls back to a previous version not in cooldown" do
-        recent_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
-        old_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
-
-        latest_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "latest_sha"
-        }
-        older_tag = {
+      let(:older_tag) do
+        {
           tag: "v5.0.0",
           version: Dependabot::PreCommit::Version.new("5.0.0"),
-          commit_sha: "older_sha"
+          commit_sha: "older_sha",
+          tag_sha: "older_tag_sha"
         }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_return([latest_tag, older_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return(recent_date, old_date)
-
-        result = finder.latest_release_version
-        expect(result.to_s).to eq("5.0.0")
       end
 
-      it "returns current version when no fallback candidates exist" do
+      before do
+        # The shared GitCommitChecker cooldown resolves tag dates and returns
+        # the newest tag outside its cooldown window; here we drive the finder
+        # with its result. Date resolution itself is covered by common's
+        # git_commit_checker_spec.
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_return([])
-
-        result = finder.latest_release_version
-        expect(result.to_s).to eq("4.4.0")
+          .to receive(:local_tag_for_latest_version_matching_existing_precision)
+          .with(update_cooldown)
+          .and_return(cooldown_selected)
       end
 
-      it "returns nil from latest_version_tag when all versions are in cooldown" do
-        recent_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
+      context "when an older version is outside cooldown" do
+        let(:cooldown_selected) { older_tag }
 
-        latest_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "latest_sha"
-        }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_return([latest_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return(recent_date)
-
-        # Trigger cooldown evaluation
-        finder.latest_release_version
-
-        # latest_version_tag must be nil so that sha1_version_up_to_date?
-        # does not resolve a commit SHA for the cooldown-blocked version
-        expect(finder.latest_version_tag).to be_nil
-      end
-
-      it "returns the cooldown-selected tag from latest_version_tag" do
-        recent_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
-        old_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
-
-        latest_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "latest_sha"
-        }
-        older_tag = {
-          tag: "v5.0.0",
-          version: Dependabot::PreCommit::Version.new("5.0.0"),
-          commit_sha: "older_sha"
-        }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_return([latest_tag, older_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return(recent_date, old_date)
-
-        # Trigger cooldown evaluation
-        finder.latest_release_version
-
-        # latest_version_tag should return the cooldown-selected tag (v5.0.0)
-        expect(finder.latest_version_tag).to eq(older_tag)
-      end
-
-      context "with v-prefixed version in dependency" do
-        let(:dependency) do
-          Dependabot::Dependency.new(
-            name: "https://github.com/#{dependency_name}",
-            version: "v4.4.0",
-            requirements: [{
-              requirement: nil,
-              groups: [],
-              file: ".pre-commit-config.yaml",
-              source: dependency_source
-            }],
-            package_manager: "pre_commit"
-          )
+        it "falls back to that version" do
+          expect(finder.latest_release_version.to_s).to eq("5.0.0")
         end
 
-        it "does not select versions older than the current pinned ref" do
-          # v3.0.0 is older than v4.4.0 — must not be selected even if not in cooldown
-          old_tag = {
+        it "exposes the cooldown-selected tag via latest_version_tag" do
+          expect(finder.latest_version_tag).to eq(older_tag)
+        end
+      end
+
+      context "when every candidate is in cooldown" do
+        let(:cooldown_selected) { nil }
+
+        it "keeps the current version" do
+          expect(finder.latest_release_version.to_s).to eq("4.4.0")
+        end
+
+        it "returns nil from latest_version_tag" do
+          expect(finder.latest_version_tag).to be_nil
+        end
+      end
+
+      context "when only versions older than the current ref remain" do
+        let(:cooldown_selected) do
+          {
             tag: "v3.0.0",
             version: Dependabot::PreCommit::Version.new("3.0.0"),
-            commit_sha: "old_sha"
+            commit_sha: "old_sha",
+            tag_sha: "old_tag_sha"
           }
-          latest_tag = {
-            tag: "v6.0.0",
-            version: Dependabot::PreCommit::Version.new("6.0.0"),
-            commit_sha: "latest_sha"
-          }
+        end
 
-          recent_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
-
-          allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-            .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-            .and_return([latest_tag, old_tag])
-          allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-            .to receive(:dependency_source_details)
-            .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                          ref: "v4.4.0", branch: nil })
-          allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-          allow(Dir).to receive(:chdir).and_yield
-          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-            .with(/git clone --bare/, any_args).and_return("")
-          # All remaining candidates (v6.0.0) are in cooldown
-          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-            .with(/git for-each-ref/, hash_including(fingerprint: anything))
-            .and_return(recent_date)
-
-          result = finder.latest_release_version
-          expect(result.to_s).to eq("4.4.0")
+        it "does not move backwards and keeps the current version" do
+          expect(finder.latest_release_version.to_s).to eq("4.4.0")
+          expect(finder.latest_version_tag).to be_nil
         end
       end
     end
@@ -372,7 +267,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
       end
     end
 
-    context "when pinned to a SHA with frozen comment and cooldown enabled" do
+    context "when pinned to a SHA with a frozen version comment" do
       let(:reference) { "cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b" }
       let(:dependency) do
         Dependabot::Dependency.new(
@@ -389,294 +284,53 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
         )
       end
       let(:update_cooldown) do
-        Dependabot::Package::ReleaseCooldownOptions.new(
-          default_days: 7
-        )
+        Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
       end
 
       before do
+        # A SHA has no version precision to match against, so the finder uses
+        # the non-precision shared cooldown and compares against the frozen
+        # comment version (v5.0.0). The available release is a version (not a
+        # SHA string), so this isn't treated as a plain SHA release.
+        allow_any_instance_of(Dependabot::PreCommit::Package::PackageDetailsFetcher) # rubocop:disable RSpec/AnyInstance
+          .to receive(:release_list_for_git_dependency)
+          .and_return(Dependabot::PreCommit::Version.new("6.0.0"))
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:local_tag_for_pinned_sha).and_return(nil)
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tag_for_latest_version)
+          .with(update_cooldown)
+          .and_return(selected_tag)
       end
 
-      it "uses the frozen comment version for cooldown comparison" do
-        old_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
+      context "when a newer tag is outside cooldown" do
+        let(:selected_tag) do
+          {
+            tag: "v6.0.0",
+            version: Dependabot::PreCommit::Version.new("6.0.0"),
+            commit_sha: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c",
+            tag_sha: "sha6"
+          }
+        end
 
-        v6_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"
-        }
-        v5_tag = {
-          tag: "v5.0.0",
-          version: Dependabot::PreCommit::Version.new("5.0.0"),
-          commit_sha: "cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b"
-        }
-        v4_tag = {
-          tag: "v4.4.0",
-          version: Dependabot::PreCommit::Version.new("4.4.0"),
-          commit_sha: "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e"
-        }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions)
-          .and_return([v6_tag, v5_tag, v4_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_raise("unexpected precision filtering")
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: reference, branch: nil })
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return(old_date)
-
-        result = finder.latest_release_version
-        # Should return v6.0.0 (not nil) because the frozen comment tells us
-        # current version is v5.0.0, so only v6.0.0 is a candidate,
-        # and it's outside the cooldown window
-        expect(result).to be_a(Dependabot::PreCommit::Version)
-        expect(result.to_s).to eq("6.0.0")
+        it "uses the frozen comment version and returns the newer tag" do
+          expect(finder.latest_release_version.to_s).to eq("6.0.0")
+        end
       end
 
-      it "does not falsely flag all versions as in cooldown" do
-        recent_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
-        old_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
+      context "when only v5.1.0 is outside cooldown" do
+        let(:selected_tag) do
+          {
+            tag: "v5.1.0",
+            version: Dependabot::PreCommit::Version.new("5.1.0"),
+            commit_sha: "abc123",
+            tag_sha: "sha51"
+          }
+        end
 
-        v6_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"
-        }
-        v5_1_tag = {
-          tag: "v5.1.0",
-          version: Dependabot::PreCommit::Version.new("5.1.0"),
-          commit_sha: "abc123"
-        }
-        v5_tag = {
-          tag: "v5.0.0",
-          version: Dependabot::PreCommit::Version.new("5.0.0"),
-          commit_sha: "cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b"
-        }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions)
-          .and_return([v6_tag, v5_1_tag, v5_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_raise("unexpected precision filtering")
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: reference, branch: nil })
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        # v6.0.0 is in cooldown, but v5.1.0 is not
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return(recent_date, old_date)
-
-        result = finder.latest_release_version
-        # Should fall back to v5.1.0 (> v5.0.0 and outside cooldown)
-        expect(result).to be_a(Dependabot::PreCommit::Version)
-        expect(result.to_s).to eq("5.1.0")
-      end
-    end
-
-    context "when tag creation date differs from commit date" do
-      let(:update_cooldown) do
-        Dependabot::Package::ReleaseCooldownOptions.new(
-          default_days: 7
-        )
-      end
-
-      it "uses tag creation date (not commit date) for cooldown evaluation" do
-        # Tag was created today but points to a commit from 30 days ago.
-        # The tag creation date (today) should be used for cooldown, meaning
-        # the version IS in cooldown. If the commit date were used instead,
-        # the version would incorrectly bypass cooldown.
-        tag_creation_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
-
-        latest_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "latest_sha"
-        }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_return([latest_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        # for-each-ref returns the tag creation date (today) — in cooldown
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return(tag_creation_date)
-
-        result = finder.latest_release_version
-        # Should stay on current version because tag was just created (in cooldown)
-        expect(result.to_s).to eq("4.4.0")
-      end
-
-      it "falls back to commit date when for-each-ref returns empty" do
-        # Simulates a lightweight tag that for-each-ref can't find (empty result)
-        # Should fall back to git show %cd
-        old_commit_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
-
-        latest_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "latest_sha"
-        }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_return([latest_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        # for-each-ref returns empty (tag not found)
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return("")
-        # Fallback to git show returns old commit date (outside cooldown)
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git show --no-patch/, hash_including(fingerprint: anything))
-          .and_return(old_commit_date)
-
-        result = finder.latest_release_version
-        # Should accept version because fallback commit date is old (outside cooldown)
-        expect(result.to_s).to eq("6.0.0")
-      end
-
-      it "correctly applies cooldown with annotated tag that points to old commit" do
-        # Annotated tag created 2 days ago pointing to a commit from 30 days ago
-        # Cooldown is 7 days — tag creation date (2 days) is within cooldown
-        tag_creation_date = (Time.now - (2 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
-        old_tag_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
-
-        latest_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "latest_sha"
-        }
-        older_tag = {
-          tag: "v5.0.0",
-          version: Dependabot::PreCommit::Version.new("5.0.0"),
-          commit_sha: "older_sha"
-        }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_return([latest_tag, older_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        # v6.0.0 tag was created 2 days ago (in cooldown), v5.0.0 tag 30 days ago (outside)
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return(tag_creation_date, old_tag_date)
-
-        result = finder.latest_release_version
-        # Should skip v6.0.0 (in cooldown) and select v5.0.0 (outside cooldown)
-        expect(result.to_s).to eq("5.0.0")
-      end
-    end
-
-    context "when GitHub Release published_at is available" do
-      let(:update_cooldown) do
-        Dependabot::Package::ReleaseCooldownOptions.new(
-          default_days: 7
-        )
-      end
-
-      it "uses GitHub Release published_at for cooldown (bypasses git clone)" do
-        recent_published_at = Time.now - (2 * 24 * 60 * 60) # 2 days ago
-
-        latest_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "latest_sha"
-        }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_return([latest_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
-
-        # Mock GitHub Release with recent published_at (in cooldown)
-        mock_release = Struct.new(:tag_name, :published_at, :prerelease)
-                             .new("v6.0.0", recent_published_at, false)
-        mock_client = instance_double(Octokit::Client, releases: [mock_release])
-        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
-
-        # Should NOT clone the repo since we got the date from Octokit
-        expect(Dependabot::SharedHelpers).not_to receive(:run_shell_command).with(/git clone/)
-
-        result = finder.latest_release_version
-        # v6.0.0 is in cooldown (published 2 days ago, cooldown is 7 days)
-        expect(result.to_s).to eq("4.4.0")
-      end
-
-      it "falls back to git when no GitHub Release exists for the tag" do
-        old_date = (Time.now - (30 * 24 * 60 * 60)).utc.strftime("%Y-%m-%d %H:%M:%S %z")
-
-        latest_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "latest_sha"
-        }
-
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
-          .and_return([latest_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
-
-        # No release for this tag
-        mock_client = instance_double(Octokit::Client, releases: [])
-        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
-
-        # Falls back to git clone
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return(old_date)
-
-        result = finder.latest_release_version
-        # Falls back to for-each-ref, date is old (outside cooldown)
-        expect(result.to_s).to eq("6.0.0")
+        it "does not flag all versions as in cooldown" do
+          expect(finder.latest_release_version.to_s).to eq("5.1.0")
+        end
       end
     end
   end

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -171,35 +171,16 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
       end
 
       before do
+        # A SHA pinned with a "# frozen: v4.4.0" comment: the finder compares
+        # against the frozen version and delegates cooldown to the shared
+        # GitCommitChecker, which returns nil when every candidate tag is still
+        # within its cooldown window. available_release stays a version so this
+        # isn't treated as a plain SHA release.
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:local_tag_for_pinned_sha).and_return(nil)
-
-        recent_date = Time.now.utc.strftime("%Y-%m-%d %H:%M:%S %z")
-
-        v6_tag = {
-          tag: "v6.0.0",
-          version: Dependabot::PreCommit::Version.new("6.0.0"),
-          commit_sha: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"
-        }
-
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:local_tags_for_allowed_versions)
-          .and_return([v6_tag])
-        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: reference, branch: nil })
-        # Stub GitHub Releases (empty — forces git clone fallback)
-        mock_client = instance_double(Octokit::Client, releases: [])
-        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)
-
-        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
-        allow(Dir).to receive(:chdir).and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git clone --bare/, any_args).and_return("")
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .with(/git for-each-ref/, hash_including(fingerprint: anything))
-          .and_return(recent_date)
+          .to receive(:local_tag_for_latest_version)
+          .and_return(nil)
       end
 
       it "reports the dependency as up to date" do


### PR DESCRIPTION
### What are you trying to accomplish?

Migrate **pre_commit** off its bespoke git-tag cooldown implementation onto the shared `GitCommitChecker` cooldown, removing ~200 lines of duplicated date-resolution and cooldown-filtering logic.

Part of the git-tag cooldown generalization spike (github/dependabot-updates#13901), batch github/dependabot-updates#13952 (issue #13959).

pre_commit was the most entangled of the batch — its cooldown was woven into pre-commit-specific version resolution (frozen `# frozen: vX.Y.Z` comments, SHA-pinned hooks, precision matching, "keep the current version when everything is cooled"). This preserves all of that while delegating the actual cooldown to `common`.

Changes:
- **common**: add `GitCommitChecker#local_tag_for_latest_version_matching_existing_precision(cooldown_options)` — a precision-aware counterpart to `local_tag_for_latest_version`, so precision-pinned deps keep their tag precision while gaining the shared, semver-aware cooldown.
- **pre_commit**: `LatestVersionFinder` now delegates cooldown selection to the shared checker (precision variant for version-pinned deps; plain variant for a SHA pinned with a version comment). A `> current_version` guard preserves the "never move backwards" behaviour, and "all candidates cooled → keep the current version" is retained. Removes the `GitCooldownDateResolver` include and the bespoke `filter_release_with_cooldown` / `find_latest_version_outside_cooldown` / `check_candidates_*` / `version_candidates_descending` / `release_in_cooldown_period?` helpers plus now-unused requires.

Net: **-448 lines**.

> Note: this branch includes the fail-open fix from #15475 (rescue in `build_release_dates_by_tag_name`) because the shared date-fetch path is now on pre_commit's critical path. If #15475 merges first, that commit dedupes on rebase; otherwise this carries it. Best merged after #15475.

### Anything you want to highlight for special attention from reviewers?

- **Behaviour change (improvement):** pre_commit cooldown is now **semver-aware** (`CooldownCalculation.cooldown_days_for`); previously it honoured only `default_days`. Spike problem #4.
- **Date resolution** moves from pre_commit's own GitHub-releases lookup + bare `git clone` (`for-each-ref`) to the shared `GitCommitChecker` (`refs_for_tag_with_detail` + GitHub Release `published_at`). Equivalent priority (Release date preferred, tag creation date fallback), now in one place.
- **Never applies to security updates** — `update_cooldown` is `nil` for security jobs and the shared method short-circuits via `CooldownCalculation.skip_cooldown?`.
- Preserved: SHA-pinned hooks (no version-tag cooldown), frozen-comment version comparison, precision matching, and the never-move-backwards / keep-current semantics.

### How will you know you've accomplished your goal?

Verified in Docker:
- The date-resolution unit tests move to `git_commit_checker_spec` (which also covers the new precision method); the finder/update_checker cooldown specs now drive the shared checker's result instead of stubbing the removed git-clone/for-each-ref internals.

Results:
- sorbet `srb tc`: no errors (whole repo)
- rubocop: clean (5 files)
- `git_commit_checker_spec`: 142 examples, 0 failures
- pre_commit `latest_version_finder_spec`: 17 examples, 0 failures
- full `pre_commit` suite: 284 examples, 0 failures

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
