### PR TITLE
Use shared git-tag cooldown in github_actions

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -851,6 +851,10 @@ module Dependabot
       )
     end
 
+    # Fails open: if the tag-detail fetch is unavailable (e.g. a network or
+    # registry error while resolving tag dates), return no dates so cooldown
+    # treats every tag as outside its window and the latest tag is still
+    # proposed, rather than failing the whole update check.
     sig { returns(T::Hash[String, Time]) }
     def build_release_dates_by_tag_name
       dates = T.let({}, T::Hash[String, Time])
@@ -859,6 +863,11 @@ module Dependabot
         dates[detail.tag] = released_at if released_at
       end
       dates
+    rescue StandardError => e
+      Dependabot.logger.error(
+        "Error fetching git tag release dates for #{dependency.name}: #{e.message}"
+      )
+      {}
     end
 
     sig { params(release_date: T.nilable(String)).returns(T.nilable(Time)) }

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -851,10 +851,10 @@ module Dependabot
       )
     end
 
-    # Fails open: if the tag-detail fetch is unavailable (e.g. a network or
-    # registry error while resolving tag dates), return no dates so cooldown
-    # treats every tag as outside its window and the latest tag is still
-    # proposed, rather than failing the whole update check.
+    # Fails open: if the tag-detail fetch is unavailable (e.g. a network error
+    # or an error from the git host / GitHub API while resolving tag dates),
+    # return no dates so cooldown treats every tag as outside its window and the
+    # latest tag is still proposed, rather than failing the whole update check.
     sig { returns(T::Hash[String, Time]) }
     def build_release_dates_by_tag_name
       dates = T.let({}, T::Hash[String, Time])
@@ -864,8 +864,9 @@ module Dependabot
       end
       dates
     rescue StandardError => e
-      Dependabot.logger.error(
-        "Error fetching git tag release dates for #{dependency.name}: #{e.message}"
+      Dependabot.logger.warn(
+        "Skipping git tag cooldown for #{dependency.name}: could not resolve tag release dates " \
+        "(#{e.class}: #{e.message})"
       )
       {}
     end

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -1339,6 +1339,20 @@ RSpec.describe Dependabot::GitCommitChecker do
         end
       end
 
+      context "when fetching tag release dates raises" do
+        let(:refs_with_detail) { [] }
+
+        before do
+          allow(checker)
+            .to receive(:refs_for_tag_with_detail)
+            .and_raise(Dependabot::GitDependenciesNotReachable.new(["https://github.com/gocardless/business"]))
+        end
+
+        it "fails open and returns the latest version tag" do
+          expect(latest_tag[:tag]).to eq("v1.13.0")
+        end
+      end
+
       context "when the dependency is excluded from cooldown" do
         let(:cooldown_options) do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90, exclude: ["business"])

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -205,47 +205,18 @@ module Dependabot
             return nil
           end
 
-          # For version tag proposals, fetch all allowed versions with release dates (single clone)
-          # This reuses a single GitCommitChecker instance within package_details_fetcher
-          allowed_versions_with_dates = T.must(package_details_fetcher).allowed_version_tags_with_release_dates
-          tags_in_cooldown = Set.new(select_version_tags_in_cooldown_period(allowed_versions_with_dates))
-          return release if tags_in_cooldown.empty?
-
-          # Walk through all allowed version tags in descending order (newest first)
-          # and return the first one NOT in cooldown
-          allowed_versions_with_dates.each do |tag_info|
-            tag_name = tag_info.fetch(:tag)
-            next if tags_in_cooldown.include?(tag_name)
-
-            # Found a version not in cooldown, return it
-            version = tag_info.fetch(:version)
-            Dependabot.logger.info("Found acceptable version outside cooldown: #{version}")
-            return version
+          # For version-tag proposals, delegate to the shared GitCommitChecker
+          # cooldown, which resolves tag release dates (GitHub Release date then
+          # tag creation date) and returns the newest tag outside its cooldown
+          # window — or nil when every candidate tag is still cooling down.
+          selected_tag = @git_helper.git_commit_checker.local_tag_for_latest_version(cooldown_options)
+          if selected_tag
+            Dependabot.logger.info("Found acceptable version outside cooldown: #{selected_tag.fetch(:version)}")
+            return selected_tag.fetch(:version)
           end
 
-          # All versions are in cooldown, return nil to fallback to current version
           Dependabot.logger.info("All versions are in cooldown period, returning current version")
           nil
-        end
-
-        sig do
-          params(
-            tags_with_dates: T.nilable(
-              T.any(T::Array[Dependabot::GitTagWithDetail], T::Array[T::Hash[Symbol, T.untyped]])
-            )
-          ).returns(T::Array[String])
-        end
-        def select_version_tags_in_cooldown_period(tags_with_dates = nil)
-          tags_to_check = tags_with_dates || T.must(package_details_fetcher).fetch_tag_and_release_date
-          # Handle both GitTagWithDetail objects and hashes with release_date
-          in_cooldown = tags_to_check.select do |tag|
-            release_date = tag.is_a?(Hash) ? tag.fetch(:release_date, nil) : tag.release_date
-            check_if_version_in_cooldown_period?(release_date)
-          end
-          in_cooldown.map { |tag| tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag }
-        rescue StandardError => e
-          Dependabot.logger.error("Error checking if version is in cooldown (using empty filter): #{e.message}")
-          []
         end
 
         # Returns the release date for the latest version tag.

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -252,12 +252,16 @@ RSpec.describe namespace::LatestVersionFinder do
       end
 
       before do
-        allow(finder).to receive(:select_version_tags_in_cooldown_period) do |tags_with_dates|
-          tags_with_dates.filter_map do |tag|
-            tag_name = tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag
-            tag_name if tag_name.start_with?("v3")
-          end
-        end
+        # The shared GitCommitChecker cooldown returns the newest tag outside
+        # its window; here the latest v3.x is cooling down so it falls back to
+        # v2.7.0. Date resolution itself is covered by git_commit_checker_spec.
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tag_for_latest_version)
+          .and_return(
+            tag: "v2.7.0",
+            version: Dependabot::GithubActions::Version.new("2.7.0"),
+            commit_sha: "ee0669bd1cc54295c223e0bb666b733df41de1c5"
+          )
       end
 
       it "returns the tag hash for the selected cooled-down release" do
@@ -295,7 +299,12 @@ RSpec.describe namespace::LatestVersionFinder do
       end
 
       before do
-        allow(finder).to receive(:select_version_tags_in_cooldown_period).and_return([])
+        # Nothing is cooling down, so the shared cooldown returns the same tag
+        # as the plain latest_version_tag.
+        latest_tag = finder.latest_version_tag
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tag_for_latest_version)
+          .and_return(latest_tag)
       end
 
       it "returns the same tag as latest_version_tag" do
@@ -372,152 +381,6 @@ RSpec.describe namespace::LatestVersionFinder do
           commit_sha: "b4cc9058ebd2336f73752f9d3c9b3835d52c66de",
           version: Dependabot::GithubActions::Version.new("0.0.24")
         )
-      end
-    end
-
-    describe "#select_version_tags_in_cooldown_period" do
-      subject(:selected_tags) { finder.send(:select_version_tags_in_cooldown_period) }
-
-      # Current time: 2024-04-03T16:00:00Z
-      let(:current_time) { Time.parse("2024-04-03T16:00:00Z") }
-
-      # Test fixtures: tags released at various dates
-      let(:git_tags_with_dates) do
-        [
-          # Within 90-day cooldown (released ~60 days ago)
-          Dependabot::GitTagWithDetail.new(tag: "v1.2.0", release_date: "2024-02-03T16:00:00Z"),
-          # Within 90-day cooldown (released ~30 days ago)
-          Dependabot::GitTagWithDetail.new(tag: "v1.1.5", release_date: "2024-03-04T16:00:00Z"),
-          # Outside 90-day cooldown (released ~100 days ago)
-          Dependabot::GitTagWithDetail.new(tag: "v1.1.0", release_date: "2023-12-25T16:00:00Z"),
-          # Within 90-day cooldown (released ~5 days ago)
-          Dependabot::GitTagWithDetail.new(tag: "v1.3.0", release_date: "2024-03-29T16:00:00Z")
-        ]
-      end
-
-      let(:finder) do
-        described_class.new(
-          dependency: dependency,
-          dependency_files: [],
-          credentials: github_credentials,
-          security_advisories: security_advisories,
-          ignored_versions: ignored_versions,
-          raise_on_ignored: raise_on_ignored,
-          cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
-        )
-      end
-
-      before do
-        allow(Time).to receive(:now).and_return(current_time)
-
-        # Stub the package_details_fetcher to return our test data
-        mock_fetcher = instance_double(Dependabot::GithubActions::Package::PackageDetailsFetcher)
-        allow(mock_fetcher).to receive(:fetch_tag_and_release_date).and_return(git_tags_with_dates)
-        allow(finder).to receive(:package_details_fetcher).and_return(mock_fetcher)
-      end
-
-      context "with 90-day cooldown enabled" do
-        it "returns array of tag names" do
-          expect(selected_tags).to be_an(Array)
-          expect(selected_tags).to all(be_a(String))
-        end
-
-        it "includes only tags released within cooldown period" do
-          # Tags released within 90 days: v1.2.0, v1.1.5, v1.3.0
-          # Tags outside cooldown: v1.1.0 (released 100 days ago)
-          expect(selected_tags).to include("v1.2.0", "v1.1.5", "v1.3.0")
-          expect(selected_tags).not_to include("v1.1.0")
-        end
-
-        it "excludes tags outside cooldown period" do
-          excluded_tags = selected_tags & ["v1.1.0"]
-          expect(excluded_tags).to be_empty
-        end
-
-        it "returns all filtered tags in correct format" do
-          expect(selected_tags.count).to eq(3)
-          expect(selected_tags.sort).to eq(["v1.1.5", "v1.2.0", "v1.3.0"].sort)
-        end
-      end
-
-      context "with 1-day cooldown" do
-        let(:finder) do
-          described_class.new(
-            dependency: dependency,
-            dependency_files: [],
-            credentials: github_credentials,
-            security_advisories: security_advisories,
-            ignored_versions: ignored_versions,
-            raise_on_ignored: raise_on_ignored,
-            cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 1)
-          )
-        end
-
-        it "returns only tags released within 1 day" do
-          # Only v1.3.0 (released ~5 days ago) should be excluded
-          # Only v1.1.5 and v1.3.0 and v1.2.0 and v1.1.0 should ALL be checked
-          # With 1-day cooldown: only v1.3.0 (5 days old) is outside
-          # Actually v1.2.0 (60 days), v1.1.5 (30 days), v1.1.0 (100 days) are all outside
-          # Only newly released tags within 1 day would be included
-          expect(selected_tags).to be_empty
-        end
-      end
-
-      context "when git fetch fails" do
-        let(:finder) do
-          described_class.new(
-            dependency: dependency,
-            dependency_files: [],
-            credentials: github_credentials,
-            security_advisories: security_advisories,
-            ignored_versions: ignored_versions,
-            raise_on_ignored: raise_on_ignored,
-            cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 90)
-          )
-        end
-
-        before do
-          mock_fetcher = instance_double(Dependabot::GithubActions::Package::PackageDetailsFetcher)
-          allow(mock_fetcher).to receive(:fetch_tag_and_release_date).and_raise(StandardError, "git error")
-          allow(finder).to receive(:package_details_fetcher).and_return(mock_fetcher)
-        end
-
-        it "handles error gracefully and returns empty array" do
-          expect(selected_tags).to eq([])
-        end
-
-        it "logs the error" do
-          expect(Dependabot.logger).to receive(:error).with(/Error checking if version is in cooldown/)
-          selected_tags
-        end
-      end
-
-      context "when all tags are in cooldown" do
-        let(:git_tags_with_dates) do
-          [
-            # All released recently
-            Dependabot::GitTagWithDetail.new(tag: "v1.0.0", release_date: "2024-04-01T16:00:00Z"),
-            Dependabot::GitTagWithDetail.new(tag: "v1.0.1", release_date: "2024-04-02T16:00:00Z")
-          ]
-        end
-
-        it "returns all tags" do
-          expect(selected_tags).to eq(["v1.0.0", "v1.0.1"])
-        end
-      end
-
-      context "when no tags are in cooldown" do
-        let(:git_tags_with_dates) do
-          [
-            # All released long ago
-            Dependabot::GitTagWithDetail.new(tag: "v1.0.0", release_date: "2023-01-01T16:00:00Z"),
-            Dependabot::GitTagWithDetail.new(tag: "v1.0.1", release_date: "2023-02-01T16:00:00Z")
-          ]
-        end
-
-        it "returns empty array" do
-          expect(selected_tags).to be_empty
-        end
       end
     end
   end

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -444,24 +444,15 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         end
 
         before do
-          allow(Time).to receive(:now).and_return(Time.parse("2019-08-06 18:29:44 -0400"))
-
-          # Mock GitCommitChecker to return tag data for cooldown_filter
-          allow(Dependabot::GitCommitChecker).to receive(:new).and_wrap_original do |method, **kwargs|
-            instance = method.call(**kwargs)
-
-            allow(instance).to receive_messages(
-              refs_for_tag_with_detail: [
-                Dependabot::GitTagWithDetail.new(tag: "v1.0.1", release_date: "2019-01-01T00:00:00+00:00"),
-                Dependabot::GitTagWithDetail.new(tag: "v1.1.0", release_date: "2019-07-20T00:00:00+00:00")
-              ],
-              local_tags_for_allowed_versions: [
-                { tag: "v1.0.1", version: Dependabot::GithubActions::Version.new("1.0.1") },
-                { tag: "v1.1.0", version: Dependabot::GithubActions::Version.new("1.1.0") }
-              ]
+          # v1.1.0 is still cooling down, so the shared GitCommitChecker
+          # cooldown surfaces v1.0.1 instead. The date-filtering itself is
+          # covered by common/spec git_commit_checker_spec.
+          allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+            .to receive(:local_tag_for_latest_version)
+            .and_return(
+              tag: "v1.0.1",
+              version: Dependabot::GithubActions::Version.new("1.0.1")
             )
-            instance
-          end
         end
 
         it { is_expected.to eq(Gem::Version.new("1.0.1")) }
@@ -1103,13 +1094,16 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       end
 
       before do
-        finder = checker.send(:latest_version_finder)
-        allow(finder).to receive(:select_version_tags_in_cooldown_period) do |tags_with_dates|
-          tags_with_dates.filter_map do |tag|
-            tag_name = tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag
-            tag_name if tag_name.start_with?("v3")
-          end
-        end
+        # Cooldown pushes the target down from the latest v3 to v2.7.0; the
+        # shared GitCommitChecker cooldown surfaces that tag. Date resolution
+        # itself is covered by git_commit_checker_spec.
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tag_for_latest_version)
+          .and_return(
+            tag: "v2.7.0",
+            version: Dependabot::GithubActions::Version.new("2.7.0"),
+            commit_sha: "ee0669bd1cc54295c223e0bb666b733df41de1c5"
+          )
       end
 
       it "keeps metadata and rewritten version tag aligned to cooled-down target" do
@@ -1127,13 +1121,15 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       end
 
       before do
-        finder = checker.send(:latest_version_finder)
-        allow(finder).to receive(:select_version_tags_in_cooldown_period) do |tags_with_dates|
-          tags_with_dates.filter_map do |tag|
-            tag_name = tag.is_a?(Hash) ? tag.fetch(:tag) : tag.tag
-            tag_name if tag_name.start_with?("v3")
-          end
-        end
+        # As above, cooldown selects v2.7.0; because the dependency is pinned to
+        # a SHA the requirement is rewritten to that tag's commit, not its name.
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tag_for_latest_version)
+          .and_return(
+            tag: "v2.7.0",
+            version: Dependabot::GithubActions::Version.new("2.7.0"),
+            commit_sha: "ee0669bd1cc54295c223e0bb666b733df41de1c5"
+          )
       end
 
       it "rewrites SHA to the cooled-down tag commit, not the uncooldowned latest tag commit" do


### PR DESCRIPTION
### What are you trying to accomplish?

Now that git-tag cooldown is generalized in `common` (`GitCommitChecker#local_tag_for_latest_version(cooldown_options)`), the ecosystems that already implement it still carry their own duplicated copies. This migrates **github_actions**' version-tag cooldown onto the shared implementation.

This is part of the git-tag cooldown generalization spike (github/dependabot-updates#13901), tracked under the migration batch (github/dependabot-updates#13952, issue #13956).

Changes:
- `update_checker/latest_version_finder.rb`: the version-tag branch of `cooldown_filter` now delegates to `git_commit_checker.local_tag_for_latest_version(cooldown_options)`, which resolves each candidate tag's release date (GitHub Release `published_at`, then tag creation date) and returns the newest tag outside its cooldown window, or `nil` when every tag is still cooling down. The bespoke `select_version_tags_in_cooldown_period` candidate walk is removed.
- github_actions is the only ecosystem that also does **commit-SHA cooldown** (when the proposed release is a bare SHA rather than a version tag). That path has no shared equivalent, so it is intentionally kept ecosystem-local (`commit_metadata_details` / `resolve_commit_metadata_details` / `fetch_date_from_git` / `check_if_version_in_cooldown_period?` are retained).

### Anything you want to highlight for special attention from reviewers?

- **Never applies to security updates** — `cooldown_options` is `nil` for security jobs, and the shared method short-circuits on `nil`/disabled/excluded via `CooldownCalculation.skip_cooldown?`.
- The shared path is semver-aware (via `CooldownCalculation.cooldown_days_for`), whereas the old github_actions code applied a single `default_days` window to every tag — a behaviour improvement consistent with the rest of the batch.
- This branch carries the shared **fail-open** change (#15475): the old `select_version_tags_in_cooldown_period` wrapped its date lookup in a `rescue` that fell back to the non-cooldown latest tag; that fault-tolerance is restored centrally in `build_release_dates_by_tag_name`, so a tag-date fetch failure skips cooldown instead of failing the whole update check. It is best merged **after** #15475 so the commit de-dupes on merge.
- The commit-SHA cooldown path is unchanged and still fully tested.

### How will you know you've accomplished your goal?

Functionally equivalent, verified in Docker:

- Real cooldown date-filtering (latest tag cooled → older, all cooled → `nil`, none cooled → latest) is covered by common's `git_commit_checker_spec`.
- The ecosystem cooldown specs that stubbed the removed private method now stub the shared `local_tag_for_latest_version` and still assert the same end-to-end results (`checker.latest_version` / `updated_requirements`), including the SHA-reference rewrite to the cooled-down tag's commit.

Results:
- rubocop: clean (changed files + `common/lib/dependabot/git_commit_checker.rb`)
- sorbet `srb tc`: no errors (whole repo)
- `latest_version_finder_spec`: 20 examples, 0 failures
- `update_checker_spec`: 89 examples, 0 failures
- full `github_actions` suite: 259 examples, 0 failures
- common `git_commit_checker_spec`: 140 examples, 0 failures

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
