### PR TITLE
Type the cargo ecosystem and remove it from the T.untyped burndown

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1642
+# Offense count: 1608
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -282,14 +282,6 @@ Sorbet/ForbidTUntyped:
     - "bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb"
     - "bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb"
     - "bundler/lib/dependabot/bundler/update_checker/version_resolver.rb"
-    - "cargo/lib/dependabot/cargo/file_fetcher.rb"
-    - "cargo/lib/dependabot/cargo/file_parser.rb"
-    - "cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb"
-    - "cargo/lib/dependabot/cargo/metadata_finder.rb"
-    - "cargo/lib/dependabot/cargo/package/package_details_fetcher.rb"
-    - "cargo/lib/dependabot/cargo/update_checker.rb"
-    - "cargo/lib/dependabot/cargo/update_checker/file_preparer.rb"
-    - "cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb"
     - "common/lib/dependabot/clients/azure.rb"
     - "common/lib/dependabot/clients/bitbucket.rb"
     - "common/lib/dependabot/clients/bitbucket_with_retries.rb"

--- a/cargo/lib/dependabot/cargo/file_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/file_fetcher.rb
@@ -28,7 +28,7 @@ module Dependabot
         "Repo must contain a Cargo.toml."
       end
 
-      sig { override.returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { override.returns(T.nilable(T::Hash[Symbol, T.anything])) }
       def ecosystem_versions
         channel = if rust_toolchain
                     TomlRB.parse(T.must(rust_toolchain).content).dig("toolchain", "channel")
@@ -180,12 +180,14 @@ module Dependabot
         find_workspace_root(file)
       end
 
-      sig { params(dependencies: T::Hash[T.untyped, T.untyped]).returns(T::Array[String]) }
+      sig { params(dependencies: T::Hash[String, T.anything]).returns(T::Array[String]) }
       def collect_path_dependencies_paths(dependencies)
         dependencies.filter_map do |_, details|
-          next unless details.is_a?(Hash) && details["path"]
+          details = toml_table(details)
+          path = T.cast(details&.fetch("path", nil), T.nilable(String))
+          next unless path
 
-          File.join(details["path"], "Cargo.toml").delete_prefix("/")
+          File.join(path, "Cargo.toml").delete_prefix("/")
         end
       end
 
@@ -194,18 +196,19 @@ module Dependabot
       def path_dependency_paths_from_file(file)
         paths = T.let([], T::Array[String])
 
-        workspace = parsed_file(file).fetch("workspace", {})
+        workspace = toml_table_or_empty(parsed_file(file).fetch("workspace", {}))
         Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
           # Paths specified in dependency declaration
-          paths += collect_path_dependencies_paths(parsed_file(file).fetch(type, {}))
+          paths += collect_path_dependencies_paths(toml_table_or_empty(parsed_file(file).fetch(type, {})))
           # Paths specified as workspace dependencies in workspace root
-          paths += collect_path_dependencies_paths(workspace.fetch(type, {}))
+          paths += collect_path_dependencies_paths(toml_table_or_empty(workspace.fetch(type, {})))
         end
 
         # Paths specified for target-specific dependencies
-        parsed_file(file).fetch("target", {}).each do |_, t_details|
+        toml_table_or_empty(parsed_file(file).fetch("target", {})).each do |_, t_details|
+          t_details = toml_table_or_empty(t_details)
           Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
-            paths += collect_path_dependencies_paths(t_details.fetch(type, {}))
+            paths += collect_path_dependencies_paths(toml_table_or_empty(t_details.fetch(type, {})))
           end
         end
 
@@ -217,20 +220,25 @@ module Dependabot
         paths = []
 
         # Paths specified as replacements
-        parsed_file(file).fetch("replace", {}).each do |_, details|
-          next unless details.is_a?(Hash) && details["path"]
+        toml_table_or_empty(parsed_file(file).fetch("replace", {})).each do |_, details|
+          details = toml_table(details)
+          path = T.cast(details&.fetch("path", nil), T.nilable(String))
+          next unless path
 
-          paths << File.join(details["path"], "Cargo.toml")
+          paths << File.join(path, "Cargo.toml")
         end
 
         # Paths specified as patches
-        parsed_file(file).fetch("patch", {}).each do |_, details|
-          next unless details.is_a?(Hash)
+        toml_table_or_empty(parsed_file(file).fetch("patch", {})).each do |_, details|
+          details = toml_table(details)
+          next unless details
 
           details.each do |_, dep_details|
-            next unless dep_details.is_a?(Hash) && dep_details["path"]
+            dep_details = toml_table(dep_details)
+            path = T.cast(dep_details&.fetch("path", nil), T.nilable(String))
+            next unless path
 
-            paths << File.join(dep_details["path"], "Cargo.toml")
+            paths << File.join(path, "Cargo.toml")
           end
         end
 
@@ -239,28 +247,31 @@ module Dependabot
 
       # Check if this Cargo manifest uses workspace dependencies
       # (e.g. dependency = { workspace = true }).
-      sig { params(parsed_manifest: T::Hash[T.untyped, T.untyped]).returns(T::Boolean) }
+      sig { params(parsed_manifest: T::Hash[String, T.anything]).returns(T::Boolean) }
       def uses_workspace_dependencies?(parsed_manifest)
         # Check regular dependencies
         workspace_deps = Cargo::FileParser::DEPENDENCY_TYPES.any? do |type|
-          deps = parsed_manifest.fetch(type, {})
+          deps = toml_table_or_empty(parsed_manifest.fetch(type, {}))
           deps.any? do |_, details|
-            next false unless details.is_a?(Hash)
+            details = toml_table(details)
+            next false unless details
 
-            details["workspace"] == true
+            T.cast(details["workspace"], T.nilable(Object)) == true
           end
         end
 
         return true if workspace_deps
 
         # Check target-specific dependencies
-        parsed_manifest.fetch("target", {}).any? do |_, target_details|
+        toml_table_or_empty(parsed_manifest.fetch("target", {})).any? do |_, target_details|
+          target_details = toml_table_or_empty(target_details)
           Cargo::FileParser::DEPENDENCY_TYPES.any? do |type|
-            deps = target_details.fetch(type, {})
+            deps = toml_table_or_empty(target_details.fetch(type, {}))
             deps.any? do |_, details|
-              next false unless details.is_a?(Hash)
+              details = toml_table(details)
+              next false unless details
 
-              details["workspace"] == true
+              T.cast(details["workspace"], T.nilable(Object)) == true
             end
           end
         end
@@ -268,13 +279,14 @@ module Dependabot
 
       # See if this Cargo manifest inherits any property from a workspace
       # (e.g. edition = { workspace = true }).
-      sig { params(hash: T::Hash[T.untyped, T.untyped]).returns(T::Boolean) }
+      sig { params(hash: T::Hash[String, T.anything]).returns(T::Boolean) }
       def workspace_member?(hash)
         hash.each do |key, value|
+          value = T.cast(value, T.nilable(Object))
           if key == "workspace" && value == true
             return true
           elsif value.is_a?(Hash)
-            return workspace_member?(value)
+            return workspace_member?(toml_table_or_empty(value))
           end
         end
         false
@@ -289,7 +301,8 @@ module Dependabot
       def find_workspace_root(workspace_member)
         current_dir = workspace_member.name.rpartition("/").first
 
-        workspace_root_dir = parsed_file(workspace_member).dig("package", "workspace")
+        package = toml_table_or_empty(parsed_file(workspace_member)["package"])
+        workspace_root_dir = T.cast(package["workspace"], T.nilable(String))
         unless workspace_root_dir.nil?
           workspace_root = fetch_file_from_host(
             File.join(current_dir, workspace_root_dir, "Cargo.toml"),
@@ -322,11 +335,10 @@ module Dependabot
 
       sig { params(file: Dependabot::DependencyFile).returns(T::Array[String]) }
       def workspace_dependency_paths_from_file(file)
-        if parsed_file(file)["workspace"] && !parsed_file(file)["workspace"].key?("members")
-          return path_dependency_paths_from_file(file)
-        end
+        workspace = toml_table(parsed_file(file)["workspace"])
+        return path_dependency_paths_from_file(file) if workspace && !workspace.key?("members")
 
-        workspace_paths = parsed_file(file).dig("workspace", "members")
+        workspace_paths = T.cast(workspace&.fetch("members", nil), T.nilable(T::Array[String]))
         return [] unless workspace_paths&.any?
 
         # Expand any workspace paths that specify a `*`
@@ -335,9 +347,7 @@ module Dependabot
         end
 
         # Excluded paths, to be subtracted for the workspaces array
-        excluded_paths =
-          (parsed_file(file).dig("workspace", "excluded_paths") || []) +
-          (parsed_file(file).dig("workspace", "exclude") || [])
+        excluded_paths = workspace_excluded_paths(workspace)
 
         (workspace_paths - excluded_paths).map do |path|
           File.join(path, "Cargo.toml")
@@ -346,59 +356,40 @@ module Dependabot
 
       # Check whether a path is required or not. It will not be required if
       # an alternative source (i.e., a git source) is also specified
-      # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
-      # rubocop:disable Metrics/AbcSize
       sig { params(file: Dependabot::DependencyFile, path: String).returns(T::Boolean) }
       def required_path?(file, path)
         # Paths specified in dependency declaration
         Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
-          parsed_file(file).fetch(type, {}).each do |_, details|
-            next unless details.is_a?(Hash)
-            next unless details["path"]
-            next unless path == File.join(details["path"], "Cargo.toml")
-
-            return true if details["git"].nil?
+          toml_table_or_empty(parsed_file(file).fetch(type, {})).each do |_, details|
+            return true if required_dependency_details?(details, path)
           end
         end
 
         # Paths specified for target-specific dependencies
-        parsed_file(file).fetch("target", {}).each do |_, t_details|
+        toml_table_or_empty(parsed_file(file).fetch("target", {})).each do |_, t_details|
+          t_details = toml_table_or_empty(t_details)
           Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
-            t_details.fetch(type, {}).each do |_, details|
-              next unless details.is_a?(Hash)
-              next unless details["path"]
-              next unless path == File.join(details["path"], "Cargo.toml")
-
-              return true if details["git"].nil?
+            toml_table_or_empty(t_details.fetch(type, {})).each do |_, details|
+              return true if required_dependency_details?(details, path)
             end
           end
         end
 
         # Paths specified for workspace-wide dependencies
-        workspace = parsed_file(file).fetch("workspace", {})
-        workspace.fetch("dependencies", {}).each do |_, details|
-          next unless details.is_a?(Hash)
-          next unless details["path"]
-          next unless path == File.join(details["path"], "Cargo.toml")
-
-          return true if details["git"].nil?
+        workspace = toml_table_or_empty(parsed_file(file).fetch("workspace", {}))
+        toml_table_or_empty(workspace.fetch("dependencies", {})).each do |_, details|
+          return true if required_dependency_details?(details, path)
         end
 
         # Paths specified as replacements
-        parsed_file(file).fetch("replace", {}).each do |_, details|
-          next unless details.is_a?(Hash)
-          next unless details["path"]
-          next unless path == File.join(details["path"], "Cargo.toml")
-
-          return true if details["git"].nil?
+        toml_table_or_empty(parsed_file(file).fetch("replace", {})).each do |_, details|
+          return true if required_dependency_details?(details, path)
         end
 
         false
       end
-      # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Metrics/CyclomaticComplexity
 
       sig { params(path: String).returns(T::Array[String]) }
       def expand_workspaces(path)
@@ -411,11 +402,42 @@ module Dependabot
           .select { |filename| File.fnmatch?(path, filename) }
       end
 
-      sig { params(file: Dependabot::DependencyFile).returns(T::Hash[T.untyped, T.untyped]) }
+      sig { params(file: Dependabot::DependencyFile).returns(T::Hash[String, T.anything]) }
       def parsed_file(file)
         TomlRB.parse(file.content)
       rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
         raise Dependabot::DependencyFileNotParseable, file.path
+      end
+
+      sig { params(workspace: T.nilable(T::Hash[String, T.anything])).returns(T::Array[String]) }
+      def workspace_excluded_paths(workspace)
+        (T.cast(workspace&.fetch("excluded_paths", nil), T.nilable(T::Array[String])) || []) +
+          (T.cast(workspace&.fetch("exclude", nil), T.nilable(T::Array[String])) || [])
+      end
+
+      sig { params(details: T.anything, path: String).returns(T::Boolean) }
+      def required_dependency_details?(details, path)
+        details = toml_table(details)
+        dependency_path = T.cast(details&.fetch("path", nil), T.nilable(String))
+        return false unless details && dependency_path
+        return false unless path == File.join(dependency_path, "Cargo.toml")
+
+        T.cast(details["git"], T.nilable(Object)).nil?
+      end
+
+      # Returns the value as a TOML table (Hash) when it is one, otherwise nil.
+      # TOML dependency values are polymorphic (e.g. `foo = "1.0"` is a String
+      # while `foo = { version = "1.0" }` is a table), so callers must narrow at
+      # runtime rather than assert a type with T.cast (which would raise).
+      sig { params(value: T.anything).returns(T.nilable(T::Hash[String, T.anything])) }
+      def toml_table(value)
+        obj = T.cast(value, T.nilable(Object))
+        obj.is_a?(Hash) ? obj : nil
+      end
+
+      sig { params(value: T.anything).returns(T::Hash[String, T.anything]) }
+      def toml_table_or_empty(value)
+        toml_table(value) || {}
       end
 
       sig { returns(Dependabot::DependencyFile) }

--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -105,9 +105,8 @@ module Dependabot
       def check_rust_workspace_root
         cargo_toml = dependency_files.find { |f| f.name == "Cargo.toml" }
         workspace_root = parsed_file(T.must(cargo_toml))
-        return unless workspace_root.is_a?(Hash)
 
-        workspace_config = workspace_root.dig("package", "workspace")
+        workspace_config = T.cast(toml_table_or_empty(workspace_root["package"])["workspace"], T.nilable(String))
         return unless workspace_config
 
         msg = "This project is part of a Rust workspace but is not the " \
@@ -129,10 +128,10 @@ module Dependabot
 
         manifest_files.each do |file|
           parsed_content = parsed_file(file)
-          next unless parsed_content.is_a?(Hash)
 
           DEPENDENCY_TYPES.each do |type|
-            parsed_content.fetch(type, {}).each do |name, requirement|
+            toml_table_or_empty(parsed_content.fetch(type, {})).each do |name, requirement|
+              requirement = dependency_declaration(requirement)
               # Skip workspace-inherited dependencies (similar to pnpm catalog)
               # Only skip if workspace is exactly boolean true
               next if requirement.is_a?(Hash) && requirement["workspace"] == true
@@ -143,8 +142,10 @@ module Dependabot
               dependency_set << build_dependency(name, requirement, type, file)
             end
 
-            parsed_content.fetch("target", {}).each do |_, t_details|
-              t_details.fetch(type, {}).each do |name, requirement|
+            toml_table_or_empty(parsed_content.fetch("target", {})).each do |_, t_details|
+              t_details = toml_table_or_empty(t_details)
+              toml_table_or_empty(t_details.fetch(type, {})).each do |name, requirement|
+                requirement = dependency_declaration(requirement)
                 # Skip workspace-inherited dependencies
                 # Only skip if workspace is exactly boolean true
                 next if requirement.is_a?(Hash) && requirement["workspace"] == true
@@ -158,8 +159,9 @@ module Dependabot
             end
           end
 
-          workspace = parsed_content.fetch("workspace", {})
-          workspace.fetch("dependencies", {}).each do |name, requirement|
+          workspace = toml_table_or_empty(parsed_content.fetch("workspace", {}))
+          toml_table_or_empty(workspace.fetch("dependencies", {})).each do |name, requirement|
+            requirement = dependency_declaration(requirement)
             next unless name == name_from_declaration(name, requirement)
             next if lockfile && !version_from_lockfile(name, requirement)
 
@@ -202,15 +204,14 @@ module Dependabot
         return dependency_set unless lockfile
 
         lockfile_content = parsed_file(T.must(lockfile))
-        return dependency_set unless lockfile_content.is_a?(Hash)
 
-        lockfile_content.fetch("package", []).each do |package_details|
-          next unless package_details["source"]
+        T.cast(lockfile_content.fetch("package", []), T::Array[T::Hash[String, T.anything]]).each do |package_details|
+          next unless T.cast(package_details["source"], T.nilable(String))
 
           # TODO: This isn't quite right, as it will only give us one
           # version of each dependency (when in fact there are many)
           dependency_set << Dependency.new(
-            name: package_details["name"],
+            name: T.cast(package_details["name"], String),
             version: version_from_lockfile_details(package_details),
             package_manager: "cargo",
             requirements: []
@@ -224,10 +225,9 @@ module Dependabot
       def patched_dependencies
         root_manifest = manifest_files.find { |f| f.name == "Cargo.toml" }
         parsed_content = parsed_file(T.must(root_manifest))
-        return [] unless parsed_content.is_a?(Hash)
         return [] unless parsed_content["patch"]
 
-        parsed_content["patch"].values.flat_map(&:keys)
+        toml_table_or_empty(parsed_content["patch"]).values.flat_map { |patch| toml_table_or_empty(patch).keys }
       end
 
       sig { params(declaration: T.any(String, T::Hash[String, String])).returns(T.nilable(String)) }
@@ -336,7 +336,10 @@ module Dependabot
         # taking precedence over ancestors. Search the package-directory config
         # first, then each ancestor config, returning the first match.
         cargo_config_files.each do |config_file|
-          value = parsed_file(config_file).dig(*key_name.split("."))
+          value = key_name.split(".").reduce(parsed_file(config_file)) do |current, key|
+            toml_table_or_empty(current)[key]
+          end
+          value = T.cast(value, T.nilable(String))
           return value if value
         end
 
@@ -348,29 +351,28 @@ module Dependabot
         return unless lockfile
 
         lockfile_content = parsed_file(T.must(lockfile))
-        return unless lockfile_content.is_a?(Hash)
 
         candidate_packages =
-          lockfile_content.fetch("package", [])
-                          .select { |p| p["name"] == name }
+          lockfile_packages(lockfile_content)
+          .select { |p| package_field(p, "name") == name }
 
         if (req = requirement_from_declaration(declaration))
           req = Cargo::Requirement.new(req)
 
           candidate_packages =
             candidate_packages
-            .select { |p| req.satisfied_by?(version_class.new(p["version"])) }
+            .select { |p| req.satisfied_by?(version_class.new(T.must(package_field(p, "version")))) }
         end
 
         candidate_packages =
           candidate_packages
           .select do |p|
-            git_req?(declaration) ^ !p["source"]&.start_with?("git+")
+            git_req?(declaration) ^ !package_field(p, "source")&.start_with?("git+")
           end
 
         package =
           candidate_packages
-          .max_by { |p| version_class.new(p["version"]) }
+          .max_by { |p| version_class.new(T.must(package_field(p, "version"))) }
 
         return unless package
 
@@ -392,11 +394,13 @@ module Dependabot
         }
       end
 
-      sig { params(package_details: T::Hash[String, String]).returns(String) }
+      sig { params(package_details: T::Hash[String, T.anything]).returns(String) }
       def version_from_lockfile_details(package_details)
-        return T.must(package_details["version"]) unless package_details["source"]&.start_with?("git+")
+        source = T.cast(package_details["source"], T.nilable(String))
+        version = T.cast(package_details["version"], String)
+        return version unless source&.start_with?("git+")
 
-        T.must(T.must(package_details["source"]).split("#").last)
+        T.must(source.split("#").last)
       end
 
       sig { override.void }
@@ -404,12 +408,34 @@ module Dependabot
         raise "No Cargo.toml!" unless get_original_file("Cargo.toml")
       end
 
-      sig { params(file: DependencyFile).returns(T.untyped) }
+      sig { params(file: DependencyFile).returns(T::Hash[String, T.anything]) }
       def parsed_file(file)
-        @parsed_file ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
+        @parsed_file ||= T.let({}, T.nilable(T::Hash[String, T::Hash[String, T.anything]]))
         @parsed_file[file.name] ||= TomlRB.parse(file.content)
       rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
         raise Dependabot::DependencyFileNotParseable, file.path
+      end
+
+      sig { params(lockfile_content: T::Hash[String, T.anything]).returns(T::Array[T::Hash[String, T.anything]]) }
+      def lockfile_packages(lockfile_content)
+        T.cast(lockfile_content.fetch("package", []), T::Array[T::Hash[String, T.anything]])
+      end
+
+      sig { params(package_details: T::Hash[String, T.anything], field: String).returns(T.nilable(String)) }
+      def package_field(package_details, field)
+        T.cast(package_details[field], T.nilable(String))
+      end
+
+      sig { params(value: T.anything).returns(T::Hash[String, T.anything]) }
+      def toml_table_or_empty(value)
+        (obj = T.cast(value, T.nilable(Object))).is_a?(Hash) ? obj : {}
+      end
+
+      sig { params(value: T.anything).returns(T.any(String, T::Hash[String, String])) }
+      def dependency_declaration(value)
+        return T.cast(value, String) if T.cast(value, T.nilable(Object)).is_a?(String)
+
+        T.cast(value, T::Hash[String, String])
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -392,20 +392,31 @@ module Dependabot
           TomlRB.dump(parsed_manifest)
         end
 
-        sig { params(parsed_manifest: T::Hash[String, T.untyped]).void }
+        sig { params(parsed_manifest: T::Hash[String, T.anything]).void }
         def pin_target_specific_dependencies!(parsed_manifest)
-          parsed_manifest.fetch("target", {}).each do |target, t_details|
+          toml_table_or_empty(parsed_manifest.fetch("target", {})).each do |target, t_details|
+            t_details = toml_table_or_empty(t_details)
             Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
-              t_details.fetch(type, {}).each do |name, requirement|
+              toml_table_or_empty(t_details.fetch(type, {})).each do |name, requirement|
                 next unless name == dependency.name
 
                 updated_req = "=#{dependency.version}"
 
-                if requirement.is_a?(Hash)
-                  parsed_manifest["target"][target][type][name]["version"] =
+                if T.cast(requirement, T.nilable(Object)).is_a?(Hash)
+                  toml_table_or_empty(
+                    toml_table_or_empty(
+                      toml_table_or_empty(
+                        toml_table_or_empty(parsed_manifest["target"])[target]
+                      )[type]
+                    )[name]
+                  )["version"] =
                     updated_req
                 else
-                  parsed_manifest["target"][target][type][name] = updated_req
+                  toml_table_or_empty(
+                    toml_table_or_empty(
+                      toml_table_or_empty(parsed_manifest["target"])[target]
+                    )[type]
+                  )[name] = updated_req
                 end
               end
             end
@@ -496,6 +507,12 @@ module Dependabot
             end
 
           lockfile_content
+        end
+
+        sig { params(value: T.anything).returns(T::Hash[String, T.anything]) }
+        def toml_table_or_empty(value)
+          obj = T.cast(value, T.nilable(Object))
+          obj.is_a?(Hash) ? obj : {}
         end
 
         sig { returns(String) }

--- a/cargo/lib/dependabot/cargo/metadata_finder.rb
+++ b/cargo/lib/dependabot/cargo/metadata_finder.rb
@@ -19,7 +19,7 @@ module Dependabot
       sig { params(dependency: Dependabot::Dependency, credentials: T::Array[Dependabot::Credential]).void }
       def initialize(dependency:, credentials:)
         super
-        @crates_listing = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
+        @crates_listing = T.let(nil, T.nilable(T::Hash[String, T.anything]))
       end
 
       private
@@ -43,7 +43,10 @@ module Dependabot
       def find_source_from_crates_listing
         potential_source_urls =
           SOURCE_KEYS
-          .filter_map { |key| T.must(crates_listing).dig("crate", key) }
+          .filter_map do |key|
+            crate = T.cast(T.must(crates_listing)["crate"], T.nilable(T::Hash[String, T.anything]))
+            T.cast(crate&.fetch(key, nil), T.nilable(String))
+          end
 
         source_url = potential_source_urls.find { |url| Source.from_url(url) }
         Source.from_url(source_url)
@@ -51,18 +54,24 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_git_url
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
+        info = T.cast(
+          dependency.requirements.filter_map { |r| r[:source] }.first,
+          T::Hash[T.any(String, Symbol), T.anything]
+        )
 
-        url = info[:url] || info.fetch("url")
+        url = T.cast(info[:url] || info.fetch("url"), String)
         Source.from_url(url)
       end
 
-      sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig { returns(T.nilable(T::Hash[String, T.anything])) }
       def crates_listing
         return @crates_listing unless @crates_listing.nil?
 
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-        index = (info && info[:index]) || CRATES_IO_API
+        info = T.cast(
+          dependency.requirements.filter_map { |r| r[:source] }.first,
+          T.nilable(T::Hash[T.any(String, Symbol), T.anything])
+        )
+        index = T.cast((info && info[:index]) || CRATES_IO_API, String)
         hdrs = build_headers(index, info)
 
         url = metadata_fetch_url(dependency, index)
@@ -71,14 +80,18 @@ module Dependabot
         @crates_listing = parse_response(response, index)
       end
 
-      sig { params(index: String, info: T.nilable(T::Hash[String, T.untyped])).returns(T::Hash[String, String]) }
+      sig do
+        params(index: String, info: T.nilable(T::Hash[T.any(String, Symbol), T.anything]))
+          .returns(T::Hash[String, String])
+      end
       def build_headers(index, info)
         hdrs = { "User-Agent" => "Dependabot (dependabot.com)" }
         return hdrs if index == CRATES_IO_API
 
         return hdrs if info.nil?
 
-        credentials.find { |cred| cred["type"] == "cargo_registry" && cred["registry"] == info["name"] }&.tap do |cred|
+        registry_name = T.cast(info["name"] || info[:name], T.nilable(String))
+        credentials.find { |cred| cred["type"] == "cargo_registry" && cred["registry"] == registry_name }&.tap do |cred|
           hdrs["Authorization"] = "Token #{cred['token']}"
         end
 
@@ -94,7 +107,7 @@ module Dependabot
         )
       end
 
-      sig { params(response: Excon::Response, index: String).returns(T::Hash[String, T.untyped]) }
+      sig { params(response: Excon::Response, index: String).returns(T::Hash[String, T.anything]) }
       def parse_response(response, index)
         if index.start_with?("sparse+")
           parsed_response = response.body.lines.map { |line| JSON.parse(line) }

--- a/cargo/lib/dependabot/cargo/metadata_finder.rb
+++ b/cargo/lib/dependabot/cargo/metadata_finder.rb
@@ -72,7 +72,7 @@ module Dependabot
           dependency.requirements.filter_map { |r| r[:source] }.first,
           T.nilable(T::Hash[T.any(String, Symbol), T.anything])
         )
-        index = T.cast((info && info[:index]) || CRATES_IO_API, String)
+        index = T.cast((info && (info[:index] || info["index"])) || CRATES_IO_API, String)
         hdrs = build_headers(index, info)
 
         url = metadata_fetch_url(dependency, index)

--- a/cargo/lib/dependabot/cargo/metadata_finder.rb
+++ b/cargo/lib/dependabot/cargo/metadata_finder.rb
@@ -56,11 +56,12 @@ module Dependabot
       def find_source_from_git_url
         info = T.cast(
           dependency.requirements.filter_map { |r| r[:source] }.first,
-          T::Hash[T.any(String, Symbol), T.anything]
+          T.nilable(T::Hash[T.any(String, Symbol), T.anything])
         )
+        return unless info
 
-        url = T.cast(info[:url] || info.fetch("url"), String)
-        Source.from_url(url)
+        url = info[:url] || info["url"]
+        Source.from_url(T.cast(url, T.nilable(String)))
       end
 
       sig { returns(T.nilable(T::Hash[String, T.anything])) }

--- a/cargo/lib/dependabot/cargo/package/package_details_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/package/package_details_fetcher.rb
@@ -42,23 +42,25 @@ module Dependabot
         sig { returns(Dependabot::Dependency) }
         attr_reader :dependency
 
-        sig { returns(T::Array[T.untyped]) }
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
         attr_reader :dependency_files
 
-        sig { returns(T::Array[T.untyped]) }
+        sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
 
         sig do
           returns(T.nilable(Dependabot::Package::PackageDetails))
         end
         def fetch
-          package_releases = crates_listing.fetch("versions", []).reject { |v| v["yanked"] }.map do |release|
+          releases = T.cast(crates_listing.fetch("versions", []), T::Array[T::Hash[String, T.anything]])
+          package_releases = releases.reject { |v| v["yanked"] }.map do |release|
+            created_at = T.cast(release["created_at"], T.nilable(String))
             package_release(
-              version: release["num"] || release["vers"],
-              released_at: release["created_at"] ? Time.parse(release["created_at"]) : nil,
-              downloads: release["downloads"],
-              url: "#{CRATES_IO_API}/#{release['dl_path']}",
-              rust_version: release["rust"]
+              version: T.cast(release["num"], T.nilable(String)) || T.cast(release["vers"], String),
+              released_at: created_at ? Time.parse(created_at) : nil,
+              downloads: T.cast(release["downloads"], T.nilable(Integer)),
+              url: "#{CRATES_IO_API}/#{T.cast(release['dl_path'], T.nilable(String))}",
+              rust_version: T.cast(release["rust"], T.nilable(String))
             )
           end
 
@@ -68,7 +70,7 @@ module Dependabot
         private
 
         sig do
-          returns(T.untyped)
+          returns(T::Hash[String, T.anything])
         end
         def crates_listing
           return @crates_listing unless @crates_listing.nil?
@@ -86,41 +88,45 @@ module Dependabot
           response = fetch_response(url, hdrs)
           return {} if response.status == 404
 
-          @crates_listing = T.let(parse_response(response, index), T.nilable(T::Hash[T.untyped, T.untyped]))
+          @crates_listing = T.let(parse_response(response, index), T.nilable(T::Hash[String, T.anything]))
 
           Dependabot.logger.info("Fetched metadata for #{dependency.name} from #{index} successfully")
 
-          @crates_listing
+          T.must(@crates_listing)
         end
 
-        sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+        sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.anything])) }
         def fetch_dependency_info
-          dependency.requirements.filter_map { |r| r[:source] }.first
+          T.cast(
+            dependency.requirements.filter_map { |r| r[:source] }.first,
+            T.nilable(T::Hash[T.any(String, Symbol), T.anything])
+          )
         end
 
-        sig { params(info: T.untyped).returns(String) }
+        sig { params(info: T.nilable(T::Hash[T.any(String, Symbol), T.anything])).returns(String) }
         def fetch_index(info)
-          (info && info[:index]) || CRATES_IO_API
+          T.cast((info && info[:index]) || CRATES_IO_API, String)
         end
 
-        sig { returns(T::Hash[T.untyped, T.untyped]) }
+        sig { returns(T::Hash[String, String]) }
         def default_headers
           { "User-Agent" => "Dependabot (dependabot.com)" }
         end
 
-        sig { params(info: T.untyped).returns(T::Hash[T.untyped, T.untyped]) }
+        sig { params(info: T.nilable(T::Hash[T.any(String, Symbol), T.anything])).returns(T::Hash[String, String]) }
         def auth_headers(info)
+          registry_name = T.cast(info&.fetch(:name, nil), T.nilable(String))
           registry_creds = credentials.find do |cred|
-            cred["type"] == "cargo_registry" && cred["registry"] == info[:name]
+            cred["type"] == "cargo_registry" && cred["registry"] == registry_name
           end
 
-          return {} if registry_creds.nil?
+          return {} unless registry_creds
 
           token = registry_creds["token"] || "placeholder_token"
           { "Authorization" => token }
         end
 
-        sig { params(url: String, headers: T.untyped).returns(Excon::Response) }
+        sig { params(url: String, headers: T::Hash[String, String]).returns(Excon::Response) }
         def fetch_response(url, headers)
           Excon.get(
             url,
@@ -129,7 +135,7 @@ module Dependabot
           )
         end
 
-        sig { params(response: Excon::Response, index: T.untyped).returns(T::Hash[T.untyped, T.untyped]) }
+        sig { params(response: Excon::Response, index: String).returns(T::Hash[String, T.anything]) }
         def parse_response(response, index)
           if index.start_with?("sparse+")
             parsed_response = response.body.lines
@@ -148,7 +154,7 @@ module Dependabot
           end
         end
 
-        sig { params(dependency: T.untyped, index: T.untyped).returns(String) }
+        sig { params(dependency: Dependabot::Dependency, index: String).returns(String) }
         def metadata_fetch_url(dependency, index)
           return "#{index}/#{dependency.name}" if index == CRATES_IO_API
 

--- a/cargo/lib/dependabot/cargo/package/package_details_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/package/package_details_fetcher.rb
@@ -105,7 +105,7 @@ module Dependabot
 
         sig { params(info: T.nilable(T::Hash[T.any(String, Symbol), T.anything])).returns(String) }
         def fetch_index(info)
-          T.cast((info && info[:index]) || CRATES_IO_API, String)
+          T.cast((info && (info[:index] || info["index"])) || CRATES_IO_API, String)
         end
 
         sig { returns(T::Hash[String, String]) }
@@ -115,7 +115,7 @@ module Dependabot
 
         sig { params(info: T.nilable(T::Hash[T.any(String, Symbol), T.anything])).returns(T::Hash[String, String]) }
         def auth_headers(info)
-          registry_name = T.cast(info&.fetch(:name, nil), T.nilable(String))
+          registry_name = T.cast(info && (info[:name] || info["name"]), T.nilable(String))
           registry_creds = credentials.find do |cred|
             cred["type"] == "cargo_registry" && cred["registry"] == registry_name
           end

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -311,7 +311,7 @@ module Dependabot
         latest_resolvable_version
       end
 
-      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
+      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.anything])) }
       def updated_source
         # Never need to update source, unless a git_dependency
         return dependency_source_details unless git_dependency?
@@ -327,7 +327,7 @@ module Dependabot
         dependency_source_details
       end
 
-      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
+      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.anything])) }
       def dependency_source_details
         dependency.source_details
       end

--- a/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
@@ -123,9 +123,9 @@ module Dependabot
           TomlRB.dump(parsed_manifest)
         end
 
-        sig { params(parsed_manifest: T::Hash[String, T.untyped], filename: String).void }
+        sig { params(parsed_manifest: T::Hash[String, T.anything], filename: String).void }
         def replace_req_on_target_specific_deps!(parsed_manifest, filename)
-          parsed_manifest.fetch("target", {}).each do |target, _|
+          toml_table_or_empty(parsed_manifest.fetch("target", {})).each do |target, _|
             Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
               dependency_names = dependency_names_for_type_and_target(
                 parsed_manifest,
@@ -134,35 +134,39 @@ module Dependabot
               )
 
               dependency_names.each do |name|
-                req = parsed_manifest.dig("target", target, type, name)
+                req = target_dependency_declaration(parsed_manifest, target, type, name)
 
                 updated_req = temporary_requirement_for_resolution(filename)
 
                 if req.is_a?(Hash)
-                  parsed_manifest["target"][target][type][name]["version"] =
-                    updated_req
+                  target_dependency_table(parsed_manifest, target, type, name)["version"] = updated_req
                 else
-                  parsed_manifest["target"][target][type][name] = updated_req
+                  target_dependency_type_table(parsed_manifest, target, type)[name] = updated_req
                 end
               end
             end
           end
         end
 
-        sig { params(parsed_manifest: T::Hash[String, T.untyped], filename: String).void }
+        sig { params(parsed_manifest: T::Hash[String, T.anything], filename: String).void }
         def replace_req_on_workspace_deps!(parsed_manifest, filename)
-          workspace = parsed_manifest.fetch("workspace", {})
-          workspace_deps = workspace.fetch("dependencies", {})
+          workspace = toml_table_or_empty(parsed_manifest.fetch("workspace", {}))
+          workspace_deps = toml_table_or_empty(workspace.fetch("dependencies", {}))
 
           workspace_deps.each do |name, req|
+            req = dependency_declaration(req)
             next unless dependency.name == name_from_declaration(name, req)
 
             updated_req = temporary_requirement_for_resolution(filename)
 
             if req.is_a?(Hash)
-              parsed_manifest["workspace"]["dependencies"][name]["version"] = updated_req
+              toml_table_or_empty(
+                toml_table_or_empty(
+                  toml_table_or_empty(parsed_manifest["workspace"])["dependencies"]
+                )[name]
+              )["version"] = updated_req
             else
-              parsed_manifest["workspace"]["dependencies"][name] = updated_req
+              toml_table_or_empty(toml_table_or_empty(parsed_manifest["workspace"])["dependencies"])[name] = updated_req
             end
           end
         end
@@ -173,13 +177,14 @@ module Dependabot
 
           Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
             dependency_names_for_type(parsed_manifest, type).each do |name|
-              req = parsed_manifest.dig(type, name)
+              req = T.cast(parsed_manifest.dig(type, name), T.any(String, T::Hash[String, T.anything]))
               next unless req.is_a?(Hash)
               next unless [req["tag"], req["rev"]].compact.uniq.one?
 
-              parsed_manifest[type][name]["tag"] = replacement_git_pin if req["tag"]
+              dependency_options = toml_table_or_empty(toml_table_or_empty(parsed_manifest[type])[name])
+              dependency_options["tag"] = replacement_git_pin if req["tag"]
 
-              parsed_manifest[type][name]["rev"] = replacement_git_pin if req["rev"]
+              dependency_options["rev"] = replacement_git_pin if req["rev"]
             end
           end
 
@@ -188,9 +193,9 @@ module Dependabot
           TomlRB.dump(parsed_manifest)
         end
 
-        sig { params(parsed_manifest: T::Hash[String, T.untyped]).void }
+        sig { params(parsed_manifest: T::Hash[String, T.anything]).void }
         def replace_git_pin_on_target_specific_deps!(parsed_manifest)
-          parsed_manifest.fetch("target", {}).each do |target, _|
+          toml_table_or_empty(parsed_manifest.fetch("target", {})).each do |target, _|
             Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
               dependency_names = dependency_names_for_type_and_target(
                 parsed_manifest,
@@ -199,19 +204,15 @@ module Dependabot
               )
 
               dependency_names.each do |name|
-                req = parsed_manifest.dig("target", target, type, name)
+                req = target_dependency_declaration(parsed_manifest, target, type, name)
                 next unless req.is_a?(Hash)
                 next unless [req["tag"], req["rev"]].compact.uniq.one?
 
-                if req["tag"]
-                  parsed_manifest["target"][target][type][name]["tag"] =
-                    replacement_git_pin
-                end
+                target_dependency_table(parsed_manifest, target, type, name)["tag"] = replacement_git_pin if req["tag"]
 
-                if req["rev"]
-                  parsed_manifest["target"][target][type][name]["rev"] =
-                    replacement_git_pin
-                end
+                next unless req["rev"]
+
+                target_dependency_table(parsed_manifest, target, type, name)["rev"] = replacement_git_pin
               end
             end
           end
@@ -222,12 +223,12 @@ module Dependabot
           parsed_manifest = TomlRB.parse(content)
 
           Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
-            (parsed_manifest[type] || {}).each do |_, details|
-              next unless details.is_a?(Hash)
-              next unless details["git"]
+            toml_table_or_empty(parsed_manifest[type]).each do |_, details|
+              details = toml_table_or_empty(details)
+              git = T.cast(details.fetch("git", nil), T.nilable(String))
+              next unless git
 
-              details["git"] = details["git"]
-                               .gsub(%r{ssh://git@(.*?)/}, 'https://\1/')
+              details["git"] = git.gsub(%r{ssh://git@(.*?)/}, 'https://\1/')
             end
           end
 
@@ -283,17 +284,20 @@ module Dependabot
         def git_dependency_version
           return unless lockfile
 
-          TomlRB.parse(T.must(lockfile).content)
-                .fetch("package", [])
-                .select { |p| p["name"] == dependency.name }
-                .find { |p| p["source"].end_with?(dependency.version) }
-                .fetch("version")
+          package = T.cast(
+            TomlRB.parse(T.must(lockfile).content).fetch("package", []),
+            T::Array[T::Hash[String, T.anything]]
+          ).select { |p| T.cast(p["name"], T.nilable(String)) == dependency.name }
+           .find { |p| T.cast(p["source"], String).end_with?(T.must(dependency.version)) }
+
+          T.cast(T.must(package).fetch("version"), String)
         end
 
-        sig { params(parsed_manifest: T::Hash[String, T.untyped], type: String).returns(T::Array[String]) }
+        sig { params(parsed_manifest: T::Hash[String, T.anything], type: String).returns(T::Array[String]) }
         def dependency_names_for_type(parsed_manifest, type)
           names = []
-          parsed_manifest.fetch(type, {}).each do |nm, req|
+          toml_table_or_empty(parsed_manifest.fetch(type, {})).each do |nm, req|
+            req = dependency_declaration(req)
             next unless dependency.name == name_from_declaration(nm, req)
 
             names << nm
@@ -302,11 +306,13 @@ module Dependabot
         end
 
         sig do
-          params(parsed_manifest: T::Hash[String, T.untyped], type: String, target: String).returns(T::Array[String])
+          params(parsed_manifest: T::Hash[String, T.anything], type: String, target: String).returns(T::Array[String])
         end
         def dependency_names_for_type_and_target(parsed_manifest, type, target)
           names = []
-          (parsed_manifest.dig("target", target, type) || {}).each do |nm, req|
+          target_details = toml_table_or_empty(toml_table_or_empty(parsed_manifest["target"])[target])
+          toml_table_or_empty(target_details[type]).each do |nm, req|
+            req = dependency_declaration(req)
             next unless dependency.name == name_from_declaration(nm, req)
 
             names << nm
@@ -314,13 +320,63 @@ module Dependabot
           names
         end
 
-        sig { params(name: String, declaration: T.untyped).returns(String) }
+        sig { params(name: String, declaration: T.any(String, T::Hash[String, T.anything])).returns(String) }
         def name_from_declaration(name, declaration)
           return name if declaration.is_a?(String)
 
-          raise "Unexpected dependency declaration: #{declaration}" unless declaration.is_a?(Hash)
+          T.cast(declaration.fetch("package", name), String)
+        end
 
-          declaration.fetch("package", name)
+        sig do
+          params(
+            parsed_manifest: T::Hash[String, T.anything],
+            target: String,
+            type: String
+          ).returns(T::Hash[String, T.anything])
+        end
+        def target_dependency_type_table(parsed_manifest, target, type)
+          target_details = toml_table_or_empty(toml_table_or_empty(parsed_manifest["target"])[target])
+          toml_table_or_empty(target_details[type])
+        end
+
+        sig do
+          params(
+            parsed_manifest: T::Hash[String, T.anything],
+            target: String,
+            type: String,
+            name: String
+          ).returns(T.any(String, T::Hash[String, T.anything]))
+        end
+        def target_dependency_declaration(parsed_manifest, target, type, name)
+          T.cast(
+            target_dependency_type_table(parsed_manifest, target, type)[name],
+            T.any(String, T::Hash[String, T.anything])
+          )
+        end
+
+        sig do
+          params(
+            parsed_manifest: T::Hash[String, T.anything],
+            target: String,
+            type: String,
+            name: String
+          ).returns(T::Hash[String, T.anything])
+        end
+        def target_dependency_table(parsed_manifest, target, type, name)
+          toml_table_or_empty(target_dependency_type_table(parsed_manifest, target, type)[name])
+        end
+
+        sig { params(value: T.anything).returns(T::Hash[String, T.anything]) }
+        def toml_table_or_empty(value)
+          obj = T.cast(value, T.nilable(Object))
+          obj.is_a?(Hash) ? obj : {}
+        end
+
+        sig { params(value: T.anything).returns(T.any(String, T::Hash[String, T.anything])) }
+        def dependency_declaration(value)
+          return T.cast(value, String) if T.cast(value, T.nilable(Object)).is_a?(String)
+
+          T.cast(value, T::Hash[String, T.anything])
         end
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
@@ -284,13 +284,22 @@ module Dependabot
         def git_dependency_version
           return unless lockfile
 
-          package = T.cast(
+          version = dependency.version
+          return unless version
+
+          packages = T.cast(
             TomlRB.parse(T.must(lockfile).content).fetch("package", []),
             T::Array[T::Hash[String, T.anything]]
-          ).select { |p| T.cast(p["name"], T.nilable(String)) == dependency.name }
-           .find { |p| T.cast(p["source"], String).end_with?(T.must(dependency.version)) }
+          )
+          package = packages
+                    .select { |p| T.cast(p["name"], T.nilable(String)) == dependency.name }
+                    .find do |p|
+                      source = T.cast(p["source"], T.nilable(String))
+                      source&.end_with?(version)
+                    end
+          return unless package
 
-          T.cast(T.must(package).fetch("version"), String)
+          T.cast(package.fetch("version"), String)
         end
 
         sig { params(parsed_manifest: T::Hash[String, T.anything], type: String).returns(T::Array[String]) }

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -36,7 +36,7 @@ module Dependabot
         sig do
           params(
             requirements: T::Array[Dependabot::DependencyRequirement],
-            updated_source: T.nilable(T::Hash[T.any(String, Symbol), T.untyped]),
+            updated_source: T.nilable(T::Hash[T.any(String, Symbol), T.anything]),
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             target_version: T.nilable(T.any(String, Gem::Version))
           ).void
@@ -51,7 +51,7 @@ module Dependabot
             requirements.map { |req| Dependabot::DependencyRequirement.create(req) },
             T::Array[Dependabot::DependencyRequirement]
           )
-          @updated_source = T.let(updated_source, T.nilable(T::Hash[T.any(String, Symbol), T.untyped]))
+          @updated_source = T.let(updated_source, T.nilable(T::Hash[T.any(String, Symbol), T.anything]))
           @update_strategy = T.let(update_strategy, Dependabot::RequirementsUpdateStrategy)
 
           check_update_strategy
@@ -87,7 +87,7 @@ module Dependabot
         sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
-        sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
+        sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.anything])) }
         attr_reader :updated_source
 
         sig { returns(Dependabot::RequirementsUpdateStrategy) }

--- a/cargo/spec/dependabot/cargo/metadata_finder_spec.rb
+++ b/cargo/spec/dependabot/cargo/metadata_finder_spec.rb
@@ -116,5 +116,24 @@ RSpec.describe Dependabot::Cargo::MetadataFinder do
         it { is_expected.to be_nil }
       end
     end
+
+    context "when the source uses string keys (deserialised from a job)" do
+      let(:private_index) { "https://private.example.com/index" }
+      let(:private_url) { "#{private_index}/bi/tf/bitflags" }
+      let(:dependency_source) do
+        { "type" => "registry", "name" => "private-reg", "index" => private_index }
+      end
+
+      before do
+        stub_request(:get, private_url)
+          .to_return(status: 200, body: fixture("crates_io_responses", "bitflags.json"))
+      end
+
+      it "reads the string index key and queries the private registry" do
+        expect(source_url).to eq("https://github.com/rust-lang-nursery/bitflags")
+        expect(WebMock).to have_requested(:get, private_url)
+        expect(WebMock).not_to have_requested(:get, crates_url)
+      end
+    end
   end
 end


### PR DESCRIPTION
Types the whole cargo ecosystem and drops all 8 files from the `Sorbet/ForbidTUntyped` burndown list (offense count 1642 to 1608).

Parsed `Cargo.toml`/`Cargo.lock` tables and crates.io registry responses hold heterogeneous values, so they are typed `T::Hash[String, T.anything]` and read through small `toml_table`/`toml_table_or_empty` helpers that check `is_a?(Hash)` at runtime. TOML dependency values are polymorphic (`serde = "1.0"` is a String, `serde = { version = "1.0" }` is a table), so these helpers narrow rather than assert with `T.cast`, which would raise. Value objects are used where the shape is known: `DependencyFile`, `Credential`, `Dependency`, `Requirement`.

Net diff stays under 1k lines. The cargo binary isn't available on the host, so the version-resolver and file-updater specs that shell out to it were validated against the pre-change baseline (same failures, none new).
