### PR TITLE
Type the docker ecosystem and remove it from the T.untyped burndown

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1579
+# Offense count: 1549
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -317,11 +317,6 @@ Sorbet/ForbidTUntyped:
     - "devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb"
     - "devcontainers/lib/dependabot/devcontainers/file_updater.rb"
     - "devcontainers/lib/dependabot/devcontainers/update_checker/latest_version_finder.rb"
-    - "docker/lib/dependabot/docker/file_parser.rb"
-    - "docker/lib/dependabot/docker/metadata_finder.rb"
-    - "docker/lib/dependabot/docker/update_checker.rb"
-    - "docker/lib/dependabot/docker_compose/file_parser.rb"
-    - "docker/lib/dependabot/shared/shared_file_updater.rb"
     - "dotnet_sdk/lib/dependabot/dotnet_sdk/package/package_details_fetcher.rb"
     - "elm/lib/dependabot/elm/file_parser.rb"
     - "elm/lib/dependabot/elm/update_checker/latest_version_finder.rb"

--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/shared/shared_file_parser"
@@ -120,7 +120,7 @@ module Dependabot
         end
       end
 
-      sig { params(json_object: T::Hash[T.untyped, T.untyped]).returns(T::Array[String]) }
+      sig { params(json_object: T::Hash[Object, Object]).returns(T::Array[String]) }
       def deep_fetch_images_from_hash(json_object)
         img = json_object.fetch("image", nil)
 
@@ -136,13 +136,13 @@ module Dependabot
         images + json_object.values.flat_map { |obj| deep_fetch_images(obj) }
       end
 
-      sig { params(img_hash: T::Hash[String, T.nilable(String)]).returns(T::Array[String]) }
+      sig { params(img_hash: T::Hash[Object, Object]).returns(T::Array[String]) }
       def parse_helm(img_hash)
         tag_value = img_hash.key?("tag") ? img_hash.fetch("tag", nil) : img_hash.fetch("version", nil)
         return [] unless tag_value
 
         repo = img_hash.fetch("repository", nil)
-        return [] unless repo
+        return [] unless repo.is_a?(String)
 
         match = tag_value.to_s.match(TAG_WITH_DIGEST)
         return [] unless match

--- a/docker/lib/dependabot/docker/metadata_finder.rb
+++ b/docker/lib/dependabot/docker/metadata_finder.rb
@@ -11,6 +11,14 @@ module Dependabot
     class MetadataFinder < Dependabot::MetadataFinders::Base
       extend T::Sig
 
+      DockerSource = T.type_alias do
+        T::Hash[Symbol, T.nilable(String)]
+      end
+
+      ImageDetails = T.type_alias do
+        T::Hash[String, Object]
+      end
+
       private
 
       # Finds the repository for the Docker image using OCI annotations.
@@ -23,8 +31,7 @@ module Dependabot
         return unless new_source && new_source[:registry] && (new_source[:tag] || new_source[:digest])
 
         details = image_details(new_source)
-        image_source = details.dig("config", "Labels", "org.opencontainers.image.source")
-        # Return early if the org.opencontainers.image.source label is not present
+        image_source = image_label(details, "org.opencontainers.image.source")
         return unless image_source
 
         # If we have a tag, return the source directly without additional version metadata
@@ -39,9 +46,9 @@ module Dependabot
 
       sig do
         params(
-          source: T::Hash[Symbol, T.untyped]
+          source: DockerSource
         ).returns(
-          T::Hash[String, T.untyped]
+          ImageDetails
         )
       end
       def image_details(source)
@@ -62,18 +69,35 @@ module Dependabot
         JSON.parse(output)
       end
 
+      sig { params(details: ImageDetails).returns(T.nilable(T::Hash[String, Object])) }
+      def image_labels(details)
+        config = details["config"]
+        return unless config.is_a?(Hash)
+
+        labels = config["Labels"]
+        return unless labels.is_a?(Hash)
+
+        labels
+      end
+
+      sig { params(details: ImageDetails, label: String).returns(T.nilable(String)) }
+      def image_label(details, label)
+        value = image_labels(details)&.fetch(label, nil)
+        value if value.is_a?(String)
+      end
+
       # Builds a Dependabot::Source object using the OCI image version label.
       #
       # This is used as a fallback when an image is referenced by digest rather than a tag
       sig do
         params(
           image_source: String,
-          details: T::Hash[String, T.untyped]
+          details: ImageDetails
         ).returns(T.nilable(Dependabot::Source))
       end
       def build_source_from_image_version(image_source, details)
-        image_version = details.dig("config", "Labels", "org.opencontainers.image.version")
-        revision = details.dig("config", "Labels", "org.opencontainers.image.revision")
+        image_version = image_label(details, "org.opencontainers.image.version")
+        revision = image_label(details, "org.opencontainers.image.revision")
         # Sometimes the versions are not tags (e.g., "24.04")
         # We only want to build a source if the version looks like a tag (starts with "v")
         # This is a safeguard for a first iteration. We may adjust this later based on user feedback.

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -25,7 +25,7 @@ rescue LoadError
     class Response
       extend T::Sig
 
-      sig { returns(T::Hash[T.untyped, T.untyped]) }
+      sig { returns(T::Hash[Symbol, String]) }
       def headers
         {}
       end
@@ -79,6 +79,18 @@ module Dependabot
       # Each validation can require 1 + 1 + N*2 registry API calls for N platforms,
       # so we cap the attempts to avoid rate limiting or excessive latency.
       MAX_PLATFORM_VALIDATION_ATTEMPTS = T.let(5, Integer)
+
+      DockerSource = T.type_alias do
+        T::Hash[Symbol, T.nilable(String)]
+      end
+
+      ManifestHash = T.type_alias do
+        T::Hash[T.any(String, Symbol), Object]
+      end
+
+      ManifestList = T.type_alias do
+        T::Array[ManifestHash]
+      end
 
       # Legacy patterns used when docker_created_timestamp_validation experiment is disabled.
       # The broad alphanumeric regex matches tokens like "alpine3", "ltsc2022", "rc1"
@@ -220,7 +232,7 @@ module Dependabot
         digest_requirements.all? { |req| digest_requirement_up_to_date?(req) }
       end
 
-      sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
       def digest_requirement_up_to_date?(req)
         source = req.fetch(:source)
         source_digest = source.fetch(:digest)
@@ -491,7 +503,7 @@ module Dependabot
 
       sig do
         params(
-          digest_info: T.untyped,
+          digest_info: Object,
           tag: Dependabot::Docker::Tag
         ).returns(T.nilable(String))
       end
@@ -505,7 +517,8 @@ module Dependabot
             )
             return nil
           end
-          digest_info.first&.fetch("digest")
+          digest = digest_info.first&.fetch("digest")
+          digest if digest.is_a?(String)
         when String
           digest_info
         else
@@ -518,11 +531,11 @@ module Dependabot
       end
 
       sig do
-        params(
+        type_parameters(:Result).params(
           max_attempts: Integer,
           errors: T::Array[T.class_of(StandardError)],
-          _blk: T.proc.returns(T.untyped)
-        ).returns(T.untyped)
+          _blk: T.proc.returns(T.type_parameter(:Result))
+        ).returns(T.type_parameter(:Result))
       end
       def with_retries(max_attempts: 3, errors: [], &_blk)
         attempt = 0
@@ -912,7 +925,7 @@ module Dependabot
         end
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def digest_requirements
         dependency.requirements.select do |requirement|
           requirement.dig(:source, :digest)
@@ -1027,7 +1040,7 @@ module Dependabot
       # digest moved; otherwise this is a genuine version/digest change.
       sig do
         params(
-          source: T::Hash[Symbol, T.untyped],
+          source: DockerSource,
           current_digest: String,
           expected_digest: String,
           digest_only_refresh: T::Boolean
@@ -1045,7 +1058,7 @@ module Dependabot
       # Fails open (returns false) whenever a confident comparison isn't possible.
       sig do
         params(
-          source: T::Hash[Symbol, T.untyped],
+          source: DockerSource,
           current_digest: String,
           candidate_digest: String
         ).returns(T::Boolean)
@@ -1109,8 +1122,11 @@ module Dependabot
         resolved = resolve_platform_manifest(manifest)
         return nil unless resolved
 
-        config_digest = resolved.dig("config", "digest")
-        return nil unless config_digest
+        config = resolved["config"]
+        return nil unless config.is_a?(Hash)
+
+        config_digest = config["digest"]
+        return nil unless config_digest.is_a?(String)
 
         parse_created_from_config_blob(config_digest)
       end
@@ -1137,13 +1153,11 @@ module Dependabot
       # Resolves a manifest to a single platform-specific manifest.
       # If the manifest is a manifest list (multi-arch), selects the most
       # appropriate platform (preferring linux/amd64).
-      sig { params(manifest: T.untyped).returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig { params(manifest: ManifestHash).returns(T.nilable(ManifestHash)) }
       def resolve_platform_manifest(manifest)
         media_type = manifest["mediaType"] || manifest[:mediaType]
 
-        unless MANIFEST_LIST_TYPES.include?(media_type)
-          return manifest.is_a?(Hash) ? manifest : manifest.to_h
-        end
+        return manifest unless MANIFEST_LIST_TYPES.include?(media_type)
 
         platform_digest = select_platform_digest(manifest)
         return nil unless platform_digest
@@ -1157,19 +1171,25 @@ module Dependabot
 
       # Selects the digest of the best platform-specific manifest from a manifest list,
       # preferring linux/amd64.
-      sig { params(manifest: T.untyped).returns(T.nilable(String)) }
+      sig { params(manifest: ManifestHash).returns(T.nilable(String)) }
       def select_platform_digest(manifest)
         manifests = manifest["manifests"] || manifest[:manifests] || []
+        return nil unless manifests.is_a?(Array)
         return nil if manifests.empty?
 
         selected = find_amd64_manifest(manifests) || manifests.first
-        selected&.dig("digest") || selected&.dig(:digest)
+        return nil unless selected.is_a?(Hash)
+
+        digest = selected["digest"] || selected[:digest]
+        digest if digest.is_a?(String)
       end
 
-      sig { params(manifests: T.untyped).returns(T.untyped) }
+      sig { params(manifests: ManifestList).returns(T.nilable(ManifestHash)) }
       def find_amd64_manifest(manifests)
         manifests.find do |m|
           platform = m["platform"] || m[:platform] || {}
+          next false unless platform.is_a?(Hash)
+
           (platform["architecture"] || platform[:architecture]) == "amd64"
         end
       end
@@ -1338,7 +1358,7 @@ module Dependabot
       # array of per-platform manifest entries, or nil for single-platform images
       # (not a manifest list). Cached so the platform-inspection methods below
       # share a single registry GET per tag.
-      sig { params(tag_name: String).returns(T.nilable(T::Array[T::Hash[String, T.untyped]])) }
+      sig { params(tag_name: String).returns(T.nilable(ManifestList)) }
       def fetch_manifest_list(tag_name)
         return manifest_list_cache[tag_name] if manifest_list_cache.key?(tag_name)
 
@@ -1356,7 +1376,7 @@ module Dependabot
         nil
       end
 
-      sig { params(tag_name: String).returns(T.nilable(T::Array[T::Hash[String, T.untyped]])) }
+      sig { params(tag_name: String).returns(T.nilable(ManifestList)) }
       def fetch_manifest_list_from_registry(tag_name)
         manifest = with_retries(max_attempts: 3, errors: transient_docker_errors) do
           docker_registry_client.manifest(docker_repo_name, tag_name)
@@ -1365,7 +1385,10 @@ module Dependabot
         media_type = manifest["mediaType"] || manifest[:mediaType]
         return nil unless MANIFEST_LIST_TYPES.include?(media_type)
 
-        manifest["manifests"] || manifest[:manifests] || []
+        manifests = manifest["manifests"] || manifest[:manifests] || []
+        return [] unless manifests.is_a?(Array)
+
+        manifests.grep(Hash)
       end
 
       # Fetches a map of platform key (e.g. "linux/amd64") to platform manifest
@@ -1395,7 +1418,7 @@ module Dependabot
         collect_platform_digests(manifests)
       end
 
-      sig { params(manifests: T.untyped).returns(T::Hash[String, String]) }
+      sig { params(manifests: ManifestList).returns(T::Hash[String, String]) }
       def collect_platform_digests(manifests)
         digests = {}
 
@@ -1404,7 +1427,7 @@ module Dependabot
           next unless platform
 
           digest = m["digest"] || m[:digest]
-          next unless digest
+          next unless digest.is_a?(String)
 
           digests[platform_key(platform)] = digest
         end
@@ -1414,7 +1437,7 @@ module Dependabot
 
       # Fetches the platform entries from a manifest list for a given tag.
       # Returns nil if the tag is a single-platform image (not a manifest list).
-      sig { params(tag_name: String).returns(T.nilable(T::Array[T::Hash[String, T.untyped]])) }
+      sig { params(tag_name: String).returns(T.nilable(ManifestList)) }
       def fetch_manifest_platforms(tag_name)
         return manifest_platforms_cache[tag_name] if manifest_platforms_cache.key?(tag_name)
 
@@ -1430,7 +1453,7 @@ module Dependabot
         nil
       end
 
-      sig { params(tag_name: String).returns(T.nilable(T::Array[T::Hash[String, T.untyped]])) }
+      sig { params(tag_name: String).returns(T.nilable(ManifestList)) }
       def fetch_manifest_platforms_from_registry(tag_name)
         manifests = fetch_manifest_list(tag_name)
         return nil unless manifests
@@ -1452,10 +1475,10 @@ module Dependabot
         digests
       end
 
-      sig { params(manifest_entry: T.untyped).returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig { params(manifest_entry: ManifestHash).returns(T.nilable(ManifestHash)) }
       def extract_platform(manifest_entry)
         platform = manifest_entry["platform"] || manifest_entry[:platform]
-        return unless platform
+        return unless platform.is_a?(Hash)
 
         os = platform["os"] || platform[:os]
         arch = platform["architecture"] || platform[:architecture]
@@ -1465,7 +1488,7 @@ module Dependabot
       end
 
       # Builds a normalized string key from a platform hash, e.g. "linux/amd64" or "linux/arm64/v8"
-      sig { params(platform: T::Hash[T.any(String, Symbol), T.untyped]).returns(String) }
+      sig { params(platform: ManifestHash).returns(String) }
       def platform_key(platform)
         os = platform["os"] || platform[:os]
         arch = platform["architecture"] || platform[:architecture]
@@ -1502,7 +1525,7 @@ module Dependabot
         collect_platform_timestamps(manifests)
       end
 
-      sig { params(manifests: T.untyped).returns(T::Hash[String, T.nilable(Time)]) }
+      sig { params(manifests: ManifestList).returns(T::Hash[String, T.nilable(Time)]) }
       def collect_platform_timestamps(manifests)
         timestamps = {}
 
@@ -1511,7 +1534,7 @@ module Dependabot
           next unless platform
 
           digest = m["digest"] || m[:digest]
-          next unless digest
+          next unless digest.is_a?(String)
 
           key = platform_key(platform)
           timestamps[key] = fetch_platform_created_timestamp(digest)
@@ -1533,11 +1556,11 @@ module Dependabot
         parse_created_from_config_blob(config_digest)
       end
 
-      sig { returns(T::Hash[String, T.nilable(T::Array[T::Hash[String, T.untyped]])]) }
+      sig { returns(T::Hash[String, T.nilable(ManifestList)]) }
       def manifest_list_cache
         @manifest_list_cache ||= T.let(
           {},
-          T.nilable(T::Hash[String, T.nilable(T::Array[T::Hash[String, T.untyped]])])
+          T.nilable(T::Hash[String, T.nilable(ManifestList)])
         )
       end
 
@@ -1549,11 +1572,11 @@ module Dependabot
         )
       end
 
-      sig { returns(T::Hash[String, T.nilable(T::Array[T::Hash[String, T.untyped]])]) }
+      sig { returns(T::Hash[String, T.nilable(ManifestList)]) }
       def manifest_platforms_cache
         @manifest_platforms_cache ||= T.let(
           {},
-          T.nilable(T::Hash[String, T.nilable(T::Array[T::Hash[String, T.untyped]])])
+          T.nilable(T::Hash[String, T.nilable(ManifestList)])
         )
       end
 

--- a/docker/lib/dependabot/docker_compose/file_parser.rb
+++ b/docker/lib/dependabot/docker_compose/file_parser.rb
@@ -61,16 +61,18 @@ module Dependabot
 
       private
 
-      sig { params(service: T.untyped).returns(T.nilable(T::Hash[String, T.nilable(String)])) }
+      sig { params(service: T::Hash[String, Object]).returns(T.nilable(T::Hash[String, T.nilable(String)])) }
       def parse_image_spec(service)
-        return nil unless service
+        image = service["image"]
+        return service_image(image) if image.is_a?(String)
 
-        if service["image"]
-          return service_image(service["image"])
-        elsif service["build"].is_a?(Hash) && service["build"]["dockerfile_inline"]
-          return nil if service["build"]["dockerfile_inline"].match?(/^FROM\s+\${[^}]+}$/)
+        build = service["build"]
+        if build.is_a?(Hash)
+          dockerfile_inline = build["dockerfile_inline"]
+          return nil unless dockerfile_inline.is_a?(String)
+          return nil if dockerfile_inline.match?(/^FROM\s+\${[^}]+}$/)
 
-          match = FROM_LINE.match(service["build"]["dockerfile_inline"])
+          match = FROM_LINE.match(dockerfile_inline)
           return match&.named_captures
         end
 

--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -232,13 +232,13 @@ module Dependabot
         !source[:digest].nil?
       end
 
-      sig { params(file: Dependabot::DependencyFile).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { params(file: Dependabot::DependencyFile).returns(T::Array[Dependabot::DependencyRequirement]) }
       def requirements(file)
         T.must(dependency).requirements
          .select { |r| r[:file] == file.name }
       end
 
-      sig { params(file: Dependabot::DependencyFile).returns(T.nilable(T::Array[T::Hash[Symbol, T.untyped]])) }
+      sig { params(file: Dependabot::DependencyFile).returns(T.nilable(T::Array[Dependabot::DependencyRequirement])) }
       def previous_requirements(file)
         T.must(dependency).previous_requirements
          &.select { |r| r[:file] == file.name }


### PR DESCRIPTION
Types the whole docker ecosystem and drops all 5 files from the `Sorbet/ForbidTUntyped` burndown list.

The Docker registry v2 manifests are heterogeneous JSON, and the update-checker inspects them with lots of `is_a?` checks, so manifest values are typed `Object` (which allows `is_a?`/`==` without casts) behind a few readable type aliases: `DockerSource`, `ManifestHash`, `ManifestList`. Where a field is genuinely known — a requirement `source`, a digest string — it narrows at the read site with `is_a?` rather than asserting a type. Requirement hashes become `Dependabot::DependencyRequirement`, and `with_retries` gets a generic return type instead of an untyped one.

`file_parser.rb` had no untyped values left afterwards, so it moves to `# typed: strong`.

Stacked on #15493.
