### PR TITLE
pre-commit: track raw SHAs for bare (unfrozen) SHA pins

### DIFF
--- a/pre_commit/lib/dependabot/pre_commit/package/package_details_fetcher.rb
+++ b/pre_commit/lib/dependabot/pre_commit/package/package_details_fetcher.rb
@@ -72,15 +72,13 @@ module Dependabot
         def commit_sha_release
           return unless git_commit_checker.pinned_ref_looks_like_commit_sha?
 
-          if latest_version_tag
-            if git_commit_checker.local_tag_for_pinned_sha || version_comment?
-              return T.must(latest_version_tag).fetch(:version)
-            end
+          # A `# frozen:` version comment is the only opt-in signal for tag
+          # tracking (pre-commit's `autoupdate --freeze`). Without it the user is
+          # tracking raw SHAs, so we bump to the newest commit rather than
+          # promoting to a tag — even when the pinned SHA happens to sit on a tag.
+          return T.must(latest_version_tag).fetch(:version) if version_comment? && latest_version_tag
 
-            return latest_commit_for_pinned_ref
-          end
-
-          latest_commit_for_pinned_ref
+          latest_commit_for_default_branch
         end
 
         sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
@@ -189,6 +187,16 @@ module Dependabot
         sig { returns(T.nilable(Dependabot::Version)) }
         def current_version
           @current_version ||= T.let(dependency.numeric_version, T.nilable(Dependabot::Version))
+        end
+
+        sig { returns(T.nilable(String)) }
+        def latest_commit_for_default_branch
+          # A bare SHA tracks raw commits, so the "latest" is the newest commit
+          # on the repo's default branch — the same revision `pre-commit
+          # autoupdate` (without `--freeze`) would resolve to. Resolve it from
+          # the upload-pack advertisement (no clone), falling back to the
+          # container-branch clone logic only if HEAD isn't advertised.
+          git_commit_checker.head_commit_for_local_branch("HEAD") || latest_commit_for_pinned_ref
         end
 
         sig { returns(T.nilable(String)) }

--- a/pre_commit/lib/dependabot/pre_commit/update_checker.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker.rb
@@ -138,34 +138,6 @@ module Dependabot
         raise NotImplementedError
       end
 
-      sig { returns(T.nilable(String)) }
-      def latest_commit_for_pinned_ref
-        @latest_commit_for_pinned_ref ||= T.let(
-          begin
-            head_commit_for_ref_sha = git_commit_checker.head_commit_for_pinned_ref
-            if head_commit_for_ref_sha
-              head_commit_for_ref_sha
-            else
-              url = T.cast(git_commit_checker.dependency_source_details&.fetch(:url), T.nilable(String))
-              source = T.must(Source.from_url(T.must(url)))
-
-              SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
-                repo_contents_path = File.join(temp_dir, File.basename(source.repo))
-
-                SharedHelpers.run_shell_command("git clone --no-recurse-submodules #{url} #{repo_contents_path}")
-
-                Dir.chdir(repo_contents_path) do
-                  ref = T.cast(git_commit_checker.dependency_source_details&.fetch(:ref), T.nilable(String))
-                  ref_branch = find_container_branch(T.must(ref))
-                  git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
-                end
-              end
-            end
-          end,
-          T.nilable(String)
-        )
-      end
-
       sig { params(source: T.nilable(T::Hash[Symbol, T.untyped])).returns(T.nilable(String)) }
       def updated_ref(source)
         return unless git_commit_checker.git_dependency?
@@ -191,15 +163,12 @@ module Dependabot
       def latest_commit_sha
         new_tag = T.must(latest_version_finder).latest_version_tag
 
-        if new_tag
-          if version_from_comment || git_commit_checker.local_tag_for_pinned_sha
-            return T.cast(new_tag.fetch(:commit_sha), String)
-          end
+        # Only rewrite to a tag's commit when the user opted into tag tracking
+        # via a `# frozen:` comment. A bare SHA (no comment) tracks raw commits.
+        return T.cast(new_tag.fetch(:commit_sha), String) if new_tag && version_from_comment
 
-          return latest_commit_for_pinned_ref
-        end
-
-        # If there's no tag but we have a latest_version (commit SHA), use it
+        # Otherwise use latest_version, which for a bare SHA is the newest commit
+        # on the default branch (or the current SHA when held back by cooldown).
         latest_ver = latest_version
         return latest_ver if latest_ver.is_a?(String)
 
@@ -282,25 +251,6 @@ module Dependabot
           consider_version_branches_pinned: false,
           dependency_source_details: nil
         )
-      end
-
-      sig { params(sha: String).returns(T.nilable(String)) }
-      def find_container_branch(sha)
-        branches_including_ref = SharedHelpers.run_shell_command(
-          "git branch --remotes --contains #{sha}",
-          fingerprint: "git branch --remotes --contains <sha>"
-        ).split("\n").map { |branch| branch.strip.gsub("origin/", "") }
-        return if branches_including_ref.empty?
-
-        current_branch = branches_including_ref.find { |branch| branch.start_with?("HEAD -> ") }
-
-        if current_branch
-          current_branch.delete_prefix("HEAD -> ")
-        elsif branches_including_ref.size > 1
-          raise "Multiple ambiguous branches (#{branches_including_ref.join(', ')}) include #{sha}!"
-        else
-          branches_including_ref.first
-        end
       end
 
       # Additional dependency support methods

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -120,8 +120,10 @@ module Dependabot
         def filter_release_with_cooldown(release)
           return release unless cooldown_enabled?
           return release unless cooldown_options
-          # Commit SHA releases have no version ordering to fall back through
-          return release if release_type_sha?
+
+          # A bare SHA tracks raw commits, so cooldown is measured against the
+          # candidate commit's date rather than a version's release date.
+          return filter_sha_release_with_cooldown(release) if release_type_sha?
 
           Dependabot.logger.info("Applying cooldown filter for #{dependency.name}")
 
@@ -131,6 +133,68 @@ module Dependabot
           Dependabot.logger.info("All candidate versions are in cooldown, keeping current version #{current_version}")
           @cooldown_rejected_all = true
           current_version
+        end
+
+        # Holds a bare-SHA bump when the newest commit is younger than the
+        # cooldown window, keeping the currently pinned commit. There is no
+        # intermediate commit to fall back through, so cooldown either allows
+        # the newest commit or keeps the current one.
+        sig do
+          params(release: T.any(Dependabot::Version, String))
+            .returns(T.nilable(T.any(Dependabot::Version, String)))
+        end
+        def filter_sha_release_with_cooldown(release)
+          sha = T.cast(release, String)
+          cur = current_version
+
+          # Already on the newest commit — nothing to hold back.
+          return release if cur && sha == cur.to_s
+
+          commit_date = commit_date_for_sha(sha)
+          # If the commit date can't be determined, don't block the update.
+          return release unless commit_date
+          return release unless release_in_cooldown_period?(commit_date)
+
+          Dependabot.logger.info(
+            "Newest commit #{sha} for #{dependency.name} is within the cooldown window " \
+            "(committed #{commit_date}); keeping current commit"
+          )
+          @cooldown_rejected_all = true
+          cur
+        end
+
+        # Resolves the committer date for a commit SHA via the GitHub git-data
+        # API (a single request, no clone). Returns nil for non-GitHub sources
+        # or on any error so cooldown fails open.
+        sig { params(sha: String).returns(T.nilable(Time)) }
+        def commit_date_for_sha(sha)
+          url = cooldown_source_url
+          return nil unless url
+
+          source = Source.from_url(url)
+          return nil unless source
+          return nil unless source.provider == "github"
+
+          commit = github_commit(source, sha)
+          date = commit&.committer&.date
+          return nil unless date
+
+          date.is_a?(Time) ? date : Time.parse(date.to_s)
+        rescue StandardError => e
+          Dependabot.logger.debug("Error fetching commit date for #{sha}: #{e.message}")
+          nil
+        end
+
+        # Fetches the git-data commit object for a SHA. Typed as untyped because
+        # its attributes live inside a Sawyer::Resource and are read dynamically,
+        # matching how GitHub release attributes are read for cooldown.
+        sig { params(source: Dependabot::Source, sha: String).returns(T.untyped) }
+        def github_commit(source, sha)
+          client = Dependabot::Clients::GithubWithRetries.for_source(
+            source: source,
+            credentials: cooldown_credentials
+          )
+          client.git_commit(source.repo, sha)
         end
 
         sig { returns(T.nilable(Dependabot::PreCommit::Package::PackageDetailsFetcher)) }

--- a/pre_commit/spec/dependabot/pre_commit/package/package_details_fetcher_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/package/package_details_fetcher_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Dependabot::PreCommit::Package::PackageDetailsFetcher do
   describe "#commit_sha_release" do
     subject(:commit_sha_release) { fetcher.commit_sha_release }
 
-    context "when SHA maps to a known version tag" do
+    context "when a bare SHA maps to a tag but has no frozen comment" do
       let(:reference) { "f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9" }
       let(:dependency) do
         Dependabot::Dependency.new(
@@ -222,13 +222,17 @@ RSpec.describe Dependabot::PreCommit::Package::PackageDetailsFetcher do
       end
 
       before do
+        # Even though the SHA sits on a tag, without a `# frozen:` comment the
+        # user tracks raw SHAs, so we must not promote to the tag.
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:local_tag_for_pinned_sha).and_return("v4.4.0")
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:head_commit_for_local_branch).with("HEAD")
+          .and_return("headsha0000000000000000000000000000000000")
       end
 
-      it "returns the latest tagged version" do
-        expect(commit_sha_release).to be_a(Dependabot::PreCommit::Version)
-        expect(commit_sha_release.to_s).to eq("6.0.0")
+      it "returns the newest commit on the default branch, not the tag" do
+        expect(commit_sha_release).to eq("headsha0000000000000000000000000000000000")
       end
     end
 
@@ -252,10 +256,10 @@ RSpec.describe Dependabot::PreCommit::Package::PackageDetailsFetcher do
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:local_tag_for_pinned_sha).and_return(nil)
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:head_commit_for_pinned_ref).and_return("abc123def456")
+          .to receive(:head_commit_for_local_branch).with("HEAD").and_return("abc123def456")
       end
 
-      it "falls back to latest commit for pinned ref" do
+      it "returns the newest commit on the default branch" do
         expect(commit_sha_release).to eq("abc123def456")
       end
     end

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
       end
     end
 
-    context "when pinned to a commit SHA with a known tag" do
+    context "when a bare SHA maps to a tag but has no frozen comment" do
       let(:reference) { "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e" }
       let(:dependency) do
         Dependabot::Dependency.new(
@@ -98,10 +98,13 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
       before do
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:local_tag_for_pinned_sha).and_return("v4.4.0")
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:head_commit_for_local_branch).with("HEAD").and_return("abc123def456")
       end
 
-      it "returns the latest tagged version" do
-        expect(latest_release_version).to be_a(Dependabot::PreCommit::Version)
+      it "returns the newest default-branch commit, not the tag" do
+        expect(latest_release_version).to be_a(String)
+        expect(latest_release_version).to eq("abc123def456")
       end
     end
 
@@ -125,11 +128,12 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:local_tag_for_pinned_sha).and_return(nil)
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:head_commit_for_pinned_ref).and_return("abc123def456")
+          .to receive(:head_commit_for_local_branch).with("HEAD").and_return("abc123def456")
       end
 
       it "falls back to latest commit SHA" do
         expect(latest_release_version).to be_a(String)
+        expect(latest_release_version).to eq("abc123def456")
       end
     end
 
@@ -157,6 +161,55 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
 
       it "returns the latest tagged version using comment metadata" do
         expect(latest_release_version).to be_a(Dependabot::PreCommit::Version)
+      end
+    end
+
+    context "when a bare SHA is subject to a commit-date cooldown" do
+      let(:reference) { "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e" }
+      let(:head_sha) { "aaaa1111bbbb2222cccc3333dddd4444eeee5555" }
+      let(:update_cooldown) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "https://github.com/#{dependency_name}",
+          version: nil,
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: ".pre-commit-config.yaml",
+            source: dependency_source
+          }],
+          package_manager: "pre_commit"
+        )
+      end
+
+      before do
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tag_for_pinned_sha).and_return(nil)
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:head_commit_for_local_branch).with("HEAD").and_return(head_sha)
+
+        commit = Sawyer::Resource.new(
+          Sawyer::Agent.new("https://api.github.com"),
+          committer: { date: commit_date }
+        )
+        client = instance_double(Octokit::Client, git_commit: commit)
+        allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(client)
+      end
+
+      context "when the newest commit is younger than the cooldown window" do
+        let(:commit_date) { (Time.now - (2 * 24 * 60 * 60)).utc }
+
+        it "keeps the currently pinned commit" do
+          expect(latest_release_version).to eq(reference)
+        end
+      end
+
+      context "when the newest commit is older than the cooldown window" do
+        let(:commit_date) { (Time.now - (60 * 24 * 60 * 60)).utc }
+
+        it "bumps to the newest commit" do
+          expect(latest_release_version).to eq(head_sha)
+        end
       end
     end
 

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -87,18 +87,22 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
       end
     end
 
-    context "when the dependency is pinned to a commit SHA with a known tag" do
+    context "when the dependency is a bare SHA mapping to a tag (no frozen comment)" do
       let(:reference) { "6f6a02c2c85a1b45e39c1aa5e6cc40f7a3d6df5e" }
       let(:dependency_version) { nil }
 
       before do
+        # SHA maps to a tag, but without a `# frozen:` comment we track raw SHAs.
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:local_tag_for_pinned_sha).and_return("v4.4.0")
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:head_commit_for_local_branch).with("HEAD")
+          .and_return("headsha0000000000000000000000000000000000")
       end
 
-      it "returns the latest tagged version" do
-        expect(latest_version).to be_a(Dependabot::PreCommit::Version)
-        expect(latest_version.to_s).to eq("6.0.0")
+      it "returns the newest default-branch commit, not the tag" do
+        expect(latest_version).to be_a(String)
+        expect(latest_version).to eq("headsha0000000000000000000000000000000000")
       end
     end
 
@@ -110,10 +114,10 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:local_tag_for_pinned_sha).and_return(nil)
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
-          .to receive(:head_commit_for_pinned_ref).and_return("abc123def456")
+          .to receive(:head_commit_for_local_branch).with("HEAD").and_return("abc123def456")
       end
 
-      it "falls back to latest commit SHA" do
+      it "falls back to the newest default-branch commit" do
         expect(latest_version).to be_a(String)
         expect(latest_version).to eq("abc123def456")
       end


### PR DESCRIPTION
## Summary

For a pre-commit `rev:` pinned to a **bare SHA with no `# frozen:` comment**, the user is tracking **raw commits**, not tags — [`pre-commit autoupdate --freeze`](https://pre-commit.com/#pre-commit-autoupdate) is opt-in. Today Dependabot instead keys off whether the SHA happens to map to a tag, which produces two wrong outcomes:

| Pin | Today | This PR |
| --- | --- | --- |
| bare SHA on a **v-prefixed** tag repo (e.g. `pre-commit-hooks`) | **no update at all** — `local_tag_for_pinned_sha` is nil because `Version.correct?("v4.4.0")` is false | bumps to the newest commit on the default branch |
| bare SHA on a **plain** tag repo (e.g. `black`) | promotes the SHA to the **newest tag's commit** (tag tracking) | bumps to the newest commit on the default branch |

## What changed

- The `# frozen:` comment is now the **only** opt-in signal for tag tracking. `commit_sha_release` (package details fetcher) and `latest_commit_sha` (update checker) resolve to a tag only when a version comment is present; otherwise they resolve to the newest commit on the default branch via `head_commit_for_local_branch("HEAD")` — the same revision `pre-commit autoupdate` (without `--freeze`) uses.
- **Cooldown for a bare SHA is measured against the candidate commit's date** (via the GitHub git-data API). The bump is held when the newest commit is younger than the cooldown window.
- Removed the now-dead `latest_commit_for_pinned_ref` / `find_container_branch` from the update checker.

Frozen-comment (`# frozen: <tag>`) and plain-tag (`rev: v1.2.3`) pins are unchanged, cooldown included.

## Validation

- `rubocop`: clean on all changed files.
- `srb tc`: no new errors.
- `rspec pre_commit/spec`: **291 examples, 0 failures**.
- Dry-run against real pin-style fixtures (`dsp-testing/test-pre-commit-ecosystems`):
  - v-prefix bare SHA: `f71fa2c1` → `fa6b006f` (default-branch HEAD); with a large cooldown, held ("within the cooldown window").
  - plain-tag bare SHA: `05f0a8ce` → `d7587ce9` (default-branch HEAD, **not** the `26.5.1` tag); large cooldown holds.
  - frozen-comment / floating-tag / plain-tag pins: unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>