### PR TITLE
Handle global.json with no SDK version in dotnet_sdk parser

### DIFF
--- a/dotnet_sdk/lib/dependabot/dotnet_sdk/file_parser.rb
+++ b/dotnet_sdk/lib/dependabot/dotnet_sdk/file_parser.rb
@@ -4,6 +4,7 @@
 require "dependabot/dependency"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
+require "dependabot/logger"
 require "sorbet-runtime"
 require "dependabot/dotnet_sdk/package_manager"
 require "dependabot/dotnet_sdk/language"
@@ -79,7 +80,10 @@ module Dependabot
       sig { returns(T.nilable(Ecosystem::VersionManager)) }
       def dotnetsdk
         version = sdk_version
-        return unless version
+        unless version
+          Dependabot.logger.warn("No .NET SDK version found in global.json; no update will be performed.")
+          return
+        end
 
         DotnetSDK.new(version)
       end

--- a/dotnet_sdk/lib/dependabot/dotnet_sdk/file_parser.rb
+++ b/dotnet_sdk/lib/dependabot/dotnet_sdk/file_parser.rb
@@ -78,7 +78,10 @@ module Dependabot
 
       sig { returns(T.nilable(Ecosystem::VersionManager)) }
       def dotnetsdk
-        DotnetSDK.new(T.must(sdk_version))
+        version = sdk_version
+        return unless version
+
+        DotnetSDK.new(version)
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/dotnet_sdk/spec/dependabot/dotnet_sdk/file_parser_spec.rb
+++ b/dotnet_sdk/spec/dependabot/dotnet_sdk/file_parser_spec.rb
@@ -111,6 +111,11 @@ RSpec.describe Dependabot::DotnetSdk::FileParser do
       expect(ecosystem.package_manager.name).to eq("dotnet_sdk")
       expect(ecosystem.language).to be_nil
     end
+
+    it "logs a warning" do
+      expect(Dependabot.logger).to receive(:warn).with(/No .NET SDK version found in global.json/)
+      parser.ecosystem
+    end
   end
 
   context "with a global.json containing UTF-8 BOM" do

--- a/dotnet_sdk/spec/dependabot/dotnet_sdk/file_parser_spec.rb
+++ b/dotnet_sdk/spec/dependabot/dotnet_sdk/file_parser_spec.rb
@@ -80,6 +80,39 @@ RSpec.describe Dependabot::DotnetSdk::FileParser do
     it_behaves_like "parse"
   end
 
+  context "with a global.json that has no SDK version" do
+    let(:project_name) { "config_in_root" }
+    let(:directory) { "/" }
+    let(:files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "global.json",
+          content: <<~JSON,
+            {
+              "msbuild-sdks": {
+                "MSBuild.Sdk.Extras": "1.6.65"
+              }
+            }
+          JSON
+          directory: directory
+        )
+      ]
+    end
+
+    it "does not raise and returns no dependencies" do
+      expect { dependencies }.not_to raise_error
+      expect(dependencies).to be_empty
+    end
+
+    it "does not raise when building the ecosystem" do
+      ecosystem = nil
+      expect { ecosystem = parser.ecosystem }.not_to raise_error
+      expect(ecosystem.name).to eq("dotnet-sdk")
+      expect(ecosystem.package_manager.name).to eq("dotnet_sdk")
+      expect(ecosystem.language).to be_nil
+    end
+  end
+
   context "with a global.json containing UTF-8 BOM" do
     let(:project_name) { "config_in_root" }
     let(:directory) { "/" }


### PR DESCRIPTION
## Summary

The `dotnet_sdk` `FileParser` raised `TypeError: Passed nil into T.must` when a `global.json` file contained no SDK version (for example, a `global.json` that only declares `msbuild-sdks`). The crash occurred in `#dotnetsdk` via `#ecosystem`, which unconditionally called `DotnetSDK.new(T.must(sdk_version))`.

## Fix

`#dotnetsdk` now returns `nil` when there is no SDK version, instead of forcing a value with `T.must`. This makes the ecosystem build with a `nil` language (`Ecosystem#language` is already `T.nilable`), consistent with `#parse`, which already returns no dependencies in this case.

## Testing

Added a spec covering a `global.json` with no SDK version, asserting that parsing does not raise, returns no dependencies, and that `#ecosystem` builds with a `nil` language. Full parser spec passes (9 examples, 0 failures) and `srb tc` reports no errors.