### PR TITLE
Bundler: apply empty-checksum metadata patch to the v2 helper

### DIFF
--- a/bundler/helpers/v2/monkey_patches/endpoint_specification_metadata_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/endpoint_specification_metadata_patch.rb
@@ -3,7 +3,7 @@
 
 require "bundler/endpoint_specification"
 
-# Bundler 4 parses the metadata a registry's compact index (`/info/<gem>`)
+# Bundler parses the metadata a registry's compact index (`/info/<gem>`)
 # returns per gem version. Its guard is `next unless v`, but an empty array
 # `[]` is truthy, so for an empty `checksum` it calls `Checksum.from_api(nil)`
 # -> `nil.match?(...)` and raises `Bundler::GemspecError` ("There was an error

--- a/bundler/helpers/v2/monkey_patches/endpoint_specification_metadata_patch.rb
+++ b/bundler/helpers/v2/monkey_patches/endpoint_specification_metadata_patch.rb
@@ -1,0 +1,33 @@
+# typed: false
+# frozen_string_literal: true
+
+require "bundler/endpoint_specification"
+
+# Bundler 4 parses the metadata a registry's compact index (`/info/<gem>`)
+# returns per gem version. Its guard is `next unless v`, but an empty array
+# `[]` is truthy, so for an empty `checksum` it calls `Checksum.from_api(nil)`
+# -> `nil.match?(...)` and raises `Bundler::GemspecError` ("There was an error
+# parsing the metadata for the gem ..."), aborting the whole resolution.
+#
+# GitHub Packages serves this empty-checksum shape for some old gems (e.g.
+# failbot 2.0.1), so one such gem blocks every update for the repo. Compact-
+# index checksum verification landed in Bundler 2.5, so both the Bundler 2 and
+# Bundler 4 helpers parse checksums and need this patch (the Bundler 2 helper
+# activates ">= 2.4, < 3", i.e. a checksum-parsing 2.5+).
+#
+# Drop nil/empty metadata values before Bundler parses them. An empty checksum
+# carries nothing to verify, so skipping it is safe; well-formed values (and
+# genuinely malformed ones, which still raise) are untouched.
+module BundlerEndpointSpecificationMetadataPatch
+  def parse_metadata(data)
+    if data.respond_to?(:reject)
+      data = data.reject do |_key, value|
+        value.nil? || (value.respond_to?(:empty?) && value.empty?)
+      end
+    end
+
+    super
+  end
+end
+
+Bundler::EndpointSpecification.prepend(BundlerEndpointSpecificationMetadataPatch)

--- a/bundler/helpers/v2/run.rb
+++ b/bundler/helpers/v2/run.rb
@@ -25,6 +25,7 @@ end
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
 require "git_source_patch"
+require "endpoint_specification_metadata_patch"
 
 require "functions"
 

--- a/bundler/helpers/v2/spec/bundler_endpoint_specification_metadata_patch_spec.rb
+++ b/bundler/helpers/v2/spec/bundler_endpoint_specification_metadata_patch_spec.rb
@@ -1,0 +1,49 @@
+# typed: false
+# frozen_string_literal: true
+
+require "native_spec_helper"
+
+RSpec.describe BundlerEndpointSpecificationMetadataPatch do
+  let(:spec_fetcher) { instance_double(Bundler::Fetcher, uri: URI("https://example.com")) }
+
+  def build_spec(metadata)
+    Bundler::EndpointSpecification.new("failbot", "2.0.1", "ruby", spec_fetcher, [], metadata)
+  end
+
+  it "does not raise when the registry serves an empty checksum array" do
+    expect { build_spec([["checksum", []]]) }.not_to raise_error
+  end
+
+  it "leaves the checksum unset for an empty checksum array" do
+    spec = build_spec([["checksum", []]])
+    expect(spec.checksum).to be_nil
+  end
+
+  # The compact-index parser can emit a value-less entry (`["checksum"]`) rather
+  # than an empty array, depending on the RubyGems GemParser version. Both shapes
+  # reach this code, so both must be tolerated.
+  it "does not raise when the checksum entry has no value at all" do
+    expect { build_spec([["checksum"]]) }.not_to raise_error
+  end
+
+  it "ignores nil and blank metadata values" do
+    expect { build_spec([["checksum", nil], ["ruby", []]]) }.not_to raise_error
+  end
+
+  it "still parses a well-formed checksum" do
+    digest = "f" * 64
+    spec = build_spec([["checksum", [digest]]])
+    expect(spec.checksum).not_to be_nil
+  end
+
+  it "still parses ruby and rubygems requirements" do
+    spec = build_spec([["ruby", [">= 3.1"]], ["rubygems", [">= 3.0"]], ["checksum", []]])
+    expect(spec.required_ruby_version.to_s).to eq(">= 3.1")
+    expect(spec.required_rubygems_version.to_s).to eq(">= 3.0")
+  end
+
+  it "still raises on a genuinely malformed (non-empty) checksum" do
+    expect { build_spec([["checksum", ["not-a-valid-digest"]]]) }
+      .to raise_error(Bundler::GemspecError)
+  end
+end

--- a/bundler/helpers/v2/spec/native_spec_helper.rb
+++ b/bundler/helpers/v2/spec/native_spec_helper.rb
@@ -21,6 +21,7 @@ $LOAD_PATH.unshift(File.expand_path("../../spec_helpers", __dir__))
 require "definition_ruby_version_patch"
 require "definition_bundler_version_patch"
 require "git_source_patch"
+require "endpoint_specification_metadata_patch"
 
 require "functions"
 


### PR DESCRIPTION
### What are you trying to accomplish?

Follow-up to #15359, which taught the updater to tolerate empty compact-index checksum metadata that GitHub Packages serves for some old gems (e.g. `failbot 2.0.1` → `checksum: []`). Bundler reads the value-less checksum as `nil`, calls `nil.match?`, and raises a `GemspecError` that aborts the **entire** resolution — so one bad gem blocks every dependency update for the repo.

That fix was applied **only to the Bundler 4 helper** (`bundler/helpers/v4/`). The native helper version is chosen from the target repo's `Gemfile.lock` `BUNDLED WITH` line, so any repo pinned to a 2.x Bundler resolves through the **Bundler 2 helper**, which never received the patch. Those repos still fail with the empty-checksum crash.

The premise in #15359 ("Bundler 2 didn't parse compact-index checksums") is no longer true: compact-index checksum verification landed in **Bundler 2.5**, and the v2 helper activates `">= 2.4, < 3"` — i.e. a checksum-parsing 2.5+. So the v2 helper hits the exact same `nil.match?` failure.

This PR ports the fix to the Bundler 2 helper:

- Adds `endpoint_specification_metadata_patch` to `bundler/helpers/v2/monkey_patches/` (identical strip-empty-metadata logic).
- Loads it in `bundler/helpers/v2/run.rb` and the v2 `native_spec_helper`.
- Mirrors the parser spec against real Bundler 2.
- Corrects the now-inaccurate comment about Bundler 2 not parsing checksums.

### Anything you want to highlight for special attention from reviewers?

- The patch is byte-for-byte the same logic as the v4 version (each helper vendors its own monkey patches, so it's duplicated by design). Only the explanatory comment differs, to reflect that both helpers parse checksums post-2.5.
- Genuinely malformed (non-empty) checksums still raise — the spec covers that — so real corruption isn't silently swallowed.
- Verified the v2 helper actually parses checksums: the "still raises on a genuinely malformed checksum" example passes against the real Bundler the v2 helper activates, which is what makes this patch necessary.

### How will you know you've accomplished your goal?

- New v2 helper spec runs against real Bundler 2 and covers empty, value-less, and nil checksum shapes (parse cleanly), a well-formed checksum (parsed), and a malformed checksum (still raises). 7 examples, 0 failures.
- RuboCop clean on all changed files.
- After this ships, a repo whose lockfile is `BUNDLED WITH 2.x` and depends on a gem with an empty registry checksum will resolve instead of failing every dependency with `private_source_bad_response`.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request.
- [x] I have ensured that the code is well-documented and easy to understand.
