### PR TITLE
[Update graph] Avoid PathDependenciesNotReachable killing the whole job

### DIFF
--- a/python/lib/dependabot/python/dependency_grapher/requirements_layers.rb
+++ b/python/lib/dependabot/python/dependency_grapher/requirements_layers.rb
@@ -44,7 +44,7 @@ module Dependabot
 
         # More lenient: matches "depend" / "depends" at the start of the filename or after a hyphen/period/
         # underscore/slash delimiter, with an optional hyphen/underscore/slash suffix. The leading delimiter
-        # prevents matching "depend" as a substring of another word (e.g. "independ.txt").
+        # prevents matching "depend" as a substring of another word (e.g. "codependent.txt").
         # Examples: depend.txt, depends.txt, depend-test.txt, py3-depends.txt
         DEPEND_TXT_REGEX = T.let(%r{(?:[-._]|^|/)depend(?:s)?(?:[-_/][^\s.]*)?\.txt$}i, Regexp)
 

--- a/python/spec/dependabot/python/dependency_grapher/requirements_layers_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher/requirements_layers_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dependabot::Python::DependencyGrapher::RequirementsLayers do
       "LICENSE.txt",
       "prequire.txt",
       "acquire.txt",
-      "independ.txt"
+      "codependent.txt"
     ].each do |name|
       it "does not treat #{name} as a manifest" do
         expect(described_class.manifest_txt_filename?(name)).to be(false)

--- a/updater/lib/dependabot/fetched_files.rb
+++ b/updater/lib/dependabot/fetched_files.rb
@@ -13,10 +13,26 @@ module Dependabot
     sig { returns(String) }
     attr_reader :base_commit_sha
 
-    sig { params(dependency_files: T::Array[Dependabot::DependencyFile], base_commit_sha: String).void }
-    def initialize(dependency_files:, base_commit_sha:)
+    # Maps a directory to the non-fatal fetch error encountered while fetching it
+    # (e.g. an unresolvable path dependency for a graph job). The directory is
+    # still reported, but with a degraded snapshot describing the failure.
+    sig { returns(T::Hash[String, Dependabot::DependabotError]) }
+    attr_reader :directory_fetch_errors
+
+    sig do
+      params(
+        dependency_files: T::Array[Dependabot::DependencyFile],
+        base_commit_sha: String,
+        directory_fetch_errors: T::Hash[String, Dependabot::DependabotError]
+      ).void
+    end
+    def initialize(dependency_files:, base_commit_sha:, directory_fetch_errors: {})
       @dependency_files = T.let(dependency_files, T::Array[Dependabot::DependencyFile])
       @base_commit_sha = T.let(base_commit_sha, String)
+      @directory_fetch_errors = T.let(
+        directory_fetch_errors,
+        T::Hash[String, Dependabot::DependabotError]
+      )
     end
   end
 end

--- a/updater/lib/dependabot/fetched_files.rb
+++ b/updater/lib/dependabot/fetched_files.rb
@@ -15,7 +15,7 @@ module Dependabot
 
     # Maps a directory to the non-fatal fetch error encountered while fetching it
     # (e.g. an unresolvable path dependency for a graph job). The directory is
-    # still reported, but with a degraded snapshot describing the failure.
+    # still reported, but with a skipped snapshot describing the failure.
     sig { returns(T::Hash[String, Dependabot::DependabotError]) }
     attr_reader :directory_fetch_errors
 

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -79,11 +79,20 @@ module Dependabot
     def files
       Dependabot::FetchedFiles.new(
         dependency_files: T.must(job.source.directories ? dependency_files_for_multi_directories : dependency_files),
-        base_commit_sha: T.must(base_commit_sha)
+        base_commit_sha: T.must(base_commit_sha),
+        directory_fetch_errors: directory_fetch_errors
       )
     end
 
     private
+
+    # Records non-fatal, per-directory fetch errors encountered while listing a
+    # multi-directory graph job (e.g. an unresolvable path dependency). These are
+    # surfaced downstream as degraded snapshots rather than aborting the whole job.
+    sig { returns(T::Hash[String, Dependabot::DependabotError]) }
+    def directory_fetch_errors
+      @directory_fetch_errors ||= T.let({}, T.nilable(T::Hash[String, Dependabot::DependabotError]))
+    end
 
     sig { params(directory: T.nilable(String)).returns(Dependabot::FileFetchers::Base) }
     def create_file_fetcher(directory: nil)
@@ -168,6 +177,14 @@ module Dependabot
         begin
           files = ff.files
         rescue Dependabot::DependencyFileNotFound
+          next
+        rescue Dependabot::PathDependenciesNotReachable => e
+          # For graph jobs, an unreachable path dependency in one directory must not
+          # abort the whole multi-directory job. Record it so the directory is later
+          # reported as a degraded snapshot, and continue with the other directories.
+          raise unless job.update_graph?
+
+          directory_fetch_errors[dir] = e
           next
         end
         post_ecosystem_versions(ff) if should_record_ecosystem_versions?

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -88,7 +88,7 @@ module Dependabot
 
     # Records non-fatal, per-directory fetch errors encountered while listing a
     # multi-directory graph job (e.g. an unresolvable path dependency). These are
-    # surfaced downstream as degraded snapshots rather than aborting the whole job.
+    # surfaced downstream as skipped snapshots rather than aborting the whole job.
     sig { returns(T::Hash[String, Dependabot::DependabotError]) }
     def directory_fetch_errors
       @directory_fetch_errors ||= T.let({}, T.nilable(T::Hash[String, Dependabot::DependabotError]))
@@ -181,7 +181,7 @@ module Dependabot
         rescue Dependabot::PathDependenciesNotReachable => e
           # For graph jobs, an unreachable path dependency in one directory must not
           # abort the whole multi-directory job. Record it so the directory is later
-          # reported as a degraded snapshot, and continue with the other directories.
+          # reported as a skipped snapshot, and continue with the other directories.
           raise unless job.update_graph?
 
           directory_fetch_errors[dir] = e

--- a/updater/lib/dependabot/update_graph_command.rb
+++ b/updater/lib/dependabot/update_graph_command.rb
@@ -30,7 +30,8 @@ module Dependabot
           service: service,
           job: job,
           base_commit_sha: @fetched_files.base_commit_sha,
-          dependency_files: @fetched_files.dependency_files
+          dependency_files: @fetched_files.dependency_files,
+          directory_fetch_errors: @fetched_files.directory_fetch_errors
         ).run
       rescue StandardError => e
         handle_error(e)

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -104,10 +104,10 @@ module Dependabot
 
       # A non-fatal fetch error (e.g. an unresolvable path dependency) means we
       # could not fetch this directory's files, but the rest of the job proceeded.
-      # Report it as a degraded snapshot describing the failure rather than a
+      # Report it as a skipped snapshot describing the failure rather than a
       # misleading "no manifests" skip.
       if (fetch_error = directory_fetch_errors[directory])
-        submit_degraded_fetch_error(branch, directory, directory_source, fetch_error)
+        submit_skipped_fetch_error(branch, directory, directory_source, fetch_error)
         return
       end
 
@@ -214,7 +214,7 @@ module Dependabot
       dependency_files.select { |f| f.directory == directory }
     end
 
-    # Submits a degraded snapshot for a directory whose files could not be fetched
+    # Submits a skipped snapshot for a directory whose files could not be fetched
     # due to a non-fatal error (e.g. an unresolvable path dependency). The snapshot
     # carries the failure reason so consumers can distinguish it from a directory
     # that genuinely has no manifests.
@@ -226,8 +226,8 @@ module Dependabot
         error: Dependabot::DependabotError
       ).void
     end
-    def submit_degraded_fetch_error(branch, directory, source, error)
-      reason = degraded_reason_for(error)
+    def submit_skipped_fetch_error(branch, directory, source, error)
+      reason = skipped_reason_for(error)
 
       Dependabot.logger.warn("Dependency graph incomplete in directory #{directory}: #{error.message}")
 
@@ -240,7 +240,7 @@ module Dependabot
       submission = empty_submission(
         branch,
         source,
-        GithubApi::DependencySubmission::SnapshotStatus::DEGRADED,
+        GithubApi::DependencySubmission::SnapshotStatus::SKIPPED,
         reason
       )
       Dependabot.logger.info("Dependency submission payload:\n#{JSON.pretty_generate(submission.payload)}")
@@ -248,16 +248,16 @@ module Dependabot
 
       record_workflow_result(
         directory,
-        GithubApi::DependencySubmission::SnapshotStatus::DEGRADED,
+        GithubApi::DependencySubmission::SnapshotStatus::SKIPPED,
         reason
       )
     end
 
     sig { params(error: Dependabot::DependabotError).returns(String) }
-    def degraded_reason_for(error)
+    def skipped_reason_for(error)
       case error
       when Dependabot::PathDependenciesNotReachable
-        GithubApi::DependencySubmission::DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
+        GithubApi::DependencySubmission::SKIPPED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
       else
         error.message
       end

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -5,6 +5,7 @@ require "sorbet-runtime"
 
 # Dependabot components
 require "dependabot/environment"
+require "dependabot/errors"
 require "dependabot/experiments"
 require "dependabot/dependency_graphers"
 require "dependabot/logger"
@@ -32,19 +33,23 @@ module Dependabot
     # - The Dependabot::Job that describes the work to be done
     # - The Dependabot::DependencyFile list retrieved by the file fetcher
     # - The base_commit_sha being processed
+    # - Optionally, a map of directory to a non-fatal fetch error (e.g. an
+    #   unresolvable path dependency) to report as a degraded snapshot
     sig do
       params(
         service: Dependabot::Service,
         job: Dependabot::Job,
         base_commit_sha: String,
-        dependency_files: T::Array[Dependabot::DependencyFile]
+        dependency_files: T::Array[Dependabot::DependencyFile],
+        directory_fetch_errors: T::Hash[String, Dependabot::DependabotError]
       ).void
     end
-    def initialize(service:, job:, base_commit_sha:, dependency_files:)
+    def initialize(service:, job:, base_commit_sha:, dependency_files:, directory_fetch_errors: {})
       @service = service
       @job = job
       @base_commit_sha = base_commit_sha
       @dependency_files = dependency_files
+      @directory_fetch_errors = directory_fetch_errors
 
       @error_handler = T.let(
         Dependabot::Updater::ErrorHandler.new(service: service, job: job),
@@ -87,12 +92,25 @@ module Dependabot
     sig { returns(T::Array[Dependabot::DependencyFile]) }
     attr_reader :dependency_files
 
+    sig { returns(T::Hash[String, Dependabot::DependabotError]) }
+    attr_reader :directory_fetch_errors
+
     sig { returns(Dependabot::Updater::ErrorHandler) }
     attr_reader :error_handler
 
     sig { params(branch: String, directory: String).void }
     def process_directory(branch:, directory:) # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
       directory_source = create_source_for(directory)
+
+      # A non-fatal fetch error (e.g. an unresolvable path dependency) means we
+      # could not fetch this directory's files, but the rest of the job proceeded.
+      # Report it as a degraded snapshot describing the failure rather than a
+      # misleading "no manifests" skip.
+      if (fetch_error = directory_fetch_errors[directory])
+        submit_degraded_fetch_error(branch, directory, directory_source, fetch_error)
+        return
+      end
+
       directory_dependency_files = dependency_files_for(directory)
 
       submission = if directory_dependency_files.empty?
@@ -194,6 +212,55 @@ module Dependabot
     sig { params(directory: String).returns(T::Array[Dependabot::DependencyFile]) }
     def dependency_files_for(directory)
       dependency_files.select { |f| f.directory == directory }
+    end
+
+    # Submits a degraded snapshot for a directory whose files could not be fetched
+    # due to a non-fatal error (e.g. an unresolvable path dependency). The snapshot
+    # carries the failure reason so consumers can distinguish it from a directory
+    # that genuinely has no manifests.
+    sig do
+      params(
+        branch: String,
+        directory: String,
+        source: Dependabot::Source,
+        error: Dependabot::DependabotError
+      ).void
+    end
+    def submit_degraded_fetch_error(branch, directory, source, error)
+      reason = degraded_reason_for(error)
+
+      Dependabot.logger.warn("Dependency graph incomplete in directory #{directory}: #{error.message}")
+
+      service.record_update_job_warning(
+        warn_type: "dependency_graph_incomplete",
+        warn_title: "dependency graph incomplete",
+        warn_description: "The dependency graph may be incomplete. #{error.message}"
+      )
+
+      submission = empty_submission(
+        branch,
+        source,
+        GithubApi::DependencySubmission::SnapshotStatus::DEGRADED,
+        reason
+      )
+      Dependabot.logger.info("Dependency submission payload:\n#{JSON.pretty_generate(submission.payload)}")
+      service.create_dependency_submission(dependency_submission: submission)
+
+      record_workflow_result(
+        directory,
+        GithubApi::DependencySubmission::SnapshotStatus::DEGRADED,
+        reason
+      )
+    end
+
+    sig { params(error: Dependabot::DependabotError).returns(String) }
+    def degraded_reason_for(error)
+      case error
+      when Dependabot::PathDependenciesNotReachable
+        GithubApi::DependencySubmission::DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
+      else
+        error.message
+      end
     end
 
     sig do

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -253,13 +253,16 @@ module Dependabot
       )
     end
 
+    # Maps a per-directory fetch error to a stable snapshot reason. An unresolvable
+    # path dependency gets a specific reason; any other error falls back to a
+    # generic reason so we never leak an unexpected raw error message.
     sig { params(error: Dependabot::DependabotError).returns(String) }
     def skipped_reason_for(error)
       case error
       when Dependabot::PathDependenciesNotReachable
         GithubApi::DependencySubmission::SKIPPED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
       else
-        error.message
+        GithubApi::DependencySubmission::SKIPPED_REASON_FILE_FETCH_ERROR
       end
     end
 

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -34,7 +34,7 @@ module Dependabot
     # - The Dependabot::DependencyFile list retrieved by the file fetcher
     # - The base_commit_sha being processed
     # - Optionally, a map of directory to a non-fatal fetch error (e.g. an
-    #   unresolvable path dependency) to report as a degraded snapshot
+    #   unresolvable path dependency) to report as a skipped snapshot
     sig do
       params(
         service: Dependabot::Service,

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -18,9 +18,9 @@ module GithubApi
     SNAPSHOT_DETECTOR_NAME = "dependabot"
     SNAPSHOT_DETECTOR_URL = "https://github.com/dependabot/dependabot-core"
 
-    # Expected reasons for empty or degraded snapshots
+    # Expected reasons for empty, skipped or degraded snapshots
     DEGRADED_REASON_SUBDEPENDENCY_ERR = "error fetching sub-dependencies"
-    DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE = "unresolvable path dependency"
+    SKIPPED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE = "unresolvable path dependency"
     EMPTY_REASON_NO_MANIFESTS = "missing manifest files"
 
     class SnapshotStatus < T::Enum

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -20,6 +20,7 @@ module GithubApi
 
     # Expected reasons for empty or degraded snapshots
     DEGRADED_REASON_SUBDEPENDENCY_ERR = "error fetching sub-dependencies"
+    DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE = "unresolvable path dependency"
     EMPTY_REASON_NO_MANIFESTS = "missing manifest files"
 
     class SnapshotStatus < T::Enum

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -21,6 +21,7 @@ module GithubApi
     # Expected reasons for empty, skipped or degraded snapshots
     DEGRADED_REASON_SUBDEPENDENCY_ERR = "error fetching sub-dependencies"
     SKIPPED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE = "unresolvable path dependency"
+    SKIPPED_REASON_FILE_FETCH_ERROR = "unable to fetch files"
     EMPTY_REASON_NO_MANIFESTS = "missing manifest files"
 
     class SnapshotStatus < T::Enum

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -712,6 +712,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
         File.write(File.join(repo_contents_path, "tools/a.dummy"), "dummy content")
 
         allow(command.job).to receive(:update_graph?).and_return(true)
+        allow(command).to receive(:base_commit_sha).and_return("sha")
 
         allow(command).to receive(:file_fetcher_for_directory) do |dir|
           fetcher = double("FileFetcher")
@@ -728,7 +729,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
       end
 
       it "does not abort the whole job and still returns the other directory's files" do
-        files = command.send(:files_from_multidirectories)
+        files = command.files.dependency_files
 
         tools_files = files.select { |f| f.directory == "/tools" }
         root_files = files.select { |f| f.directory == "/" }
@@ -737,18 +738,9 @@ RSpec.describe Dependabot::FileFetcherCommand do
         expect(root_files).to be_empty
       end
 
-      it "records the fetch error for the affected directory" do
-        command.send(:files_from_multidirectories)
-
-        errors = command.send(:directory_fetch_errors)
-        expect(errors).to have_key("/")
-        expect(errors["/"]).to be_a(Dependabot::PathDependenciesNotReachable)
-      end
-
-      it "surfaces the fetch error on the returned FetchedFiles" do
-        allow(command).to receive(:base_commit_sha).and_return("sha")
-
+      it "surfaces the fetch error for the affected directory on the returned FetchedFiles" do
         fetched = command.files
+
         expect(fetched.directory_fetch_errors).to have_key("/")
         expect(fetched.directory_fetch_errors["/"]).to be_a(Dependabot::PathDependenciesNotReachable)
       end
@@ -778,7 +770,7 @@ RSpec.describe Dependabot::FileFetcherCommand do
       end
 
       it "propagates the error so the update job surfaces it" do
-        expect { command.send(:files_from_multidirectories) }
+        expect { command.files }
           .to raise_error(Dependabot::PathDependenciesNotReachable)
       end
     end

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -704,6 +704,85 @@ RSpec.describe Dependabot::FileFetcherCommand do
       end
     end
 
+    context "when a directory raises PathDependenciesNotReachable for a graph job" do
+      let(:command) { described_class.new }
+
+      before do
+        FileUtils.mkdir_p(File.join(repo_contents_path, "tools"))
+        File.write(File.join(repo_contents_path, "tools/a.dummy"), "dummy content")
+
+        allow(command.job).to receive(:update_graph?).and_return(true)
+
+        allow(command).to receive(:file_fetcher_for_directory) do |dir|
+          fetcher = double("FileFetcher")
+          if dir == "/tools"
+            dummy_file = double("DependencyFile")
+            allow(dummy_file).to receive_messages(name: "a.dummy", directory: "/tools")
+            allow(fetcher).to receive(:files).and_return([dummy_file])
+          else
+            allow(fetcher).to receive(:files)
+              .and_raise(Dependabot::PathDependenciesNotReachable.new(["./local"]))
+          end
+          fetcher
+        end
+      end
+
+      it "does not abort the whole job and still returns the other directory's files" do
+        files = command.send(:files_from_multidirectories)
+
+        tools_files = files.select { |f| f.directory == "/tools" }
+        root_files = files.select { |f| f.directory == "/" }
+
+        expect(tools_files.map(&:name)).to include("a.dummy")
+        expect(root_files).to be_empty
+      end
+
+      it "records the fetch error for the affected directory" do
+        command.send(:files_from_multidirectories)
+
+        errors = command.send(:directory_fetch_errors)
+        expect(errors).to have_key("/")
+        expect(errors["/"]).to be_a(Dependabot::PathDependenciesNotReachable)
+      end
+
+      it "surfaces the fetch error on the returned FetchedFiles" do
+        allow(command).to receive(:base_commit_sha).and_return("sha")
+
+        fetched = command.files
+        expect(fetched.directory_fetch_errors).to have_key("/")
+        expect(fetched.directory_fetch_errors["/"]).to be_a(Dependabot::PathDependenciesNotReachable)
+      end
+    end
+
+    context "when a directory raises PathDependenciesNotReachable for a non-graph job" do
+      let(:command) { described_class.new }
+
+      before do
+        FileUtils.mkdir_p(File.join(repo_contents_path, "tools"))
+        File.write(File.join(repo_contents_path, "tools/a.dummy"), "dummy content")
+
+        allow(command.job).to receive(:update_graph?).and_return(false)
+
+        allow(command).to receive(:file_fetcher_for_directory) do |dir|
+          fetcher = double("FileFetcher")
+          if dir == "/tools"
+            dummy_file = double("DependencyFile")
+            allow(dummy_file).to receive_messages(name: "a.dummy", directory: "/tools")
+            allow(fetcher).to receive(:files).and_return([dummy_file])
+          else
+            allow(fetcher).to receive(:files)
+              .and_raise(Dependabot::PathDependenciesNotReachable.new(["./local"]))
+          end
+          fetcher
+        end
+      end
+
+      it "propagates the error so the update job surfaces it" do
+        expect { command.send(:files_from_multidirectories) }
+          .to raise_error(Dependabot::PathDependenciesNotReachable)
+      end
+    end
+
     context "when all directories have required files" do
       let(:command) { described_class.new }
 

--- a/updater/spec/dependabot/update_graph_command_spec.rb
+++ b/updater/spec/dependabot/update_graph_command_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Dependabot::UpdateGraphCommand do
       mark_job_as_processed: nil,
       record_update_job_error: nil,
       record_update_job_unknown_error: nil,
+      record_update_job_warning: nil,
       record_workflow_result: nil,
       update_dependency_list: nil,
       increment_metric: nil,
@@ -62,6 +63,45 @@ RSpec.describe Dependabot::UpdateGraphCommand do
         expect(args[:dependency_submission].job_id).to eql(job_id)
         expect(args[:dependency_submission].package_manager).to eql("bundler")
       end
+
+      perform_job
+    end
+  end
+
+  describe "#perform_job when a directory has a non-fatal fetch error" do
+    subject(:perform_job) { job.perform_job }
+
+    let(:fetched_files) do
+      Dependabot::FetchedFiles.new(
+        dependency_files: [],
+        base_commit_sha: "1c6331732c41e4557a16dacb82534f1d1c831848",
+        directory_fetch_errors: {
+          "/" => Dependabot::PathDependenciesNotReachable.new(["./local-gem"])
+        }
+      )
+    end
+
+    before do
+      allow(Dependabot::FileParsers).to receive(:for_package_manager)
+      allow(Dependabot::DependencyGraphers).to receive(:for_package_manager)
+    end
+
+    it "hands the fetch error to the processor and submits a skipped snapshot for the affected directory" do
+      expect(service).to receive(:create_dependency_submission) do |args|
+        submission = args[:dependency_submission]
+
+        expect(submission).to be_a(GithubApi::DependencySubmission)
+        expect(submission.job_id).to eql(job_id)
+        expect(submission.status).to eq(GithubApi::DependencySubmission::SnapshotStatus::SKIPPED)
+        expect(submission.reason).to eq(
+          GithubApi::DependencySubmission::SKIPPED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
+        )
+        expect(submission.resolved_dependencies).to be_empty
+      end
+
+      # The affected directory is reported without ever parsing or graphing its files.
+      expect(Dependabot::FileParsers).not_to receive(:for_package_manager)
+      expect(Dependabot::DependencyGraphers).not_to receive(:for_package_manager)
 
       perform_job
     end

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -670,6 +670,47 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
     end
   end
 
+  context "with a directory that failed to fetch due to an unspecified file fetch error" do
+    let(:directories) { [dir_ok, dir_broken] }
+    let(:dir_ok) { "/" }
+    let(:dir_broken) { "/broken" }
+    let(:repo_contents_path) { build_tmp_repo("bundler/original", path: "") }
+
+    let(:directory_fetch_errors) do
+      { dir_broken => Dependabot::DependabotError.new("something went wrong") }
+    end
+
+    let(:dependency_files) { [] }
+
+    it "submits a skipped snapshot with a generic file fetch error reason" do
+      submissions = []
+      allow(service).to receive(:create_dependency_submission) do |args|
+        submissions << args[:dependency_submission]
+      end
+
+      update_graph_processor.run
+
+      skipped = submissions.find do |s|
+        s.payload[:metadata][:scanned_manifest_path] == "rubygems::/broken"
+      end
+
+      expect(skipped).not_to be_nil
+      expect(skipped.payload[:metadata][:status])
+        .to eq(GithubApi::DependencySubmission::SnapshotStatus::SKIPPED.serialize)
+      expect(skipped.payload[:metadata][:reason])
+        .to eq(GithubApi::DependencySubmission::SKIPPED_REASON_FILE_FETCH_ERROR)
+    end
+
+    it "does not leak the raw error message into the snapshot reason" do
+      allow(service).to receive(:create_dependency_submission) do |args|
+        payload = args[:dependency_submission].payload
+        expect(payload[:metadata][:reason]).not_to include("something went wrong")
+      end
+
+      update_graph_processor.run
+    end
+  end
+
   context "with non-existent dependency files in a subpath" do
     let(:directories) { [directory] }
     let(:directory) { "/subproject/" }

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -601,10 +601,10 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
     end
 
     # The other directory has no manifests so it is reported without needing to
-    # parse an ecosystem, keeping the focus on the degraded-fetch behaviour.
+    # parse an ecosystem, keeping the focus on the skipped-fetch behaviour.
     let(:dependency_files) { [] }
 
-    it "submits a degraded snapshot describing the unreachable path dependency" do
+    it "submits a skipped snapshot describing the unreachable path dependency" do
       submissions = []
       allow(service).to receive(:create_dependency_submission) do |args|
         submissions << args[:dependency_submission]
@@ -612,15 +612,16 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
 
       update_graph_processor.run
 
-      degraded = submissions.find do |s|
-        s.payload[:metadata][:status] == GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.serialize
+      skipped = submissions.find do |s|
+        s.payload[:metadata][:scanned_manifest_path] == "rubygems::/broken"
       end
 
-      expect(degraded).not_to be_nil
-      expect(degraded.payload[:metadata][:reason])
-        .to eq(GithubApi::DependencySubmission::DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE)
-      expect(degraded.payload[:metadata][:scanned_manifest_path]).to eq("rubygems::/broken")
-      expect(degraded.payload[:manifests]).to be_empty
+      expect(skipped).not_to be_nil
+      expect(skipped.payload[:metadata][:status])
+        .to eq(GithubApi::DependencySubmission::SnapshotStatus::SKIPPED.serialize)
+      expect(skipped.payload[:metadata][:reason])
+        .to eq(GithubApi::DependencySubmission::SKIPPED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE)
+      expect(skipped.payload[:manifests]).to be_empty
     end
 
     it "does not mislabel the affected directory as having no manifests" do
@@ -628,7 +629,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
         payload = args[:dependency_submission].payload
         if payload[:metadata][:scanned_manifest_path] == "rubygems::/broken"
           expect(payload[:metadata][:status])
-            .to eq(GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.serialize)
+            .to eq(GithubApi::DependencySubmission::SnapshotStatus::SKIPPED.serialize)
           expect(payload[:metadata][:reason])
             .not_to eq(GithubApi::DependencySubmission::EMPTY_REASON_NO_MANIFESTS)
         end
@@ -637,12 +638,12 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       update_graph_processor.run
     end
 
-    it "records a degraded workflow result for the affected directory" do
+    it "records a skipped workflow result for the affected directory" do
       allow(service).to receive(:record_workflow_result)
       expect(service).to receive(:record_workflow_result).with(
         directory: dir_broken,
-        status: GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.serialize,
-        details: GithubApi::DependencySubmission::DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
+        status: GithubApi::DependencySubmission::SnapshotStatus::SKIPPED.serialize,
+        details: GithubApi::DependencySubmission::SKIPPED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
       )
 
       update_graph_processor.run

--- a/updater/spec/dependabot/update_graph_processor_spec.rb
+++ b/updater/spec/dependabot/update_graph_processor_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
       service:,
       job:,
       base_commit_sha:,
-      dependency_files:
+      dependency_files:,
+      directory_fetch_errors:
     )
   end
 
@@ -68,6 +69,7 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
 
   let(:base_commit_sha) { "fake-sha" }
   let(:repo_contents_path) { nil }
+  let(:directory_fetch_errors) { {} }
 
   context "with a basic Gemfile project" do
     let(:directories) { [directory] }
@@ -583,6 +585,85 @@ RSpec.describe Dependabot::UpdateGraphProcessor do
         expect(payload[:metadata][:reason]).to eq(GithubApi::DependencySubmission::EMPTY_REASON_NO_MANIFESTS)
         expect(payload[:metadata][:scanned_manifest_path]).to eql("rubygems::/")
       end
+
+      update_graph_processor.run
+    end
+  end
+
+  context "with a directory that failed to fetch due to an unreachable path dependency" do
+    let(:directories) { [dir_ok, dir_broken] }
+    let(:dir_ok) { "/" }
+    let(:dir_broken) { "/broken" }
+    let(:repo_contents_path) { build_tmp_repo("bundler/original", path: "") }
+
+    let(:directory_fetch_errors) do
+      { dir_broken => Dependabot::PathDependenciesNotReachable.new(["./local"]) }
+    end
+
+    # The other directory has no manifests so it is reported without needing to
+    # parse an ecosystem, keeping the focus on the degraded-fetch behaviour.
+    let(:dependency_files) { [] }
+
+    it "submits a degraded snapshot describing the unreachable path dependency" do
+      submissions = []
+      allow(service).to receive(:create_dependency_submission) do |args|
+        submissions << args[:dependency_submission]
+      end
+
+      update_graph_processor.run
+
+      degraded = submissions.find do |s|
+        s.payload[:metadata][:status] == GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.serialize
+      end
+
+      expect(degraded).not_to be_nil
+      expect(degraded.payload[:metadata][:reason])
+        .to eq(GithubApi::DependencySubmission::DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE)
+      expect(degraded.payload[:metadata][:scanned_manifest_path]).to eq("rubygems::/broken")
+      expect(degraded.payload[:manifests]).to be_empty
+    end
+
+    it "does not mislabel the affected directory as having no manifests" do
+      allow(service).to receive(:create_dependency_submission) do |args|
+        payload = args[:dependency_submission].payload
+        if payload[:metadata][:scanned_manifest_path] == "rubygems::/broken"
+          expect(payload[:metadata][:status])
+            .to eq(GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.serialize)
+          expect(payload[:metadata][:reason])
+            .not_to eq(GithubApi::DependencySubmission::EMPTY_REASON_NO_MANIFESTS)
+        end
+      end
+
+      update_graph_processor.run
+    end
+
+    it "records a degraded workflow result for the affected directory" do
+      allow(service).to receive(:record_workflow_result)
+      expect(service).to receive(:record_workflow_result).with(
+        directory: dir_broken,
+        status: GithubApi::DependencySubmission::SnapshotStatus::DEGRADED.serialize,
+        details: GithubApi::DependencySubmission::DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
+      )
+
+      update_graph_processor.run
+    end
+
+    it "does not abort the job: the other directory is still processed" do
+      submissions = []
+      allow(service).to receive(:create_dependency_submission) do |args|
+        submissions << args[:dependency_submission].payload
+      end
+
+      update_graph_processor.run
+
+      scanned_paths = submissions.map { |p| p[:metadata][:scanned_manifest_path] }
+      expect(scanned_paths).to include("rubygems::/", "rubygems::/broken")
+    end
+
+    it "records a warning about the incomplete graph" do
+      expect(service).to receive(:record_update_job_warning).with(
+        hash_including(warn_type: "dependency_graph_incomplete")
+      )
 
       update_graph_processor.run
     end

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe GithubApi::DependencySubmission do
     it_behaves_like "dependency_submission", true
   end
 
-  context "with a skipped status and an unresolvable path dependency reason" do
+  context "with a skipped status and a file fetch error reason" do
     subject(:dependency_submission) do
       described_class.new(
         job_id: "9999",
@@ -218,7 +218,7 @@ RSpec.describe GithubApi::DependencySubmission do
         manifest_file: empty_file,
         resolved_dependencies: {},
         status: described_class::SnapshotStatus::SKIPPED,
-        reason: described_class::SKIPPED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
+        reason: described_class::SKIPPED_REASON_FILE_FETCH_ERROR
       )
     end
 
@@ -232,7 +232,7 @@ RSpec.describe GithubApi::DependencySubmission do
       expect(payload[:manifests]).to be_empty
       expect(payload[:metadata][:status])
         .to eq(described_class::SnapshotStatus::SKIPPED.serialize)
-      expect(payload[:metadata][:reason]).to eq("unresolvable path dependency")
+      expect(payload[:metadata][:reason]).to eq("unable to fetch files")
     end
   end
 

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -208,6 +208,34 @@ RSpec.describe GithubApi::DependencySubmission do
     it_behaves_like "dependency_submission", true
   end
 
+  context "with a degraded status and an unresolvable path dependency reason" do
+    subject(:dependency_submission) do
+      described_class.new(
+        job_id: "9999",
+        branch: "main",
+        sha: "fake-sha",
+        package_manager: "bundler",
+        manifest_file: empty_file,
+        resolved_dependencies: {},
+        status: described_class::SnapshotStatus::DEGRADED,
+        reason: described_class::DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
+      )
+    end
+
+    let(:empty_file) do
+      Dependabot::DependencyFile.new(name: "", content: "", directory: "/broken")
+    end
+
+    it "surfaces the degraded status and reason in the payload metadata" do
+      payload = dependency_submission.payload
+
+      expect(payload[:manifests]).to be_empty
+      expect(payload[:metadata][:status])
+        .to eq(described_class::SnapshotStatus::DEGRADED.serialize)
+      expect(payload[:metadata][:reason]).to eq("unresolvable path dependency")
+    end
+  end
+
   context "with a manifest file but no resolved dependencies" do
     subject(:dependency_submission) do
       described_class.new(

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -215,8 +215,12 @@ RSpec.describe GithubApi::DependencySubmission do
         branch: "main",
         sha: "fake-sha",
         package_manager: "bundler",
-        manifest_file: empty_file,
-        resolved_dependencies: {},
+        manifest_snapshots: [
+          Dependabot::DependencyGraphers::ManifestGroupSnapshot.new(
+            manifest_file: empty_file,
+            resolved_dependencies: {}
+          )
+        ],
         status: described_class::SnapshotStatus::SKIPPED,
         reason: described_class::SKIPPED_REASON_FILE_FETCH_ERROR
       )

--- a/updater/spec/github_api/dependency_submission_spec.rb
+++ b/updater/spec/github_api/dependency_submission_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe GithubApi::DependencySubmission do
     it_behaves_like "dependency_submission", true
   end
 
-  context "with a degraded status and an unresolvable path dependency reason" do
+  context "with a skipped status and an unresolvable path dependency reason" do
     subject(:dependency_submission) do
       described_class.new(
         job_id: "9999",
@@ -217,8 +217,8 @@ RSpec.describe GithubApi::DependencySubmission do
         package_manager: "bundler",
         manifest_file: empty_file,
         resolved_dependencies: {},
-        status: described_class::SnapshotStatus::DEGRADED,
-        reason: described_class::DEGRADED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
+        status: described_class::SnapshotStatus::SKIPPED,
+        reason: described_class::SKIPPED_REASON_PATH_DEPENDENCIES_NOT_REACHABLE
       )
     end
 
@@ -226,12 +226,12 @@ RSpec.describe GithubApi::DependencySubmission do
       Dependabot::DependencyFile.new(name: "", content: "", directory: "/broken")
     end
 
-    it "surfaces the degraded status and reason in the payload metadata" do
+    it "surfaces the skipped status and reason in the payload metadata" do
       payload = dependency_submission.payload
 
       expect(payload[:manifests]).to be_empty
       expect(payload[:metadata][:status])
-        .to eq(described_class::SnapshotStatus::DEGRADED.serialize)
+        .to eq(described_class::SnapshotStatus::SKIPPED.serialize)
       expect(payload[:metadata][:reason]).to eq("unresolvable path dependency")
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

`Dependabot::PathDependenciesNotReachable` is a fatal error for updates as it means at least one file in the cohort to be graphed references a file that cannot be fetched within the repository.

For Graph jobs there is more lattitude to work with a missing path dependency:
1. We can ignore just the project with the unreachable path dependency in the worst case
2. In the best case, we can workaround the missing path dependency and parse/capture the remaining information

Either of these scenarios resulting in a snapshot with a `degraded` flag would be preferable to losing the entire job, so this PR adds a flag which allows the `FileFetcher` to optionally **notice** unreachable paths without raising.

### Anything you want to highlight for special attention from reviewers?

This allows the grapher to continue to make best effort to progress the overall job while stamping the path with the unreachable dependency as skipped; for now, I'm not making an effort to solve (2) as part of this PR.

I'd prefer not to modify the updater code, but in this case it is unavoidable as we need to change the `FileFetcher` behaviour so I've limited the blast radius to a Grapher-specific setting and defaulted it to existing behaviour.

### How will you know you've accomplished your goal?

I no longer see monorepos fail to snapshot anything when there is a single unreachable path dependency in the file tree.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
