### PR TITLE
Type the bazel and helm ecosystems

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,12 +239,9 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1531
+# Offense count: 1499
 Sorbet/ForbidTUntyped:
   Exclude:
-    - "bazel/lib/dependabot/bazel/file_fetcher.rb"
-    - "bazel/lib/dependabot/bazel/file_parser/starlark_parser.rb"
-    - "bazel/lib/dependabot/bazel/update_checker/registry_client.rb"
     - "bun/lib/dependabot/bun.rb"
     - "bun/lib/dependabot/bun/dependency_files_filterer.rb"
     - "bun/lib/dependabot/bun/file_fetcher.rb"
@@ -333,10 +330,6 @@ Sorbet/ForbidTUntyped:
     - "gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb"
     - "gradle/lib/dependabot/gradle/update_checker/version_finder.rb"
     - "gradle/lib/dependabot/gradle/version.rb"
-    - "helm/lib/dependabot/helm/file_parser.rb"
-    - "helm/lib/dependabot/helm/file_updater/chart_updater.rb"
-    - "helm/lib/dependabot/helm/update_checker.rb"
-    - "helm/lib/dependabot/helm/update_checker/latest_version_resolver.rb"
     - "hex/lib/dependabot/hex/credential_helpers.rb"
     - "hex/lib/dependabot/hex/file_parser.rb"
     - "hex/lib/dependabot/hex/metadata_finder.rb"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1549
+# Offense count: 1531
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bazel/lib/dependabot/bazel/file_fetcher.rb"
@@ -309,18 +309,7 @@ Sorbet/ForbidTUntyped:
     - "composer/lib/dependabot/composer/metadata_finder.rb"
     - "composer/lib/dependabot/composer/package/package_details_fetcher.rb"
     - "composer/lib/dependabot/composer/update_checker/version_resolver.rb"
-    - "deno/lib/dependabot/deno/file_fetcher.rb"
-    - "deno/lib/dependabot/deno/file_parser.rb"
-    - "deno/lib/dependabot/deno/file_updater/manifest_updater.rb"
-    - "deno/lib/dependabot/deno/helpers.rb"
-    - "devcontainers/lib/dependabot/devcontainers/file_fetcher.rb"
-    - "devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb"
-    - "devcontainers/lib/dependabot/devcontainers/file_updater.rb"
-    - "devcontainers/lib/dependabot/devcontainers/update_checker/latest_version_finder.rb"
     - "dotnet_sdk/lib/dependabot/dotnet_sdk/package/package_details_fetcher.rb"
-    - "elm/lib/dependabot/elm/file_parser.rb"
-    - "elm/lib/dependabot/elm/update_checker/latest_version_finder.rb"
-    - "elm/lib/dependabot/elm/update_checker/requirements_updater.rb"
     - "git_submodules/lib/dependabot/git_submodules/package/package_details_fetcher.rb"
     - "github_actions/lib/dependabot/github_actions/file_parser.rb"
     - "github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb"

--- a/bazel/lib/dependabot/bazel/file_fetcher.rb
+++ b/bazel/lib/dependabot/bazel/file_fetcher.rb
@@ -46,7 +46,7 @@ module Dependabot
         raise Dependabot::DependencyFileNotFound.new(nil, self.class.required_files_message)
       end
 
-      sig { override.returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { override.returns(T.nilable(T::Hash[Symbol, T.anything])) }
       def ecosystem_versions
         bazel_version = "unknown"
 
@@ -75,14 +75,14 @@ module Dependabot
         files = T.let([], T::Array[DependencyFile])
 
         module_file_items.each do |item|
-          file = fetch_file_if_present(item.name)
+          file = fetch_file_if_present(T.must(item.name))
           files << file if file
         end
 
         files
       end
 
-      sig { returns(T::Array[T.untyped]) }
+      sig { returns(T::Array[Dependabot::FileFetchers::RepositoryContent]) }
       def module_file_items
         repo_contents(raise_errors: false).select { |f| f.type == "file" && f.name.end_with?(MODULE_FILE) }
       end
@@ -140,8 +140,8 @@ module Dependabot
 
         all_module_files.each do |module_file|
           module_refs = fetch_module_referenced_files(module_file, directories_with_files)
-          files += module_refs[:files]
-          module_refs[:local_override_dirs].each { |dir| local_override_directories.add(dir) }
+          files += T.cast(module_refs[:files], T::Array[DependencyFile])
+          T.cast(module_refs[:local_override_dirs], T::Array[String]).each { |dir| local_override_directories.add(dir) }
         end
 
         tree_fetcher = DirectoryTreeFetcher.new(fetcher: self)
@@ -156,7 +156,7 @@ module Dependabot
         params(
           module_file: DependencyFile,
           directories_with_files: T::Set[String]
-        ).returns(T::Hash[Symbol, T.untyped])
+        ).returns(T::Hash[Symbol, T.anything])
       end
       def fetch_module_referenced_files(module_file, directories_with_files)
         files = T.let([], T::Array[DependencyFile])

--- a/bazel/lib/dependabot/bazel/file_parser/starlark_parser.rb
+++ b/bazel/lib/dependabot/bazel/file_parser/starlark_parser.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -12,8 +12,8 @@ module Dependabot
 
         class FunctionCall < T::Struct
           const :name, String
-          const :arguments, T::Hash[String, T.untyped]
-          const :positional_arguments, T::Array[T.untyped]
+          const :arguments, T::Hash[String, Object]
+          const :positional_arguments, T::Array[Object]
           const :line, Integer
         end
 
@@ -128,10 +128,10 @@ module Dependabot
           identifier.empty? ? nil : identifier
         end
 
-        sig { returns([T::Hash[String, T.untyped], T::Array[T.untyped]]) }
+        sig { returns([T::Hash[String, Object], T::Array[Object]]) }
         def parse_function_arguments
-          keyword_arguments = T.let({}, T::Hash[String, T.untyped])
-          positional_arguments = T.let([], T::Array[T.untyped])
+          keyword_arguments = T.let({}, T::Hash[String, Object])
+          positional_arguments = T.let([], T::Array[Object])
 
           skip_whitespace_and_comments
 
@@ -161,7 +161,7 @@ module Dependabot
           [keyword_arguments, positional_arguments]
         end
 
-        sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+        sig { returns(T.nilable(T::Hash[String, Object])) }
         def parse_keyword_argument
           start_pos = @position
           start_line = @line
@@ -186,7 +186,7 @@ module Dependabot
           { param_name => value }
         end
 
-        sig { returns(T.untyped) }
+        sig { returns(T.nilable(Object)) }
         def parse_value
           skip_whitespace_and_comments
 
@@ -256,7 +256,7 @@ module Dependabot
           end
         end
 
-        sig { returns(T.untyped) }
+        sig { returns(T.nilable(T.any(Integer, Float))) }
         def parse_number
           number_str = T.let("", String)
 
@@ -271,13 +271,13 @@ module Dependabot
           number_str.include?(".") ? number_str.to_f : number_str.to_i
         end
 
-        sig { returns(T.nilable(T::Array[T.untyped])) }
+        sig { returns(T.nilable(T::Array[Object])) }
         def parse_array
           return nil unless current_char == "["
 
           move_to_next_char
 
-          array_items = T.let([], T::Array[T.untyped])
+          array_items = T.let([], T::Array[Object])
 
           skip_whitespace_and_comments
 

--- a/bazel/lib/dependabot/bazel/metadata_finder.rb
+++ b/bazel/lib/dependabot/bazel/metadata_finder.rb
@@ -57,7 +57,7 @@ module Dependabot
         return nil unless version
 
         source_info = registry_client.get_source(dependency.name, version)
-        url = source_info&.dig("url")
+        url = T.cast(source_info&.dig("url"), T.nilable(String))
         return nil unless url
 
         source_from_url(url)

--- a/bazel/lib/dependabot/bazel/update_checker/registry_client.rb
+++ b/bazel/lib/dependabot/bazel/update_checker/registry_client.rb
@@ -49,7 +49,7 @@ module Dependabot
           versions.max_by { |v| version_sort_key(v) }
         end
 
-        sig { params(module_name: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+        sig { params(module_name: String).returns(T.nilable(T::Hash[String, Object])) }
         def get_metadata(module_name)
           versions = all_module_versions(module_name)
           return nil if versions.empty?
@@ -61,7 +61,7 @@ module Dependabot
           }
         end
 
-        sig { params(module_name: String, version: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+        sig { params(module_name: String, version: String).returns(T.nilable(T::Hash[String, Object])) }
         def get_source(module_name, version)
           file_path = "modules/#{module_name}/#{version}/source.json"
 

--- a/deno/lib/dependabot/deno/file_fetcher.rb
+++ b/deno/lib/dependabot/deno/file_fetcher.rb
@@ -31,7 +31,7 @@ module Dependabot
         fetched_files.uniq(&:name)
       end
 
-      sig { override.returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { override.returns(T.nilable(T::Hash[Symbol, T.anything])) }
       def ecosystem_versions
         nil
       end

--- a/deno/lib/dependabot/deno/file_parser.rb
+++ b/deno/lib/dependabot/deno/file_parser.rb
@@ -76,9 +76,9 @@ module Dependabot
         )
       end
 
-      sig { params(file: DependencyFile).returns(T::Hash[String, T.untyped]) }
+      sig { params(file: DependencyFile).returns(T::Hash[String, String]) }
       def imports_for(file)
-        Helpers.parse_json_or_jsonc(file.content).fetch("imports", {})
+        T.cast(Helpers.parse_json_or_jsonc(file.content).fetch("imports", {}), T::Hash[String, String])
       end
 
       sig { params(specifier: String, file: DependencyFile).returns(T.nilable(Dependabot::Dependency)) }

--- a/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
@@ -52,14 +52,15 @@ module Dependabot
           params(
             content: String,
             dep: Dependabot::Dependency,
-            prev_req: T::Hash[Symbol, T.untyped],
-            new_req: T::Hash[Symbol, T.untyped]
+            prev_req: T::Hash[Symbol, T.anything],
+            new_req: T::Hash[Symbol, T.anything]
           ).returns(String)
         end
         def apply_substitution(content, dep, prev_req, new_req)
-          source_type = prev_req[:source][:type]
-          prev_req_str = prev_req[:requirement]
-          new_req_str = new_req[:requirement]
+          source = T.cast(prev_req[:source], T::Hash[Symbol, T.anything])
+          source_type = T.cast(source[:type], String)
+          prev_req_str = T.cast(prev_req[:requirement], T.nilable(String))
+          new_req_str = T.cast(new_req[:requirement], T.nilable(String))
 
           base = "#{source_type}:#{dep.name}"
           old_specifier = prev_req_str ? "#{base}@#{prev_req_str}" : base

--- a/deno/lib/dependabot/deno/helpers.rb
+++ b/deno/lib/dependabot/deno/helpers.rb
@@ -26,7 +26,7 @@ module Dependabot
         Regexp
       )
 
-      sig { params(content: T.nilable(String)).returns(T::Hash[String, T.untyped]) }
+      sig { params(content: T.nilable(String)).returns(T::Hash[String, T.anything]) }
       def self.parse_json_or_jsonc(content)
         return {} unless content
 

--- a/devcontainers/lib/dependabot/devcontainers/file_fetcher.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_fetcher.rb
@@ -63,21 +63,21 @@ module Dependabot
         return [] unless devcontainer_directory
 
         custom_directories.flat_map do |directory|
-          fetch_config_and_lockfile_from(directory.path)
+          fetch_config_and_lockfile_from(T.must(directory.path))
         end
       end
 
-      sig { returns(T::Array[T.untyped]) }
+      sig { returns(T::Array[Dependabot::FileFetchers::RepositoryContent]) }
       def custom_directories
         repo_contents(dir: ".devcontainer").select { |f| f.type == "dir" && f.name != ".devcontainer" }
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(T.nilable(Dependabot::FileFetchers::RepositoryContent)) }
       def devcontainer_directory
         @devcontainer_directory ||=
           T.let(
             repo_contents.find { |f| f.type == "dir" && f.name == ".devcontainer" },
-            T.untyped
+            T.nilable(Dependabot::FileFetchers::RepositoryContent)
           )
       end
 

--- a/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb
@@ -46,7 +46,7 @@ module Dependabot
         end
 
         # https://github.com/devcontainers/cli/blob/9444540283b236298c28f397dea879e7ec222ca1/src/spec-node/devContainersSpecCLI.ts#L1072
-        sig { returns(T::Hash[String, T.untyped]) }
+        sig { returns(T::Hash[String, T.anything]) }
         def evaluate_with_cli
           raise "config_file_path must be a string" unless config_file_path.is_a?(String) && !config_file_path.empty?
 
@@ -61,13 +61,14 @@ module Dependabot
           JSON.parse(json)
         end
 
-        sig { params(json: T::Hash[String, T.untyped]).returns(T::Array[Dependabot::Dependency]) }
+        sig { params(json: T::Hash[String, T.anything]).returns(T::Array[Dependabot::Dependency]) }
         def parse_cli_json(json)
           dependencies = []
 
-          features = json["features"]
+          features = T.cast(json["features"], T::Hash[String, T.anything])
           features.each do |feature, versions_object|
             name, requirement = feature.split(":")
+            next if name.nil?
 
             # Skip sha pinned tags for now. Ideally the devcontainers CLI would give us updated SHA info
             next if name.end_with?("@sha256")
@@ -76,7 +77,7 @@ module Dependabot
             # and `devcontainer upgrade` work with them. See https://github.com/devcontainers/cli/issues/712
             next unless name.include?("/")
 
-            current = versions_object["current"]
+            current = T.cast(T.cast(versions_object, T::Hash[String, T.anything])["current"], T.nilable(String))
 
             dep = Dependency.new(
               name: name,

--- a/devcontainers/lib/dependabot/devcontainers/file_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater.rb
@@ -77,14 +77,14 @@ module Dependabot
       sig do
         params(
           manifest: Dependabot::DependencyFile,
-          requirement: T::Hash[Symbol, T.untyped]
+          requirement: T::Hash[Symbol, T.anything]
         )
           .returns(T::Array[String])
       end
       def update(manifest, requirement)
         ConfigUpdater.new(
           feature: dependency.name,
-          requirement: requirement[:requirement],
+          requirement: T.cast(requirement[:requirement], T.nilable(String)),
           version: T.must(dependency.version),
           manifest: manifest,
           repo_contents_path: T.must(repo_contents_path),

--- a/devcontainers/lib/dependabot/devcontainers/update_checker/latest_version_finder.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker/latest_version_finder.rb
@@ -31,7 +31,7 @@ module Dependabot
             ignored_versions: T::Array[String],
             security_advisories: T::Array[Dependabot::SecurityAdvisory],
             raise_on_ignored: T::Boolean,
-            options: T::Hash[Symbol, T.untyped],
+            options: T::Hash[Symbol, T.anything],
             cooldown_options: T.nilable(Dependabot::Package::ReleaseCooldownOptions)
           ).void
         end

--- a/elm/lib/dependabot/elm/file_parser.rb
+++ b/elm/lib/dependabot/elm/file_parser.rb
@@ -96,7 +96,7 @@ module Dependabot
 
       sig { params(field: String).returns(T.nilable(String)) }
       def extract_version_content(field)
-        parsed_version = parsed_elm_json.fetch(field, nil)
+        parsed_version = T.cast(parsed_elm_json.fetch(field, nil), T.nilable(String))
 
         return if parsed_version.nil? || parsed_version.empty?
 
@@ -112,7 +112,10 @@ module Dependabot
 
         DEPENDENCY_TYPES.each do |dep_type|
           if repo_type == "application"
-            dependencies_hash = parsed_elm_json.fetch(dep_type, {})
+            dependencies_hash = T.cast(
+              parsed_elm_json.fetch(dep_type, {}),
+              T::Hash[String, T::Hash[String, String]]
+            )
             dependencies_hash.fetch("direct", {}).each do |name, req|
               dependency_set << build_elm_json_dependency(
                 name: name, group: dep_type, requirement: req, direct: true
@@ -124,7 +127,7 @@ module Dependabot
               )
             end
           elsif repo_type == "package"
-            parsed_elm_json.fetch(dep_type, {}).each do |name, req|
+            T.cast(parsed_elm_json.fetch(dep_type, {}), T::Hash[String, String]).each do |name, req|
               dependency_set << build_elm_json_dependency(
                 name: name, group: dep_type, requirement: req, direct: true
               )
@@ -164,7 +167,7 @@ module Dependabot
 
       sig { returns(String) }
       def repo_type
-        parsed_elm_json.fetch("type")
+        T.cast(parsed_elm_json.fetch("type"), String)
       end
 
       sig { override.void }
@@ -183,9 +186,9 @@ module Dependabot
         req.requirements.first.last
       end
 
-      sig { returns(T::Hash[String, T.untyped]) }
+      sig { returns(T::Hash[String, T.anything]) }
       def parsed_elm_json
-        @parsed_elm_json ||= T.let(JSON.parse(T.must(elm_json&.content)), T.nilable(T::Hash[String, T.untyped]))
+        @parsed_elm_json ||= T.let(JSON.parse(T.must(elm_json&.content)), T.nilable(T::Hash[String, T.anything]))
       rescue JSON::ParserError
         raise Dependabot::DependencyFileNotParseable, elm_json&.path || MANIFEST_FILE
       end

--- a/elm/lib/dependabot/elm/update_checker/latest_version_finder.rb
+++ b/elm/lib/dependabot/elm/update_checker/latest_version_finder.rb
@@ -32,7 +32,7 @@ module Dependabot
             ignored_versions: T::Array[String],
             security_advisories: T::Array[Dependabot::SecurityAdvisory],
             raise_on_ignored: T::Boolean,
-            options: T::Hash[Symbol, T.untyped],
+            options: T::Hash[Symbol, T.anything],
             cooldown_options: T.nilable(Dependabot::Package::ReleaseCooldownOptions)
           ).void
         end

--- a/elm/lib/dependabot/elm/update_checker/requirements_updater.rb
+++ b/elm/lib/dependabot/elm/update_checker/requirements_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/elm/version"
@@ -40,7 +40,7 @@ module Dependabot
           requirements.map do |req|
             updated_req_string = update_requirement(
               req[:requirement],
-              latest_resolvable_version
+              T.must(latest_resolvable_version)
             )
 
             req.merge(requirement: updated_req_string)
@@ -55,12 +55,12 @@ module Dependabot
         sig { returns(T.nilable(Dependabot::Version)) }
         attr_reader :latest_resolvable_version
 
-        sig { params(old_req: T.nilable(String), new_version: T.untyped).returns(String) }
+        sig { params(old_req: T.nilable(String), new_version: Dependabot::Version).returns(T.nilable(String)) }
         def update_requirement(old_req, new_version)
           if requirement_class.new(old_req).satisfied_by?(new_version)
             old_req
           elsif (match = RANGE_REQUIREMENT_REGEX.match(old_req))
-            require_range(match[1], new_version)
+            require_range(T.must(match[1]), new_version)
           elsif SINGLE_VERSION_REGEX.match?(old_req)
             new_version.to_s
           else
@@ -68,13 +68,13 @@ module Dependabot
           end
         end
 
-        sig { params(minimum: T.untyped, version: T.untyped).returns(String) }
+        sig { params(minimum: String, version: Dependabot::Version).returns(String) }
         def require_range(minimum, version)
           major, _minor, _patch = version.to_s.split(".").map(&:to_i)
-          "#{minimum} <= v < #{major + 1}.0.0"
+          "#{minimum} <= v < #{T.must(major) + 1}.0.0"
         end
 
-        sig { params(version: Dependabot::Elm::Version).returns(String) }
+        sig { params(version: Dependabot::Version).returns(String) }
         def require_exactly(version)
           "#{version} <= v <= #{version}"
         end

--- a/helm/lib/dependabot/helm/file_parser.rb
+++ b/helm/lib/dependabot/helm/file_parser.rb
@@ -39,13 +39,13 @@ module Dependabot
 
       sig do
         params(
-          yaml: T::Hash[T.untyped, T.untyped],
+          yaml: T::Hash[String, Object],
           chart_file: Dependabot::DependencyFile,
           dependency_set: DependencySet
         ).void
       end
       def parse_dependencies(yaml, chart_file, dependency_set)
-        yaml["dependencies"].each do |dep|
+        T.cast(yaml["dependencies"], T::Array[Object]).each do |dep|
           next unless dep.is_a?(Hash) && dep["name"] && dep["version"]
 
           parsed_line = {
@@ -95,7 +95,7 @@ module Dependabot
           next unless yaml.is_a?(Hash)
 
           find_images_in_hash(yaml).each do |image_details|
-            parsed_line = extract_image_details(image_details[:image])
+            parsed_line = extract_image_details(T.must(image_details[:image]))
             next unless parsed_line
 
             version = version_from(parsed_line)
@@ -132,7 +132,7 @@ module Dependabot
         params(
           key: String,
           value: String,
-          hash: T::Hash[T.untyped, T.untyped],
+          hash: T::Hash[String, Object],
           current_path: T::Array[String]
         ).returns(T::Array[T::Hash[Symbol, String]])
       end
@@ -153,7 +153,7 @@ module Dependabot
       end
 
       sig do
-        params(value: T::Array[T.untyped], current_path: T::Array[String]).returns(T::Array[T::Hash[Symbol, String]])
+        params(value: T::Array[Object], current_path: T::Array[String]).returns(T::Array[T::Hash[Symbol, String]])
       end
       def handle_array_value(value, current_path)
         images = []
@@ -163,9 +163,10 @@ module Dependabot
         images
       end
 
-      sig { params(hash: T.untyped, path: T.untyped).returns(T::Array[T.untyped]) }
+      sig { params(hash: Object, path: T::Array[String]).returns(T::Array[T::Hash[Symbol, String]]) }
       def find_images_in_hash(hash, path = [])
-        images = []
+        images = T.let([], T::Array[T::Hash[Symbol, String]])
+        return images unless hash.is_a?(Hash)
 
         hash.each do |key, value|
           current_path = path + [key.to_s]

--- a/helm/lib/dependabot/helm/file_updater/chart_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/chart_updater.rb
@@ -43,13 +43,13 @@ module Dependabot
         sig do
           params(
             content: String,
-            yaml_obj: T::Hash[T.untyped, T.untyped],
+            yaml_obj: T::Hash[String, Object],
             file: Dependabot::DependencyFile
           ).returns(String)
         end
         def update_chart_dependencies(content, yaml_obj, file)
           if update_chart_dependency?(file) && yaml_obj["dependencies"]
-            yaml_obj["dependencies"].each do |dep|
+            T.cast(yaml_obj["dependencies"], T::Array[T::Hash[String, Object]]).each do |dep|
               next unless dep["name"] == dependency.name
 
               old_version = dep["version"].to_s

--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -77,11 +77,20 @@ module Dependabot
           valid_releases =  latest_version_resolver
                             .fetch_tag_and_release_date_helm_chart(valid_releases, repo_name, chart_name)
         end
-        highest_release = valid_releases.max_by { |release| version_class.new(release["version"]) }
+        highest_release = valid_releases.max_by { |release| version_class.new(T.cast(release["version"], String)) }
         Dependabot.logger.info(
           "Found latest version #{T.must(highest_release)['version']} for #{chart_name} using helm search"
         )
-        version_class.new(T.must(highest_release)["version"])
+        version_class.new(T.cast(T.must(highest_release)["version"], String))
+      end
+
+      sig do
+        params(index: T.nilable(T::Hash[String, Object]), chart_name: String)
+          .returns(T.nilable(T::Array[T::Hash[String, Object]]))
+      end
+      def chart_entries_from_index(index, chart_name)
+        entries = T.cast(index&.fetch("entries", nil), T.nilable(T::Hash[String, Object]))
+        T.cast(entries&.fetch(chart_name, nil), T.nilable(T::Array[T::Hash[String, Object]]))
       end
 
       sig { params(chart_name: String, repo_url: T.nilable(String)).returns(T.nilable(Gem::Version)) }
@@ -91,9 +100,10 @@ module Dependabot
 
         index_url = build_index_url(repo_url)
         index = fetch_helm_chart_index(index_url)
-        return nil unless index && index["entries"] && index["entries"][chart_name]
+        chart_entries = chart_entries_from_index(index, chart_name)
+        return nil unless chart_entries
 
-        all_versions = index["entries"][chart_name].map { |entry| entry["version"] }
+        all_versions = chart_entries.map { |entry| T.cast(entry["version"], String) }
         Dependabot.logger.info("Found #{all_versions.length} versions for #{chart_name} in index.yaml")
 
         valid_versions = filter_valid_versions(all_versions)
@@ -115,12 +125,13 @@ module Dependabot
         highest_version
       end
 
-      sig { params(releases: T::Array[T::Hash[String, T.untyped]]).returns(T::Array[T::Hash[String, T.untyped]]) }
+      sig { params(releases: T::Array[T::Hash[String, Object]]).returns(T::Array[T::Hash[String, Object]]) }
       def filter_valid_releases(releases)
         releases.reject do |release|
-          version_class.new(release["version"]) <= version_class.new(dependency.version) ||
+          release_version = version_class.new(T.cast(release["version"], String))
+          release_version <= version_class.new(dependency.version) ||
             ignore_requirements.any? do |r|
-              r.instance_of?(Dependabot::Requirement) && r.satisfied_by?(version_class.new(release["version"]))
+              r.instance_of?(Dependabot::Requirement) && r.satisfied_by?(release_version)
             end
         end
       end
@@ -170,7 +181,7 @@ module Dependabot
           chart_name: String,
           repo_name: T.nilable(String),
           repo_url: T.nilable(String)
-        ).returns(T.nilable(T::Array[T::Hash[String, T.untyped]]))
+        ).returns(T.nilable(T::Array[T::Hash[String, Object]]))
       end
       def fetch_chart_releases(chart_name, repo_name = nil, repo_url = nil)
         Dependabot.logger.info("Fetching releases for Helm chart: #{chart_name}")
@@ -267,7 +278,7 @@ module Dependabot
         name
       end
 
-      sig { params(index_url: String).returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+      sig { params(index_url: String).returns(T.nilable(T::Hash[String, Object])) }
       def fetch_helm_chart_index(index_url)
         Dependabot.logger.info("Fetching Helm chart index from #{index_url}")
 

--- a/helm/lib/dependabot/helm/update_checker/latest_version_resolver.rb
+++ b/helm/lib/dependabot/helm/update_checker/latest_version_resolver.rb
@@ -49,11 +49,11 @@ module Dependabot
 
       sig do
         params(
-          versions: T::Array[T::Hash[String, T.untyped]],
+          versions: T::Array[T::Hash[String, Object]],
           repo_name: T.nilable(String),
           chart_name: T.nilable(String)
         )
-          .returns(T::Array[T::Hash[String, T.untyped]])
+          .returns(T::Array[T::Hash[String, Object]])
       end
       def fetch_tag_and_release_date_helm_chart(versions, repo_name, chart_name)
         Dependabot.logger.info("Filtering versions in cooldown period from chart: #{repo_name}")


### PR DESCRIPTION
Types the bazel and helm ecosystems and drops all 7 files from the `Sorbet/ForbidTUntyped` burndown list.

Bazel's Starlark parser holds genuinely polymorphic values (strings, numbers, booleans, lists), so those are typed `Object` and narrowed with `is_a?`; the AST-walking helpers get precise return types and `starlark_parser.rb` moves to `# typed: strong`. Helm parses Chart.yaml and index.yaml the same way — `Object` values that support `is_a?`/`==`/interpolation without casts — with `T.cast` where a value feeds a typed parameter (a version string, a registry entry).

Fully validated on host: bazel specs pass, helm matches its pre-change baseline.

Stacked on #15527.
