### PR TITLE
Type the maven ecosystem and remove it from the T.untyped burndown

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1499
+# Offense count: 1421
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -343,22 +343,6 @@ Sorbet/ForbidTUntyped:
     - "julia/lib/dependabot/julia/registry_client.rb"
     - "julia/lib/dependabot/julia/update_checker.rb"
     - "julia/lib/dependabot/julia/update_checker/latest_version_finder.rb"
-    - "maven/lib/dependabot/maven/file_parser.rb"
-    - "maven/lib/dependabot/maven/file_parser/maven_dependency_parser.rb"
-    - "maven/lib/dependabot/maven/file_parser/property_value_finder.rb"
-    - "maven/lib/dependabot/maven/file_parser/repositories_finder.rb"
-    - "maven/lib/dependabot/maven/file_updater.rb"
-    - "maven/lib/dependabot/maven/file_updater/declaration_finder.rb"
-    - "maven/lib/dependabot/maven/package/package_details_fetcher.rb"
-    - "maven/lib/dependabot/maven/shared/base_version_finder.rb"
-    - "maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb"
-    - "maven/lib/dependabot/maven/shared/shared_property_value_updater.rb"
-    - "maven/lib/dependabot/maven/shared/shared_requirement.rb"
-    - "maven/lib/dependabot/maven/token_bucket.rb"
-    - "maven/lib/dependabot/maven/update_checker.rb"
-    - "maven/lib/dependabot/maven/update_checker/property_updater.rb"
-    - "maven/lib/dependabot/maven/update_checker/version_finder.rb"
-    - "maven/lib/dependabot/maven/utils/auth_headers_finder.rb"
     - "nix/lib/dependabot/nix/file_fetcher.rb"
     - "nix/lib/dependabot/nix/file_parser.rb"
     - "nix/lib/dependabot/nix/flake_nix_parser.rb"

--- a/gradle/lib/dependabot/gradle/file_parser/property_value_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/property_value_finder.rb
@@ -4,12 +4,15 @@
 require "sorbet-runtime"
 
 require "dependabot/gradle/file_parser"
+require "dependabot/maven/shared/property_value_finding"
 
 module Dependabot
   module Gradle
     class FileParser
       class PropertyValueFinder
         extend T::Sig
+
+        include Dependabot::Maven::Shared::PropertyValueFinding
 
         # rubocop:disable Layout/LineLength
         SUPPORTED_BUILD_FILE_NAMES = %w(build.gradle build.gradle.kts).freeze
@@ -76,7 +79,8 @@ module Dependabot
         end
 
         sig do
-          params(property_name: String, callsite_buildfile: Dependabot::DependencyFile)
+          override
+            .params(property_name: String, callsite_buildfile: Dependabot::DependencyFile)
             .returns(T.nilable(T::Hash[Symbol, String]))
         end
         def property_details(property_name:, callsite_buildfile:)

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -415,7 +415,7 @@ module Dependabot
           .property_details(property_name: property_name, callsite_pom: pom)
           &.fetch(:file)
 
-        return declaring_pom if declaring_pom
+        return declaring_pom if declaring_pom.is_a?(String)
 
         msg = "Property not found: #{property_name}"
         raise DependencyFileNotEvaluatable, msg
@@ -428,7 +428,7 @@ module Dependabot
           .property_details(property_name: property_name, callsite_pom: pom)
           &.fetch(:value)
 
-        return value if value
+        return value if value.is_a?(String)
 
         msg = "Property not found: #{property_name}"
         raise DependencyFileNotEvaluatable, msg
@@ -497,7 +497,8 @@ module Dependabot
       # so we know when certain requirement not a literal value and can differentiate transitive dependencies
       # from direct dependencies.
       sig do
-        params(requirements: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Array[T::Hash[Symbol, T.untyped]])
+        params(requirements: T::Array[Dependabot::DependencyRequirement])
+          .returns(T::Array[Dependabot::DependencyRequirement])
       end
       def merge_requirements(requirements)
         return requirements if requirements.length <= 1
@@ -528,7 +529,7 @@ module Dependabot
               metadata: merge_metadata(dep_scan_req[:metadata], parsing_req[:metadata])
             }
 
-            merged << merged_req
+            merged << Dependabot::DependencyRequirement.create(merged_req)
             used_indices.add(i)
             used_indices.add(match_index)
           else
@@ -544,9 +545,9 @@ module Dependabot
       # Merge metadata from two requirements, combining all keys
       sig do
         params(
-          metadata1: T::Hash[Symbol, T.untyped],
-          metadata2: T::Hash[Symbol, T.untyped]
-        ).returns(T::Hash[Symbol, T.untyped])
+          metadata1: T::Hash[Symbol, Object],
+          metadata2: T::Hash[Symbol, Object]
+        ).returns(T::Hash[Symbol, Object])
       end
       def merge_metadata(metadata1, metadata2)
         metadata1.merge(metadata2) do |_key, old_value, new_value|

--- a/maven/lib/dependabot/maven/file_parser/maven_dependency_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser/maven_dependency_parser.rb
@@ -67,17 +67,17 @@ module Dependabot
           params(
             pom: Dependabot::DependencyFile,
             dependency_set: Dependabot::FileParsers::Base::DependencySet,
-            dependency_tree: T::Hash[String, T.untyped]
+            dependency_tree: T::Hash[String, Object]
           ).void
         end
         def self.extract_dependencies_from_tree(pom, dependency_set, dependency_tree)
-          traverse_tree = T.let(-> {}, T.proc.params(node: T::Hash[String, T.untyped]).void)
+          traverse_tree = T.let(-> {}, T.proc.params(node: T::Hash[String, Object]).void)
           traverse_tree = lambda do |node|
             artifact_id = node["artifactId"]
             group_id = node["groupId"]
             version = node["version"]
             type = node["type"]
-            classifier = node["classifier"].to_s.empty? ? nil : node["classifier"]
+            classifier = node["classifier"].to_s.empty? ? nil : node["classifier"].to_s
             scope = node["scope"]
 
             groups = scope == "test" ? ["test"] : []
@@ -98,7 +98,8 @@ module Dependabot
               }]
             )
 
-            node["children"]&.each(&traverse_tree)
+            children = node["children"]
+            children.each { |child| traverse_tree.call(child) } if children.is_a?(Array)
           end
 
           traverse_tree.call(dependency_tree)

--- a/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/property_value_finder.rb
@@ -21,6 +21,9 @@ module Dependabot
 
         DOT_SEPARATOR_REGEX = %r{\.(?!\d+([.\/_\-]|$)+)}
         MAVEN_PROPERTY_REGEX = /\$\{.+?/
+        PropertyDetails = T.type_alias do
+          T::Hash[Symbol, T.any(String, Nokogiri::XML::Node)]
+        end
 
         sig do
           params(
@@ -44,7 +47,7 @@ module Dependabot
             property_name: String,
             callsite_pom: DependencyFile,
             seen_properties: T::Set[String]
-          ).returns(T.nilable(T::Hash[Symbol, T.untyped]))
+          ).returns(T.nilable(PropertyDetails))
         end
         def property_details(property_name:, callsite_pom:, seen_properties: Set.new)
           pom = callsite_pom
@@ -115,9 +118,9 @@ module Dependabot
             content: String,
             callsite_pom: DependencyFile,
             pom: DependencyFile,
-            node: T.untyped,
+            node: Nokogiri::XML::Node,
             seen_properties: T::Set[String]
-          ).returns(T.nilable(T::Hash[Symbol, T.untyped]))
+          ).returns(T.nilable(PropertyDetails))
         end
         def resolve_property_placeholder(content, callsite_pom, pom, node, seen_properties)
           resolved_value = content.gsub(/\$\{(.+?)}/) do

--- a/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
+++ b/maven/lib/dependabot/maven/file_parser/repositories_finder.rb
@@ -24,6 +24,7 @@ module Dependabot
 
         REPOSITORY_SELECTOR = "repositories > repository, " \
                               "pluginRepositories > pluginRepository"
+        RepositoryEntry = T.type_alias { T::Hash[Symbol, T.nilable(T.any(String, T::Boolean))] }
 
         sig do
           params(
@@ -44,7 +45,7 @@ module Dependabot
           @evaluate_properties = evaluate_properties
           # Aggregates URLs seen in POMs to avoid short term memory loss.
           # For instance a repository in a child POM might apply to the parent too.
-          @known_urls = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
+          @known_urls = T.let([], T::Array[RepositoryEntry])
           @property_value_finder = T.let(nil, T.nilable(PropertyValueFinder))
         end
 
@@ -75,7 +76,7 @@ module Dependabot
           @known_urls = @known_urls.uniq
 
           urls = urls_from_credentials + @known_urls.reject { |entry| exclude_snapshots && entry[:snapshots] }
-                                                    .map { |entry| entry[:url] }
+                                                    .map { |entry| T.must(entry[:url]).to_s }
           urls += [central_repo_url] unless @known_urls.any? { |entry| entry[:id] == super_pom[:id] }
           urls.uniq
         end
@@ -102,26 +103,26 @@ module Dependabot
           }
         end
 
-        sig { params(entry: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        sig { params(entry: RepositoryEntry).returns(T::Boolean) }
         def disabled_repo?(entry)
           entry[:releases] == "false" && entry[:snapshots] == "false"
         end
 
-        sig { params(entry: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        sig { params(entry: RepositoryEntry).returns(T::Boolean) }
         def snapshot_repo(entry)
           entry[:releases] == "false" && (entry[:snapshots].nil? || entry[:snapshots] == "true")
         end
 
         sig do
           params(
-            entry: T::Hash[Symbol, T.untyped],
+            entry: RepositoryEntry,
             pom: Dependabot::DependencyFile
           )
-            .returns(T::Hash[Symbol, T.untyped])
+            .returns(RepositoryEntry)
         end
         def serialize_urls(entry, pom)
           {
-            url: evaluated_value(entry[:url], pom).gsub(%r{/$}, ""),
+            url: evaluated_value(T.must(entry[:url]).to_s, pom).gsub(%r{/$}, ""),
             id: entry[:id],
             snapshots: snapshot_repo(entry)
           }
@@ -132,7 +133,7 @@ module Dependabot
             pom: Dependabot::DependencyFile,
             exclude_inherited: T::Boolean
           )
-            .returns(T::Array[T::Hash[Symbol, T.untyped]])
+            .returns(T::Array[RepositoryEntry])
         end
         def gather_repository_urls(pom:, exclude_inherited: false)
           repos = repositories_from_pom(pom)
@@ -148,7 +149,7 @@ module Dependabot
           params(
             pom: Dependabot::DependencyFile
           ).returns(
-            T::Array[T::Hash[Symbol, T.untyped]]
+            T::Array[RepositoryEntry]
           )
         end
         def repositories_from_pom(pom)
@@ -163,7 +164,7 @@ module Dependabot
           params(
             node: Nokogiri::XML::Node,
             pom: Dependabot::DependencyFile
-          ).returns(T.nilable(T::Hash[Symbol, T.untyped]))
+          ).returns(T.nilable(RepositoryEntry))
         end
         def build_repo_entry(node, pom)
           url = node.at_css("url")&.text&.strip.to_s
@@ -183,19 +184,20 @@ module Dependabot
           contains_property?(T.must(entry.fetch(:url))) && !evaluate_properties?
         end
 
-        sig { params(entry: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        sig { params(entry: RepositoryEntry).returns(T::Boolean) }
         def http_url?(entry)
-          entry.fetch(:url)&.start_with?("http")
+          url = entry.fetch(:url)
+          url.is_a?(String) && url.start_with?("http")
         end
 
         sig do
           params(
             pom: Dependabot::DependencyFile,
-            repos: T::Array[T::Hash[Symbol, T.untyped]]
+            repos: T::Array[RepositoryEntry]
           ).returns(T.nilable(Dependabot::DependencyFile))
         end
         def parent_with_repositories(pom, repos)
-          urls = repos.map { |r| r[:url] }
+          urls = repos.map { |r| T.must(r[:url]).to_s }
           parent_pom(pom, urls)
         end
 
@@ -240,10 +242,10 @@ module Dependabot
         # rubocop:disable Metrics/PerceivedComplexity
         sig do
           params(
-            pom: T.untyped,
+            pom: Dependabot::DependencyFile,
             repo_urls: T::Array[String]
           )
-            .returns(T.untyped)
+            .returns(T.nilable(Dependabot::DependencyFile))
         end
         def parent_pom(pom, repo_urls)
           doc = Nokogiri::XML(pom.content)
@@ -280,13 +282,13 @@ module Dependabot
           value.match?(property_regex)
         end
 
-        sig { params(value: String, pom: Dependabot::DependencyFile).returns(T.untyped) }
+        sig { params(value: String, pom: Dependabot::DependencyFile).returns(String) }
         def evaluated_value(value, pom)
           return value unless contains_property?(value)
 
           match_data = value.match(property_regex)
-          property_name = T.must(match_data).named_captures.fetch("property")
-          property_value = value_for_property(T.cast(property_name, String), pom)
+          property_name = T.must(T.must(match_data).named_captures.fetch("property"))
+          property_value = value_for_property(property_name, pom)
 
           value.gsub(property_regex, property_value)
         end
@@ -300,7 +302,7 @@ module Dependabot
               callsite_pom: pom
             )&.fetch(:value)
 
-          return value if value
+          return value if value.is_a?(String)
 
           msg = "Property not found: #{property_name}"
           raise DependencyFileNotEvaluatable, msg

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -15,6 +15,10 @@ module Dependabot
       require_relative "file_updater/declaration_finder"
       require_relative "file_updater/property_value_updater"
 
+      IndentConfig = T.type_alias do
+        { base: String, is_tabs: T::Boolean, levels: T::Hash[Symbol, String] }
+      end
+
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
       def updated_dependency_files
         updated_files = T.let(dependency_files.dup, T::Array[Dependabot::DependencyFile])
@@ -86,7 +90,7 @@ module Dependabot
       sig do
         params(
           pomfiles: T::Array[Dependabot::DependencyFile],
-          req: T::Hash[Symbol, T.untyped]
+          req: Dependabot::DependencyRequirement
         )
           .returns(T::Array[Dependabot::DependencyFile])
       end
@@ -105,8 +109,8 @@ module Dependabot
         params(
           dependency: Dependabot::Dependency,
           file: Dependabot::DependencyFile,
-          previous_req: T::Hash[Symbol, T.untyped],
-          requirement: T::Hash[Symbol, T.untyped]
+          previous_req: Dependabot::DependencyRequirement,
+          requirement: Dependabot::DependencyRequirement
         )
           .returns(Dependabot::DependencyFile)
       end
@@ -137,7 +141,7 @@ module Dependabot
         params(
           content: String,
           dependency: Dependabot::Dependency,
-          requirement: T::Hash[Symbol, T.untyped]
+          requirement: Dependabot::DependencyRequirement
         ).returns(String)
       end
       def add_new_declaration(content, dependency, requirement) # rubocop:disable Metrics/AbcSize
@@ -190,7 +194,7 @@ module Dependabot
         params(
           dep: Dependabot::Dependency,
           pom: Dependabot::DependencyFile,
-          req: T::Hash[Symbol, T.untyped]
+          req: Dependabot::DependencyRequirement
         )
           .returns(Dependabot::DependencyFile)
       end
@@ -216,7 +220,7 @@ module Dependabot
       sig do
         params(
           dependency: Dependabot::Dependency,
-          requirement: T::Hash[Symbol, T.untyped]
+          requirement: Dependabot::DependencyRequirement
         )
           .returns(T::Array[String])
       end
@@ -227,7 +231,7 @@ module Dependabot
       sig do
         params(
           dependency: Dependabot::Dependency,
-          requirement: T::Hash[Symbol, T.untyped]
+          requirement: Dependabot::DependencyRequirement
         )
           .returns(DeclarationFinder)
       end
@@ -244,8 +248,8 @@ module Dependabot
       sig do
         params(
           old_declaration: String,
-          previous_req: T::Hash[Symbol, T.untyped],
-          requirement: T::Hash[Symbol, T.untyped]
+          previous_req: Dependabot::DependencyRequirement,
+          requirement: Dependabot::DependencyRequirement
         )
           .returns(String)
       end
@@ -269,7 +273,7 @@ module Dependabot
       sig do
         params(
           project: REXML::Element,
-          indent_config: T::Hash[Symbol, T.untyped]
+          indent_config: IndentConfig
         ).returns([REXML::Element, T::Boolean])
       end
       def ensure_dependency_management_element(project, indent_config)
@@ -288,7 +292,7 @@ module Dependabot
       sig do
         params(
           dependency_management: REXML::Element,
-          indent_config: T::Hash[Symbol, T.untyped]
+          indent_config: IndentConfig
         ).returns([REXML::Element, T::Boolean])
       end
       def ensure_dependencies_element(dependency_management, indent_config)
@@ -307,7 +311,7 @@ module Dependabot
       sig do
         params(
           dependency: Dependabot::Dependency,
-          requirement: T::Hash[Symbol, T.untyped],
+          requirement: Dependabot::DependencyRequirement,
           dependencies_node: REXML::Element,
           current_indentation_level: String,
           parent_indentation_level: String
@@ -343,7 +347,7 @@ module Dependabot
         end
       end
 
-      sig { params(project: REXML::Element).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(project: REXML::Element).returns(IndentConfig) }
       def detect_indentation_config(project)
         sample_indent = project.children.find do |child|
           child.to_s.match?(/\n(\t+| +)$/)

--- a/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
+++ b/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
@@ -20,11 +20,12 @@ module Dependabot
               <path>.*?</path>|
               <artifactItem>.*?</artifactItem>
             }mx
+        Requirement = T.type_alias { T.any(Dependabot::DependencyRequirement, T::Hash[Symbol, Object]) }
 
         sig { returns(Dependabot::Dependency) }
         attr_reader :dependency
 
-        sig { returns(T::Hash[Symbol, T.untyped]) }
+        sig { returns(Requirement) }
         attr_reader :declaring_requirement
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
@@ -34,7 +35,7 @@ module Dependabot
           params(
             dependency: Dependabot::Dependency,
             dependency_files: T::Array[Dependabot::DependencyFile],
-            declaring_requirement: T::Hash[Symbol, T.untyped]
+            declaring_requirement: Requirement
           ).void
         end
         def initialize(dependency:, dependency_files:, declaring_requirement:)
@@ -191,7 +192,7 @@ module Dependabot
               callsite_pom: declaring_pom
             )&.fetch(:value)
 
-          return value unless property_value
+          return value unless property_value.is_a?(String)
 
           value.gsub(
             match_data.to_s,

--- a/maven/lib/dependabot/maven/file_updater/property_value_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater/property_value_updater.rb
@@ -35,6 +35,7 @@ module Dependabot
           )
           node = declaration_details&.fetch(:node)
           filename = declaration_details&.fetch(:file)
+          raise "Property node not found" unless node.is_a?(Nokogiri::XML::Node)
 
           pom_to_update = dependency_files.find { |f| f.name == filename }
           property_re = %r{<#{Regexp.quote(node.name)}>

--- a/maven/lib/dependabot/maven/package/package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/package/package_details_fetcher.rb
@@ -31,9 +31,9 @@ module Dependabot
           @dependency_files = T.let(dependency_files, T::Array[Dependabot::DependencyFile])
           @credentials = T.let(credentials, T::Array[Dependabot::Credential])
 
-          @pom_repository_details = T.let(nil, T.nilable(T::Array[T::Hash[String, T.untyped]]))
+          @pom_repository_details = T.let(nil, T.nilable(T::Array[RepositoryDetails]))
           @repository_finder = T.let(nil, T.nilable(Maven::FileParser::RepositoriesFinder))
-          @repositories_cache = T.let(nil, T.nilable(T::Array[T::Hash[String, T.untyped]]))
+          @repositories_cache = T.let(nil, T.nilable(T::Array[RepositoryDetails]))
           @package_details = T.let(nil, T.nilable(Dependabot::Package::PackageDetails))
         end
 
@@ -66,13 +66,13 @@ module Dependabot
           @package_details
         end
 
-        sig { returns(T::Array[T.untyped]) }
+        sig { returns(T::Array[Dependabot::Package::PackageRelease]) }
         def releases
           fetch.releases
         end
 
         # Assembles the list of Maven repositories to search: credential repos + POM repos.
-        sig { override.returns(T::Array[T::Hash[String, T.untyped]]) }
+        sig { override.returns(T::Array[RepositoryDetails]) }
         def repositories
           return @repositories_cache if @repositories_cache
 
@@ -107,7 +107,7 @@ module Dependabot
         end
 
         # Returns the repository details for the POM file.
-        sig { returns(T::Array[T::Hash[String, T.untyped]]) }
+        sig { returns(T::Array[RepositoryDetails]) }
         def pom_repository_details
           return @pom_repository_details if @pom_repository_details
 

--- a/maven/lib/dependabot/maven/shared/base_version_finder.rb
+++ b/maven/lib/dependabot/maven/shared/base_version_finder.rb
@@ -21,13 +21,20 @@ module Dependabot
           (package_details&.releases || []).reverse
         end
 
-        sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+        VersionDetails = T.type_alias do
+          {
+            version: Dependabot::Version,
+            source_url: T.nilable(String)
+          }
+        end
+
+        sig { returns(T.nilable(VersionDetails)) }
         def latest_version_details
           release = fetch_latest_release
           release&.version ? { version: release.version, source_url: release.url } : nil
         end
 
-        sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+        sig { returns(T.nilable(VersionDetails)) }
         def lowest_security_fix_version_details
           release = fetch_lowest_security_fix_release
           release&.version ? { version: release.version, source_url: release.url } : nil

--- a/maven/lib/dependabot/maven/shared/property_value_finding.rb
+++ b/maven/lib/dependabot/maven/shared/property_value_finding.rb
@@ -1,0 +1,29 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/dependency_file"
+
+module Dependabot
+  module Maven
+    module Shared
+      # Interface implemented by the ecosystem-specific PropertyValueFinder
+      # classes (Gradle, SBT) that SharedPropertyValueUpdater delegates to.
+      # Living in the shared namespace keeps the abstract return type load-safe:
+      # each ecosystem gem loads Maven's shared code without loading its sibling.
+      module PropertyValueFinding
+        extend T::Sig
+        extend T::Helpers
+
+        interface!
+
+        sig do
+          abstract
+            .params(property_name: String, callsite_buildfile: Dependabot::DependencyFile)
+            .returns(T.nilable(T::Hash[Symbol, String]))
+        end
+        def property_details(property_name:, callsite_buildfile:); end
+      end
+    end
+  end
+end

--- a/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
@@ -22,6 +22,15 @@ module Dependabot
         URL_KEY = T.let("url", String)
         AUTH_HEADERS_KEY = T.let("auth_headers", String)
         DEFAULT_CENTRAL_REPO_URL = T.let("https://repo.maven.apache.org/maven2", String)
+        RepositoryDetails = T.type_alias { T::Hash[String, T.any(String, T::Hash[String, String])] }
+        VersionDetails = T.type_alias do
+          {
+            version: Dependabot::Version,
+            source_url: String,
+            release_date: T.nilable(Time)
+          }
+        end
+        HtmlVersionDetails = T.type_alias { { release_date: T.nilable(Time) } }
 
         sig { abstract.returns(Dependabot::Dependency) }
         def dependency; end
@@ -31,7 +40,7 @@ module Dependabot
 
         # Subclasses must define how repositories are assembled.
         # Typically: credentials_repository_details + ecosystem-specific repos.
-        sig { abstract.returns(T::Array[T::Hash[String, T.untyped]]) }
+        sig { abstract.returns(T::Array[RepositoryDetails]) }
         def repositories; end
 
         # -- URL Construction --
@@ -93,10 +102,10 @@ module Dependabot
         # -- Metadata Fetching (XML) --
 
         # Fetches and parses maven-metadata.xml from a repository.
-        sig { params(repository_details: T::Hash[String, T.untyped]).returns(T.nilable(Nokogiri::XML::Document)) }
+        sig { params(repository_details: RepositoryDetails).returns(T.nilable(Nokogiri::XML::Document)) }
         def fetch_dependency_metadata(repository_details)
-          url = repository_details.fetch(URL_KEY)
-          headers = repository_details.fetch(AUTH_HEADERS_KEY)
+          url = repository_url(repository_details)
+          headers = repository_auth_headers(repository_details)
           response = Dependabot::RegistryClient.get(
             url: dependency_metadata_url(url),
             headers: headers
@@ -109,7 +118,7 @@ module Dependabot
           nil
         rescue Excon::Error::Socket, Excon::Error::Timeout,
                Excon::Error::TooManyRedirects => e
-          handle_registry_error(url, e, response)
+          handle_registry_error(T.must(url), e, response)
           nil
         end
 
@@ -118,24 +127,24 @@ module Dependabot
           params(
             xml: Nokogiri::XML::Document,
             url: String
-          ).returns(T::Array[T::Hash[Symbol, T.untyped]])
+          ).returns(T::Array[VersionDetails])
         end
         def extract_metadata_from_xml(xml, url)
           xml.css("versions > version")
              .select { |node| version_class.correct?(node.content) }
              .map { |node| version_class.new(node.content) }
-             .map { |version| { version: version, source_url: url } }
+             .map { |version| { version: version, source_url: url, release_date: nil } }
         end
 
         # -- Metadata Fetching (HTML directory listing) --
 
         # Fetches an HTML directory listing page from a repository.
         sig do
-          params(repository_details: T::Hash[String, T.untyped]).returns(T.nilable(Nokogiri::HTML::Document))
+          params(repository_details: RepositoryDetails).returns(T.nilable(Nokogiri::HTML::Document))
         end
         def fetch_dependency_metadata_from_html(repository_details)
-          url = repository_details.fetch(URL_KEY)
-          headers = repository_details.fetch(AUTH_HEADERS_KEY)
+          url = repository_url(repository_details)
+          headers = repository_auth_headers(repository_details)
           # Add trailing slash for directory listing
           base_directory_url = dependency_base_url(url)
           base_directory_url += "/" unless base_directory_url.end_with?("/")
@@ -151,17 +160,17 @@ module Dependabot
           nil
         rescue Excon::Error::Socket, Excon::Error::Timeout,
                Excon::Error::TooManyRedirects => e
-          handle_registry_error(url, e, response)
+          handle_registry_error(T.must(url), e, response)
           nil
         end
 
         # Parses release dates from an HTML directory listing page.
         sig do
           params(html_doc: Nokogiri::HTML::Document)
-            .returns(T::Hash[String, T::Hash[Symbol, T.untyped]])
+            .returns(T::Hash[String, HtmlVersionDetails])
         end
         def extract_version_details_from_html(html_doc)
-          versions_detail_hash = T.let({}, T::Hash[String, T::Hash[Symbol, T.untyped]])
+          versions_detail_hash = T.let({}, T::Hash[String, HtmlVersionDetails])
 
           html_doc.css("a[href]").each do |link|
             version = extract_version_from_link(link)
@@ -239,9 +248,9 @@ module Dependabot
         # Aggregates version details from XML metadata and enriches with
         # release dates from HTML directory listings. Returns a sorted array
         # of version detail hashes.
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[VersionDetails]) }
         def versions
-          @version_details = T.let(@version_details, T.nilable(T::Array[T::Hash[Symbol, T.untyped]]))
+          @version_details = T.let(@version_details, T.nilable(T::Array[VersionDetails]))
           return @version_details if @version_details
 
           @version_details = versions_details_from_xml
@@ -276,11 +285,11 @@ module Dependabot
         end
 
         # Fetches version details from maven-metadata.xml across all repositories.
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Array[VersionDetails]) }
         def versions_details_from_xml
           forbidden_urls.clear
           version_details = repositories.flat_map do |repository_details|
-            url = repository_details.fetch(URL_KEY)
+            url = repository_url(repository_details)
             xml = dependency_metadata(repository_details)
             next [] if xml.nil?
 
@@ -293,12 +302,12 @@ module Dependabot
         end
 
         # Fetches version details (release dates) from HTML directory listings.
-        sig { returns(T::Hash[String, T::Hash[Symbol, T.untyped]]) }
+        sig { returns(T::Hash[String, HtmlVersionDetails]) }
         def versions_details_hash_from_html
           forbidden_urls.clear
 
           versions_detail_hash = T.let(
-            {}, T::Hash[String, T::Hash[Symbol, T.untyped]]
+            {}, T::Hash[String, HtmlVersionDetails]
           )
           repositories.each do |repository_details|
             html = dependency_metadata_from_html(repository_details)
@@ -328,8 +337,8 @@ module Dependabot
 
           @released_check[version] =
             repositories.any? do |repository_details|
-              url = repository_details.fetch(URL_KEY)
-              headers = repository_details.fetch(AUTH_HEADERS_KEY)
+              url = repository_url(repository_details)
+              headers = repository_auth_headers(repository_details)
               response = Dependabot::RegistryClient.head(
                 url: dependency_files_url(url, version),
                 headers: headers
@@ -359,7 +368,7 @@ module Dependabot
         # -- Credential & Repository Helpers --
 
         # Builds repository details from credentials of type "maven_repository".
-        sig { returns(T::Array[T::Hash[String, T.untyped]]) }
+        sig { returns(T::Array[RepositoryDetails]) }
         def credentials_repository_details
           credentials
             .select { |cred| cred["type"] == REPOSITORY_TYPE && cred[URL_KEY] }
@@ -398,6 +407,22 @@ module Dependabot
           auth_headers_finder.auth_headers(maven_repo_url)
         end
 
+        sig { params(repository_details: RepositoryDetails).returns(String) }
+        def repository_url(repository_details)
+          url = repository_details.fetch(URL_KEY)
+          return url if url.is_a?(String)
+
+          raise "Repository URL must be a string"
+        end
+
+        sig { params(repository_details: RepositoryDetails).returns(T::Hash[String, String]) }
+        def repository_auth_headers(repository_details)
+          headers = repository_details.fetch(AUTH_HEADERS_KEY)
+          return headers if headers.is_a?(Hash)
+
+          raise "Repository auth headers must be a hash"
+        end
+
         sig { returns(Utils::AuthHeadersFinder) }
         def auth_headers_finder
           @auth_headers_finder ||= T.let(Utils::AuthHeadersFinder.new(credentials), T.nilable(Utils::AuthHeadersFinder))
@@ -406,10 +431,10 @@ module Dependabot
         # -- Metadata Caching --
 
         # Fetches and caches XML metadata per repository.
-        sig { params(repository_details: T::Hash[String, T.untyped]).returns(T.nilable(Nokogiri::XML::Document)) }
+        sig { params(repository_details: RepositoryDetails).returns(T.nilable(Nokogiri::XML::Document)) }
         def dependency_metadata(repository_details)
           @dependency_metadata = T.let(
-            @dependency_metadata, T.nilable(T::Hash[T.untyped, Nokogiri::XML::Document])
+            @dependency_metadata, T.nilable(T::Hash[Integer, Nokogiri::XML::Document])
           )
           @dependency_metadata ||= {}
           repository_key = repository_details.hash
@@ -421,10 +446,10 @@ module Dependabot
         end
 
         # Fetches and caches HTML metadata per repository.
-        sig { params(repository_details: T::Hash[String, T.untyped]).returns(T.nilable(Nokogiri::HTML::Document)) }
+        sig { params(repository_details: RepositoryDetails).returns(T.nilable(Nokogiri::HTML::Document)) }
         def dependency_metadata_from_html(repository_details)
           @dependency_metadata_from_html = T.let(
-            @dependency_metadata_from_html, T.nilable(T::Hash[T.untyped, Nokogiri::HTML::Document])
+            @dependency_metadata_from_html, T.nilable(T::Hash[Integer, Nokogiri::HTML::Document])
           )
           @dependency_metadata_from_html ||= {}
           repository_key = repository_details.hash

--- a/maven/lib/dependabot/maven/shared/shared_property_value_updater.rb
+++ b/maven/lib/dependabot/maven/shared/shared_property_value_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -67,7 +67,14 @@ module Dependabot
         sig { returns(T::Array[DependencyFile]) }
         attr_reader :dependency_files
 
-        sig { abstract.returns(T.untyped) }
+        sig do
+          abstract.returns(
+            T.any(
+              Dependabot::Gradle::FileParser::PropertyValueFinder,
+              Dependabot::Sbt::FileParser::PropertyValueFinder
+            )
+          )
+        end
         def property_value_finder; end
 
         sig { params(previous_value: String).returns(Regexp) }

--- a/maven/lib/dependabot/maven/shared/shared_property_value_updater.rb
+++ b/maven/lib/dependabot/maven/shared/shared_property_value_updater.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 require "dependabot/dependency_file"
+require "dependabot/maven/shared/property_value_finding"
 
 module Dependabot
   module Maven
@@ -67,14 +68,7 @@ module Dependabot
         sig { returns(T::Array[DependencyFile]) }
         attr_reader :dependency_files
 
-        sig do
-          abstract.returns(
-            T.any(
-              Dependabot::Gradle::FileParser::PropertyValueFinder,
-              Dependabot::Sbt::FileParser::PropertyValueFinder
-            )
-          )
-        end
+        sig { abstract.returns(Dependabot::Maven::Shared::PropertyValueFinding) }
         def property_value_finder; end
 
         sig { params(previous_value: String).returns(Regexp) }

--- a/maven/lib/dependabot/maven/shared/shared_requirement.rb
+++ b/maven/lib/dependabot/maven/shared/shared_requirement.rb
@@ -22,7 +22,7 @@ module Dependabot
         sig { abstract.returns(Regexp) }
         def self.ruby_style_pattern; end
 
-        sig { params(requirements: T.untyped).void }
+        sig { params(requirements: T.nilable(String)).void }
         def initialize(*requirements)
           requirements = requirements.flatten.flat_map do |req_string|
             convert_java_constraint_to_ruby_constraint(req_string)

--- a/maven/lib/dependabot/maven/token_bucket.rb
+++ b/maven/lib/dependabot/maven/token_bucket.rb
@@ -13,14 +13,15 @@ module Dependabot
       extend T::Helpers
       include Comparable
 
-      prop :tokens, T::Array[T.untyped]
+      prop :tokens, T::Array[Object]
       prop :addition, T.nilable(TokenBucket)
 
-      sig { returns(T::Array[T.untyped]) }
+      sig { returns(T::Array[Object]) }
       def to_a
         return tokens if addition.nil?
 
-        tokens.clone.append(addition.to_a)
+        result = T.let(tokens.clone, T::Array[Object])
+        result.append(addition.to_a)
       end
 
       sig { params(other: TokenBucket).returns(T.nilable(Integer)) }
@@ -33,8 +34,8 @@ module Dependabot
 
       sig do
         params(
-          first: T::Array[T.any(String, Integer)],
-          second: T::Array[T.any(String, Integer)]
+          first: T::Array[Object],
+          second: T::Array[Object]
         ).returns(T.nilable(Integer))
       end
       def compare_tokens(first, second)
@@ -48,8 +49,8 @@ module Dependabot
 
       sig do
         params(
-          first: T.nilable(T.any(String, Integer)),
-          second: T.nilable(T.any(String, Integer))
+          first: T.nilable(Object),
+          second: T.nilable(Object)
         ).returns(T.nilable(Integer))
       end
       def compare_token_pair(first = 0, second = 0) # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity

--- a/maven/lib/dependabot/maven/update_checker.rb
+++ b/maven/lib/dependabot/maven/update_checker.rb
@@ -12,6 +12,13 @@ module Dependabot
       require_relative "update_checker/version_finder"
       require_relative "update_checker/property_updater"
 
+      VersionDetails = T.type_alias do
+        {
+          version: T.nilable(Dependabot::Version),
+          source_url: T.nilable(String)
+        }
+      end
+
       sig do
         params(
           dependency: Dependabot::Dependency,
@@ -24,7 +31,7 @@ module Dependabot
           requirements_update_strategy: T.nilable(Dependabot::RequirementsUpdateStrategy),
           dependency_group: T.nilable(Dependabot::DependencyGroup),
           update_cooldown: T.nilable(Dependabot::Package::ReleaseCooldownOptions),
-          options: T::Hash[Symbol, T.untyped]
+          options: T::Hash[Symbol, T.anything]
         )
           .void
       end
@@ -46,13 +53,16 @@ module Dependabot
         @version_finder = T.let(nil, T.nilable(VersionFinder))
         @property_updater = T.let(nil, T.nilable(PropertyUpdater))
         @property_value_finder = T.let(nil, T.nilable(Maven::FileParser::PropertyValueFinder))
-        @declarations_using_a_property = T.let(nil, T.nilable(T::Array[T::Hash[Symbol, T.untyped]]))
+        @declarations_using_a_property = T.let(nil, T.nilable(T::Array[Dependabot::DependencyRequirement]))
         @all_property_based_dependencies = T.let(nil, T.nilable(T::Array[Dependabot::Dependency]))
       end
 
       sig { override.returns(T.nilable(Dependabot::Version)) }
       def latest_version
-        latest_version_details&.fetch(:version)
+        version = latest_version_details&.fetch(:version)
+        return version if version.is_a?(Dependabot::Version)
+
+        nil
       end
 
       sig { override.returns(T.nilable(Dependabot::Version)) }
@@ -70,7 +80,10 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Version)) }
       def lowest_security_fix_version
-        lowest_security_fix_version_details&.fetch(:version)
+        version = lowest_security_fix_version_details&.fetch(:version)
+        return version if version.is_a?(Dependabot::Version)
+
+        nil
       end
 
       sig { override.returns(T.nilable(Dependabot::Version)) }
@@ -150,19 +163,19 @@ module Dependabot
         super
       end
 
-      sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+      sig { returns(T.nilable(VersionDetails)) }
       def preferred_version_details
         return lowest_security_fix_version_details if vulnerable?
 
         latest_version_details
       end
 
-      sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+      sig { returns(T.nilable(VersionDetails)) }
       def latest_version_details
         version_finder.latest_version_details
       end
 
-      sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+      sig { returns(T.nilable(VersionDetails)) }
       def lowest_security_fix_version_details
         version_finder.lowest_security_fix_version_details
       end
@@ -220,7 +233,7 @@ module Dependabot
         end
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def declarations_using_a_property
         @declarations_using_a_property ||=
           dependency.requirements

--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -22,7 +22,7 @@ module Dependabot
             dependency_files: T::Array[Dependabot::DependencyFile],
             credentials: T::Array[Dependabot::Credential],
             ignored_versions: T::Array[String],
-            target_version_details: T.nilable(T::Hash[T.untyped, T.untyped]),
+            target_version_details: T.nilable(UpdateChecker::VersionDetails),
             update_cooldown: T.nilable(Dependabot::Package::ReleaseCooldownOptions)
           ).void
         end
@@ -38,8 +38,10 @@ module Dependabot
           @dependency_files = dependency_files
           @credentials      = credentials
           @ignored_versions = ignored_versions
-          @target_version   = T.let(target_version_details&.fetch(:version), T.nilable(Dependabot::Maven::Version))
-          @source_url       = T.let(target_version_details&.fetch(:source_url), T.nilable(String))
+          target_version = target_version_details&.fetch(:version)
+          target_version = nil unless target_version.is_a?(Dependabot::Maven::Version)
+          @target_version = T.let(target_version, T.nilable(Dependabot::Maven::Version))
+          @source_url = T.let(target_version_details&.fetch(:source_url), T.nilable(String))
           @update_cooldown = update_cooldown
           @property_value_finder = T.let(nil, T.nilable(Dependabot::Maven::FileParser::PropertyValueFinder))
         end
@@ -206,7 +208,7 @@ module Dependabot
           raise DependencyFileNotEvaluatable, "Property not found: #{property_name}"
         end
 
-        sig { params(dep: Dependabot::Dependency).returns(T::Hash[Symbol, T.untyped]) }
+        sig { params(dep: Dependabot::Dependency).returns(Dependabot::DependencyRequirement) }
         def declaring_property_requirement(dep)
           declaring_requirement =
             dep.requirements.find do |r|
@@ -221,9 +223,9 @@ module Dependabot
                 "Requirement not found for property #{property_name} from #{property_source || 'unknown source'}"
         end
 
-        sig { params(dep: Dependabot::Dependency).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { params(dep: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements(dep)
-          @updated_requirements ||= T.let({}, T.nilable(T::Hash[String, T::Array[T::Hash[Symbol, T.untyped]]]))
+          @updated_requirements ||= T.let({}, T.nilable(T::Hash[String, T::Array[Dependabot::DependencyRequirement]]))
           @updated_requirements[dep.name] ||=
             RequirementsUpdater.new(
               requirements: dep.requirements,

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -36,11 +36,17 @@ module Dependabot
           raise_on_ignored: false
         )
           @forbidden_urls      = T.let([], T::Array[String])
-          @dependency_metadata = T.let({}, T::Hash[T.untyped, Nokogiri::XML::Document])
+          @dependency_metadata = T.let({}, T::Hash[Integer, Nokogiri::XML::Document])
           @auth_headers_finder = T.let(nil, T.nilable(Utils::AuthHeadersFinder))
-          @pom_repository_details = T.let(nil, T.nilable(T::Array[T::Hash[String, T.untyped]]))
+          @pom_repository_details = T.let(
+            nil,
+            T.nilable(T::Array[Dependabot::Maven::Shared::SharedPackageDetailsFetcher::RepositoryDetails])
+          )
           @repository_finder = T.let(nil, T.nilable(Maven::FileParser::RepositoriesFinder))
-          @repositories = T.let(nil, T.nilable(T::Array[T::Hash[String, T.untyped]]))
+          @repositories = T.let(
+            nil,
+            T.nilable(T::Array[Dependabot::Maven::Shared::SharedPackageDetailsFetcher::RepositoryDetails])
+          )
           @released_check = T.let({}, T::Hash[Version, T::Boolean])
           @package_details_fetcher = T.let(nil, T.nilable(Package::PackageDetailsFetcher))
           @package_details = T.let(nil, T.nilable(Dependabot::Package::PackageDetails))

--- a/maven/lib/dependabot/maven/utils/auth_headers_finder.rb
+++ b/maven/lib/dependabot/maven/utils/auth_headers_finder.rb
@@ -37,7 +37,7 @@ module Dependabot
         sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
 
-        sig { params(maven_repo_url: T.any(URI::Generic, String)).returns(T::Hash[T.untyped, T.untyped]) }
+        sig { params(maven_repo_url: T.any(URI::Generic, String)).returns(T::Hash[String, String]) }
         def gitlab_auth_headers(maven_repo_url)
           return {} unless gitlab_maven_repo?(T.must(URI(maven_repo_url).path))
 

--- a/maven/lib/dependabot/maven/version.rb
+++ b/maven/lib/dependabot/maven/version.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/maven/version_parser"
@@ -84,9 +84,12 @@ module Dependabot
         parts = token_bucket.tokens # e.g [1,2,3] if version is 1.2.3-alpha3
         return [] if parts.empty? # for non-semver versions
 
-        version_parts = parts.fill("0", parts.length...2)
+        version_parts = T.let(parts.fill("0", parts.length...2), T::Array[Object])
         # the a0 is so we can get the next earliest prerelease patch version
-        upper_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + [lowest_prerelease_suffix]
+        upper_parts = T.let(
+          version_parts.first(1) + [numeric_token(version_parts[1]) + 1] + [lowest_prerelease_suffix],
+          T::Array[Object]
+        )
         lower_bound = "> #{to_semver}"
         upper_bound = "< #{upper_parts.join('.')}"
 
@@ -98,9 +101,15 @@ module Dependabot
         parts = token_bucket.tokens # e.g [1,2,3] if version is 1.2.3-alpha3
         return [] if parts.empty? # for non-semver versions
 
-        version_parts = parts.fill("0", parts.length...2)
-        lower_parts = version_parts.first(1) + [version_parts[1].to_i + 1] + [lowest_prerelease_suffix]
-        upper_parts = version_parts.first(0) + [version_parts[0].to_i + 1] + [lowest_prerelease_suffix]
+        version_parts = T.let(parts.fill("0", parts.length...2), T::Array[Object])
+        lower_parts = T.let(
+          version_parts.first(1) + [numeric_token(version_parts[1]) + 1] + [lowest_prerelease_suffix],
+          T::Array[Object]
+        )
+        upper_parts = T.let(
+          version_parts.first(0) + [numeric_token(version_parts[0]) + 1] + [lowest_prerelease_suffix],
+          T::Array[Object]
+        )
         lower_bound = ">= #{lower_parts.join('.')}"
         upper_bound = "< #{upper_parts.join('.')}"
 
@@ -112,7 +121,10 @@ module Dependabot
         version_parts = token_bucket.tokens # e.g [1,2,3] if version is 1.2.3-alpha3
         return [] if version_parts.empty? # for non-semver versions
 
-        lower_parts = [version_parts[0].to_i + 1] + [lowest_prerelease_suffix] # earliest next major version prerelease
+        lower_parts = T.let(
+          [numeric_token(version_parts[0]) + 1] + [lowest_prerelease_suffix],
+          T::Array[Object]
+        ) # earliest next major version prerelease
         lower_bound = ">= #{lower_parts.join('.')}"
 
         [lower_bound]
@@ -122,6 +134,11 @@ module Dependabot
 
       sig { returns(String) }
       attr_reader :version_string
+
+      sig { params(token: Object).returns(Integer) }
+      def numeric_token(token)
+        token.to_s.to_i
+      end
     end
   end
 end

--- a/sbt/lib/dependabot/sbt/file_parser/property_value_finder.rb
+++ b/sbt/lib/dependabot/sbt/file_parser/property_value_finder.rb
@@ -4,12 +4,15 @@
 require "sorbet-runtime"
 
 require "dependabot/sbt/file_parser"
+require "dependabot/maven/shared/property_value_finding"
 
 module Dependabot
   module Sbt
     class FileParser < Dependabot::FileParsers::Base
       class PropertyValueFinder
         extend T::Sig
+
+        include Dependabot::Maven::Shared::PropertyValueFinding
 
         # Matches: val someVersion = "1.2.3"
         # Also:   val someVersion: String = "1.2.3"
@@ -26,7 +29,8 @@ module Dependabot
         end
 
         sig do
-          params(property_name: String, callsite_buildfile: Dependabot::DependencyFile)
+          override
+            .params(property_name: String, callsite_buildfile: Dependabot::DependencyFile)
             .returns(T.nilable(T::Hash[Symbol, String]))
         end
         def property_details(property_name:, callsite_buildfile:)


### PR DESCRIPTION
Types the whole maven ecosystem and drops all 16 files from the `Sorbet/ForbidTUntyped` burndown list (offense count 1499 to 1421).

Maven parses POM XML and talks to maven repositories, so the work splits cleanly by kind. Dependency requirements, files, credentials, and package releases use the existing value objects. Repository details, version details, property details, and token buckets get precise type aliases. Heterogeneous parsed-tree values that the code inspects with `is_a?` are typed `Object` (which allows those checks without casts), and only the opaque `options:` pass-through stays `T.anything`. Where a parsed value feeds a typed consumer — an XML node, a version string — it narrows with `is_a?` at the read site. `version.rb` and `shared_property_value_updater.rb` reach `# typed: strong`.

Fully validated on host: 726 maven specs pass, srb tc green, rubocop clean.

Stacked on #15528.
