### PR TITLE
Handler for ERR_PNPM_STRICT_MIN_RELEASE_AGE_REQUIRES_SAVE error type

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -127,7 +127,7 @@ module Dependabot
         PLATFORM_PACAKGE_DEP = /Unsupported platform for (?<dep>.*)\: wanted/
         PLATFORM_VERSION_REQUIREMENT = /wanted {(?<supported_ver>.*)} \(current: (?<detected_ver>.*)\)/
         PLATFORM_PACAKGE_MANAGER = "pnpm"
-
+        ERR_PNPM_STRICT_MIN_RELEASE_AGE_REQUIRES_SAVE = /ERR_PNPM_STRICT_MIN_RELEASE_AGE_REQUIRES_SAVE/
         INVALID_PACKAGE_SPEC = /Invalid package manager specification/
 
         # Metadata inconsistent error codes
@@ -420,6 +420,11 @@ module Dependabot
                   "A previously published version had provenance attestation, but the target version does not."
             Dependabot.logger.warn(error_message)
             raise Dependabot::InconsistentRegistryResponse, msg
+          end
+
+          if error_message.match?(ERR_PNPM_STRICT_MIN_RELEASE_AGE_REQUIRES_SAVE)
+            msg = "minimumReleaseAgeStrict in pnpm-workspace.yaml is incompatible with Dependabot."
+            raise Dependabot::DependencyFileNotResolvable, msg
           end
 
           error_handler.handle_pnpm_error(error)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -405,6 +405,28 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
       end
     end
 
+    context "when minimumReleaseAgeStrict conflicts with --no-save" do
+      let(:project_name) { "pnpm/simple" }
+
+      before do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command)
+          .and_raise(
+            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "[ERR_PNPM_STRICT_MIN_RELEASE_AGE_REQUIRES_SAVE] minimumReleaseAgeStrict cannot be " \
+                       "combined with --no-save",
+              error_context: {}
+            )
+          )
+      end
+
+      it "raises a helpful error" do
+        expect { updated_pnpm_lock_content }
+          .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
+          expect(error.message).to include("minimumReleaseAgeStrict")
+        end
+      end
+    end
+
     context "when there is a private repo we don't have access to and returns a 4xx error" do
       let(:project_name) { "pnpm/private_repo_no_access" }
       let(:dependency_name) { "@dsp-testing/node" }


### PR DESCRIPTION
### What are you trying to accomplish?

We are adding a exception handler for `ERR_PNPM_STRICT_MIN_RELEASE_AGE_REQUIRES_SAVE` error as it is incompatible with `--no-save` option that we are using (This surfaces when `minimumReleaseAgeStrict` is used in settings file). The exception body is as following:

_[ERR_PNPM_STRICT_MIN_RELEASE_AGE_REQUIRES_SAVE] minimumReleaseAgeStrict cannot be combined with --no-save: approval would require writing to minimumReleaseAgeExclude in pnpm-workspace.yaml, which --no-save prevents._

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
