### PR TITLE
Use shared CooldownCalculation window check in helm

### DIFF
--- a/helm/lib/dependabot/helm/update_checker/latest_version_resolver.rb
+++ b/helm/lib/dependabot/helm/update_checker/latest_version_resolver.rb
@@ -3,15 +3,14 @@
 
 require "dependabot/helm/package/package_details_fetcher"
 require "sorbet-runtime"
-require "dependabot/git_commit_checker"
+require "dependabot/git_tag_with_detail"
+require "dependabot/update_checkers/cooldown_calculation"
 require "dependabot/helm/version"
 
 module Dependabot
   module Helm
     class LatestVersionResolver
       extend T::Sig
-
-      DAY_IN_SECONDS = T.let(24 * 60 * 60, Integer)
 
       sig do
         params(
@@ -135,20 +134,24 @@ module Dependabot
         cooldown = @cooldown_options
         return false unless cooldown
 
-        return false if cooldown.nil?
+        released_at = parse_release_date(release_date)
+        return false unless released_at
 
-        # Calculate the number of seconds passed since the release
-        passed_seconds = Time.now.to_i - release_date_to_seconds(release_date)
-        # Check if the release is within the cooldown period
-        passed_seconds < cooldown.default_days * DAY_IN_SECONDS
+        # Delegate the cooldown-window arithmetic to the shared primitive so it
+        # stays consistent with every other ecosystem. helm resolves versions
+        # from heterogeneous chart/OCI tags, so it applies the flat default_days
+        # window rather than a semver-aware one.
+        Dependabot::UpdateCheckers::CooldownCalculation.within_cooldown_window?(
+          released_at, cooldown.default_days
+        )
       end
 
-      sig { params(release_date: String).returns(Integer) }
-      def release_date_to_seconds(release_date)
-        Time.parse(release_date).to_i
+      sig { params(release_date: String).returns(T.nilable(Time)) }
+      def parse_release_date(release_date)
+        Time.parse(release_date)
       rescue ArgumentError => e
         Dependabot.logger.error("Invalid release date format: #{release_date} and error: #{e.message}")
-        0 # Default to 360 days in seconds if parsing fails, so that it will not be in cooldown
+        nil
       end
 
       sig { params(tags_with_release_date: T::Array[GitTagWithDetail]).returns(T.nilable(T::Array[String])) }

--- a/helm/spec/dependabot/helm/update_checker/latest_version_resolver_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker/latest_version_resolver_spec.rb
@@ -177,16 +177,16 @@ RSpec.describe Dependabot::Helm::LatestVersionResolver do
     end
   end
 
-  describe "#release_date_to_seconds" do
-    it "parses a valid release date into seconds" do
+  describe "#parse_release_date" do
+    it "parses a valid release date into a Time" do
       release_date = "2023-01-01T00:00:00Z"
-      expect(resolver.release_date_to_seconds(release_date)).to eq(Time.parse(release_date).to_i)
+      expect(resolver.parse_release_date(release_date)).to eq(Time.parse(release_date))
     end
 
-    it "returns 0 for an invalid release date" do
+    it "returns nil for an invalid release date" do
       invalid_release_date = "invalid-date"
       expect(Dependabot.logger).to receive(:error).with(/Invalid release date format/)
-      expect(resolver.release_date_to_seconds(invalid_release_date)).to eq(0)
+      expect(resolver.parse_release_date(invalid_release_date)).to be_nil
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Part of the cooldown de-duplication batch (spike github/dependabot-updates#13901, batch github/dependabot-updates#13952, issue #13957). This removes helm's bespoke cooldown-window arithmetic in favour of the shared `CooldownCalculation` primitive.

**Scope determination:** helm has no `GitCommitChecker` git-tag cooldown path — it resolves versions from chart-index and OCI/registry tags (`filter_versions_in_cooldown_period_using_oci`, `select_tags_which_in_cooldown_from_chart{,_index}`). So it is out of scope for the *git-tag* generalization, but it did carry its own copy of the cooldown-window math, which is what this PR consolidates.

Changes to `update_checker/latest_version_resolver.rb`:
- `check_if_version_in_cooldown_period?` now delegates the window arithmetic to `Dependabot::UpdateCheckers::CooldownCalculation.within_cooldown_window?` instead of the inline `passed_seconds < default_days * DAY_IN_SECONDS`.
- Removed the private `DAY_IN_SECONDS` constant and the `release_date_to_seconds` helper; date parsing moves to a small `parse_release_date` (invalid dates log and yield no cooldown, exactly as before).
- Dropped the unused `dependabot/git_commit_checker` require (helm never uses `GitCommitChecker`) in favour of the specific `dependabot/git_tag_with_detail` and `dependabot/update_checkers/cooldown_calculation` requires that the file actually needs.

### Anything you want to highlight for special attention from reviewers?

- **Behaviour is unchanged.** `within_cooldown_window?(released_at, default_days)` is arithmetically identical to the code it replaces. helm resolves versions from heterogeneous chart/OCI tag strings (not all semver-parseable), so it intentionally keeps the flat `default_days` window rather than adopting the semver-aware `cooldown_days_for` — the existing tests configure `semver_*_days` but assert `default_days` behaviour, confirming that intent.
- **Never applies to security updates** — helm's `cooldown_enabled?` (in `update_checker.rb`) is `false` when `update_cooldown` is nil / non-positive, so security jobs skip cooldown before the resolver is consulted.

### How will you know you've accomplished your goal?

Functionally equivalent, verified in Docker:
- `select_tags_which_in_cooldown_from_chart` still selects only the in-window tag (10-day-old tag in cooldown, 40-day-old outside, `default_days: 30`).
- The date-parsing unit test was retargeted from `release_date_to_seconds` to the new `parse_release_date` (valid → `Time`, invalid → logs + `nil`).
- The OCI/chart filter specs are unchanged and still pass.

Results:
- rubocop: clean (changed files)
- sorbet `srb tc`: no errors (whole repo)
- `latest_version_resolver_spec`: 12 examples, 0 failures
- full `helm` suite: 156 examples, 0 failures

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
