### PR TITLE
[Update graph] Python constraint files are not manifests and should not contribute to snapshots

### DIFF
--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -111,7 +111,7 @@ module Dependabot
       sig { void }
       def exclude_constraint_dependencies!
         @dependencies = @dependencies.reject do |dep|
-          origin_files = dep.requirements.filter_map { |r| r[:file] }
+          origin_files = dep.requirements.filter_map(&:file)
           origin_files.any? && origin_files.all? { |name| File.basename(name).include?("constraint") }
         end
       end

--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -105,14 +105,21 @@ module Dependabot
       # pip constraint files (referenced via `-c`) install nothing - they only pin versions of packages required
       # elsewhere - so neither the legacy dependency-graph-api nor the dependency-snapshots-api treats them as
       # manifests. We keep the file on disk so `-c` references resolve, but after parsing we drop any dependency
-      # whose requirements ALL originate from a constraint file (a package also declared in a real requirement
-      # file keeps that origin and survives). This runs on every grapher, including the scoped per-layer graphers,
-      # so a shared constraints.txt is not over-attributed as a direct dependency of each layer.
+      # whose requirements ALL originate from a `-c`-referenced file (a package also declared in a real
+      # requirement file keeps that origin and survives). This runs on every grapher, including the scoped
+      # per-layer graphers, so a shared constraints file is not over-attributed as a direct dependency of each
+      # layer.
+      #
+      # Constraint status is determined by `-c` references, not by filename: pip permits arbitrary names (e.g.
+      # `-c pins.txt`), and a real manifest such as `requirements-constraints.txt` must not be mistaken for one.
       sig { void }
       def exclude_constraint_dependencies!
+        constraint_paths = SharedFileFetcher.constraint_file_paths(dependency_files)
+        return if constraint_paths.empty?
+
         @dependencies = @dependencies.reject do |dep|
           origin_files = dep.requirements.filter_map(&:file)
-          origin_files.any? && origin_files.all? { |name| File.basename(name).include?("constraint") }
+          origin_files.any? && origin_files.all? { |path| constraint_paths.include?(path) }
         end
       end
 

--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -17,7 +17,7 @@ require "toml-rb"
 
 module Dependabot
   module Python
-    class DependencyGrapher < Dependabot::DependencyGraphers::Base
+    class DependencyGrapher < Dependabot::DependencyGraphers::Base # rubocop:disable Metrics/ClassLength
       require_relative "dependency_grapher/lockfile_generator"
       require_relative "dependency_grapher/requirements_layers"
 
@@ -64,6 +64,7 @@ module Dependabot
           emit_missing_lockfile_warning! if @ephemeral_lockfile_generated
         end
         super
+        exclude_constraint_dependencies!
       end
 
       # Layering is specific to pip / pip-compile for Python.
@@ -98,6 +99,20 @@ module Dependabot
       def non_requirements_manifest_groups
         [setup_file, setup_cfg_file, pyproject_toml].compact.map do |file|
           Dependabot::DependencyGraphers::ManifestGroup.new(primary: file, files: [file])
+        end
+      end
+
+      # pip constraint files (referenced via `-c`) install nothing - they only pin versions of packages required
+      # elsewhere - so neither the legacy dependency-graph-api nor the dependency-snapshots-api treats them as
+      # manifests. We keep the file on disk so `-c` references resolve, but after parsing we drop any dependency
+      # whose requirements ALL originate from a constraint file (a package also declared in a real requirement
+      # file keeps that origin and survives). This runs on every grapher, including the scoped per-layer graphers,
+      # so a shared constraints.txt is not over-attributed as a direct dependency of each layer.
+      sig { void }
+      def exclude_constraint_dependencies!
+        @dependencies = @dependencies.reject do |dep|
+          origin_files = dep.requirements.filter_map { |r| r[:file] }
+          origin_files.any? && origin_files.all? { |name| File.basename(name).include?("constraint") }
         end
       end
 

--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -17,7 +17,7 @@ require "toml-rb"
 
 module Dependabot
   module Python
-    class DependencyGrapher < Dependabot::DependencyGraphers::Base # rubocop:disable Metrics/ClassLength
+    class DependencyGrapher < Dependabot::DependencyGraphers::Base
       require_relative "dependency_grapher/lockfile_generator"
       require_relative "dependency_grapher/requirements_layers"
 
@@ -140,67 +140,18 @@ module Dependabot
       # matcher recognises it as a compiled lockfile, or it is referenced (transitively) via `-r`/`-c` from a
       # retained requirements file. The last case preserves constraint/child files (e.g. `constraints.txt`) that
       # the parser needs on disk to resolve a real manifest, while still dropping bystander `.txt` files.
+      #
+      # RequirementsLayers owns the "which .txt files matter" knowledge (manifest detection and `-r`/`-c`
+      # resolution) so grouping and this bystander filter never drift apart.
       sig { void }
       def filter_non_manifest_txt_files!
-        keep = txt_files_to_keep
+        keep = RequirementsLayers.new(dependency_files: dependency_files).txt_files_to_keep
 
         file_parser.dependency_files.reject! do |file|
           next false unless file.name.end_with?(".txt")
 
           !keep.include?(file.name)
         end
-      end
-
-      # Names of the `.txt` files that must be retained: those that look like manifests or pip-compile lockfiles,
-      # plus any `.txt` reachable via `-r`/`-c` references from a retained requirements file (`.in` files are
-      # never dropped, so references originating from them are followed too).
-      sig { returns(T::Set[String]) }
-      def txt_files_to_keep
-        files_by_name = dependency_files.to_h { |file| [file.name, file] }
-
-        seeds = dependency_files.select do |file|
-          file.name.end_with?(".txt") &&
-            (RequirementsLayers.manifest_txt_filename?(file.name) ||
-              pip_compile_file_matcher.lockfile_for_pip_compile_file?(file))
-        end
-
-        # `.in` files are always retained, so a `.txt` they reference must be kept too.
-        roots = seeds + dependency_files.select { |file| file.name.end_with?(".in") }
-
-        reachable_txt_names(roots, files_by_name, Set.new(seeds.map(&:name)))
-      end
-
-      # Breadth-first closure over `-r`/`-c` references starting from `roots`, adding every referenced `.txt`
-      # file that exists in `files_by_name` to `keep`.
-      sig do
-        params(
-          roots: T::Array[Dependabot::DependencyFile],
-          files_by_name: T::Hash[String, Dependabot::DependencyFile],
-          keep: T::Set[String]
-        ).returns(T::Set[String])
-      end
-      def reachable_txt_names(roots, files_by_name, keep)
-        queue = roots.dup
-        until queue.empty?
-          file = T.must(queue.shift)
-          referenced_txt_names(file).each do |name|
-            referenced_file = files_by_name[name]
-            next if referenced_file.nil? || keep.include?(name)
-
-            keep << name
-            queue << referenced_file
-          end
-        end
-
-        keep
-      end
-
-      # Resolves the `.txt` files referenced from a requirements file via `-r`/`-c`, returning their names
-      # relative to the repo (matching the fetched DependencyFile names) so we can retain them. Delegates to
-      # RequirementsLayers.referenced_paths so grouping and the bystander filter resolve references identically.
-      sig { params(file: Dependabot::DependencyFile).returns(T::Array[String]) }
-      def referenced_txt_names(file)
-        RequirementsLayers.referenced_paths(file).select { |path| path.end_with?(".txt") }
       end
 
       sig { returns(T::Boolean) }

--- a/python/lib/dependabot/python/dependency_grapher/requirements_layers.rb
+++ b/python/lib/dependabot/python/dependency_grapher/requirements_layers.rb
@@ -6,6 +6,7 @@ require "sorbet-runtime"
 
 require "dependabot/dependency_file"
 require "dependabot/dependency_graphers/base"
+require "dependabot/python/pip_compile_file_matcher"
 require "dependabot/python/shared_file_fetcher"
 
 module Dependabot
@@ -97,10 +98,67 @@ module Dependabot
           end
         end
 
+        # Names of the `.txt` files that must be retained: those that look like manifests or pip-compile
+        # lockfiles, plus any `.txt` reachable via `-r`/`-c` references from a retained requirements file (`.in`
+        # files are never dropped, so references originating from them are followed too).
+        #
+        # Shared with the grapher's bystander filter so the same knowledge that groups layers also decides which
+        # `.txt` files survive, keeping the two in lockstep.
+        sig { returns(T::Set[String]) }
+        def txt_files_to_keep
+          files_by_name = dependency_files.to_h { |file| [file.name, file] }
+
+          seeds = dependency_files.select do |file|
+            file.name.end_with?(".txt") &&
+              (self.class.manifest_txt_filename?(file.name) ||
+                pip_compile_file_matcher.lockfile_for_pip_compile_file?(file))
+          end
+
+          # `.in` files are always retained, so a `.txt` they reference must be kept too.
+          roots = seeds + dependency_files.select { |file| file.name.end_with?(".in") }
+
+          reachable_txt_names(roots, files_by_name, Set.new(seeds.map(&:name)))
+        end
+
         private
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         attr_reader :dependency_files
+
+        # Breadth-first closure over `-r`/`-c` references starting from `roots`, adding every referenced `.txt`
+        # file that exists in `files_by_name` to `keep`.
+        sig do
+          params(
+            roots: T::Array[Dependabot::DependencyFile],
+            files_by_name: T::Hash[String, Dependabot::DependencyFile],
+            keep: T::Set[String]
+          ).returns(T::Set[String])
+        end
+        def reachable_txt_names(roots, files_by_name, keep)
+          queue = roots.dup
+          until queue.empty?
+            file = T.must(queue.shift)
+            self.class.referenced_paths(file).each do |name|
+              next unless name.end_with?(".txt")
+
+              referenced_file = files_by_name[name]
+              next if referenced_file.nil? || keep.include?(name)
+
+              keep << name
+              queue << referenced_file
+            end
+          end
+
+          keep
+        end
+
+        sig { returns(PipCompileFileMatcher) }
+        def pip_compile_file_matcher
+          @pip_compile_file_matcher ||= T.let(
+            PipCompileFileMatcher.new(dependency_files.select { |f| f.name.end_with?(".in") }),
+            T.nilable(PipCompileFileMatcher)
+          )
+        end
 
         # The set of files that act as the owning manifest for a layer: every requirements `.txt` that looks
         # like a real manifest, plus any `.in` file that has no compiled `.txt` counterpart.

--- a/python/lib/dependabot/python/shared_file_fetcher.rb
+++ b/python/lib/dependabot/python/shared_file_fetcher.rb
@@ -39,6 +39,25 @@ module Dependabot
         false
       end
 
+      # Scans the given requirement files for pip `-c` references and returns the de-duplicated set of
+      # constraint file paths, each resolved relative to the referencing file.
+      #
+      # Exposed as a class method so the DependencyGrapher can identify constraint files from
+      # already-fetched dependency files.
+      sig { params(files: T::Array[Dependabot::DependencyFile]).returns(T::Array[String]) }
+      def self.constraint_file_paths(files)
+        files.flat_map do |file|
+          content = file.content
+          next [] if content.nil?
+
+          current_dir = File.dirname(file.name)
+          content.scan(CONSTRAINT_REGEX).flatten.map do |path|
+            path = File.join(current_dir, path) unless current_dir == "."
+            Pathname.new(path).cleanpath.to_path
+          end
+        end.uniq
+      end
+
       sig { override.returns(T.nilable(T::Hash[Symbol, T.untyped])) }
       def ecosystem_versions
         python_requirement_parser = FileParser::PythonRequirementParser.new(dependency_files: files)
@@ -272,18 +291,7 @@ module Dependabot
                                 child_requirement_txt_files +
                                 requirements_in_files
 
-        constraints_paths = all_requirement_files.map do |req_file|
-          current_dir = File.dirname(req_file.name)
-          content = req_file.content
-          next [] if content.nil?
-
-          paths = content.scan(CONSTRAINT_REGEX).flatten
-
-          paths.map do |path|
-            path = File.join(current_dir, path) unless current_dir == "."
-            clean_path(path)
-          end
-        end.flatten.uniq
+        constraints_paths = self.class.constraint_file_paths(all_requirement_files)
 
         already_fetched_names = child_requirement_files.map(&:name)
         constraints_paths

--- a/python/spec/dependabot/python/dependency_grapher_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher_spec.rb
@@ -1175,6 +1175,68 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
     end
   end
 
+  # A pip `-c` constraints file installs nothing; it only pins versions of packages required elsewhere. Neither
+  # the legacy dependency-graph-api nor the snapshots API treats constraints.txt as a manifest, so a package that
+  # originates only from a constraints file must not be attributed to any snapshot - and definitely not duplicated
+  # across every layer that shares the constraints file.
+  describe "excluding dependencies that originate only from a pip constraints file" do
+    let(:constraints_txt) do
+      Dependabot::DependencyFile.new(
+        name: "constraints.txt",
+        content: "urllib3==2.0.0\n",
+        directory: "/"
+      )
+    end
+
+    def resolved_package_names(snapshot)
+      snapshot.resolved_dependencies.each_key.map { |purl| purl[%r{\Apkg:pypi/([^@]+)}, 1] }
+    end
+
+    context "with a single requirements file that references a constraints file" do
+      let(:requirements_with_constraint) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "-c constraints.txt\nflask==3.0.0\n",
+          directory: "/"
+        )
+      end
+      let(:dependency_files) { [requirements_with_constraint, constraints_txt] }
+
+      it "attributes the real dependency but drops the constraint-only package" do
+        names = grapher.manifest_group_snapshots.flat_map { |snapshot| resolved_package_names(snapshot) }
+
+        expect(names).to include("flask")
+        expect(names).not_to include("urllib3")
+      end
+    end
+
+    context "with multiple requirements layers sharing a constraints file" do
+      let(:app_requirements) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "-c constraints.txt\nflask==3.0.0\n",
+          directory: "/"
+        )
+      end
+      let(:dev_requirements) do
+        Dependabot::DependencyFile.new(
+          name: "dev-requirements.txt",
+          content: "-c constraints.txt\npytest==8.3.3\n",
+          directory: "/"
+        )
+      end
+      let(:dependency_files) { [dev_requirements, app_requirements, constraints_txt] }
+
+      it "does not attribute the constraint-only package to any layer" do
+        snapshots = grapher.manifest_group_snapshots.to_h { |snapshot| [snapshot.manifest_file.name, snapshot] }
+
+        expect(resolved_package_names(snapshots.fetch("requirements.txt"))).to contain_exactly("flask")
+        expect(resolved_package_names(snapshots.fetch("dev-requirements.txt"))).to contain_exactly("pytest")
+        expect(snapshots.values.flat_map { |snapshot| resolved_package_names(snapshot) }).not_to include("urllib3")
+      end
+    end
+  end
+
   describe "#manifest_group_snapshots for package managers that do not support layering" do
     context "when the directory is a Poetry project" do
       let(:poetry_lock_file) do

--- a/python/spec/dependabot/python/dependency_grapher_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher_spec.rb
@@ -1235,6 +1235,48 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
         expect(snapshots.values.flat_map { |snapshot| resolved_package_names(snapshot) }).not_to include("urllib3")
       end
     end
+
+    context "with an arbitrarily named constraints file referenced via `-c`" do
+      let(:pins_txt) do
+        Dependabot::DependencyFile.new(
+          name: "pins.txt",
+          content: "urllib3==2.0.0\n",
+          directory: "/"
+        )
+      end
+      let(:requirements_with_arbitrary_constraint) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "-c pins.txt\nflask==3.0.0\n",
+          directory: "/"
+        )
+      end
+      let(:dependency_files) { [requirements_with_arbitrary_constraint, pins_txt] }
+
+      it "drops the constraint-only package even though the filename does not contain 'constraint'" do
+        names = grapher.manifest_group_snapshots.flat_map { |snapshot| resolved_package_names(snapshot) }
+
+        expect(names).to include("flask")
+        expect(names).not_to include("urllib3")
+      end
+    end
+
+    context "with a real manifest whose name merely contains 'constraint'" do
+      let(:requirements_constraints_txt) do
+        Dependabot::DependencyFile.new(
+          name: "requirements-constraints.txt",
+          content: "flask==3.0.0\n",
+          directory: "/"
+        )
+      end
+      let(:dependency_files) { [requirements_constraints_txt] }
+
+      it "retains its dependencies because it is not referenced via `-c`" do
+        names = grapher.manifest_group_snapshots.flat_map { |snapshot| resolved_package_names(snapshot) }
+
+        expect(names).to include("flask")
+      end
+    end
   end
 
   describe "#manifest_group_snapshots for package managers that do not support layering" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fast-follow on:
- https://github.com/dependabot/dependabot-core/pull/15521

We are currently allowing any dependencies named in a `constraints.txt` file to contribute to snapshots.

This isn't working as intended as this file is not a manifest and does not actually install any dependencies, it restricts resolution.

### Anything you want to highlight for special attention from reviewers?

We need to pass any constraint into the parser or it will raise an error, so instead of filtering the file out, we allow it to reach the parser and then remove any dependencies attributed to it.

### How will you know you've accomplished your goal?

We will stop seeing duplication of a package in snapshots showing both their resolved versions and their constrained version(s).

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
