### PR TITLE
fix(gradle): prefer local gradlew for lockfile updates

### DIFF
--- a/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
@@ -42,13 +42,14 @@ module Dependabot
             write_init_script(init_script_path)
 
             command_parts = [
-              gradle_executable_for(cwd),
+              gradle_executable_for(cwd: cwd, workspace_root: temp_dir.to_s),
               "--init-script", init_script_path,
               INIT_SCRIPT_TASK_NAME,
               "--write-locks",
               "--no-daemon"
             ]
-            run_lockfile_update_command(command_parts: command_parts, cwd: cwd)
+            command = Shellwords.join(command_parts)
+            SharedHelpers.run_shell_command(command, cwd: cwd)
 
             update_lockfiles_content(temp_dir, lockfiles, updated_files)
           rescue SharedHelpers::HelperSubprocessFailed => e
@@ -220,9 +221,10 @@ systemProp.https.proxyPort=#{https_proxy_port}"
           File.write(file_name, script_content)
         end
 
-        sig { params(cwd: String).returns(String) }
-        def gradle_executable_for(cwd)
+        sig { params(cwd: String, workspace_root: String).returns(String) }
+        def gradle_executable_for(cwd:, workspace_root:)
           cwd_path = Pathname.new(cwd)
+          workspace_root_path = Pathname.new(workspace_root)
           search_path = cwd_path
 
           loop do
@@ -236,31 +238,12 @@ systemProp.https.proxyPort=#{https_proxy_port}"
             end
 
             parent_path = search_path.parent
-            break if parent_path == search_path
+            break if parent_path == search_path || search_path == workspace_root_path
 
             search_path = parent_path
           end
 
           "gradle"
-        end
-
-        sig { params(command_parts: T::Array[String], cwd: String).void }
-        def run_lockfile_update_command(command_parts:, cwd:)
-          command = Shellwords.join(command_parts)
-          SharedHelpers.run_shell_command(command, cwd: cwd)
-        rescue SharedHelpers::HelperSubprocessFailed => e
-          raise e unless local_wrapper_command?(command_parts[0])
-
-          display_command = command_parts.join(" ")
-          Dependabot.logger.warn("Running #{display_command} failed, retrying with system Gradle: #{e.message}")
-
-          fallback_command = Shellwords.join(["gradle"] + command_parts.drop(1))
-          SharedHelpers.run_shell_command(fallback_command, cwd: cwd)
-        end
-
-        sig { params(executable: String).returns(T::Boolean) }
-        def local_wrapper_command?(executable)
-          executable != "gradle" && File.basename(executable) == "gradlew"
         end
 
         sig { params(build_file: Dependabot::DependencyFile).returns(T.nilable(Dependabot::DependencyFile)) }

--- a/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
@@ -223,8 +223,11 @@ systemProp.https.proxyPort=#{https_proxy_port}"
 
         sig { params(cwd: String, workspace_root: String).returns(String) }
         def gradle_executable_for(cwd:, workspace_root:)
-          cwd_path = Pathname.new(cwd)
-          workspace_root_path = Pathname.new(workspace_root)
+          cwd_path = Pathname.new(cwd).expand_path
+          workspace_root_path = Pathname.new(workspace_root).expand_path
+
+          return "gradle" unless cwd_path == workspace_root_path || cwd_path.to_s.start_with?("#{workspace_root_path}/")
+
           search_path = cwd_path
 
           loop do

--- a/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "pathname"
 require "shellwords"
 require "sorbet-runtime"
 
@@ -47,9 +48,7 @@ module Dependabot
               "--write-locks",
               "--no-daemon"
             ]
-            command = Shellwords.join(command_parts)
-
-            SharedHelpers.run_shell_command(command, cwd: cwd)
+            run_lockfile_update_command(command_parts: command_parts, cwd: cwd)
 
             update_lockfiles_content(temp_dir, lockfiles, updated_files)
           rescue SharedHelpers::HelperSubprocessFailed => e
@@ -176,7 +175,7 @@ module Dependabot
             relative_dir = file.directory == "/" ? "" : file.directory
             in_path_name = File.join(temp_dir, relative_dir, file.name)
             FileUtils.mkdir_p(File.dirname(in_path_name))
-            File.write(in_path_name, file.content)
+            File.binwrite(in_path_name, file.decoded_content)
           end
         end
 
@@ -223,11 +222,45 @@ systemProp.https.proxyPort=#{https_proxy_port}"
 
         sig { params(cwd: String).returns(String) }
         def gradle_executable_for(cwd)
-          wrapper_script = File.join(cwd, "gradlew")
-          return "gradle" unless File.exist?(wrapper_script)
+          cwd_path = Pathname.new(cwd)
+          search_path = cwd_path
 
-          FileUtils.chmod("+x", wrapper_script)
-          "./gradlew"
+          loop do
+            wrapper_script = search_path.join("gradlew")
+            if File.file?(wrapper_script)
+              wrapper_script_path = wrapper_script.to_s
+              FileUtils.chmod("+x", wrapper_script_path)
+
+              relative_path = wrapper_script.relative_path_from(cwd_path).to_s
+              return relative_path.start_with?(".") ? relative_path : "./#{relative_path}"
+            end
+
+            parent_path = search_path.parent
+            break if parent_path == search_path
+
+            search_path = parent_path
+          end
+
+          "gradle"
+        end
+
+        sig { params(command_parts: T::Array[String], cwd: String).void }
+        def run_lockfile_update_command(command_parts:, cwd:)
+          command = Shellwords.join(command_parts)
+          SharedHelpers.run_shell_command(command, cwd: cwd)
+        rescue SharedHelpers::HelperSubprocessFailed => e
+          raise e unless local_wrapper_command?(command_parts[0])
+
+          display_command = command_parts.join(" ")
+          Dependabot.logger.warn("Running #{display_command} failed, retrying with system Gradle: #{e.message}")
+
+          fallback_command = Shellwords.join(["gradle"] + command_parts.drop(1))
+          SharedHelpers.run_shell_command(fallback_command, cwd: cwd)
+        end
+
+        sig { params(executable: String).returns(T::Boolean) }
+        def local_wrapper_command?(executable)
+          executable != "gradle" && File.basename(executable) == "gradlew"
         end
 
         sig { params(build_file: Dependabot::DependencyFile).returns(T.nilable(Dependabot::DependencyFile)) }

--- a/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/lockfile_updater.rb
@@ -41,7 +41,7 @@ module Dependabot
             write_init_script(init_script_path)
 
             command_parts = [
-              "gradle",
+              gradle_executable_for(cwd),
               "--init-script", init_script_path,
               INIT_SCRIPT_TASK_NAME,
               "--write-locks",
@@ -219,6 +219,15 @@ systemProp.https.proxyPort=#{https_proxy_port}"
             }
           GRADLE
           File.write(file_name, script_content)
+        end
+
+        sig { params(cwd: String).returns(String) }
+        def gradle_executable_for(cwd)
+          wrapper_script = File.join(cwd, "gradlew")
+          return "gradle" unless File.exist?(wrapper_script)
+
+          FileUtils.chmod("+x", wrapper_script)
+          "./gradlew"
         end
 
         sig { params(build_file: Dependabot::DependencyFile).returns(T.nilable(Dependabot::DependencyFile)) }

--- a/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+require "base64"
+
 require "spec_helper"
 require "dependabot/dependency_file"
 require "dependabot/gradle/file_updater"
@@ -45,6 +47,17 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
       name: "gradlew",
       directory: "/",
       content: "#!/bin/sh\necho wrapper\n"
+    )
+  end
+
+  let(:gradle_wrapper_jar_raw) { "fake-gradle-wrapper\x00bytes" }
+
+  let(:gradle_wrapper_jar) do
+    Dependabot::DependencyFile.new(
+      name: "gradle/wrapper/gradle-wrapper.jar",
+      directory: "/",
+      content: Base64.strict_encode64(gradle_wrapper_jar_raw),
+      content_encoding: Dependabot::DependencyFile::ContentEncoding::BASE64
     )
   end
 
@@ -102,10 +115,12 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
       end
 
       let(:observed_cwds) { [] }
+      let(:observed_commands) { [] }
 
       before do
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |_command, cwd:|
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
           observed_cwds << cwd
+          observed_commands << command
           File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
           FileUtils.mkdir_p(File.join(cwd, "app"))
           File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
@@ -151,6 +166,59 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
 
           expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
           expect(observed_command.last).to include("./gradlew")
+        end
+
+        it "falls back to system gradle when wrapper execution fails" do
+          allow(Dependabot.logger).to receive(:warn)
+          observed_command = []
+
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
+            observed_command << command
+
+            if command.start_with?("./gradlew")
+              raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                message: "Error: Invalid or corrupt jarfile gradle/wrapper/gradle-wrapper.jar",
+                error_context: { command: command }
+              )
+            end
+
+            File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
+          end
+
+          result = lockfile_updater.update_lockfiles(root_buildfile)
+
+          expect(observed_command[0]).to start_with("./gradlew")
+          expect(observed_command[1]).to start_with("gradle ")
+          expect(result.find { |f| f.name == "gradle.lockfile" }.content).to eq("# updated root lockfile\n")
+          expect(Dependabot.logger).to have_received(:warn).with(include("dependabotResolveAll --write-locks"))
+        end
+      end
+
+      context "when gradle-wrapper.jar is base64 encoded" do
+        let(:dependency_files) do
+          [
+            gradlew,
+            gradle_wrapper_jar,
+            root_settings,
+            root_buildfile,
+            root_lockfile
+          ]
+        end
+
+        let(:observed_wrapper_jar_content) { [] }
+
+        before do
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |_command, cwd:|
+            wrapper_jar_path = File.join(cwd, "gradle/wrapper/gradle-wrapper.jar")
+            observed_wrapper_jar_content << File.binread(wrapper_jar_path)
+            File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
+          end
+        end
+
+        it "writes decoded binary wrapper jar content to disk" do
+          lockfile_updater.update_lockfiles(root_buildfile)
+
+          expect(observed_wrapper_jar_content.last).to eq(gradle_wrapper_jar_raw)
         end
       end
 
@@ -233,10 +301,12 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
       end
 
       let(:observed_cwds) { [] }
+      let(:observed_commands) { [] }
 
       before do
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |_command, cwd:|
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
           observed_cwds << cwd
+          observed_commands << command
           File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
           FileUtils.mkdir_p(File.join(cwd, "app"))
           File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
@@ -382,10 +452,12 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
       end
 
       let(:observed_cwds) { [] }
+      let(:observed_commands) { [] }
 
       before do
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |_command, cwd:|
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
           observed_cwds << cwd
+          observed_commands << command
           File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
           FileUtils.mkdir_p(File.join(cwd, "app"))
           File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
@@ -399,6 +471,19 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
 
         expect(result.find { |f| f.name == "gradle.lockfile" }.content).to eq("# updated root lockfile\n")
         expect(result.find { |f| f.name == "app/gradle.lockfile" }.content).to eq("# updated app lockfile\n")
+      end
+
+      context "when gradlew exists at the repository root" do
+        let(:dependency_files) do
+          [gradlew, subdir_settings, subdir_buildfile, subdir_root_lockfile, subdir_app_lockfile]
+        end
+
+        it "uses the parent-directory wrapper script" do
+          lockfile_updater.update_lockfiles(subdir_buildfile)
+
+          expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
+          expect(observed_commands.last).to start_with("../gradlew ")
+        end
       end
     end
   end

--- a/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
     )
   end
 
+  let(:gradlew) do
+    Dependabot::DependencyFile.new(
+      name: "gradlew",
+      directory: "/",
+      content: "#!/bin/sh\necho wrapper\n"
+    )
+  end
+
   let(:included_buildfile) do
     Dependabot::DependencyFile.new(
       name: "included/build.gradle",
@@ -117,6 +125,59 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
         expect(result.find { |f| f.name == "gradle.lockfile" }.content).to eq("# updated root lockfile\n")
         expect(result.find { |f| f.name == "app/gradle.lockfile" }.content).to eq("# updated app lockfile\n")
         expect(result.find { |f| f.name == "external/gradle.lockfile" }.content).to eq("# external lockfile\n")
+      end
+
+      context "when a local gradlew script is available" do
+        let(:dependency_files) do
+          [
+            gradlew,
+            root_settings,
+            root_buildfile,
+            root_lockfile
+          ]
+        end
+
+        let(:observed_command) { [] }
+
+        before do
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
+            File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
+            observed_command << command
+          end
+        end
+
+        it "prefers the local wrapper executable" do
+          lockfile_updater.update_lockfiles(root_buildfile)
+
+          expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
+          expect(observed_command.last).to include("./gradlew")
+        end
+      end
+
+      context "when a local gradlew script is not available" do
+        let(:dependency_files) do
+          [
+            root_settings,
+            root_buildfile,
+            root_lockfile
+          ]
+        end
+
+        let(:observed_command) { [] }
+
+        before do
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
+            File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
+            observed_command << command
+          end
+        end
+
+        it "falls back to system gradle" do
+          lockfile_updater.update_lockfiles(root_buildfile)
+
+          expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
+          expect(observed_command.last).to start_with("gradle ")
+        end
       end
     end
 

--- a/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
@@ -116,11 +116,19 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
 
       let(:observed_cwds) { [] }
       let(:observed_commands) { [] }
+      let(:observed_wrapper_executable) { [] }
 
       before do
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
           observed_cwds << cwd
           observed_commands << command
+
+          wrapper_token = command.split.first
+          if wrapper_token&.include?("gradlew")
+            wrapper_path = File.expand_path(wrapper_token, cwd)
+            observed_wrapper_executable << File.executable?(wrapper_path)
+          end
+
           File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
           FileUtils.mkdir_p(File.join(cwd, "app"))
           File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
@@ -153,11 +161,15 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
         end
 
         let(:observed_command) { [] }
+        let(:observed_wrapper_executable) { [] }
 
         before do
           allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
             File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
             observed_command << command
+
+            wrapper_path = File.expand_path(command.split.first, cwd)
+            observed_wrapper_executable << File.executable?(wrapper_path)
           end
         end
 
@@ -166,6 +178,7 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
 
           expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
           expect(observed_command.last).to include("./gradlew")
+          expect(observed_wrapper_executable.last).to be(true)
         end
 
         it "returns existing files unchanged when wrapper execution fails" do
@@ -292,11 +305,19 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
 
       let(:observed_cwds) { [] }
       let(:observed_commands) { [] }
+      let(:observed_wrapper_executable) { [] }
 
       before do
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
           observed_cwds << cwd
           observed_commands << command
+
+          wrapper_token = command.split.first
+          if wrapper_token&.include?("gradlew")
+            wrapper_path = File.expand_path(wrapper_token, cwd)
+            observed_wrapper_executable << File.executable?(wrapper_path)
+          end
+
           File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
           FileUtils.mkdir_p(File.join(cwd, "app"))
           File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
@@ -443,11 +464,19 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
 
       let(:observed_cwds) { [] }
       let(:observed_commands) { [] }
+      let(:observed_wrapper_executable) { [] }
 
       before do
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
           observed_cwds << cwd
           observed_commands << command
+
+          wrapper_token = command.split.first
+          if wrapper_token&.include?("gradlew")
+            wrapper_path = File.expand_path(wrapper_token, cwd)
+            observed_wrapper_executable << File.executable?(wrapper_path)
+          end
+
           File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
           FileUtils.mkdir_p(File.join(cwd, "app"))
           File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
@@ -473,6 +502,7 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
 
           expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
           expect(observed_commands.last).to start_with("../gradlew ")
+          expect(observed_wrapper_executable.last).to be(true)
         end
 
         it "does not execute wrappers outside the temporary repository root" do

--- a/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
@@ -533,6 +533,122 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
             FileUtils.rm_rf(outside_root)
           end
         end
+
+        it "falls back to system gradle when the build path escapes the temporary workspace" do
+          require "tmpdir"
+
+          outside_root = Dir.mktmpdir("outside-gradle-wrapper")
+          outside_wrapper = File.join(outside_root, "gradlew")
+          File.write(outside_wrapper, "#!/bin/sh\necho outside\n")
+          FileUtils.chmod("+x", outside_wrapper)
+
+          escaped_settings = Dependabot::DependencyFile.new(
+            name: "settings.gradle",
+            directory: "/gradle-lockfile/sub/../../../../shared",
+            content: "include(':app')\n"
+          )
+
+          escaped_buildfile = Dependabot::DependencyFile.new(
+            name: "app/build.gradle",
+            directory: "/gradle-lockfile/sub/../../../../shared",
+            content: "plugins { id 'java' }\n"
+          )
+
+          escaped_root_lockfile = Dependabot::DependencyFile.new(
+            name: "gradle.lockfile",
+            directory: "/gradle-lockfile/sub/../../../../shared",
+            content: "# old root lockfile\n"
+          )
+
+          escaped_app_lockfile = Dependabot::DependencyFile.new(
+            name: "app/gradle.lockfile",
+            directory: "/gradle-lockfile/sub/../../../../shared",
+            content: "# old app lockfile\n"
+          )
+
+          begin
+            stub_const("Dependabot::Utils::BUMP_TMP_DIR_PATH", outside_root)
+
+            allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
+              observed_commands << command
+              File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
+              FileUtils.mkdir_p(File.join(cwd, "app"))
+              File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
+            end
+
+            updater = described_class.new(
+              dependency_files: [escaped_settings, escaped_buildfile, escaped_root_lockfile, escaped_app_lockfile]
+            )
+            updater.update_lockfiles(escaped_buildfile)
+
+            expect(observed_commands.last).to start_with("gradle ")
+          ensure
+            FileUtils.rm_rf(outside_root)
+          end
+        end
+      end
+
+      context "when the build path contains parent traversal" do
+        let(:traversal_settings) do
+          Dependabot::DependencyFile.new(
+            name: "settings.gradle",
+            directory: "/gradle-lockfile/sub/../../build-logic",
+            content: "include(':app')\n"
+          )
+        end
+
+        let(:traversal_buildfile) do
+          Dependabot::DependencyFile.new(
+            name: "app/build.gradle",
+            directory: "/gradle-lockfile/sub/../../build-logic",
+            content: "plugins { id 'java' }\n"
+          )
+        end
+
+        let(:traversal_root_lockfile) do
+          Dependabot::DependencyFile.new(
+            name: "gradle.lockfile",
+            directory: "/gradle-lockfile/sub/../../build-logic",
+            content: "# old root lockfile\n"
+          )
+        end
+
+        let(:traversal_app_lockfile) do
+          Dependabot::DependencyFile.new(
+            name: "app/gradle.lockfile",
+            directory: "/gradle-lockfile/sub/../../build-logic",
+            content: "# old app lockfile\n"
+          )
+        end
+
+        let(:sibling_gradlew) do
+          Dependabot::DependencyFile.new(
+            name: "gradlew",
+            directory: "/gradle-lockfile/sub",
+            content: "#!/bin/sh\necho sibling wrapper\n"
+          )
+        end
+
+        let(:dependency_files) do
+          [sibling_gradlew, traversal_settings, traversal_buildfile, traversal_root_lockfile, traversal_app_lockfile]
+        end
+
+        let(:observed_commands) { [] }
+
+        before do
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
+            observed_commands << command
+            File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
+            FileUtils.mkdir_p(File.join(cwd, "app"))
+            File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
+          end
+        end
+
+        it "ignores wrappers that are only reachable through lexical parent traversal" do
+          lockfile_updater.update_lockfiles(traversal_buildfile)
+
+          expect(observed_commands.last).to start_with("gradle ")
+        end
       end
     end
   end

--- a/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
@@ -514,14 +514,14 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
           FileUtils.chmod("+x", outside_wrapper)
 
           begin
+            stub_const("Dependabot::Utils::BUMP_TMP_DIR_PATH", outside_root)
+
             allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
               observed_commands << command
               File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
               FileUtils.mkdir_p(File.join(cwd, "app"))
               File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
             end
-
-            allow(Dir).to receive(:tmpdir).and_return(outside_root)
 
             updater = described_class.new(
               dependency_files: [subdir_settings, subdir_buildfile, subdir_root_lockfile, subdir_app_lockfile]

--- a/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/lockfile_updater_spec.rb
@@ -168,29 +168,19 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
           expect(observed_command.last).to include("./gradlew")
         end
 
-        it "falls back to system gradle when wrapper execution fails" do
-          allow(Dependabot.logger).to receive(:warn)
-          observed_command = []
+        it "returns existing files unchanged when wrapper execution fails" do
+          allow(Dependabot.logger).to receive(:error)
 
-          allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
-            observed_command << command
-
-            if command.start_with?("./gradlew")
-              raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-                message: "Error: Invalid or corrupt jarfile gradle/wrapper/gradle-wrapper.jar",
-                error_context: { command: command }
-              )
-            end
-
-            File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
-          end
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                         message: "Error: Invalid or corrupt jarfile gradle/wrapper/gradle-wrapper.jar",
+                         error_context: { command: "./gradlew" }
+                       ))
 
           result = lockfile_updater.update_lockfiles(root_buildfile)
 
-          expect(observed_command[0]).to start_with("./gradlew")
-          expect(observed_command[1]).to start_with("gradle ")
-          expect(result.find { |f| f.name == "gradle.lockfile" }.content).to eq("# updated root lockfile\n")
-          expect(Dependabot.logger).to have_received(:warn).with(include("dependabotResolveAll --write-locks"))
+          expect(result.find { |f| f.name == "gradle.lockfile" }.content).to eq("# root lockfile\n")
+          expect(Dependabot.logger).to have_received(:error).with(include("Failed to update lockfiles"))
         end
       end
 
@@ -483,6 +473,35 @@ RSpec.describe Dependabot::Gradle::FileUpdater::LockfileUpdater do
 
           expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
           expect(observed_commands.last).to start_with("../gradlew ")
+        end
+
+        it "does not execute wrappers outside the temporary repository root" do
+          require "tmpdir"
+
+          outside_root = Dir.mktmpdir("outside-gradle-wrapper")
+          outside_wrapper = File.join(outside_root, "gradlew")
+          File.write(outside_wrapper, "#!/bin/sh\necho outside\n")
+          FileUtils.chmod("+x", outside_wrapper)
+
+          begin
+            allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, cwd:|
+              observed_commands << command
+              File.write(File.join(cwd, "gradle.lockfile"), "# updated root lockfile\n")
+              FileUtils.mkdir_p(File.join(cwd, "app"))
+              File.write(File.join(cwd, "app/gradle.lockfile"), "# updated app lockfile\n")
+            end
+
+            allow(Dir).to receive(:tmpdir).and_return(outside_root)
+
+            updater = described_class.new(
+              dependency_files: [subdir_settings, subdir_buildfile, subdir_root_lockfile, subdir_app_lockfile]
+            )
+            updater.update_lockfiles(subdir_buildfile)
+
+            expect(observed_commands.last).to start_with("gradle ")
+          ensure
+            FileUtils.rm_rf(outside_root)
+          end
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Make Gradle lockfile updates prefer a repository-local `./gradlew` when it exists in Dependabot's temporary workspace, while keeping wrapper selection bounded to the resolved workspace path.

### Anything you want to highlight for special attention from reviewers?

N/A

### How will you know you've accomplished your goal?

Lockfile updates use the repository wrapper when it is present, fall back to `gradle` when it is not, and a regression test covers the path-boundary case.

### Checklist

- [x] I have run the relevant test suite and linters for the touched Gradle lockfile updater slice.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.