### PR TITLE
Add helm to the smoke-test matrix

### DIFF
--- a/.github/smoke-matrix.json
+++ b/.github/smoke-matrix.json
@@ -70,6 +70,11 @@
     "ecosystem": "gradle"
   },
   {
+    "core": "helm",
+    "test": "helm",
+    "ecosystem": "helm"
+  },
+  {
     "core": "hex",
     "test": "hex",
     "ecosystem": "mix"


### PR DESCRIPTION
Follow-up to #15218 (helm `versioning-strategy` support). `.github/smoke-filters.yml` already routes `helm/**` changes to the `helm` suite, but `.github/smoke-matrix.json` had no `helm` entry, so no smoke test actually ran for helm changes. This adds it.

Pairs with dependabot/smoke-tests#547, which adds `tests/smoke-helm.yaml` — a recording that exercises an operator-preserving update (`^3.0.0` → `^3.13.1`, not exact-pinned) and replays at 100% cache locally. The `dependabot-updater-helm` image is published, so the suite has everything it needs once the test file merges.

> **Note:** the failing `Check for spelling errors` (codespell) check is **pre-existing on `main`** and unrelated to this diff — it flags `independ` in a comment in `python/lib/dependabot/python/dependency_grapher/requirements_layers.rb:47` (introduced by #15521). This PR only touches `.github/smoke-matrix.json`. It'll clear on rebase once that's fixed upstream.
