### PR TITLE
Fix Corepack signature verification against replaces-base private registries (#15567)

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -686,12 +686,11 @@ module Dependabot
         return false if default_npm_registry?(registry)
         return false unless error.message.include?(COREPACK_SIGNATURE_METADATA_ERROR)
 
-        # Allow the retry as long as verification is not already disabled. Merged
-        # integrity keys (a non-empty JSON value set for replaces-base registries)
-        # must not suppress this fallback: if the merged keys still cannot verify a
-        # package (e.g. a registry that strips signatures), we retry once with
-        # verification disabled. Only an already-disabled value ("") stops the retry.
-        env[RegistryHelper::COREPACK_INTEGRITY_KEYS_ENV] != ""
+        # Only retry (disabling verification) when no integrity keys are configured.
+        # For a replaces-base registry we proactively set merged npm + registry keys,
+        # so a remaining signature failure is a genuine integrity problem: fail closed
+        # rather than silently disabling verification.
+        !env.key?(RegistryHelper::COREPACK_INTEGRITY_KEYS_ENV)
       end
 
       sig { params(registry: String).returns(T::Boolean) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -686,7 +686,12 @@ module Dependabot
         return false if default_npm_registry?(registry)
         return false unless error.message.include?(COREPACK_SIGNATURE_METADATA_ERROR)
 
-        !env.key?(RegistryHelper::COREPACK_INTEGRITY_KEYS_ENV)
+        # Allow the retry as long as verification is not already disabled. Merged
+        # integrity keys (a non-empty JSON value set for replaces-base registries)
+        # must not suppress this fallback: if the merged keys still cannot verify a
+        # package (e.g. a registry that strips signatures), we retry once with
+        # verification disabled. Only an already-disabled value ("") stops the retry.
+        env[RegistryHelper::COREPACK_INTEGRITY_KEYS_ENV] != ""
       end
 
       sig { params(registry: String).returns(T::Boolean) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -686,10 +686,12 @@ module Dependabot
         return false if default_npm_registry?(registry)
         return false unless error.message.include?(COREPACK_SIGNATURE_METADATA_ERROR)
 
-        # Only retry (disabling verification) when no integrity keys are configured.
-        # For a replaces-base registry we proactively set merged npm + registry keys,
-        # so a remaining signature failure is a genuine integrity problem: fail closed
-        # rather than silently disabling verification.
+        # Retry (disabling verification) only when no integrity keys are
+        # configured. When a replaces-base registry's merged npm + registry keys
+        # were fetched and set, a remaining signature failure is a genuine
+        # integrity problem, so we fail closed rather than silently disabling
+        # verification. If the keys could not be fetched they are left unset, and
+        # this signature-stripping retry still applies as before.
         !env.key?(RegistryHelper::COREPACK_INTEGRITY_KEYS_ENV)
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -95,7 +95,9 @@ module Dependabot
         return nil unless response.status == 200
 
         keys = JSON.parse(response.body)["keys"]
-        return nil unless keys.is_a?(Array)
+        # Require a non-empty array: an empty response is treated as a fetch
+        # failure (nil) rather than silently dropping this source's trust.
+        return nil unless keys.is_a?(Array) && !keys.empty?
         # Each entry must be a signing-key object with at least a keyid and key.
         return nil unless keys.all? { |k| k.is_a?(Hash) && k["keyid"].is_a?(String) && k["key"].is_a?(String) }
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -1,8 +1,10 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "json"
 require "yaml"
 require "dependabot/dependency_file"
+require "dependabot/registry_client"
 require "sorbet-runtime"
 
 module Dependabot
@@ -28,6 +30,15 @@ module Dependabot
       # Default npm registry - no need to set env vars for this
       DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org"
 
+      # Corepack signing-key endpoints
+      NPM_KEYS_URL = "https://registry.npmjs.org/-/npm/v1/keys"
+      KEYS_ENDPOINT_PATH = "/-/npm/v1/keys"
+
+      # Cache of merged Corepack integrity keys, keyed by normalized registry URL,
+      # so we fetch each registry's keys at most once per update job. A nil value
+      # records that the keys could not be built, so we don't retry the fetch.
+      @integrity_keys_cache = T.let({}, T::Hash[String, T.nilable(String)])
+
       # Canonicalise a registry URL: ensure an https:// scheme and strip any
       # trailing slashes. Used wherever a registry URL is written into an env var
       # so there is a single source of truth for URL normalisation.
@@ -36,6 +47,56 @@ module Dependabot
         normalized = url.start_with?("http://", "https://") ? url.dup : "https://#{url}"
         normalized.delete_suffix!("/") while normalized.end_with?("/")
         normalized
+      end
+
+      # Build the COREPACK_INTEGRITY_KEYS value for a replaces-base registry by
+      # merging npm's public signing keys with the registry's own keys, so that
+      # Corepack signature verification stays enabled and trusts both sources.
+      #
+      # The result is cached per registry for the duration of the update job.
+      # Returns nil if either key set cannot be fetched: we never disable
+      # verification, we simply leave COREPACK_INTEGRITY_KEYS unset so Corepack
+      # keeps verifying against its bundled npm keys.
+      sig { params(registry: String, auth_token: T.nilable(String)).returns(T.nilable(String)) }
+      def self.corepack_integrity_keys(registry, auth_token)
+        return @integrity_keys_cache[registry] if @integrity_keys_cache.key?(registry)
+
+        @integrity_keys_cache[registry] = build_integrity_keys(registry, auth_token)
+      end
+
+      sig { params(registry: String, auth_token: T.nilable(String)).returns(T.nilable(String)) }
+      private_class_method def self.build_integrity_keys(registry, auth_token)
+        npm_keys = fetch_signing_keys(NPM_KEYS_URL)
+        registry_keys = fetch_signing_keys("#{registry}#{KEYS_ENDPOINT_PATH}", auth_token)
+
+        if npm_keys.nil? || registry_keys.nil?
+          Dependabot.logger.warn(
+            "Could not fetch Corepack signing keys for #{registry}; " \
+            "leaving COREPACK_INTEGRITY_KEYS unset so verification against npm's " \
+            "bundled keys is preserved."
+          )
+          return nil
+        end
+
+        JSON.generate({ "npm" => npm_keys + registry_keys })
+      end
+
+      # Fetch the `keys` array from an npm-compatible `/-/npm/v1/keys` endpoint.
+      # Returns nil on any failure so the caller can fall back gracefully.
+      sig do
+        params(url: String, auth_token: T.nilable(String))
+          .returns(T.nilable(T::Array[T::Hash[String, T.untyped]]))
+      end
+      private_class_method def self.fetch_signing_keys(url, auth_token = nil)
+        headers = auth_token ? { "Authorization" => "Bearer #{auth_token}" } : {}
+        response = Dependabot::RegistryClient.get(url: url, headers: headers)
+        return nil unless response.status == 200
+
+        keys = JSON.parse(response.body)["keys"]
+        keys.is_a?(Array) ? keys : nil
+      rescue StandardError => e
+        Dependabot.logger.warn("Failed to fetch Corepack signing keys from #{url}: #{e.message}")
+        nil
       end
 
       sig do
@@ -62,6 +123,16 @@ module Dependabot
             env_variables[COREPACK_NPM_REGISTRY_ENV] = registry # For Corepack
             env_variables[NPM_CONFIG_REGISTRY_ENV] = registry # For npm
             env_variables[REGISTRY_KEY] = registry
+
+            # A replaces-base registry (e.g. Cloudsmith) is a caching proxy that
+            # re-signs packages with its own keys, so Corepack's default npm-only
+            # signature verification fails against it. Rather than disabling the
+            # check, merge npm's public keys with the registry's own keys so that
+            # verification stays enabled and trusts both sources. See issue #15567.
+            if registry_info[:replaces_base]
+              integrity_keys = RegistryHelper.corepack_integrity_keys(registry, registry_info[:auth_token])
+              env_variables[COREPACK_INTEGRITY_KEYS_ENV] = integrity_keys if integrity_keys
+            end
           end
         end
 
@@ -106,24 +177,29 @@ module Dependabot
 
         @credentials.each do |cred|
           next unless cred["type"] == "npm_registry" # Skip if not an npm registry
-
-          # Handle both Credential objects and plain hashes
-          replaces_base = if cred.respond_to?(:replaces_base?)
-                            cred.replaces_base?
-                          else
-                            cred["replaces-base"]
-                          end
-
-          next unless replaces_base # Skip if not a reverse-proxy registry
+          next unless credential_replaces_base?(cred) # Skip if not a reverse-proxy registry
 
           # Set the registry if it's not already set
           registries[:registry] ||= cred["registry"]
 
           # Set the token if it's not already set
           registries[:auth_token] ||= cred["token"]
+
+          # Flag that this registry replaces the base (reverse-proxy / caching
+          # proxy), so Corepack's signature keys must be augmented with its own.
+          registries[:replaces_base] ||= "true"
         end
 
         registries
+      end
+
+      # Whether a credential is a reverse-proxy registry that replaces the base.
+      # Handles both Credential objects and plain hashes.
+      sig { params(cred: T.untyped).returns(T.untyped) }
+      def credential_replaces_base?(cred)
+        return cred.replaces_base? if cred.respond_to?(:replaces_base?)
+
+        cred["replaces-base"]
       end
       sig do
         params(

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -6,6 +6,7 @@ require "yaml"
 require "dependabot/credential"
 require "dependabot/dependency_file"
 require "dependabot/registry_client"
+require "dependabot/shared_helpers"
 require "sorbet-runtime"
 
 module Dependabot
@@ -71,6 +72,19 @@ module Dependabot
 
       sig { params(registry: String, auth_token: T.nilable(String)).returns(T.nilable(String)) }
       private_class_method def self.build_integrity_keys(registry, auth_token)
+        # Only augment Corepack's trust anchors when the registry is served over
+        # TLS. Fetching keys from a plaintext http:// registry would let an on-path
+        # attacker inject their own signing keys alongside a forged package, so we
+        # leave COREPACK_INTEGRITY_KEYS unset (verification against npm's bundled
+        # keys is preserved) rather than trusting keys fetched over http.
+        unless registry.start_with?("https://")
+          Dependabot.logger.warn(
+            "Refusing to fetch Corepack signing keys from a non-HTTPS registry (#{registry}); " \
+            "leaving COREPACK_INTEGRITY_KEYS unset."
+          )
+          return nil
+        end
+
         npm_keys = fetch_signing_keys(NPM_KEYS_URL)
         registry_keys = fetch_signing_keys("#{registry}#{KEYS_ENDPOINT_PATH}", auth_token)
 
@@ -95,20 +109,33 @@ module Dependabot
       end
       private_class_method def self.fetch_signing_keys(url, auth_token = nil)
         headers = auth_token ? { "Authorization" => "Bearer #{auth_token}" } : {}
-        response = Dependabot::RegistryClient.get(url: url, headers: headers)
+        # Do not follow redirects: a signing-key endpoint that redirects (e.g. an
+        # https -> http downgrade) must not silently move the fetch onto plaintext,
+        # so any redirect is treated as a failure (non-200 -> nil).
+        no_redirect_middlewares =
+          Dependabot::SharedHelpers.excon_middleware.reject { |m| m == Excon::Middleware::RedirectFollower }
+        response = Dependabot::RegistryClient.get(
+          url: url,
+          headers: headers,
+          options: { middlewares: no_redirect_middlewares }
+        )
         return nil unless response.status == 200
 
         keys = JSON.parse(response.body)["keys"]
-        # Require a non-empty array: an empty response is treated as a fetch
-        # failure (nil) rather than silently dropping this source's trust.
-        return nil unless keys.is_a?(Array) && !keys.empty?
-        # Each entry must be a signing-key object with at least a keyid and key.
-        return nil unless keys.all? { |k| k.is_a?(Hash) && k["keyid"].is_a?(String) && k["key"].is_a?(String) }
-
-        keys
+        valid_signing_keys?(keys) ? keys : nil
       rescue StandardError => e
         Dependabot.logger.warn("Failed to fetch Corepack signing keys from #{url}: #{e.message}")
         nil
+      end
+
+      # A valid signing-key set is a non-empty array whose every entry is an object
+      # with at least a string keyid and key. An empty or malformed set is rejected
+      # so callers take the fail-safe path rather than emitting an invalid payload.
+      sig { params(keys: T.nilable(Object)).returns(T::Boolean) }
+      private_class_method def self.valid_signing_keys?(keys)
+        return false unless keys.is_a?(Array) && !keys.empty?
+
+        keys.all? { |k| k.is_a?(Hash) && k["keyid"].is_a?(String) && k["key"].is_a?(String) }
       end
 
       sig do

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -35,6 +35,10 @@ module Dependabot
       NPM_KEYS_URL = "https://registry.npmjs.org/-/npm/v1/keys"
       KEYS_ENDPOINT_PATH = "/-/npm/v1/keys"
 
+      # Sentinel recorded in the registry-info hash (whose values are strings) to
+      # flag a replaces-base registry. Compared explicitly rather than by truthiness.
+      REPLACES_BASE_FLAG = "true"
+
       # Cache of merged Corepack integrity keys, keyed by normalized registry URL,
       # so we fetch each registry's keys at most once per update job. A nil value
       # records that the keys could not be built, so we don't retry the fetch.
@@ -137,7 +141,7 @@ module Dependabot
             # signature verification fails against it. Rather than disabling the
             # check, merge npm's public keys with the registry's own keys so that
             # verification stays enabled and trusts both sources. See issue #15567.
-            if registry_info[:replaces_base]
+            if registry_info[:replaces_base] == REPLACES_BASE_FLAG
               integrity_keys = RegistryHelper.corepack_integrity_keys(registry, registry_info[:auth_token])
               env_variables[COREPACK_INTEGRITY_KEYS_ENV] = integrity_keys if integrity_keys
             end
@@ -195,7 +199,7 @@ module Dependabot
 
           # Flag that this registry replaces the base (reverse-proxy / caching
           # proxy), so Corepack's signature keys must be augmented with its own.
-          registries[:replaces_base] ||= "true"
+          registries[:replaces_base] ||= REPLACES_BASE_FLAG
         end
 
         registries

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -3,6 +3,7 @@
 
 require "json"
 require "yaml"
+require "dependabot/credential"
 require "dependabot/dependency_file"
 require "dependabot/registry_client"
 require "sorbet-runtime"
@@ -82,10 +83,11 @@ module Dependabot
       end
 
       # Fetch the `keys` array from an npm-compatible `/-/npm/v1/keys` endpoint.
-      # Returns nil on any failure so the caller can fall back gracefully.
+      # Returns nil on any failure (including a malformed response) so the caller
+      # can fall back gracefully rather than emitting an invalid key payload.
       sig do
         params(url: String, auth_token: T.nilable(String))
-          .returns(T.nilable(T::Array[T::Hash[String, T.untyped]]))
+          .returns(T.nilable(T::Array[T::Hash[String, Object]]))
       end
       private_class_method def self.fetch_signing_keys(url, auth_token = nil)
         headers = auth_token ? { "Authorization" => "Bearer #{auth_token}" } : {}
@@ -93,7 +95,11 @@ module Dependabot
         return nil unless response.status == 200
 
         keys = JSON.parse(response.body)["keys"]
-        keys.is_a?(Array) ? keys : nil
+        return nil unless keys.is_a?(Array)
+        # Each entry must be a signing-key object with at least a keyid and key.
+        return nil unless keys.all? { |k| k.is_a?(Hash) && k["keyid"].is_a?(String) && k["key"].is_a?(String) }
+
+        keys
       rescue StandardError => e
         Dependabot.logger.warn("Failed to fetch Corepack signing keys from #{url}: #{e.message}")
         nil
@@ -194,12 +200,14 @@ module Dependabot
       end
 
       # Whether a credential is a reverse-proxy registry that replaces the base.
-      # Handles both Credential objects and plain hashes.
-      sig { params(cred: T.untyped).returns(T.untyped) }
+      # Handles both Credential objects and plain hashes; mirrors Credential's own
+      # `replaces-base == true` check so a truthy non-boolean (e.g. "false") does
+      # not enable replaces-base behaviour.
+      sig { params(cred: T.any(Dependabot::Credential, T::Hash[String, Object])).returns(T::Boolean) }
       def credential_replaces_base?(cred)
-        return cred.replaces_base? if cred.respond_to?(:replaces_base?)
+        return cred.replaces_base? if cred.is_a?(Dependabot::Credential)
 
-        cred["replaces-base"]
+        cred["replaces-base"] == true
       end
       sig do
         params(

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -32,9 +32,14 @@ module Dependabot
       # Default npm registry - no need to set env vars for this
       DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org"
 
-      # Corepack signing-key endpoints
-      NPM_KEYS_URL = "https://registry.npmjs.org/-/npm/v1/keys"
+      # Corepack signing-key endpoints. `KEYS_ENDPOINT_PATH` is the standard npm
+      # registry API path (`registry-host.tld/-/npm/v1/keys`) served by any
+      # signature-supporting registry, so it is appended generically to a
+      # registry URL. `NPM_KEYS_URL` is simply that same path applied to the
+      # default public npm registry, built from the constants above so the host
+      # has a single source of truth.
       KEYS_ENDPOINT_PATH = "/-/npm/v1/keys"
+      NPM_KEYS_URL = T.let("#{DEFAULT_NPM_REGISTRY}#{KEYS_ENDPOINT_PATH}".freeze, String)
 
       # Sentinel recorded in the registry-info hash (whose values are strings) to
       # flag a replaces-base registry. Compared explicitly rather than by truthiness.

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb
@@ -65,9 +65,12 @@ module Dependabot
       # Corepack signature verification stays enabled and trusts both sources.
       #
       # The result is cached per registry for the duration of the update job.
-      # Returns nil if either key set cannot be fetched: we never disable
-      # verification, we simply leave COREPACK_INTEGRITY_KEYS unset so Corepack
-      # keeps verifying against its bundled npm keys.
+      # Returns nil if either key set cannot be fetched, leaving
+      # COREPACK_INTEGRITY_KEYS unset. For a re-signing registry that means a
+      # later signature failure is surfaced (fail closed). Note the separate
+      # signature-stripping retry in Helpers.retry_without_signature_verification?
+      # still applies when the key is absent, so leaving it unset does not by
+      # itself guarantee verification stays on for every registry type.
       sig { params(registry: String, auth_token: T.nilable(String)).returns(T.nilable(String)) }
       def self.corepack_integrity_keys(registry, auth_token)
         return @integrity_keys_cache[registry] if @integrity_keys_cache.key?(registry)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -777,6 +777,8 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
     after do
       described_class.dependency_files = []
       described_class.credentials = []
+      # Clear fake keys so they don't leak into later randomized specs.
+      Dependabot::NpmAndYarn::RegistryHelper.instance_variable_set(:@integrity_keys_cache, {})
     end
 
     describe ".build_corepack_env_variables" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -284,6 +284,48 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
       expect(described_class.package_manager_run_command("npm", "-v", env: env)).to eq("11.9.0")
     end
 
+    it "still retries when merged COREPACK_INTEGRITY_KEYS are present but cannot verify" do
+      merged_keys = JSON.generate("npm" => [{ "keyid" => "SHA256:merged" }])
+      env = {
+        "COREPACK_NPM_REGISTRY" => "https://packages.example.com/artifactory/api/npm/npm",
+        "COREPACK_INTEGRITY_KEYS" => merged_keys
+      }
+
+      first_error = StandardError.new("Internal Error: No compatible signature found in package metadata")
+
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+        "corepack npm -v",
+        fingerprint: "corepack npm -v",
+        env: env
+      ).ordered.and_raise(first_error)
+
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+        "corepack npm -v",
+        fingerprint: "corepack npm -v",
+        env: env.merge("COREPACK_INTEGRITY_KEYS" => "")
+      ).ordered.and_return("11.9.0\n")
+
+      expect(described_class.package_manager_run_command("npm", "-v", env: env)).to eq("11.9.0")
+    end
+
+    it "does not retry when COREPACK_INTEGRITY_KEYS verification is already disabled" do
+      env = {
+        "COREPACK_NPM_REGISTRY" => "https://packages.example.com/artifactory/api/npm/npm",
+        "COREPACK_INTEGRITY_KEYS" => ""
+      }
+      error = StandardError.new("Internal Error: No compatible signature found in package metadata")
+
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+        "corepack npm -v",
+        fingerprint: "corepack npm -v",
+        env: env
+      ).once.and_raise(error)
+
+      expect do
+        described_class.package_manager_run_command("npm", "-v", env: env)
+      end.to raise_error(StandardError, /No compatible signature found in package metadata/)
+    end
+
     it "does not retry for signature errors when no private registry env is configured" do
       error = StandardError.new("Internal Error: No compatible signature found in package metadata")
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -284,37 +284,15 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
       expect(described_class.package_manager_run_command("npm", "-v", env: env)).to eq("11.9.0")
     end
 
-    it "still retries when merged COREPACK_INTEGRITY_KEYS are present but cannot verify" do
-      merged_keys = JSON.generate("npm" => [{ "keyid" => "SHA256:merged" }])
+    it "fails closed without retrying when merged COREPACK_INTEGRITY_KEYS are present" do
+      merged_keys = JSON.generate("npm" => [{ "keyid" => "SHA256:merged", "key" => "abc" }])
       env = {
         "COREPACK_NPM_REGISTRY" => "https://packages.example.com/artifactory/api/npm/npm",
         "COREPACK_INTEGRITY_KEYS" => merged_keys
       }
-
-      first_error = StandardError.new("Internal Error: No compatible signature found in package metadata")
-
-      expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
-        "corepack npm -v",
-        fingerprint: "corepack npm -v",
-        env: env
-      ).ordered.and_raise(first_error)
-
-      expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
-        "corepack npm -v",
-        fingerprint: "corepack npm -v",
-        env: env.merge("COREPACK_INTEGRITY_KEYS" => "")
-      ).ordered.and_return("11.9.0\n")
-
-      expect(described_class.package_manager_run_command("npm", "-v", env: env)).to eq("11.9.0")
-    end
-
-    it "does not retry when COREPACK_INTEGRITY_KEYS verification is already disabled" do
-      env = {
-        "COREPACK_NPM_REGISTRY" => "https://packages.example.com/artifactory/api/npm/npm",
-        "COREPACK_INTEGRITY_KEYS" => ""
-      }
       error = StandardError.new("Internal Error: No compatible signature found in package metadata")
 
+      # Only one attempt: with merged keys already set we never disable verification.
       expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
         "corepack npm -v",
         fingerprint: "corepack npm -v",

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -763,6 +763,15 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
         .with(:enable_private_registry_for_corepack).and_return(true)
       allow(Dependabot::Experiments).to receive(:enabled?)
         .with(:enable_corepack_for_npm_and_yarn).and_return(true)
+      # Building env for a replaces-base registry fetches Corepack signing keys.
+      # Stub the endpoints so these examples stay hermetic and don't hit the network.
+      stub_request(:get, %r{/-/npm/v1/keys\z})
+        .to_return(
+          status: 200,
+          body: JSON.generate("keys" => [{ "keyid" => "SHA256:test", "key" => "test-key" }])
+        )
+      # Ensure a fresh integrity-keys cache so the stubs are exercised each example.
+      Dependabot::NpmAndYarn::RegistryHelper.instance_variable_set(:@integrity_keys_cache, {})
     end
 
     after do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -196,6 +196,56 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
       end
     end
 
+    context "when credentials are provided as Dependabot::Credential objects" do
+      let(:registry_config_files) { {} }
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            "type" => "npm_registry",
+            "registry" => "artifactory.example.com/npm",
+            "token" => "my-token",
+            "replaces-base" => true
+          )
+        ]
+      end
+
+      before do
+        stub_request(:get, "https://registry.npmjs.org/-/npm/v1/keys")
+          .to_return(status: 200, body: JSON.generate({ "keys" => npm_signing_keys }))
+        stub_request(:get, "https://artifactory.example.com/npm/-/npm/v1/keys")
+          .with(headers: { "Authorization" => "Bearer my-token" })
+          .to_return(status: 200, body: JSON.generate({ "keys" => registry_signing_keys }))
+      end
+
+      it "uses the replaces_base? predicate and sets merged Corepack integrity keys" do
+        helper = described_class.new(registry_config_files, credentials)
+        env_variables = helper.find_corepack_env_variables
+        expect(env_variables["COREPACK_INTEGRITY_KEYS"])
+          .to eq(JSON.generate("npm" => npm_signing_keys + registry_signing_keys))
+      end
+    end
+
+    context "when a credential has replaces-base as a non-boolean truthy value" do
+      let(:registry_config_files) { {} }
+      let(:credentials) do
+        [
+          {
+            "type" => "npm_registry",
+            "registry" => "artifactory.example.com/npm",
+            "token" => "my-token",
+            "replaces-base" => "false"
+          }
+        ]
+      end
+
+      it "does not treat the registry as replaces-base" do
+        helper = described_class.new(registry_config_files, credentials)
+        env_variables = helper.find_corepack_env_variables
+        expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
+        expect(env_variables).not_to have_key("COREPACK_NPM_REGISTRY")
+      end
+    end
+
     context "when credentials are provided with a trailing slash in the registry URL" do
       let(:registry_config_files) { {} }
       let(:credentials) do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -194,6 +194,19 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
           expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
         end
       end
+
+      context "when a key endpoint returns a malformed keys payload" do
+        before do
+          stub_request(:get, "https://artifactory.example.com/npm/-/npm/v1/keys")
+            .to_return(status: 200, body: JSON.generate({ "keys" => ["invalid"] }))
+        end
+
+        it "leaves Corepack integrity keys unset rather than emitting an invalid payload" do
+          helper = described_class.new(registry_config_files, credentials)
+          env_variables = helper.find_corepack_env_variables
+          expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
+        end
+      end
     end
 
     context "when credentials are provided as Dependabot::Credential objects" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -222,6 +222,55 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
       end
     end
 
+    context "when the replaces-base registry uses a plaintext http scheme" do
+      let(:registry_config_files) { {} }
+      let(:credentials) do
+        [
+          {
+            "type" => "npm_registry",
+            "registry" => "http://artifactory.example.com/npm",
+            "token" => "my-token",
+            "replaces-base" => true
+          }
+        ]
+      end
+
+      it "does not fetch signing keys over http and leaves integrity keys unset" do
+        helper = described_class.new(registry_config_files, credentials)
+        env_variables = helper.find_corepack_env_variables
+        expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
+        expect(WebMock).not_to have_requested(:get, %r{/-/npm/v1/keys})
+      end
+    end
+
+    context "when a key endpoint responds with a redirect" do
+      let(:registry_config_files) { {} }
+      let(:credentials) do
+        [
+          {
+            "type" => "npm_registry",
+            "registry" => "artifactory.example.com/npm",
+            "token" => "my-token",
+            "replaces-base" => true
+          }
+        ]
+      end
+
+      before do
+        stub_request(:get, "https://registry.npmjs.org/-/npm/v1/keys")
+          .to_return(status: 200, body: JSON.generate({ "keys" => npm_signing_keys }))
+        stub_request(:get, "https://artifactory.example.com/npm/-/npm/v1/keys")
+          .to_return(status: 301, headers: { "Location" => "http://artifactory.example.com/npm/-/npm/v1/keys" })
+      end
+
+      it "does not follow the redirect and leaves integrity keys unset" do
+        helper = described_class.new(registry_config_files, credentials)
+        env_variables = helper.find_corepack_env_variables
+        expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
+        expect(WebMock).not_to have_requested(:get, "http://artifactory.example.com/npm/-/npm/v1/keys")
+      end
+    end
+
     context "when credentials are provided as Dependabot::Credential objects" do
       let(:registry_config_files) { {} }
       let(:credentials) do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -207,6 +207,19 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
           expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
         end
       end
+
+      context "when the npm key endpoint returns an empty keys array" do
+        before do
+          stub_request(:get, "https://registry.npmjs.org/-/npm/v1/keys")
+            .to_return(status: 200, body: JSON.generate({ "keys" => [] }))
+        end
+
+        it "leaves Corepack integrity keys unset rather than dropping npm trust" do
+          helper = described_class.new(registry_config_files, credentials)
+          env_variables = helper.find_corepack_env_variables
+          expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
+        end
+      end
     end
 
     context "when credentials are provided as Dependabot::Credential objects" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -109,6 +109,29 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
   end
 
   describe "#find_corepack_env_variables" do
+    let(:npm_signing_keys) do
+      [{
+        "expires" => nil,
+        "keyid" => "SHA256:npm",
+        "keytype" => "ecdsa-sha2-nistp256",
+        "scheme" => "ecdsa-sha2-nistp256",
+        "key" => "npm-public-key"
+      }]
+    end
+
+    let(:registry_signing_keys) do
+      [{
+        "expires" => nil,
+        "keyid" => "SHA256:registry",
+        "keytype" => "ecdsa-sha2-nistp256",
+        "scheme" => "ecdsa-sha2-nistp256",
+        "key" => "registry-public-key"
+      }]
+    end
+
+    # Reset the per-job integrity-keys cache so each example fetches afresh.
+    before { described_class.instance_variable_set(:@integrity_keys_cache, {}) }
+
     context "when npmrc is provided" do
       let(:registry_config_files) { { npmrc: npmrc_file } }
 
@@ -137,15 +160,37 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
         ]
       end
 
-      it "returns registry with https scheme" do
+      before do
+        stub_request(:get, "https://registry.npmjs.org/-/npm/v1/keys")
+          .to_return(status: 200, body: JSON.generate({ "keys" => npm_signing_keys }))
+        stub_request(:get, "https://artifactory.example.com/npm/-/npm/v1/keys")
+          .with(headers: { "Authorization" => "Bearer my-token" })
+          .to_return(status: 200, body: JSON.generate({ "keys" => registry_signing_keys }))
+      end
+
+      it "returns registry with https scheme and merged Corepack integrity keys" do
         helper = described_class.new(registry_config_files, credentials)
         env_variables = helper.find_corepack_env_variables
         expect(env_variables).to eq(
           "COREPACK_NPM_REGISTRY" => "https://artifactory.example.com/npm",
           "npm_config_registry" => "https://artifactory.example.com/npm",
           "COREPACK_NPM_TOKEN" => "my-token",
-          "registry" => "https://artifactory.example.com/npm"
+          "registry" => "https://artifactory.example.com/npm",
+          "COREPACK_INTEGRITY_KEYS" => JSON.generate("npm" => npm_signing_keys + registry_signing_keys)
         )
+      end
+
+      context "when a key endpoint fetch fails" do
+        before do
+          stub_request(:get, "https://artifactory.example.com/npm/-/npm/v1/keys")
+            .to_return(status: 500, body: "boom")
+        end
+
+        it "leaves Corepack integrity keys unset rather than disabling verification" do
+          helper = described_class.new(registry_config_files, credentials)
+          env_variables = helper.find_corepack_env_variables
+          expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
+        end
       end
     end
 
@@ -162,6 +207,13 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
         ]
       end
 
+      before do
+        stub_request(:get, "https://registry.npmjs.org/-/npm/v1/keys")
+          .to_return(status: 200, body: JSON.generate({ "keys" => npm_signing_keys }))
+        stub_request(:get, "https://artifactory.example.com/npm/-/npm/v1/keys")
+          .to_return(status: 200, body: JSON.generate({ "keys" => registry_signing_keys }))
+      end
+
       it "strips the trailing slash from the registry URL" do
         helper = described_class.new(registry_config_files, credentials)
         env_variables = helper.find_corepack_env_variables
@@ -169,8 +221,40 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
           "COREPACK_NPM_REGISTRY" => "https://artifactory.example.com/npm",
           "npm_config_registry" => "https://artifactory.example.com/npm",
           "COREPACK_NPM_TOKEN" => "my-token",
-          "registry" => "https://artifactory.example.com/npm"
+          "registry" => "https://artifactory.example.com/npm",
+          "COREPACK_INTEGRITY_KEYS" => JSON.generate("npm" => npm_signing_keys + registry_signing_keys)
         )
+      end
+    end
+
+    context "when credentials are provided without replaces-base" do
+      let(:registry_config_files) { {} }
+      let(:credentials) do
+        [
+          {
+            "type" => "npm_registry",
+            "registry" => "artifactory.example.com/npm",
+            "token" => "my-token",
+            "replaces-base" => false
+          }
+        ]
+      end
+
+      it "does not set Corepack integrity keys and does not fetch keys" do
+        helper = described_class.new(registry_config_files, credentials)
+        env_variables = helper.find_corepack_env_variables
+        expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
+        expect(WebMock).not_to have_requested(:get, "https://registry.npmjs.org/-/npm/v1/keys")
+      end
+    end
+
+    context "when no private registry is configured" do
+      let(:registry_config_files) { {} }
+
+      it "does not set Corepack integrity keys" do
+        helper = described_class.new(registry_config_files, [])
+        env_variables = helper.find_corepack_env_variables
+        expect(env_variables).not_to have_key("COREPACK_INTEGRITY_KEYS")
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/registry_helper_spec.rb
@@ -129,8 +129,10 @@ RSpec.describe Dependabot::NpmAndYarn::RegistryHelper do
       }]
     end
 
-    # Reset the per-job integrity-keys cache so each example fetches afresh.
+    # Reset the per-job integrity-keys cache around each example so fetches are
+    # fresh and no fake keys leak into other specs in the same process.
     before { described_class.instance_variable_set(:@integrity_keys_cache, {}) }
+    after { described_class.instance_variable_set(:@integrity_keys_cache, {}) }
 
     context "when npmrc is provided" do
       let(:registry_config_files) { { npmrc: npmrc_file } }


### PR DESCRIPTION
Private npm registries that act as caching proxies (e.g. Cloudsmith) re-sign packages with their own ECDSA keys. Corepack verifies against its bundled npm public keys only, so `corepack prepare`/`install` fail with "The package was not signed by any trusted keys" when a `replaces-base: true` registry is configured.

When a replaces-base registry is configured, fetch npm's public signing keys and the registry's own keys, merge them under `{"npm":[...]}`, and pass the result as COREPACK_INTEGRITY_KEYS. Signature verification stays enabled and trusts both sources rather than being disabled.

If either key set cannot be fetched, COREPACK_INTEGRITY_KEYS is left unset. For a re-signing registry a later signature failure is then surfaced (fail closed). Note the pre-existing signature-metadata retry for signature-stripping registries (#14612) still applies when the key is absent, so leaving it unset does not by itself guarantee verification stays on for every registry type. Keys are cached per registry for the update job.

Fixes #15567

### **What are you trying to accomplish?**

Corepack's prepare/install commands fail with The package was not signed by any trusted keys when Dependabot uses a private npm registry configured with replaces-base: true.

Private npm registries that act as caching proxies (e.g. Cloudsmith) re-sign packages with their own ECDSA keys instead of preserving the upstream npmjs signature. Corepack verifies package-manager signatures against its bundled npm public keys only, so verification fails against the registry's re-signed packages. Dependabot already passes COREPACK_NPM_REGISTRY and COREPACK_NPM_TOKEN to the corepack subprocess (#11077) but not any signing keys, and there is no user-side workaround (.corepack.env is not loaded by corepack prepare/install - nodejs/corepack#741 - and users can't set arbitrary env vars in Dependabot's runtime).

This change, when a replaces-base: true registry is configured, fetches npm's public signing keys and the registry's own keys and passes both, merged, as COREPACK_INTEGRITY_KEYS. Signature verification stays enabled and trusts both sources.

Fixes #15567. Related: #14612 (distinct root cause, registry strips signatures rather than re-signing, not addressed here).

### **Anything you want to highlight for special attention from reviewers?**

- Merge, don't disable. The obvious alternative is COREPACK_INTEGRITY_KEYS=0, which disables verification entirely, a security downgrade. Instead we merge npm's keys with the registry's keys ({"npm": [...npmKeys, ...registryKeys]}) so the full integrity check is preserved. Verified necessary in practice: in the test repo, the npm package is re-signed with the registry key while every pnpm version keeps its original npmjs keyid, so trusting both key sets is required for a single registry.
- Fail safe, never silently skip. If either key set can't be fetched (not every registry exposes /-/npm/v1/keys), COREPACK_INTEGRITY_KEYS is left unset rather than set to 0 -- we never proactively disable verification on this path, and for a re-signing registry the failure is surfaced (fail closed). One caveat: the pre-existing signature-metadata retry for signature-stripping registries (#14612) still fires when the key is absent, so that separate path can retry with verification disabled exactly as it did before this PR.
- Scope. Reuses the existing replaces-base credential mechanism (no re-parsing). Keys are fetched via the existing Dependabot::RegistryClient and cached per registry for the update job. The env-hash construction is the only production code touched.
- Gated behind the existing enable_private_registry_for_corepack experiment.

### **How will you know you've accomplished your goal?**

Reproduced end-to-end against a real Cloudsmith registry (corepack prepare npm@11.16.0 --activate, the engines-pin activation path):

**Before** (baseline, corepack's bundled keys):
Usage Error: The package was not signed by any trusted keys: {
  "signatures":  [{ "keyid": "SHA256:5mJAtUoc0TI7kFjJ8NoV+LnJqHmAsJSv+r7wbMoQrBs", ... }],
  "trustedKeys": [ SHA256:jl3bwswu... (expired), SHA256:DhQ8wR5... ]   # registry key absent
}
EXIT=1

**After** (merged COREPACK_INTEGRITY_KEYS produced by this change):
Preparing npm@11.16.0 for immediate activation...
EXIT=0

The merged env was generated by the actual RegistryHelper#find_corepack_env_vaeal npmjs and registry key endpoints. New unit tests cover: merged keys onreplaces-base: true; unset (not 0) when a key fetch fails; not set when replaces-base is false/absent; not set when no private registry is configured.

### **Checklist**

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expectednal tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request addresses, how it fixes the problem, and any relevant details about theimplementation.
- [x] I have ensured that the code is well-documented and easy to understand.

