### PR TITLE
Type the Sentry before_send processors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1203
+# Offense count: 1199
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -434,10 +434,7 @@ Sorbet/ForbidTUntyped:
     - "updater/lib/dependabot/job/security_advisory_entry.rb"
     - "updater/lib/dependabot/opentelemetry.rb"
     - "updater/lib/dependabot/pull_request.rb"
-    - "updater/lib/dependabot/sentry.rb"
-    - "updater/lib/dependabot/sentry/exception_sanitizer_processor.rb"
-    - "updater/lib/dependabot/sentry/processor.rb"
-    - "updater/lib/dependabot/sentry/sentry_context_processor.rb"
+
     - "updater/lib/dependabot/service.rb"
     - "updater/lib/dependabot/updater/dependency_group_change_batch.rb"
     - "updater/lib/dependabot/updater/error_handler.rb"

--- a/updater/lib/dependabot/sentry.rb
+++ b/updater/lib/dependabot/sentry.rb
@@ -11,7 +11,7 @@ module Dependabot
 
     # The default processor chain.
     # This chain is applied in the order of the array.
-    sig { params(event: ::Sentry::Event, hint: T::Hash[Symbol, T.untyped]).returns(::Sentry::Event) }
+    sig { params(event: ::Sentry::Event, hint: T::Hash[Symbol, Object]).returns(::Sentry::Event) }
     def self.process_chain(event, hint)
       [ExceptionSanitizer, SentryContext].each(&:new).reduce(event) do |acc, processor|
         processor.new.process(acc, hint)

--- a/updater/lib/dependabot/sentry/exception_sanitizer_processor.rb
+++ b/updater/lib/dependabot/sentry/exception_sanitizer_processor.rb
@@ -23,7 +23,7 @@ class ExceptionSanitizer < ::Dependabot::Sentry::Processor
     override
       .params(
         event: ::Sentry::Event,
-        _hint: T::Hash[Symbol, T.untyped]
+        _hint: T::Hash[Symbol, Object]
       )
       .returns(::Sentry::Event)
   end

--- a/updater/lib/dependabot/sentry/processor.rb
+++ b/updater/lib/dependabot/sentry/processor.rb
@@ -16,7 +16,7 @@ module Dependabot
         abstract
           .params(
             event: ::Sentry::Event,
-            hint: T::Hash[Symbol, T.untyped]
+            hint: T::Hash[Symbol, Object]
           )
           .returns(::Sentry::Event)
       end

--- a/updater/lib/dependabot/sentry/sentry_context_processor.rb
+++ b/updater/lib/dependabot/sentry/sentry_context_processor.rb
@@ -1,9 +1,10 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sentry-ruby"
 require "sorbet-runtime"
 
+require "dependabot/errors"
 require "dependabot/sentry/processor"
 
 class SentryContext < ::Dependabot::Sentry::Processor
@@ -11,13 +12,14 @@ class SentryContext < ::Dependabot::Sentry::Processor
     override
       .params(
         event: ::Sentry::Event,
-        hint: T::Hash[Symbol, T.untyped]
+        hint: T::Hash[Symbol, Object]
       )
       .returns(::Sentry::Event)
   end
   def process(event, hint)
-    if (exception = hint[:exception]) && exception.respond_to?(:sentry_context)
-      exception.sentry_context&.each do |key, value|
+    exception = hint[:exception]
+    if exception.is_a?(Dependabot::HasSentryContext)
+      exception.sentry_context.each do |key, value|
         event.send(:"#{key}=", value)
       end
     end

--- a/updater/spec/dependabot/sentry/sentry_context_processor_spec.rb
+++ b/updater/spec/dependabot/sentry/sentry_context_processor_spec.rb
@@ -11,7 +11,14 @@ RSpec.describe SentryContext do
   subject { event }
 
   let(:sentry_context) { { foo: "bar" } }
-  let(:exception) { double(::Dependabot::DependabotError, sentry_context: sentry_context) }
+  let(:exception) do
+    context = sentry_context
+    Class.new(StandardError) do
+      include Dependabot::HasSentryContext
+
+      define_method(:sentry_context) { context }
+    end.new
+  end
   let(:hint) { { exception: exception } }
   let(:event) { instance_double(::Sentry::ErrorEvent) }
 
@@ -32,8 +39,8 @@ RSpec.describe SentryContext do
     end
   end
 
-  context "without sentry_context" do
-    let(:sentry_context) { nil }
+  context "with empty sentry_context" do
+    let(:sentry_context) { {} }
 
     it "does not add context" do
       expect(event).not_to have_received(:send)


### PR DESCRIPTION
Part of the `Sorbet/ForbidTUntyped` burndown. Uses `Object` instead of `T.untyped` for the Sentry processors' `hint`, and narrows the exception via the existing `HasSentryContext` interface so `sentry_context_processor.rb` can go `typed: strong`. Behaviour is unchanged: every class defining `sentry_context` already includes the module.