### PR TITLE
Clear T.untyped from four strong updater files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1199
+# Offense count: 1190
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -425,7 +425,6 @@ Sorbet/ForbidTUntyped:
     - "terraform/lib/dependabot/terraform/update_checker/latest_version_resolver.rb"
     - "updater/lib/dependabot/api_client.rb"
     - "updater/lib/dependabot/dependency_attribution.rb"
-    - "updater/lib/dependabot/dependency_change.rb"
     - "updater/lib/dependabot/environment.rb"
     - "updater/lib/dependabot/file_fetcher_command.rb"
     - "updater/lib/dependabot/job.rb"
@@ -438,11 +437,8 @@ Sorbet/ForbidTUntyped:
     - "updater/lib/dependabot/service.rb"
     - "updater/lib/dependabot/updater/dependency_group_change_batch.rb"
     - "updater/lib/dependabot/updater/error_handler.rb"
-    - "updater/lib/dependabot/updater/errors.rb"
     - "updater/lib/dependabot/updater/group_dependency_selector.rb"
-    - "updater/lib/dependabot/updater/pattern_specificity_calculator.rb"
     - "updater/lib/dependabot/updater/update_type_helper.rb"
-    - "updater/lib/github_api/dependency_submission.rb"
     - "uv/lib/dependabot/uv.rb"
     - "uv/lib/dependabot/uv/dependency_grapher.rb"
     - "uv/lib/dependabot/uv/file_fetcher/workspace_fetcher.rb"

--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -120,7 +120,7 @@ module Dependabot
       end.join(", ")
     end
 
-    sig { returns(T::Array[T::Hash[String, T.untyped]]) }
+    sig { returns(T::Array[T::Hash[String, T.nilable(T.any(String, T::Boolean))]]) }
     def updated_dependency_files_hash
       updated_dependency_files.map(&:to_h)
     end

--- a/updater/lib/dependabot/updater/errors.rb
+++ b/updater/lib/dependabot/updater/errors.rb
@@ -9,14 +9,14 @@ module Dependabot
       extend T::Sig
       include Dependabot::HasSentryContext
 
-      sig { override.returns(T::Hash[Symbol, T.untyped]) }
+      sig { override.returns(T::Hash[Symbol, T.anything]) }
       attr_reader :sentry_context
 
-      sig { params(message: String, sentry_context: T::Hash[Symbol, T.untyped]).void }
+      sig { params(message: String, sentry_context: T::Hash[Symbol, T.anything]).void }
       def initialize(message, sentry_context:)
         super(message)
 
-        @sentry_context = T.let(sentry_context, T::Hash[Symbol, T.untyped])
+        @sentry_context = T.let(sentry_context, T::Hash[Symbol, T.anything])
       end
     end
   end

--- a/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
+++ b/updater/lib/dependabot/updater/pattern_specificity_calculator.rb
@@ -130,7 +130,7 @@ module Dependabot
           current_group: Dependabot::DependencyGroup,
           dep: Dependabot::Dependency,
           groups: T::Array[Dependabot::DependencyGroup],
-          context: T::Hash[Symbol, T.untyped],
+          context: T::Hash[Symbol, Object],
           current_specificity: Integer
         ).returns(T.nilable(Dependabot::DependencyGroup))
       end
@@ -156,7 +156,7 @@ module Dependabot
         params(
           group: Dependabot::DependencyGroup,
           dep: Dependabot::Dependency,
-          context: T::Hash[Symbol, T.untyped]
+          context: T::Hash[Symbol, Object]
         ).returns(T::Boolean)
       end
       def group_matches_context?(group, dep, context)

--- a/updater/lib/github_api/dependency_submission.rb
+++ b/updater/lib/github_api/dependency_submission.rb
@@ -114,7 +114,7 @@ module GithubApi
     # TODO: Change to a typed structure?
     #
     # See: https://sorbet.org/docs/tstruct
-    sig { returns(T::Hash[Symbol, T.untyped]) }
+    sig { returns(T::Hash[Symbol, Object]) }
     def payload
       {
         version: SNAPSHOT_VERSION,
@@ -184,7 +184,7 @@ module GithubApi
     end
 
     sig do
-      returns(T::Hash[String, T.untyped])
+      returns(T::Hash[String, Object])
     end
     def manifests
       @manifest_snapshots.each_with_object({}) do |snapshot, manifests|
@@ -202,7 +202,7 @@ module GithubApi
     # collection so the snapshot reflects that the file was scanned.
     sig do
       params(snapshot: Dependabot::DependencyGraphers::ManifestGroupSnapshot)
-        .returns(T.nilable(T::Hash[Symbol, T.untyped]))
+        .returns(T.nilable(T::Hash[Symbol, Object]))
     end
     def manifest_entry(snapshot)
       manifest_file = snapshot.manifest_file


### PR DESCRIPTION
More `Sorbet/ForbidTUntyped` burndown. These four files are already `typed: strong`; the `T.untyped` only lived in their sig annotations. `dependency_change` now uses `DependencyFile#to_h`'s real type, `updater/errors` aligns `sentry_context` with the `HasSentryContext` interface, and the other two use `Object` for their heterogeneous hash values.