### PR TITLE
fix(github-actions): update untagged SHA-pinned actions to branch head

### DIFF
--- a/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
@@ -64,7 +64,6 @@ module Dependabot
         sig { returns(T::Array[Dependabot::SecurityAdvisory]) }
         attr_reader :security_advisories
 
-        # rubocop:disable Metrics/PerceivedComplexity
         sig { returns(T.nilable(T.any(Dependabot::Version, String))) }
         def release_list_for_git_dependency
           # TODO: Support Docker sources
@@ -80,8 +79,10 @@ module Dependabot
             return latest_version
           end
 
-          if git_commit_checker.pinned_ref_looks_like_commit_sha? && latest_version_tag
-            latest_version = latest_version_tag&.fetch(:version)
+          if git_commit_checker.pinned_ref_looks_like_commit_sha?
+            return latest_commit_for_pinned_ref unless latest_version_tag
+
+            latest_version = T.must(latest_version_tag).fetch(:version)
             return latest_commit_for_pinned_ref unless git_commit_checker.local_tag_for_pinned_sha
 
             return latest_version
@@ -91,7 +92,6 @@ module Dependabot
           # version or a commit SHA then there's nothing we can do.
           nil
         end
-        # rubocop:enable Metrics/PerceivedComplexity
 
         sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
         def lowest_security_fix_version_tag

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -170,7 +170,12 @@ module Dependabot
       sig { params(source_checker: Dependabot::GitCommitChecker).returns(T.nilable(String)) }
       def latest_commit_sha(source_checker)
         latest_tag = T.must(latest_version_finder).latest_version_tag
-        return unless latest_tag
+        unless latest_tag
+          latest = latest_version
+          return latest if latest.is_a?(String)
+
+          return nil
+        end
 
         if source_checker.local_tag_for_pinned_sha
           new_tag = T.must(latest_version_finder).latest_version_tag_respecting_cooldown

--- a/github_actions/spec/dependabot/github_actions/package/package_details_fetcher_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/package/package_details_fetcher_spec.rb
@@ -161,6 +161,30 @@ RSpec.describe Dependabot::GithubActions::Package::PackageDetailsFetcher do
       end
     end
 
+    context "when a git commit SHA is not associated with any version tag" do
+      let(:reference) { "506f1e5c67f7d47b690882cd3edf808863e7139f" }
+
+      before do
+        allow(fetcher).to receive_messages(
+          git_dependency?: true,
+          latest_version_tag: nil,
+          latest_commit_for_pinned_ref: "6dd44d4acaeb25266a521d5db993d0168b74b2e9"
+        )
+        allow(fetcher).to receive(:git_commit_checker).and_return(
+          instance_double(
+            Dependabot::GitCommitChecker,
+            pinned?: true,
+            pinned_ref_looks_like_version?: false,
+            pinned_ref_looks_like_commit_sha?: true
+          )
+        )
+      end
+
+      it "falls back to the latest commit on the containing branch" do
+        expect(latest_version).to eq("6dd44d4acaeb25266a521d5db993d0168b74b2e9")
+      end
+    end
+
     context "when using a dependency with multiple git refs" do
       include_context "with multiple git sources"
 

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -756,8 +756,10 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
     end
 
     context "when no latest version tag is available" do
-      it "returns nil instead of falling back to branch head" do
-        expect(checker.send(:latest_commit_sha, source_checker)).to be_nil
+      let(:latest_version) { "branch-head-sha" }
+
+      it "falls back to the latest commit on the containing branch" do
+        expect(checker.send(:latest_commit_sha, source_checker)).to eq("branch-head-sha")
       end
     end
 
@@ -803,6 +805,55 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         end
 
         it { is_expected.to eq(expected_requirements) }
+      end
+    end
+
+    context "when a dependency is pinned to a commit without any version tag" do
+      let(:reference) { "506f1e5c67f7d47b690882cd3edf808863e7139f" }
+      let(:source_checker) do
+        instance_double(
+          Dependabot::GitCommitChecker,
+          pinned_ref_looks_like_version?: false,
+          pinned_ref_looks_like_commit_sha?: true,
+          local_tag_for_pinned_sha: nil
+        )
+      end
+      let(:expected_requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: ".github/workflows/workflow.yml",
+          source: {
+            type: "git",
+            url: "https://github.com/actions/setup-node",
+            ref: "branch-head-sha",
+            branch: nil
+          },
+          metadata: { declaration_string: "#{dependency_name}@master" }
+        }]
+      end
+      let(:latest_version_finder) do
+        instance_double(
+          Dependabot::GithubActions::UpdateChecker::LatestVersionFinder,
+          latest_version_tag: nil,
+          lowest_security_fix_release: nil
+        )
+      end
+
+      before do
+        allow(checker).to receive_messages(
+          git_commit_checker: instance_double(Dependabot::GitCommitChecker, git_dependency?: true),
+          git_helper: instance_double(
+            Dependabot::GithubActions::Helpers::Githelper,
+            git_commit_checker_for: source_checker
+          ),
+          latest_version: "branch-head-sha",
+          latest_version_finder: latest_version_finder
+        )
+      end
+
+      it "updates the pin to the latest commit on the containing branch" do
+        expect(updated_requirements).to eq(expected_requirements)
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

Fix GitHub Actions updates for SHA-pinned actions that are not associated with any version-like tag.

Today, if a workflow references a GitHub Action by repository syntax with a raw commit SHA, and that SHA is not associated with a semver-like tag, Dependabot can fail to propose any update even when newer commits exist on the containing branch. This is most visible for path-based actions such as:

```yaml
uses: owner/repo/.github/actions/test@<sha>
```

The expected behavior, based on the GitHub Actions Dependabot documentation, is to update untagged SHA pins to the latest commit on the containing/default branch.

This change makes the updater fall back to branch-head resolution when no `latest_version_tag` exists for a SHA-pinned dependency.

<!-- What issues does this affect or fix? -->

Closes: #15577 

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

I kept the change intentionally narrow and limited it to the SHA-pinned GitHub Actions path.

The behavior is unchanged for:

* branch refs like `@main`
* tag refs like `@v1`
* SHA pins that are associated with a version tag

The only changed behavior is when:

* the dependency is pinned to a raw commit SHA, and
* no version-like tag resolves that SHA

In that case, `package_details_fetcher` now returns the latest commit on the containing branch instead of returning no update path, and `update_checker` preserves that fallback when rewriting requirements.

I also added regression coverage at both layers:

* latest available ref calculation
* workflow requirement rewrite behavior

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

This is covered by targeted regression tests for the `github_actions` updater. The new regression cases specifically verify that when a GitHub Action is pinned to a commit SHA with no matching version tag, Dependabot falls back to the latest commit on the containing branch and rewrites the manifest accordingly.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
