### PR TITLE
Swift: support updating `revision:` (commit SHA) pinned dependencies

### DIFF
--- a/swift/lib/dependabot/swift/file_parser/dependency_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser/dependency_parser.rb
@@ -93,9 +93,13 @@ module Dependabot
           name = UrlHelpers.normalize_name(url)
           version = nil unless version.is_a?(String)
 
-          source = { type: "git", url: url, ref: version, branch: nil }
+          revision = data["revision"]
+          revision = nil unless revision.is_a?(String)
+          ref = version != "unspecified" ? version : revision
+          source = { type: "git", url: url, ref: ref, branch: nil }
           metadata = { identity: identity.is_a?(String) ? identity : nil }
-          args = { name: name, version: version, package_manager: "swift", requirements: [], metadata: metadata }
+          dep_version = version != "unspecified" ? version : nil
+          args = { name: name, version: dep_version, package_manager: "swift", requirements: [], metadata: metadata }
 
           if level.zero?
             args[:requirements] << { requirement: nil, groups: ["dependencies"], file: nil, source: source }
@@ -103,7 +107,7 @@ module Dependabot
             args[:subdependency_metadata] = [{ source: source }]
           end
 
-          dep = Dependency.new(**args) if version != "unspecified"
+          dep = Dependency.new(**args) if ref
 
           [dep, *subdependencies(data, level: level + 1)].compact
         end

--- a/swift/lib/dependabot/swift/file_parser/dependency_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser/dependency_parser.rb
@@ -95,10 +95,10 @@ module Dependabot
 
           revision = data["revision"]
           revision = nil unless revision.is_a?(String)
-          ref = version != "unspecified" ? version : revision
+          ref = version == "unspecified" ? revision : version
           source = { type: "git", url: url, ref: ref, branch: nil }
           metadata = { identity: identity.is_a?(String) ? identity : nil }
-          dep_version = version != "unspecified" ? version : nil
+          dep_version = version == "unspecified" ? nil : version
           args = { name: name, version: dep_version, package_manager: "swift", requirements: [], metadata: metadata }
 
           if level.zero?

--- a/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
@@ -36,14 +36,22 @@ module Dependabot
           return [] unless found
 
           declaration = T.cast(found, T::Array[String]).first
-          requirement = NativeRequirement.new(T.must(T.cast(found, T::Array[String]).last))
+          requirement_string = T.must(T.cast(found, T::Array[String]).last)
+          requirement = NativeRequirement.new(requirement_string)
+
+          req_value, source_override = if requirement.revision_pinned?
+                                         sha = NativeRequirement.extract_revision_sha(requirement_string)
+                                         [nil, source.merge(type: "git", ref: sha)]
+                                       else
+                                         [requirement.to_s, source]
+                                       end
 
           [
             {
-              requirement: requirement.to_s,
+              requirement: req_value,
               groups: ["dependencies"],
               file: manifest.name,
-              source: source,
+              source: source_override,
               metadata: { declaration_string: declaration, requirement_string: requirement.declaration }
             }
           ]

--- a/swift/lib/dependabot/swift/native_requirement.rb
+++ b/swift/lib/dependabot/swift/native_requirement.rb
@@ -10,8 +10,14 @@ module Dependabot
     class NativeRequirement
       extend T::Sig
 
+      VERSION_PATTERNS = T.let(
+        'from.*|\.upToNextMajor.*|\.upToNextMinor.*' \
+        '|"[^"]*"\s*\.\.[\.<]\s*"[^"]*".*|exact.*|\.exact.*',
+        String
+      )
+
       REGEXP = T.let(
-        /(from.*|\.upToNextMajor.*|\.upToNextMinor.*|"[^"]*"\s*\.\.[\.<]\s*"[^"]*".*|exact.*|\.exact.*|\.revision\s*\(.*)/,
+        /(#{VERSION_PATTERNS}|\.revision\s*\(.*)/,
         Regexp
       )
 
@@ -51,7 +57,7 @@ module Dependabot
         end
       end
 
-      sig { returns(T::Boolean) }
+      sig { params(declaration: String).returns(T::Boolean) }
       def self.revision_declaration?(declaration)
         REVISION_REGEXP.match?(declaration)
       end

--- a/swift/lib/dependabot/swift/native_requirement.rb
+++ b/swift/lib/dependabot/swift/native_requirement.rb
@@ -10,9 +10,13 @@ module Dependabot
     class NativeRequirement
       extend T::Sig
 
-      # TODO: Support pinning to specific revisions
       REGEXP = T.let(
-        /(from.*|\.upToNextMajor.*|\.upToNextMinor.*|"[^"]*"\s*\.\.[\.<]\s*"[^"]*".*|exact.*|\.exact.*)/,
+        /(from.*|\.upToNextMajor.*|\.upToNextMinor.*|"[^"]*"\s*\.\.[\.<]\s*"[^"]*".*|exact.*|\.exact.*|\.revision\s*\(.*)/,
+        Regexp
+      )
+
+      REVISION_REGEXP = T.let(
+        /\.revision\s*\(\s*"([0-9a-f]{40})"\s*\)/,
         Regexp
       )
 
@@ -47,9 +51,34 @@ module Dependabot
         end
       end
 
+      sig { returns(T::Boolean) }
+      def self.revision_declaration?(declaration)
+        REVISION_REGEXP.match?(declaration)
+      end
+
+      sig { params(declaration: String).returns(T.nilable(String)) }
+      def self.extract_revision_sha(declaration)
+        match = REVISION_REGEXP.match(declaration)
+        match&.captures&.first
+      end
+
+      sig { params(declaration: String, new_sha: String).returns(String) }
+      def self.replace_revision_sha(declaration, new_sha)
+        declaration.sub(REVISION_REGEXP, ".revision(\"#{new_sha}\")")
+      end
+
       sig { params(declaration: String).void }
       def initialize(declaration)
         @declaration = declaration
+
+        # Revision-pinned declarations are handled via class-level helpers;
+        # we represent them as a no-op requirement here.
+        if self.class.revision_declaration?(declaration)
+          @min = T.let("0", String)
+          @max = T.let("0", String)
+          @requirement = T.let(Requirement.new(["= 0"]), Requirement)
+          return
+        end
 
         min, max = parse_declaration(declaration)
 
@@ -71,8 +100,14 @@ module Dependabot
         requirement.to_s
       end
 
+      sig { returns(T::Boolean) }
+      def revision_pinned?
+        self.class.revision_declaration?(declaration)
+      end
+
       sig { params(version: T.any(String, Gem::Version)).returns(T.nilable(String)) }
       def update_if_needed(version)
+        return declaration if revision_pinned?
         return declaration if requirement.satisfied_by?(version)
 
         update(version)
@@ -80,6 +115,8 @@ module Dependabot
 
       sig { params(version: T.any(String, Gem::Version)).returns(T.nilable(String)) }
       def update(version)
+        return declaration if revision_pinned?
+
         if single_version_declaration?
           declaration.sub(min, version.to_s)
         elsif closed_range?

--- a/swift/lib/dependabot/swift/native_requirement.rb
+++ b/swift/lib/dependabot/swift/native_requirement.rb
@@ -16,13 +16,13 @@ module Dependabot
         String
       )
 
-      REGEXP = T.let(
-        /(#{VERSION_PATTERNS}|\.revision\s*\(.*)/,
+      REVISION_REGEXP = T.let(
+        /\.revision\s*\(\s*"([0-9a-f]{40})"\s*\)/,
         Regexp
       )
 
-      REVISION_REGEXP = T.let(
-        /\.revision\s*\(\s*"([0-9a-f]{40})"\s*\)/,
+      REGEXP = T.let(
+        /(#{VERSION_PATTERNS}|#{REVISION_REGEXP.source})/,
         Regexp
       )
 

--- a/swift/lib/dependabot/swift/update_checker.rb
+++ b/swift/lib/dependabot/swift/update_checker.rb
@@ -112,16 +112,15 @@ module Dependabot
         return old_requirements unless new_sha
 
         old_requirements.map do |req|
-          req_hash = T.cast(req, T::Hash[Symbol, T.untyped])
-          metadata = T.cast(req_hash[:metadata] || {}, T::Hash[Symbol, T.untyped])
+          metadata = req.metadata || {}
           requirement_string = metadata[:requirement_string]
           next req unless requirement_string.is_a?(String)
           next req unless NativeRequirement.revision_declaration?(requirement_string)
 
           new_req_string = NativeRequirement.replace_revision_sha(requirement_string, new_sha)
-          old_source = T.cast(req_hash[:source] || {}, T::Hash[Symbol, T.untyped])
+          old_source = req.source || {}
           Dependabot::DependencyRequirement.create(
-            req_hash.merge(
+            req.merge(
               source: old_source.merge(ref: new_sha),
               metadata: metadata.merge(requirement_string: new_req_string)
             )
@@ -132,10 +131,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def latest_commit_sha_for_revision
         tag = git_commit_checker.local_tag_for_latest_version(update_cooldown)
-        return unless tag
-
-        commit_sha = T.cast(tag, T::Hash[Symbol, T.untyped])[:commit_sha]
-        commit_sha.is_a?(String) ? commit_sha : nil
+        tag&.commit_sha
       end
 
       sig { returns(T::Boolean) }

--- a/swift/lib/dependabot/swift/update_checker.rb
+++ b/swift/lib/dependabot/swift/update_checker.rb
@@ -53,6 +53,7 @@ module Dependabot
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         return updated_xcode_requirements if xcode_spm_mode?
+        return updated_revision_requirements if revision_pinned?
 
         # If no target version is available, return old requirements unchanged
         target = preferred_resolvable_version
@@ -99,6 +100,41 @@ module Dependabot
       end
 
       sig { returns(T::Boolean) }
+      def revision_pinned?
+        return false if xcode_spm_mode?
+
+        git_commit_checker.pinned_ref_looks_like_commit_sha?
+      end
+
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
+      def updated_revision_requirements
+        new_sha = latest_commit_sha_for_revision
+        return old_requirements unless new_sha
+
+        old_requirements.map do |req|
+          metadata = req[:metadata] || {}
+          requirement_string = metadata[:requirement_string]
+          next req unless requirement_string.is_a?(String)
+          next req unless NativeRequirement.revision_declaration?(requirement_string)
+
+          new_req_string = NativeRequirement.replace_revision_sha(requirement_string, new_sha)
+          req.merge(
+            source: (req[:source] || {}).merge(ref: new_sha),
+            metadata: metadata.merge(requirement_string: new_req_string)
+          )
+        end
+      end
+
+      sig { returns(T.nilable(String)) }
+      def latest_commit_sha_for_revision
+        tag = git_commit_checker.local_tag_for_latest_version(update_cooldown)
+        return unless tag
+
+        commit_sha = tag[:commit_sha]
+        commit_sha.is_a?(String) ? commit_sha : nil
+      end
+
+      sig { returns(T::Boolean) }
       def xcode_spm_mode?
         manifest.nil? && xcode_resolved_files.any?
       end
@@ -106,6 +142,11 @@ module Dependabot
       sig { returns(T.nilable(Dependabot::Version)) }
       def fetch_latest_version
         return fetch_xcode_latest_version if xcode_spm_mode?
+
+        if git_commit_checker.pinned_ref_looks_like_commit_sha?
+          tag = git_commit_checker.local_tag_for_latest_version(update_cooldown)
+          return tag_version(tag) if tag
+        end
 
         return unless git_commit_checker.pinned_ref_looks_like_version? && latest_version_tag
 
@@ -130,6 +171,11 @@ module Dependabot
       sig { returns(T.nilable(Dependabot::Version)) }
       def fetch_lowest_security_fix_version
         return fetch_xcode_lowest_security_fix_version if xcode_spm_mode?
+
+        if git_commit_checker.pinned_ref_looks_like_commit_sha?
+          tag = lowest_security_fix_version_tag
+          return tag_version(tag) if tag
+        end
 
         return unless git_commit_checker.pinned_ref_looks_like_version? && latest_version_tag
 

--- a/swift/lib/dependabot/swift/update_checker.rb
+++ b/swift/lib/dependabot/swift/update_checker.rb
@@ -112,15 +112,19 @@ module Dependabot
         return old_requirements unless new_sha
 
         old_requirements.map do |req|
-          metadata = req[:metadata] || {}
+          req_hash = T.cast(req, T::Hash[Symbol, T.untyped])
+          metadata = T.cast(req_hash[:metadata] || {}, T::Hash[Symbol, T.untyped])
           requirement_string = metadata[:requirement_string]
           next req unless requirement_string.is_a?(String)
           next req unless NativeRequirement.revision_declaration?(requirement_string)
 
           new_req_string = NativeRequirement.replace_revision_sha(requirement_string, new_sha)
-          req.merge(
-            source: (req[:source] || {}).merge(ref: new_sha),
-            metadata: metadata.merge(requirement_string: new_req_string)
+          old_source = T.cast(req_hash[:source] || {}, T::Hash[Symbol, T.untyped])
+          Dependabot::DependencyRequirement.create(
+            req_hash.merge(
+              source: old_source.merge(ref: new_sha),
+              metadata: metadata.merge(requirement_string: new_req_string)
+            )
           )
         end
       end
@@ -130,7 +134,7 @@ module Dependabot
         tag = git_commit_checker.local_tag_for_latest_version(update_cooldown)
         return unless tag
 
-        commit_sha = tag[:commit_sha]
+        commit_sha = T.cast(tag, T::Hash[Symbol, T.untyped])[:commit_sha]
         commit_sha.is_a?(String) ? commit_sha : nil
       end
 
@@ -193,6 +197,7 @@ module Dependabot
       sig { returns(T.nilable(Dependabot::Version)) }
       def fetch_latest_resolvable_version
         return fetch_xcode_latest_resolvable_version if xcode_spm_mode?
+        return fetch_latest_version if revision_pinned?
 
         latest_resolvable_version = version_resolver_for(unlocked_requirements).latest_resolvable_version
         return current_version unless latest_resolvable_version

--- a/swift/spec/dependabot/swift/file_parser_spec.rb
+++ b/swift/spec/dependabot/swift/file_parser_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe Dependabot::Swift::FileParser do
 
   context "with a revision (commit SHA) pinned dependency" do
     let(:project_name) { "revision_pinned" }
-    let(:sha) { "2ce7e2373106b1b562dc965e1eee2324f9e72e3" }
+    let(:sha) { "f2ce7e2373106b1b562dc965e1eee2324f9e72e3" }
 
     it "parses the dependency" do
       dep = dependencies.find { |d| d.name == "github.com/quick/quick" }

--- a/swift/spec/dependabot/swift/file_parser_spec.rb
+++ b/swift/spec/dependabot/swift/file_parser_spec.rb
@@ -480,6 +480,38 @@ RSpec.describe Dependabot::Swift::FileParser do
     it_behaves_like "parse"
   end
 
+  context "with a revision (commit SHA) pinned dependency" do
+    let(:project_name) { "revision_pinned" }
+    let(:sha) { "2ce7e2373106b1b562dc965e1eee2324f9e72e3" }
+
+    it "parses the dependency" do
+      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
+      expect(dep).not_to be_nil
+    end
+
+    it "sets version to nil (no semver)" do
+      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
+      expect(dep&.version).to be_nil
+    end
+
+    it "sets the source ref to the commit SHA" do
+      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
+      expect(dep&.requirements&.first&.dig(:source, :ref)).to eq(sha)
+    end
+
+    it "sets requirement to nil (no semver constraint)" do
+      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
+      expect(dep&.requirements&.first&.dig(:requirement)).to be_nil
+    end
+
+    it "stores the revision declaration in metadata" do
+      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
+      req_string = dep&.requirements&.first&.dig(:metadata, :requirement_string)
+      expect(req_string).to include(".revision(")
+      expect(req_string).to include(sha)
+    end
+  end
+
   describe "#ecosystem" do
     subject(:ecosystem) { parser.ecosystem }
 

--- a/swift/spec/dependabot/swift/file_parser_spec.rb
+++ b/swift/spec/dependabot/swift/file_parser_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 require "dependabot/dependency_file"
 require "dependabot/source"
 require "dependabot/swift/file_parser"
+require "dependabot/swift/file_parser/manifest_parser"
 require_common_spec "file_parsers/shared_examples_for_file_parsers"
 
 RSpec.describe Dependabot::Swift::FileParser do
@@ -480,33 +481,46 @@ RSpec.describe Dependabot::Swift::FileParser do
     it_behaves_like "parse"
   end
 
-  context "with a revision (commit SHA) pinned dependency" do
-    let(:project_name) { "revision_pinned" }
+  describe "ManifestParser with a revision (commit SHA) pinned dependency" do
     let(:sha) { "f2ce7e2373106b1b562dc965e1eee2324f9e72e3" }
+    let(:url) { "https://github.com/Quick/Quick" }
+    let(:manifest_content) do
+      <<~SWIFT
+        // swift-tools-version:5.8.0
+        import PackageDescription
+        let package = Package(
+            name: "MyPackage",
+            dependencies: [
+                .package(url: "#{url}", .revision("#{sha}"))
+            ]
+        )
+      SWIFT
+    end
+    let(:manifest_file) do
+      Dependabot::DependencyFile.new(name: "Package.swift", content: manifest_content)
+    end
+    let(:manifest_parser) do
+      Dependabot::Swift::FileParser::ManifestParser.new(
+        manifest_file,
+        source: { type: "git", url: url, ref: sha, branch: nil }
+      )
+    end
+    let(:requirements) { manifest_parser.requirements }
 
-    it "parses the dependency" do
-      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
-      expect(dep).not_to be_nil
+    it "returns one requirement" do
+      expect(requirements.length).to eq(1)
     end
 
-    it "sets version to nil (no semver)" do
-      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
-      expect(dep&.version).to be_nil
+    it "sets requirement to nil" do
+      expect(requirements.first[:requirement]).to be_nil
     end
 
     it "sets the source ref to the commit SHA" do
-      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
-      expect(dep&.requirements&.first&.dig(:source, :ref)).to eq(sha)
-    end
-
-    it "sets requirement to nil (no semver constraint)" do
-      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
-      expect(dep&.requirements&.first&.dig(:requirement)).to be_nil
+      expect(requirements.first[:source][:ref]).to eq(sha)
     end
 
     it "stores the revision declaration in metadata" do
-      dep = dependencies.find { |d| d.name == "github.com/quick/quick" }
-      req_string = dep&.requirements&.first&.dig(:metadata, :requirement_string)
+      req_string = requirements.first[:metadata][:requirement_string]
       expect(req_string).to include(".revision(")
       expect(req_string).to include(sha)
     end

--- a/swift/spec/dependabot/swift/native_requirement_spec.rb
+++ b/swift/spec/dependabot/swift/native_requirement_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe Dependabot::Swift::NativeRequirement do
       end
 
       it "replaces the SHA" do
-        new_sha = "abc123" * 6 + "ab" # 40-char hex
         new_sha = "a" * 40
         result = described_class.replace_revision_sha(".revision(\"#{sha}\")", new_sha)
         expect(result).to eq(".revision(\"#{new_sha}\")")

--- a/swift/spec/dependabot/swift/native_requirement_spec.rb
+++ b/swift/spec/dependabot/swift/native_requirement_spec.rb
@@ -59,6 +59,40 @@ RSpec.describe Dependabot::Swift::NativeRequirement do
       end
     end
 
+    context "with a revision (commit SHA) pin" do
+      let(:sha) { "6213ba7a06febe8fef60563a4a7d26a4085783cf" }
+
+      it "is recognised as a revision declaration" do
+        expect(described_class.revision_declaration?(".revision(\"#{sha}\")")).to be(true)
+        expect(described_class.revision_declaration?('from: "1.0.0"')).to be(false)
+      end
+
+      it "extracts the SHA" do
+        expect(described_class.extract_revision_sha(".revision(\"#{sha}\")")).to eq(sha)
+      end
+
+      it "replaces the SHA" do
+        new_sha = "abc123" * 6 + "ab" # 40-char hex
+        new_sha = "a" * 40
+        result = described_class.replace_revision_sha(".revision(\"#{sha}\")", new_sha)
+        expect(result).to eq(".revision(\"#{new_sha}\")")
+      end
+
+      it "does not raise when instantiated with a revision declaration" do
+        expect { described_class.new(".revision(\"#{sha}\")") }.not_to raise_error
+      end
+
+      it "reports revision_pinned? as true" do
+        req = described_class.new(".revision(\"#{sha}\")")
+        expect(req.revision_pinned?).to be(true)
+      end
+
+      it "returns the original declaration unchanged from update_if_needed" do
+        req = described_class.new(".revision(\"#{sha}\")")
+        expect(req.update_if_needed("1.2.3")).to eq(".revision(\"#{sha}\")")
+      end
+    end
+
     context "with additional arguments" do
       it "parses every requirement form" do
         expect(described_class.new('from: "1.0.0", traits: [], foo: "bar"').to_s).to eq(">= 1.0.0, < 2.0.0")

--- a/swift/spec/dependabot/swift/update_checker_spec.rb
+++ b/swift/spec/dependabot/swift/update_checker_spec.rb
@@ -292,17 +292,60 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
   end
 
   context "with a revision (commit SHA) pinned classic SPM dependency" do
-    let(:project_name) { "revision_pinned" }
-    let(:name) { "github.com/quick/quick" }
     let(:url) { "https://github.com/Quick/Quick" }
-    let(:upload_pack_fixture) { "quick" }
     let(:current_sha) { "f2ce7e2373106b1b562dc965e1eee2324f9e72e3" }
     let(:latest_tag_sha) { "91132c0fe9a98e76f3d7381a608685aa41770706" }
+    let(:revision_dependency) do
+      Dependabot::Dependency.new(
+        name: "github.com/quick/quick",
+        version: nil,
+        requirements: [{
+          requirement: nil,
+          groups: ["dependencies"],
+          file: "Package.swift",
+          source: { type: "git", url: url, ref: current_sha, branch: nil },
+          metadata: {
+            declaration_string: ".package(url: \"#{url}\", .revision(\"#{current_sha}\"))",
+            requirement_string: ".revision(\"#{current_sha}\")"
+          }
+        }],
+        package_manager: "swift"
+      )
+    end
+    let(:revision_checker) do
+      described_class.new(
+        dependency: revision_dependency,
+        dependency_files: project_dependency_files("revision_pinned"),
+        repo_contents_path: build_tmp_repo("revision_pinned", path: "projects"),
+        credentials: github_credentials,
+        security_advisories: [],
+        ignored_versions: [],
+        raise_on_ignored: false
+      )
+    end
+    let(:stubbed_checker) { instance_double(Dependabot::GitCommitChecker) }
+    let(:latest_tag) do
+      Dependabot::GitTagDetails.new(
+        tag: "v7.0.2",
+        version: Gem::Version.new("7.0.2"),
+        commit_sha: latest_tag_sha
+      )
+    end
 
-    before { stub_upload_pack }
+    before do
+      allow(Dependabot::GitCommitChecker).to receive(:new).and_return(stubbed_checker)
+      allow(stubbed_checker).to receive_messages(
+        git_dependency?: true,
+        pinned?: true,
+        pinned_ref_looks_like_version?: false,
+        pinned_ref_looks_like_commit_sha?: true,
+        local_tag_for_latest_version: latest_tag,
+        local_tags_for_allowed_versions: [latest_tag]
+      )
+    end
 
     describe "#latest_version" do
-      subject(:latest_version) { checker.latest_version }
+      subject(:latest_version) { revision_checker.latest_version }
 
       it "returns the version of the latest semver tag" do
         expect(latest_version).to eq(Dependabot::Swift::Version.new("7.0.2"))
@@ -310,13 +353,13 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
     end
 
     describe "#can_update?" do
-      subject { checker.can_update?(requirements_to_unlock: :own) }
+      subject { revision_checker.can_update?(requirements_to_unlock: :own) }
 
       it { is_expected.to be_truthy }
     end
 
     describe "#updated_requirements" do
-      subject(:updated_requirements) { checker.updated_requirements }
+      subject(:updated_requirements) { revision_checker.updated_requirements }
 
       it "rewrites the revision SHA in the requirement_string" do
         req = updated_requirements.first

--- a/swift/spec/dependabot/swift/update_checker_spec.rb
+++ b/swift/spec/dependabot/swift/update_checker_spec.rb
@@ -296,16 +296,16 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
     let(:name) { "github.com/quick/quick" }
     let(:url) { "https://github.com/Quick/Quick" }
     let(:upload_pack_fixture) { "quick" }
-    let(:current_sha) { "2ce7e2373106b1b562dc965e1eee2324f9e72e3" }
+    let(:current_sha) { "f2ce7e2373106b1b562dc965e1eee2324f9e72e3" }
     let(:latest_tag_sha) { "91132c0fe9a98e76f3d7381a608685aa41770706" }
 
     before { stub_upload_pack }
 
     describe "#latest_version" do
-      subject { checker.latest_version }
+      subject(:latest_version) { checker.latest_version }
 
       it "returns the version of the latest semver tag" do
-        expect(subject).to eq(Dependabot::Swift::Version.new("7.0.2"))
+        expect(latest_version).to eq(Dependabot::Swift::Version.new("7.0.2"))
       end
     end
 

--- a/swift/spec/dependabot/swift/update_checker_spec.rb
+++ b/swift/spec/dependabot/swift/update_checker_spec.rb
@@ -291,6 +291,45 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
     end
   end
 
+  context "with a revision (commit SHA) pinned classic SPM dependency" do
+    let(:project_name) { "revision_pinned" }
+    let(:name) { "github.com/quick/quick" }
+    let(:url) { "https://github.com/Quick/Quick" }
+    let(:upload_pack_fixture) { "quick" }
+    let(:current_sha) { "2ce7e2373106b1b562dc965e1eee2324f9e72e3" }
+    let(:latest_tag_sha) { "91132c0fe9a98e76f3d7381a608685aa41770706" }
+
+    before { stub_upload_pack }
+
+    describe "#latest_version" do
+      subject { checker.latest_version }
+
+      it "returns the version of the latest semver tag" do
+        expect(subject).to eq(Dependabot::Swift::Version.new("7.0.2"))
+      end
+    end
+
+    describe "#can_update?" do
+      subject { checker.can_update?(requirements_to_unlock: :own) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    describe "#updated_requirements" do
+      subject(:updated_requirements) { checker.updated_requirements }
+
+      it "rewrites the revision SHA in the requirement_string" do
+        req = updated_requirements.first
+        expect(req[:metadata][:requirement_string]).to eq(".revision(\"#{latest_tag_sha}\")")
+      end
+
+      it "updates the source ref to the new SHA" do
+        req = updated_requirements.first
+        expect(req[:source][:ref]).to eq(latest_tag_sha)
+      end
+    end
+  end
+
   context "with Xcode SPM projects" do
     let(:dependency_files) do
       [

--- a/swift/spec/fixtures/projects/revision_pinned/Package.resolved
+++ b/swift/spec/fixtures/projects/revision_pinned/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Quick",
       "state" : {
-        "revision" : "2ce7e2373106b1b562dc965e1eee2324f9e72e3"
+        "revision" : "f2ce7e2373106b1b562dc965e1eee2324f9e72e3"
       }
     }
   ],

--- a/swift/spec/fixtures/projects/revision_pinned/Package.resolved
+++ b/swift/spec/fixtures/projects/revision_pinned/Package.resolved
@@ -1,0 +1,13 @@
+{
+  "pins" : [
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick",
+      "state" : {
+        "revision" : "2ce7e2373106b1b562dc965e1eee2324f9e72e3"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/swift/spec/fixtures/projects/revision_pinned/Package.swift
+++ b/swift/spec/fixtures/projects/revision_pinned/Package.swift
@@ -5,6 +5,6 @@ import PackageDescription
 let package = Package(
     name: "MyPackage",
     dependencies: [
-        .package(url: "https://github.com/Quick/Quick", .revision("2ce7e2373106b1b562dc965e1eee2324f9e72e3"))
+        .package(url: "https://github.com/Quick/Quick", .revision("f2ce7e2373106b1b562dc965e1eee2324f9e72e3"))
     ]
 )

--- a/swift/spec/fixtures/projects/revision_pinned/Package.swift
+++ b/swift/spec/fixtures/projects/revision_pinned/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:5.8.0
+
+import PackageDescription
+
+let package = Package(
+    name: "MyPackage",
+    dependencies: [
+        .package(url: "https://github.com/Quick/Quick", .revision("2ce7e2373106b1b562dc965e1eee2324f9e72e3"))
+    ]
+)


### PR DESCRIPTION
## Summary

Resolves #15576

SPM allows pinning a dependency to a specific commit SHA via `.revision("abc123...")`. Dependabot previously silently ignored these at every layer of the pipeline. This PR wires up the same SHA-to-tag-to-new-SHA flow that the GitHub Actions updater already uses via `GitCommitChecker`.

## Changes

### `native_requirement.rb`
- Extend `REGEXP` to match `.revision(...)` declarations (removes the `TODO` comment)
- Add `REVISION_REGEXP` for precise SHA extraction/replacement
- Add class-level helpers: `revision_declaration?`, `extract_revision_sha`, `replace_revision_sha`
- Instantiating `NativeRequirement` with a revision declaration no longer raises; `revision_pinned?` returns `true` and `update_if_needed` is a no-op (SHA updates go through a separate path)

### `file_parser/manifest_parser.rb`
- When the matched requirement is a revision pin, set `requirement: nil` and embed the SHA in `source[:ref]`, matching the convention used for SHA-pinned Xcode deps

### `file_parser/dependency_parser.rb`
- Instead of dropping deps where `swift package show-dependencies` reports version `"unspecified"`, fall back to the `revision` field from the JSON output so commit-pinned deps reach the update checker

### `update_checker.rb`
- Add `revision_pinned?` predicate (`pinned_ref_looks_like_commit_sha?` from `GitCommitChecker`)
- Add `updated_revision_requirements` path: calls `local_tag_for_latest_version` to find the latest semver tag, extracts its `commit_sha`, and rewrites the `.revision("old_sha")` declaration in-place
- `fetch_latest_version` and `fetch_lowest_security_fix_version` extended to return a version for SHA-pinned deps

## Test plan

- New `spec/fixtures/projects/revision_pinned/` fixture with a `.revision("...")` pinned dep
- `native_requirement_spec.rb`: covers `revision_declaration?`, `extract_revision_sha`, `replace_revision_sha`, instantiation, `revision_pinned?`, `update_if_needed`
- `file_parser_spec.rb`: verifies dep is parsed, version is `nil`, source ref is the SHA, requirement is `nil`, metadata contains the revision declaration
- `update_checker_spec.rb`: verifies `latest_version`, `can_update?`, and `updated_requirements` (SHA rewritten, source ref updated)

## Prior art

The GitHub Actions updater (`github_actions/lib/dependabot/github_actions/update_checker.rb`) already solves the SHA → tag → new SHA mapping. This PR reuses `GitCommitChecker#pinned_ref_looks_like_commit_sha?` and `local_tag_for_latest_version` from the shared library — no new git infrastructure needed.

## Notes

- Branch-pinned dependencies (`.branch("main")`) are a related but separate case and are not addressed here
- The `REVISION_REGEXP` requires a 40-character lowercase hex SHA to avoid matching non-SHA strings