### PR TITLE
[Update Graph] Strictly classify pip/pip-compile constraints using peer references

### DIFF
--- a/python/lib/dependabot/python/dependency_grapher/requirements_layers.rb
+++ b/python/lib/dependabot/python/dependency_grapher/requirements_layers.rb
@@ -64,15 +64,38 @@ module Dependabot
         # Reuses SharedFileFetcher's reference regexes so callers keep exactly the children the file fetcher pulled in.
         sig { params(file: Dependabot::DependencyFile).returns(T::Array[String]) }
         def self.referenced_paths(file)
+          scan_reference_paths(
+            file,
+            [
+              Dependabot::Python::SharedFileFetcher::CHILD_REQUIREMENT_REGEX,
+              Dependabot::Python::SharedFileFetcher::CONSTRAINT_REGEX
+            ]
+          )
+        end
+
+        # The sibling paths a file pins via `-c` (constraint references only). Constraint files install
+        # nothing - they only bound versions - so they are ring-fenced from being treated as layers.
+        sig { params(file: Dependabot::DependencyFile).returns(T::Array[String]) }
+        def self.constraint_paths(file)
+          scan_reference_paths(file, [Dependabot::Python::SharedFileFetcher::CONSTRAINT_REGEX])
+        end
+
+        # The sibling paths a file includes via `-r` (requirement references only). An `-r`-included file
+        # is genuinely installed, so it stays layer-eligible even if some other file also `-c`s it.
+        sig { params(file: Dependabot::DependencyFile).returns(T::Array[String]) }
+        def self.required_paths(file)
+          scan_reference_paths(file, [Dependabot::Python::SharedFileFetcher::CHILD_REQUIREMENT_REGEX])
+        end
+
+        # Scans a file's content for the given reference regexes and resolves each captured path to a
+        # repo-relative cleanpath (matching fetched DependencyFile names).
+        sig { params(file: Dependabot::DependencyFile, regexes: T::Array[Regexp]).returns(T::Array[String]) }
+        def self.scan_reference_paths(file, regexes)
           content = file.content
           return [] if content.nil?
 
           current_dir = File.dirname(file.name)
-          referenced =
-            content.scan(Dependabot::Python::SharedFileFetcher::CHILD_REQUIREMENT_REGEX).flatten +
-            content.scan(Dependabot::Python::SharedFileFetcher::CONSTRAINT_REGEX).flatten
-
-          referenced.map do |path|
+          regexes.flat_map { |regex| content.scan(regex).flatten }.map do |path|
             resolved = current_dir == "." ? path : File.join(current_dir, path)
             Pathname.new(resolved).cleanpath.to_path
           end
@@ -107,12 +130,16 @@ module Dependabot
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         def layer_primaries
           txt_primaries = requirement_family_files.select do |f|
-            f.name.end_with?(".txt") && self.class.manifest_txt_filename?(f.name)
+            f.name.end_with?(".txt") &&
+              self.class.manifest_txt_filename?(f.name) &&
+              !constraint_file_names.include?(f.name)
           end
           compiled_stems = txt_primaries.map { |f| requirements_stem(f.name) }
 
           in_primaries = requirement_family_files.select do |f|
-            f.name.end_with?(".in") && !compiled_stems.include?(requirements_stem(f.name))
+            f.name.end_with?(".in") &&
+              !constraint_file_names.include?(f.name) &&
+              !compiled_stems.include?(requirements_stem(f.name))
           end
 
           txt_primaries + in_primaries
@@ -145,9 +172,24 @@ module Dependabot
           )
         end
 
+        # Files identified as constraints by a `-c` reference anywhere in the directory, resolved to their
+        # fetched names. A file that is ALSO `-r`-included somewhere is genuinely installed, so it is
+        # excluded here and remains layer-eligible (constraints and layers are mutually exclusive).
+        sig { returns(T::Set[String]) }
+        def constraint_file_names
+          @constraint_file_names ||= T.let(
+            begin
+              constrained = Set.new(dependency_files.flat_map { |f| self.class.constraint_paths(f) })
+              required = Set.new(dependency_files.flat_map { |f| self.class.required_paths(f) })
+              constrained - required
+            end,
+            T.nilable(T::Set[String])
+          )
+        end
+
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         def constraints_files
-          requirement_family_files.select { |f| File.basename(f.name).include?("constraint") }
+          requirement_family_files.select { |f| constraint_file_names.include?(f.name) }
         end
 
         # Finds sibling files referenced by a requirements file via `-r`/`-c`, following the chain transitively.

--- a/python/spec/dependabot/python/dependency_grapher/requirements_layers_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher/requirements_layers_spec.rb
@@ -147,8 +147,8 @@ RSpec.describe Dependabot::Python::DependencyGrapher::RequirementsLayers do
     context "with a shared constraints file" do
       let(:dependency_files) do
         [
-          file("base-requirements.txt", "foo==1.0\n"),
-          file("test-requirements.txt", "bar==2.0\n"),
+          file("base-requirements.txt", "-c constraints.txt\nfoo==1.0\n"),
+          file("test-requirements.txt", "-c constraints.txt\nbar==2.0\n"),
           file("constraints.txt", "foo<2.0\n")
         ]
       end
@@ -165,6 +165,41 @@ RSpec.describe Dependabot::Python::DependencyGrapher::RequirementsLayers do
           expect(constraints).not_to be_nil
           expect(constraints).to be_support_file
         end
+      end
+    end
+
+    context "with a manifest-named constraints file referenced via `-c`" do
+      let(:dependency_files) do
+        [
+          file("requirements.txt", "-c requirements-constraints.txt\nflask==3.0.0\n"),
+          file("requirements-constraints.txt", "certifi==2023.7.22\n")
+        ]
+      end
+
+      it "does not treat the `-c` file as its own layer even though its name looks like a manifest" do
+        expect(layers.groups.map { |g| g.primary.name }).to eq(["requirements.txt"])
+      end
+
+      it "includes the `-c` file as a support file rather than a primary" do
+        group = layers.groups.first
+        constraint = group.files.find { |f| f.name == "requirements-constraints.txt" }
+
+        expect(constraint).not_to be_nil
+        expect(constraint).to be_support_file
+      end
+    end
+
+    context "when a file is both `-r`-included and `-c`-constrained" do
+      let(:dependency_files) do
+        [
+          file("dev-requirements.txt", "-r base-requirements.txt\n-c base-requirements.txt\npytest==8.3.3\n"),
+          file("base-requirements.txt", "flask==3.0.0\n")
+        ]
+      end
+
+      it "keeps the `-r`-included file layer-eligible (constraints do not override a real include)" do
+        expect(layers.groups.map { |g| g.primary.name })
+          .to contain_exactly("dev-requirements.txt", "base-requirements.txt")
       end
     end
 

--- a/python/spec/dependabot/python/dependency_grapher_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher_spec.rb
@@ -1175,6 +1175,57 @@ RSpec.describe Dependabot::Python::DependencyGrapher do
     end
   end
 
+  # A constraints file installs nothing so it must never become its own manifest group.
+  #
+  # Unfortunately, a constraints file may be named in a way that it passes our manifest filtering regex, e.g.
+  # requirements-constraint.txt.
+  #
+  # This test asserts that we classify files as constraints if any peer refers them via a `-c` reference even
+  # if they match manifest naming conventions.
+  describe "attributing dependencies when a manifest-named constraints file is referenced via -c" do
+    let(:app_requirements_txt) do
+      Dependabot::DependencyFile.new(
+        name: "requirements.txt",
+        content: <<~TXT,
+          -c requirements-constraints.txt
+          flask==3.0.0
+        TXT
+        directory: "/"
+      )
+    end
+
+    let(:requirements_constraints_txt) do
+      Dependabot::DependencyFile.new(
+        name: "requirements-constraints.txt",
+        content: <<~TXT,
+          flask==3.0.0
+          werkzeug==3.0.1
+        TXT
+        directory: "/"
+      )
+    end
+
+    # Ordered alphabetically, exactly as the GitHub API returns the directory contents, so the constraints
+    # file precedes requirements.txt (the pre-fix collapse/duplication target).
+    let(:dependency_files) { [requirements_constraints_txt, app_requirements_txt] }
+
+    def resolved_package_names(snapshot)
+      snapshot.resolved_dependencies.each_key.map { |purl| purl[%r{\Apkg:pypi/([^@]+)}, 1] }
+    end
+
+    it "emits a single manifest group attributed to the real manifest, not the constraints file" do
+      manifest_names = grapher.manifest_group_snapshots.map { |snapshot| snapshot.manifest_file.name }
+
+      expect(manifest_names).to contain_exactly("requirements.txt")
+    end
+
+    it "does not double-report the constrained package across a spurious constraints snapshot" do
+      all_reported = grapher.manifest_group_snapshots.flat_map { |snapshot| resolved_package_names(snapshot) }
+
+      expect(all_reported.count("flask")).to eq(1)
+    end
+  end
+
   describe "#manifest_group_snapshots for package managers that do not support layering" do
     context "when the directory is a Poetry project" do
       let(:poetry_lock_file) do


### PR DESCRIPTION
### What are you trying to accomplish?

This follows up on
- https://github.com/dependabot/dependabot-core/pull/15521
- https://github.com/dependabot/dependabot-core/pull/15581

A corner case left unresolved by this PR is that a constraints file can be named in a way whereby our regex to filter 'manifests' out of a set of txt files can incorrectly identify it as a manifest that requires a layer of its own, e.g. `requirements-context.txt`

This PR updates the constraint file classification to consider any file that is referenced by peers via a `-c` line as a constraint so we include it in the relevant layers but disallow it from acting as a manifest with its own layer.

### Anything you want to highlight for special attention from reviewers?

The classification code has gotten slightly more complex with this change, but the test cases themselves are fairly contained and explain the scenario clearly.

### How will you know you've accomplished your goal?

A repository with a `requirements-constraints.txt` will no longer submit a snapshot with a 'layer' for this file.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
