### PR TITLE
[Update Graph] Ensure that txt/in pairs are included properly in layers when working out references

### DIFF
--- a/python/lib/dependabot/python/dependency_grapher/requirements_layers.rb
+++ b/python/lib/dependabot/python/dependency_grapher/requirements_layers.rb
@@ -128,7 +128,8 @@ module Dependabot
             f != primary && requirements_stem(f.name) == stem
           end
 
-          referenced = referenced_requirement_files(primary)
+          # When the primary is a compiled `.txt`, the `-r`/`-c` directives live in the paired `.in` files.
+          referenced = referenced_requirement_files([primary] + paired)
 
           support = (paired + referenced + constraints_files).uniq.map do |f|
             as_support_file(f)
@@ -150,15 +151,18 @@ module Dependabot
           requirement_family_files.select { |f| File.basename(f.name).include?("constraint") }
         end
 
-        # Finds sibling files referenced by a requirements file via `-r`/`-c`, following the chain transitively.
+        # Collects sibling files referenced via `-r`/`-c`, walking the chain transitively. Returns only newly
+        # discovered files; the seed files are excluded (they are already in the layer).
         #
-        # A referenced file can itself reference further files (e.g. `develop.in -r test.in`, `test.in -r base.in`),
-        # so we walk the whole closure to gather every sibling the layer needs on disk to parse in isolation.
-        sig { params(file: Dependabot::DependencyFile).returns(T::Array[Dependabot::DependencyFile]) }
-        def referenced_requirement_files(file)
+        # - Seeded from every file in the layer (primary + paired `.in`/`.txt`): a compiled `.txt` primary has
+        #   no live `-r`/`-c` directives, so they must be read from the paired `.in`.
+        # - Walks the full closure: a referenced file can reference more (e.g. `develop.in` -> `test.in` ->
+        #   `base.in`), and the layer needs every sibling on disk to parse in isolation.
+        sig { params(seeds: T::Array[Dependabot::DependencyFile]).returns(T::Array[Dependabot::DependencyFile]) }
+        def referenced_requirement_files(seeds)
           by_name = requirement_family_files.to_h { |f| [f.name, f] }
-          seen = T.let(Set.new, T::Set[String])
-          queue = [file]
+          seen = T.let(Set.new(seeds.map(&:name)), T::Set[String])
+          queue = T.let(seeds.dup, T::Array[Dependabot::DependencyFile])
           collected = T.let([], T::Array[Dependabot::DependencyFile])
 
           until queue.empty?

--- a/python/spec/dependabot/python/dependency_grapher/requirements_layers_spec.rb
+++ b/python/spec/dependabot/python/dependency_grapher/requirements_layers_spec.rb
@@ -144,6 +144,40 @@ RSpec.describe Dependabot::Python::DependencyGrapher::RequirementsLayers do
       end
     end
 
+    # Canonical pip-compile "layered requirements" layout: a prod pair plus a dev pair whose `.in` references
+    # the prod files via `-r`/`-c`.
+    #
+    # - The dev layer's primary is the compiled requirements-dev.txt, but the live `-r`/`-c` directives live
+    #   in the paired requirements-dev.in.
+    # - The referenced prod files must still be pulled into the dev layer as support files, otherwise pip
+    #   cannot open them and the graph job fails with `dependency_file_not_evaluatable`.
+    context "with a pip-compile layered layout where the paired .in references sibling requirements" do
+      let(:dependency_files) do
+        [
+          file("requirements.in", "requests\n"),
+          file("requirements.txt", "# via requirements.in\nrequests==2.32.5\n"),
+          file("requirements-dev.in", "-c requirements.txt\n-r requirements.in\npytest\n"),
+          file("requirements-dev.txt", "# via requirements-dev.in\npytest==8.3.3\n")
+        ]
+      end
+
+      it "emits one group per compiled layer" do
+        expect(layers.groups.map { |g| g.primary.name })
+          .to contain_exactly("requirements.txt", "requirements-dev.txt")
+      end
+
+      it "pulls the -r/-c siblings referenced by the paired .in into the dev layer as support files" do
+        dev_group = layers.groups.find { |g| g.primary.name == "requirements-dev.txt" }
+        support_names = dev_group.files.select(&:support_file?).map(&:name)
+
+        expect(dev_group.files.map(&:name))
+          .to contain_exactly(
+            "requirements-dev.txt", "requirements-dev.in", "requirements.in", "requirements.txt"
+          )
+        expect(support_names).to include("requirements-dev.in", "requirements.in", "requirements.txt")
+      end
+    end
+
     context "with a shared constraints file" do
       let(:dependency_files) do
         [


### PR DESCRIPTION
### What are you trying to accomplish?

Follows up on:
- https://github.com/dependabot/dependabot-core/pull/15521

Fixes:
- https://github.com/dependabot/dependabot-core/issues/15565
- https://github.com/dependabot/dependabot-core/issues/15556

The previous PR did not include paired files when looking for references to include in a layer, in the case of pip-compile, the reference statements are present in the `.in` files, not the `.txt` files so this introduced and issue where not all files required for the parse were present.

### Anything you want to highlight for special attention from reviewers?

N/A - this is a fairly focused correction

### How will you know you've accomplished your goal?

A reference project using paired `.in` and `.txt` files with hierarchial references no longer get a `dependency_file_not_evaluatable` error anymore.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
