### PR TITLE
Add support to bazel for BuildBuddy

### DIFF
--- a/bazel/lib/dependabot/bazel/file_fetcher.rb
+++ b/bazel/lib/dependabot/bazel/file_fetcher.rb
@@ -3,6 +3,7 @@
 
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
+require "dependabot/bazel/version"
 
 module Dependabot
   module Bazel
@@ -48,10 +49,8 @@ module Dependabot
 
       sig { override.returns(T.nilable(T::Hash[Symbol, T.anything])) }
       def ecosystem_versions
-        bazel_version = "unknown"
-
         bazelversion_file = fetch_file_if_present(".bazelversion")
-        bazel_version = T.must(bazelversion_file.content).strip if bazelversion_file
+        bazel_version = Dependabot::Bazel::Version.version_from_file(bazelversion_file) || "unknown"
 
         { package_managers: { "bazel" => bazel_version } }
       end

--- a/bazel/lib/dependabot/bazel/file_parser.rb
+++ b/bazel/lib/dependabot/bazel/file_parser.rb
@@ -151,7 +151,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def bazel_version
         bazelversion_file = dependency_files.find { |f| f.name == ".bazelversion" }
-        bazelversion_file&.content&.strip
+        Dependabot::Bazel::Version.version_from_file(bazelversion_file)
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(DependencySet) }

--- a/bazel/lib/dependabot/bazel/file_updater/lockfile_updater.rb
+++ b/bazel/lib/dependabot/bazel/file_updater/lockfile_updater.rb
@@ -4,6 +4,7 @@
 require "sorbet-runtime"
 require "dependabot/bazel/file_updater"
 require "dependabot/bazel/package_manager"
+require "dependabot/bazel/version"
 require "dependabot/shared_helpers"
 require "pathname"
 require "fileutils"
@@ -51,11 +52,11 @@ module Dependabot
 
         sig { returns(String) }
         def determine_bazel_version
+          # Exact name match: nested .bazelversion files (e.g. from local_path_override
+          # modules) pin those modules' Bazel, not this workspace's.
           bazelversion_file = dependency_files.find { |f| f.name == ".bazelversion" }
-          return Dependabot::Bazel::DEFAULT_BAZEL_VERSION unless bazelversion_file
-
-          version = T.must(bazelversion_file.content).strip
-          version.empty? ? Dependabot::Bazel::DEFAULT_BAZEL_VERSION : version
+          Dependabot::Bazel::Version.version_from_file(bazelversion_file) ||
+            Dependabot::Bazel::DEFAULT_BAZEL_VERSION
         end
 
         private
@@ -144,10 +145,27 @@ module Dependabot
           dependency_files.each do |file|
             path = file.name
             FileUtils.mkdir_p(Pathname.new(path).dirname) if path.include?("/")
-            File.write(path, T.must(file.content))
+            if File.basename(path) == ".bazelversion"
+              target = bazelisk_target(file)
+              unless target == T.must(file.content).strip
+                Dependabot.logger.info("Rewriting #{path} for Bazelisk: #{target.inspect}")
+              end
+              File.write(path, target)
+            else
+              File.write(path, T.must(file.content))
+            end
           end
 
           write_bazelversion_if_missing
+        end
+
+        # What the temporary .bazelversion should contain for Bazelisk to run: the
+        # file's own target (fork entries preserved, wrapper entries stripped),
+        # falling back to the default Bazel version for wrapper-only/empty files.
+        sig { params(file: Dependabot::DependencyFile).returns(String) }
+        def bazelisk_target(file)
+          Dependabot::Bazel::Version.bazelisk_target_from_file(file) ||
+            Dependabot::Bazel::DEFAULT_BAZEL_VERSION
         end
 
         sig { void }

--- a/bazel/lib/dependabot/bazel/version.rb
+++ b/bazel/lib/dependabot/bazel/version.rb
@@ -3,6 +3,7 @@
 
 require "dependabot/version"
 require "dependabot/utils"
+require "dependabot/dependency_file"
 
 # Bazel pre-release versions use 1.0.1-rc1 syntax, which Gem::Version
 # converts into 1.0.1.pre.rc1. We override the `to_s` method to stop that
@@ -12,6 +13,11 @@ module Dependabot
   module Bazel
     class Version < Dependabot::Version
       extend T::Sig
+
+      # Wrapper CLIs that piggyback on Bazelisk's fork syntax ("<org>/<version>").
+      # Their entries name the wrapper's own version, not a Bazel version, so
+      # they must never be mistaken for a Bazel fork target.
+      KNOWN_WRAPPER_ORGS = T.let(%w(buildbuddy-io).freeze, T::Array[String])
 
       sig { override.params(version: VersionParameter).returns(T::Boolean) }
       def self.correct?(version)
@@ -28,10 +34,72 @@ module Dependabot
         super(Dependabot::Bazel::Version.normalize_bazel_version(@version_string))
       end
 
-      # Strips .bcr.N suffix and v prefix to yield a Gem::Version-compatible string.
+      # Extracts the Bazel version from .bazelversion content, skipping comments and known
+      # wrapper entries (like buildbuddy-io/5.0.321). Mirrors Bazelisk's behavior: the first
+      # surviving line wins, so this always describes the same Bazel that
+      # `bazelisk_target_from_file` would execute. For Bazelisk fork targets (like myorg/8.0.0)
+      # the trailing segment is the Bazel version, so it is returned.
+      # Only for .bazelversion content — plain version strings go through `correct?`/`new`.
+      sig { params(version_string: VersionParameter).returns(String) }
+      def self.extract_bazel_version(version_string)
+        return "" if version_string.nil?
+
+        target_line = bazel_lines(version_string.to_s).first
+        return "" unless target_line
+
+        target_line.split("/").last.to_s
+      end
+
+      # The entry Bazelisk should execute: the first line of .bazelversion content once
+      # comments and known wrapper entries are dropped. Fork targets (myorg/8.0.0) are
+      # preserved verbatim so Bazelisk fetches the fork rather than upstream Bazel.
+      # Returns nil when nothing remains (empty or wrapper-only files).
+      sig { params(file: T.nilable(Dependabot::DependencyFile)).returns(T.nilable(String)) }
+      def self.bazelisk_target_from_file(file)
+        content = file&.content
+        return nil unless content
+
+        bazel_lines(content).first
+      end
+
+      sig { params(content: String).returns(T::Array[String]) }
+      def self.bazel_lines(content)
+        content.lines.map(&:strip)
+               .reject { |l| l.empty? || l.start_with?("#") }
+               .reject { |l| wrapper_line?(l) }
+      end
+      private_class_method :bazel_lines
+
+      # GitHub org names are case-insensitive, so match wrapper entries case-insensitively.
+      sig { params(line: String).returns(T::Boolean) }
+      def self.wrapper_line?(line)
+        org = line.split("/").first.to_s
+        KNOWN_WRAPPER_ORGS.any? { |known| known.casecmp?(org) }
+      end
+      private_class_method :wrapper_line?
+
+      # Strips .bcr.N suffix and v prefix from a version string to yield a Gem::Version-compatible string.
       sig { params(version_string: String).returns(String) }
       def self.normalize_bazel_version(version_string)
         version_string.sub(/\.bcr\.\d+$/, "").sub(/^v/i, "")
+      end
+
+      # Helper to cleanly extract and normalize a Bazel version directly from a DependencyFile
+      # (`.bazelversion`). Returns nil when no parseable semantic version can be determined —
+      # including Bazelisk-relative values like "latest" or "last_green" — so callers apply
+      # their own fallbacks rather than crashing on a non-semver string.
+      sig { params(file: T.nilable(Dependabot::DependencyFile)).returns(T.nilable(String)) }
+      def self.version_from_file(file)
+        content = file&.content
+        return nil unless content
+
+        extracted = extract_bazel_version(content)
+        return nil if extracted.empty?
+
+        normalized = normalize_bazel_version(extracted)
+        return nil unless correct?(normalized)
+
+        normalized
       end
 
       sig { override.returns(String) }

--- a/bazel/spec/dependabot/bazel/file_fetcher_spec.rb
+++ b/bazel/spec/dependabot/bazel/file_fetcher_spec.rb
@@ -433,6 +433,27 @@ RSpec.describe Dependabot::Bazel::FileFetcher do
       end
     end
 
+    context "with a multi-line .bazelversion file (BuildBuddy wrapper)" do
+      before do
+        stub_request(:get, url + "?ref=sha")
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_bazel_with_version.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        allow(file_fetcher_instance).to receive(:fetch_file_if_present).with(".bazelversion").and_return(
+          Dependabot::DependencyFile.new(
+            name: ".bazelversion",
+            content: "buildbuddy-io/5.0.321\n9.1.0\n"
+          )
+        )
+      end
+
+      it "extracts the Bazel version from the multi-line wrapper file" do
+        expect(ecosystem_versions).to eq({ package_managers: { "bazel" => "9.1.0" } })
+      end
+    end
+
     context "without a .bazelversion file" do
       before do
         stub_request(:get, url + "?ref=sha")

--- a/bazel/spec/dependabot/bazel/file_parser_spec.rb
+++ b/bazel/spec/dependabot/bazel/file_parser_spec.rb
@@ -110,6 +110,26 @@ RSpec.describe Dependabot::Bazel::FileParser do
     end
   end
 
+  context "with multi-line .bazelversion file (e.g. BuildBuddy wrapper)" do
+    let(:dependency_files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "MODULE.bazel",
+          content: 'bazel_dep(name = "rules_cc", version = "0.1.1")'
+        ),
+        Dependabot::DependencyFile.new(
+          name: ".bazelversion",
+          content: "buildbuddy-io/5.0.321\n9.1.0\n"
+        )
+      ]
+    end
+
+    it "extracts the actual Bazel version ignoring the wrapper prefix" do
+      expect(parser.send(:bazel_version)).to eq("9.1.0")
+      expect(parser.ecosystem.package_manager.version.to_s).to eq("9.1.0")
+    end
+  end
+
   context "with *.MODULE.bazel files" do
     let(:dependency_files) { bazel_project_dependency_files("with_additional_module_files") }
 

--- a/bazel/spec/dependabot/bazel/file_updater/lockfile_updater_spec.rb
+++ b/bazel/spec/dependabot/bazel/file_updater/lockfile_updater_spec.rb
@@ -208,6 +208,143 @@ RSpec.describe Dependabot::Bazel::FileUpdater::LockfileUpdater do
           .to eq(Dependabot::Bazel::DEFAULT_BAZEL_VERSION)
       end
     end
+
+    context "when .bazelversion file exists with a BuildBuddy multi-line wrapper" do
+      let(:dependency_files) do
+        files = bazel_project_dependency_files("simple_module_with_lockfile")
+        files << Dependabot::DependencyFile.new(
+          name: ".bazelversion",
+          content: "buildbuddy-io/5.0.321\n9.1.0\n",
+          directory: "/"
+        )
+        files
+      end
+
+      it "returns the actual Bazel version ignoring the BuildBuddy wrapper line" do
+        expect(lockfile_updater.determine_bazel_version).to eq("9.1.0")
+      end
+    end
+
+    context "when .bazelversion contains only a BuildBuddy wrapper entry" do
+      let(:dependency_files) do
+        files = bazel_project_dependency_files("simple_module_with_lockfile")
+        files << Dependabot::DependencyFile.new(
+          name: ".bazelversion",
+          content: "buildbuddy-io/5.0.321\n",
+          directory: "/"
+        )
+        files
+      end
+
+      it "falls back to DEFAULT_BAZEL_VERSION rather than the wrapper's version" do
+        expect(lockfile_updater.determine_bazel_version)
+          .to eq(Dependabot::Bazel::DEFAULT_BAZEL_VERSION)
+      end
+    end
+
+    context "when only a nested .bazelversion exists (e.g. from a local_path_override module)" do
+      let(:dependency_files) do
+        files = bazel_project_dependency_files("simple_module_with_lockfile")
+        files << Dependabot::DependencyFile.new(
+          name: "third_party/mod/.bazelversion",
+          content: "5.3.0\n",
+          directory: "/"
+        )
+        files
+      end
+
+      it "ignores the nested module's pin and falls back to DEFAULT_BAZEL_VERSION" do
+        expect(lockfile_updater.determine_bazel_version)
+          .to eq(Dependabot::Bazel::DEFAULT_BAZEL_VERSION)
+      end
+    end
+  end
+
+  describe "the temporary .bazelversion written for Bazelisk" do
+    def bazelversion_written_for_bazel
+      content = nil
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do
+        content = File.read(".bazelversion").strip
+      end
+
+      lockfile_updater.updated_lockfile
+      content
+    end
+
+    context "with a BuildBuddy multi-line wrapper .bazelversion" do
+      let(:dependency_files) do
+        files = bazel_project_dependency_files("simple_module_with_lockfile")
+        files << Dependabot::DependencyFile.new(
+          name: ".bazelversion",
+          content: "buildbuddy-io/5.0.321\n9.1.0\n",
+          directory: "/"
+        )
+        files
+      end
+
+      it "strips the wrapper line so Bazelisk runs Bazel directly" do
+        expect(bazelversion_written_for_bazel).to eq("9.1.0")
+      end
+    end
+
+    context "with a Bazelisk fork target .bazelversion" do
+      let(:dependency_files) do
+        files = bazel_project_dependency_files("simple_module_with_lockfile")
+        files << Dependabot::DependencyFile.new(
+          name: ".bazelversion",
+          content: "myorg/8.0.0\n",
+          directory: "/"
+        )
+        files
+      end
+
+      it "preserves the fork target so Bazelisk fetches the fork, not upstream Bazel" do
+        expect(bazelversion_written_for_bazel).to eq("myorg/8.0.0")
+      end
+    end
+
+    context "with a wrapper-only .bazelversion" do
+      let(:dependency_files) do
+        files = bazel_project_dependency_files("simple_module_with_lockfile")
+        files << Dependabot::DependencyFile.new(
+          name: ".bazelversion",
+          content: "buildbuddy-io/5.0.321\n",
+          directory: "/"
+        )
+        files
+      end
+
+      it "writes the default Bazel version" do
+        expect(bazelversion_written_for_bazel)
+          .to eq(Dependabot::Bazel::DEFAULT_BAZEL_VERSION)
+      end
+    end
+
+    context "with only a nested .bazelversion from a local_path_override module" do
+      let(:dependency_files) do
+        files = bazel_project_dependency_files("simple_module_with_lockfile")
+        files << Dependabot::DependencyFile.new(
+          name: "third_party/mod/.bazelversion",
+          content: "5.3.0\n",
+          directory: "/"
+        )
+        files
+      end
+
+      it "writes the default root .bazelversion and keeps the nested module's own pin" do
+        root_content = nil
+        nested_content = nil
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do
+          root_content = File.read(".bazelversion").strip
+          nested_content = File.read("third_party/mod/.bazelversion").strip
+        end
+
+        lockfile_updater.updated_lockfile
+
+        expect(root_content).to eq(Dependabot::Bazel::DEFAULT_BAZEL_VERSION)
+        expect(nested_content).to eq("5.3.0")
+      end
+    end
   end
 
   def updated_lockfile_content

--- a/bazel/spec/dependabot/bazel/version_spec.rb
+++ b/bazel/spec/dependabot/bazel/version_spec.rb
@@ -221,12 +221,123 @@ RSpec.describe Dependabot::Bazel::Version do
       expect(described_class.correct?("v1.2.3-rc1")).to be true
     end
 
+    it "rejects .bazelversion file content — only version_from_file handles multi-line/wrapper forms" do
+      expect(described_class.correct?("buildbuddy-io/5.0.321\n9.1.0\n")).to be false
+      expect(described_class.correct?("buildbuddy-io/5.0.321")).to be false
+    end
+
+    it "rejects slash-containing strings like git tags, as before BuildBuddy support" do
+      expect(described_class.correct?("release/1.2.3")).to be false
+      expect(described_class.correct?("refs/tags/v1.2.3")).to be false
+    end
+
     it "rejects malformed strings" do
       expect(described_class.correct?("not_valid!!!")).to be false
     end
 
     it "rejects nil" do
       expect(described_class.correct?(nil)).to be false
+    end
+  end
+
+  describe ".extract_bazel_version" do
+    it "returns simple version strings untouched" do
+      expect(described_class.extract_bazel_version("9.1.0")).to eq("9.1.0")
+    end
+
+    it "extracts the Bazel version from a multi-line BuildBuddy wrapper string" do
+      content = "buildbuddy-io/5.0.321\n9.1.0\n"
+      expect(described_class.extract_bazel_version(content)).to eq("9.1.0")
+    end
+
+    it "extracts the Bazel version when comments and wrapper lines are present" do
+      content = "# Wrapper definition\nbuildbuddy-io/5.0.321\n\n# Actual Bazel version\n8.4.0-rc2\n"
+      expect(described_class.extract_bazel_version(content)).to eq("8.4.0-rc2")
+    end
+
+    it "extracts the version number when only a fork reference string is present" do
+      expect(described_class.extract_bazel_version("myorg/bazel-fork/8.0.0")).to eq("8.0.0")
+    end
+
+    it "returns empty string for a wrapper-only entry rather than the wrapper's own version" do
+      expect(described_class.extract_bazel_version("buildbuddy-io/5.0.321")).to eq("")
+      expect(described_class.extract_bazel_version("# wrapper\nbuildbuddy-io/5.0.321\n")).to eq("")
+    end
+
+    it "matches wrapper orgs case-insensitively (GitHub orgs are case-insensitive)" do
+      expect(described_class.extract_bazel_version("BuildBuddy-io/5.0.321")).to eq("")
+      expect(described_class.extract_bazel_version("BUILDBUDDY-IO/5.0.321\n9.1.0\n")).to eq("9.1.0")
+    end
+
+    it "uses the first surviving line, matching what Bazelisk would execute" do
+      expect(described_class.extract_bazel_version("myorg/8.0.0\n9.1.0\n")).to eq("8.0.0")
+    end
+
+    it "handles CRLF line endings" do
+      expect(described_class.extract_bazel_version("buildbuddy-io/5.0.321\r\n9.1.0\r\n")).to eq("9.1.0")
+    end
+
+    it "returns empty string for nil or empty input or slash-only input" do
+      expect(described_class.extract_bazel_version(nil)).to eq("")
+      expect(described_class.extract_bazel_version("   \n  ")).to eq("")
+      expect(described_class.extract_bazel_version("///")).to eq("")
+    end
+  end
+
+  describe ".bazelisk_target_from_file" do
+    def file_with(content)
+      Dependabot::DependencyFile.new(name: ".bazelversion", content: content)
+    end
+
+    it "returns a plain version untouched" do
+      expect(described_class.bazelisk_target_from_file(file_with("9.1.0\n"))).to eq("9.1.0")
+    end
+
+    it "preserves a fork target verbatim" do
+      expect(described_class.bazelisk_target_from_file(file_with("myorg/8.0.0\n"))).to eq("myorg/8.0.0")
+    end
+
+    it "drops BuildBuddy wrapper lines and returns the underlying Bazel entry" do
+      content = "buildbuddy-io/5.0.321\n9.1.0\n"
+      expect(described_class.bazelisk_target_from_file(file_with(content))).to eq("9.1.0")
+    end
+
+    it "preserves Bazelisk-relative values verbatim — Bazelisk understands them" do
+      expect(described_class.bazelisk_target_from_file(file_with("latest\n"))).to eq("latest")
+      expect(described_class.bazelisk_target_from_file(file_with("buildbuddy-io/5.0.321\nlast_green\n")))
+        .to eq("last_green")
+    end
+
+    it "returns nil for wrapper-only, comment-only, empty, or nil files" do
+      expect(described_class.bazelisk_target_from_file(file_with("buildbuddy-io/5.0.321\n"))).to be_nil
+      expect(described_class.bazelisk_target_from_file(file_with("# just a comment\n"))).to be_nil
+      expect(described_class.bazelisk_target_from_file(file_with("  \n"))).to be_nil
+      expect(described_class.bazelisk_target_from_file(nil)).to be_nil
+    end
+  end
+
+  describe ".version_from_file" do
+    it "extracts and normalizes version from a DependencyFile" do
+      file = Dependabot::DependencyFile.new(name: ".bazelversion", content: "buildbuddy-io/5.0.321\nv9.1.0.bcr.1\n")
+      expect(described_class.version_from_file(file)).to eq("9.1.0")
+    end
+
+    it "returns nil when file is nil or empty" do
+      expect(described_class.version_from_file(nil)).to be_nil
+      file = Dependabot::DependencyFile.new(name: ".bazelversion", content: "   \n")
+      expect(described_class.version_from_file(file)).to be_nil
+    end
+
+    it "returns nil for a wrapper-only file so callers apply their own fallbacks" do
+      file = Dependabot::DependencyFile.new(name: ".bazelversion", content: "buildbuddy-io/5.0.321\n")
+      expect(described_class.version_from_file(file)).to be_nil
+    end
+
+    it "returns nil for Bazelisk-relative values that aren't semantic versions" do
+      %w(latest last_green last_rc rolling myorg/last_green).each do |content|
+        file = Dependabot::DependencyFile.new(name: ".bazelversion", content: content)
+        expect(described_class.version_from_file(file)).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION


### What are you trying to accomplish?

We use Buildbuddy as a [Bazel CLI wrapper](https://www.buildbuddy.io/docs/cli/#installing-for-a-project) in a private repo. Currently when running dependabot against it to update bazel dependencies, we get an error about a malformed version string.

<img width="2273" height="318" alt="image" src="https://github.com/user-attachments/assets/c07f4409-5339-4c18-b60f-317195a3ef8a" />

This PR attempts to do more complex parsing of the `.bazelversion` file to support this use case.

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?

Theoretically, this should also work for other bazel CLI wrappers that work in a similar manner. As part of this, we also centralize the version parsing and extraction in `Dependabot::Bazel::Version.version_from_file`

### How will you know you've accomplished your goal?

I tested this using a dry run command against several public repos and it worked:
* `./bin/dry-run.rb bazel tyler-french/OutLoud --cache=files` - Public repo using buildbuddy CLI in `.bazelversion`
* `./bin/dry-run.rb bazel bazel-contrib/rules_oci --cache=files` - Public repo with comments in the `.bazelversion`
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
