### PR TITLE
Type git source details

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -15,6 +15,7 @@ require "dependabot/source"
 require "dependabot/dependency"
 require "dependabot/credential"
 require "dependabot/git_metadata_fetcher"
+require "dependabot/git_commit_checker/source_details"
 require "dependabot/git_tag_details"
 require "dependabot/package/package_release"
 require "dependabot/package/release_cooldown_options"
@@ -63,14 +64,16 @@ module Dependabot
       @ignored_versions = ignored_versions
       @raise_on_ignored = raise_on_ignored
       @consider_version_branches_pinned = consider_version_branches_pinned
-      @dependency_source_details = dependency_source_details
+      @dependency_source_details = T.let(
+        dependency_source_details,
+        T.nilable(T::Hash[Symbol, Object])
+      )
+      @parsed_dependency_source_details = T.let(nil, T.nilable(SourceDetails))
     end
 
     sig { returns(T::Boolean) }
     def git_dependency?
-      return false if dependency_source_details.nil?
-
-      dependency_source_details&.fetch(:type) == "git"
+      parsed_dependency_source_details&.type == "git"
     end
 
     # rubocop:disable Metrics/PerceivedComplexity
@@ -78,7 +81,7 @@ module Dependabot
     def pinned?
       raise "Not a git dependency!" unless git_dependency?
 
-      branch = dependency_source_details&.fetch(:branch)
+      branch = parsed_dependency_source_details&.branch
 
       return false if ref.nil?
       return false if branch == ref
@@ -118,7 +121,7 @@ module Dependabot
     sig { returns(T::Array[GitRef]) }
     def tags
       GitMetadataFetcher.new(
-        url: dependency.source_details&.fetch(:url, nil),
+        url: T.must(source_details&.url),
         credentials: credentials
       ).tags
     end
@@ -128,7 +131,7 @@ module Dependabot
       T.must(
         T.let(
           GitMetadataFetcher.new(
-            url: dependency.source_details&.fetch(:url, nil),
+            url: T.must(source_details&.url),
             credentials: credentials
           ).ref_details_for_pinned_ref(ref),
           T.nilable(Excon::Response)
@@ -333,7 +336,7 @@ module Dependabot
 
     sig { override.returns(T.nilable(String)) }
     def cooldown_source_url
-      dependency_source_details&.fetch(:url, nil)
+      parsed_dependency_source_details&.url
     end
 
     sig { override.returns(T::Array[Dependabot::Credential]) }
@@ -342,6 +345,14 @@ module Dependabot
     end
 
     private
+
+    sig { returns(T.nilable(SourceDetails)) }
+    def parsed_dependency_source_details
+      @parsed_dependency_source_details ||= begin
+        details = dependency_source_details
+        SourceDetails.from_hash(details) if details
+      end
+    end
 
     sig { returns(Dependabot::Dependency) }
     attr_reader :dependency
@@ -478,7 +489,7 @@ module Dependabot
 
     sig { params(tags: T::Array[Dependabot::GitRef]).returns(T::Array[Dependabot::GitRef]) }
     def handle_tag_prefix(tags)
-      if dependency_source_details&.fetch(:ref, nil)&.start_with?("tags/")
+      if parsed_dependency_source_details&.ref&.start_with?("tags/")
         tags = tags.map do |tag|
           tag.dup.tap { |t| t.name = "tags/#{tag.name}" }
         end
@@ -558,12 +569,12 @@ module Dependabot
 
     sig { returns(T.nilable(String)) }
     def ref_or_branch
-      ref || dependency_source_details&.fetch(:branch)
+      ref || parsed_dependency_source_details&.branch
     end
 
     sig { returns(T.nilable(String)) }
     def ref
-      dependency_source_details&.fetch(:ref)
+      parsed_dependency_source_details&.ref
     end
 
     sig { params(tag: String).returns(T::Boolean) }
@@ -667,7 +678,7 @@ module Dependabot
         begin
           tags = listing_repo_git_metadata_fetcher.tags
 
-          if dependency_source_details&.fetch(:ref, nil)&.start_with?("tags/")
+          if parsed_dependency_source_details&.ref&.start_with?("tags/")
             tags = tags.map do |tag|
               tag.dup.tap { |t| t.name = "tags/#{tag.name}" }
             end
@@ -695,7 +706,7 @@ module Dependabot
 
     sig { returns(T::Boolean) }
     def wants_prerelease?
-      return false unless dependency_source_details&.fetch(:ref, nil)
+      return false unless parsed_dependency_source_details&.ref
       return false unless pinned_ref_looks_like_version?
 
       version = version_from_ref(T.must(ref))
@@ -892,7 +903,7 @@ module Dependabot
       @local_repo_git_metadata_fetcher ||=
         T.let(
           GitMetadataFetcher.new(
-            url: dependency_source_details&.fetch(:url),
+            url: T.must(parsed_dependency_source_details&.url),
             credentials: credentials
           ),
           T.nilable(Dependabot::GitMetadataFetcher)
@@ -913,8 +924,14 @@ module Dependabot
 
     sig { returns(String) }
     def ref_pinned
-      dependency.source_details&.fetch(:ref, nil) ||
-        dependency.source_details&.fetch(:branch, nil) || "HEAD"
+      details = source_details
+      details&.ref || details&.branch || "HEAD"
+    end
+
+    sig { returns(T.nilable(SourceDetails)) }
+    def source_details
+      details = dependency.source_details
+      SourceDetails.from_hash(details) if details
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/common/lib/dependabot/git_commit_checker/source_details.rb
+++ b/common/lib/dependabot/git_commit_checker/source_details.rb
@@ -1,0 +1,42 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class GitCommitChecker
+    # Typed view over the source hash attached to a git dependency.
+    class SourceDetails < T::ImmutableStruct
+      extend T::Sig
+
+      const :type, T.nilable(String)
+      const :url, T.nilable(String)
+      const :branch, T.nilable(String)
+      const :ref, T.nilable(String)
+
+      sig do
+        params(details: T::Hash[T.any(String, Symbol), Object]).returns(SourceDetails)
+      end
+      def self.from_hash(details)
+        new(
+          type: string_value(details, :type),
+          url: string_value(details, :url),
+          branch: string_value(details, :branch),
+          ref: string_value(details, :ref)
+        )
+      end
+
+      sig do
+        params(
+          details: T::Hash[T.any(String, Symbol), Object],
+          key: Symbol
+        ).returns(T.nilable(String))
+      end
+      def self.string_value(details, key)
+        value = details.key?(key) ? details[key] : details[key.to_s]
+        value.is_a?(String) ? value : nil
+      end
+      private_class_method :string_value
+    end
+  end
+end

--- a/common/spec/dependabot/git_commit_checker/source_details_spec.rb
+++ b/common/spec/dependabot/git_commit_checker/source_details_spec.rb
@@ -1,0 +1,66 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/git_commit_checker/source_details"
+
+RSpec.describe Dependabot::GitCommitChecker::SourceDetails do
+  describe ".from_hash" do
+    subject(:source_details) { described_class.from_hash(details) }
+
+    context "with symbol keys" do
+      let(:details) do
+        {
+          type: "git",
+          url: "https://github.com/dependabot/dependabot-core",
+          branch: "main",
+          ref: "v1.0.0"
+        }
+      end
+
+      it "parses the known fields" do
+        expect(source_details).to have_attributes(
+          type: "git",
+          url: "https://github.com/dependabot/dependabot-core",
+          branch: "main",
+          ref: "v1.0.0"
+        )
+      end
+    end
+
+    context "with string keys" do
+      let(:details) do
+        {
+          "type" => "git",
+          "url" => "https://github.com/dependabot/dependabot-core",
+          "branch" => "main",
+          "ref" => "v1.0.0"
+        }
+      end
+
+      it "parses the known fields" do
+        expect(source_details).to have_attributes(
+          type: "git",
+          url: "https://github.com/dependabot/dependabot-core",
+          branch: "main",
+          ref: "v1.0.0"
+        )
+      end
+    end
+
+    context "with non-string values" do
+      let(:details) do
+        {
+          type: true,
+          url: 1,
+          branch: [],
+          ref: {}
+        }
+      end
+
+      it "drops them" do
+        expect(source_details).to have_attributes(type: nil, url: nil, branch: nil, ref: nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`GitCommitChecker` now parses source hashes into a typed `SourceDetails` before reading `type`, `url`, `branch`, or `ref`. Its public hash API stays unchanged.