### PR TITLE
Expose typed git source details

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1150
+# Offense count: 1149
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -65,15 +65,14 @@ module Dependabot
       @raise_on_ignored = raise_on_ignored
       @consider_version_branches_pinned = consider_version_branches_pinned
       @dependency_source_details = T.let(
-        dependency_source_details,
-        T.nilable(T::Hash[Symbol, Object])
+        dependency_source_details && SourceDetails.from_hash(dependency_source_details),
+        T.nilable(SourceDetails)
       )
-      @parsed_dependency_source_details = T.let(nil, T.nilable(SourceDetails))
     end
 
     sig { returns(T::Boolean) }
     def git_dependency?
-      parsed_dependency_source_details&.type == "git"
+      dependency_source_details&.type == "git"
     end
 
     # rubocop:disable Metrics/PerceivedComplexity
@@ -81,7 +80,7 @@ module Dependabot
     def pinned?
       raise "Not a git dependency!" unless git_dependency?
 
-      branch = parsed_dependency_source_details&.branch
+      branch = dependency_source_details&.branch
 
       return false if ref.nil?
       return false if branch == ref
@@ -285,9 +284,12 @@ module Dependabot
       false
     end
 
-    sig { returns(T.nilable(T::Hash[T.any(Symbol, String), T.untyped])) }
+    sig { returns(T.nilable(SourceDetails)) }
     def dependency_source_details
-      @dependency_source_details || dependency.source_details(allowed_types: ["git"])
+      @dependency_source_details ||= begin
+        details = dependency.source_details(allowed_types: ["git"])
+        SourceDetails.from_hash(details) if details
+      end
     end
 
     sig { returns(T::Array[Dependabot::GitTagWithDetail]) }
@@ -336,7 +338,7 @@ module Dependabot
 
     sig { override.returns(T.nilable(String)) }
     def cooldown_source_url
-      parsed_dependency_source_details&.url
+      dependency_source_details&.url
     end
 
     sig { override.returns(T::Array[Dependabot::Credential]) }
@@ -345,14 +347,6 @@ module Dependabot
     end
 
     private
-
-    sig { returns(T.nilable(SourceDetails)) }
-    def parsed_dependency_source_details
-      @parsed_dependency_source_details ||= begin
-        details = dependency_source_details
-        SourceDetails.from_hash(details) if details
-      end
-    end
 
     sig { returns(Dependabot::Dependency) }
     attr_reader :dependency
@@ -489,7 +483,7 @@ module Dependabot
 
     sig { params(tags: T::Array[Dependabot::GitRef]).returns(T::Array[Dependabot::GitRef]) }
     def handle_tag_prefix(tags)
-      if parsed_dependency_source_details&.ref&.start_with?("tags/")
+      if dependency_source_details&.ref&.start_with?("tags/")
         tags = tags.map do |tag|
           tag.dup.tap { |t| t.name = "tags/#{tag.name}" }
         end
@@ -569,12 +563,12 @@ module Dependabot
 
     sig { returns(T.nilable(String)) }
     def ref_or_branch
-      ref || parsed_dependency_source_details&.branch
+      ref || dependency_source_details&.branch
     end
 
     sig { returns(T.nilable(String)) }
     def ref
-      parsed_dependency_source_details&.ref
+      dependency_source_details&.ref
     end
 
     sig { params(tag: String).returns(T::Boolean) }
@@ -678,7 +672,7 @@ module Dependabot
         begin
           tags = listing_repo_git_metadata_fetcher.tags
 
-          if parsed_dependency_source_details&.ref&.start_with?("tags/")
+          if dependency_source_details&.ref&.start_with?("tags/")
             tags = tags.map do |tag|
               tag.dup.tap { |t| t.name = "tags/#{tag.name}" }
             end
@@ -706,7 +700,7 @@ module Dependabot
 
     sig { returns(T::Boolean) }
     def wants_prerelease?
-      return false unless parsed_dependency_source_details&.ref
+      return false unless dependency_source_details&.ref
       return false unless pinned_ref_looks_like_version?
 
       version = version_from_ref(T.must(ref))
@@ -903,7 +897,7 @@ module Dependabot
       @local_repo_git_metadata_fetcher ||=
         T.let(
           GitMetadataFetcher.new(
-            url: T.must(parsed_dependency_source_details&.url),
+            url: T.must(dependency_source_details&.url),
             credentials: credentials
           ),
           T.nilable(Dependabot::GitMetadataFetcher)

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -143,6 +143,20 @@ RSpec.describe Dependabot::GitCommitChecker do
     end
   end
 
+  describe "#dependency_source_details" do
+    subject(:source_details) { checker.dependency_source_details }
+
+    it "returns typed source details" do
+      expect(source_details).to be_a(described_class::SourceDetails)
+      expect(source_details).to have_attributes(
+        type: "git",
+        url: "https://github.com/gocardless/business",
+        branch: "master",
+        ref: "master"
+      )
+    end
+  end
+
   describe "#branch_or_ref_in_release?" do
     subject(:branch_or_ref_in_release?) { checker.branch_or_ref_in_release?(Dependabot::Version.new("1.5.0")) }
 

--- a/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
@@ -215,7 +215,7 @@ module Dependabot
               if head_commit_for_ref_sha
                 head_commit_for_ref_sha
               else
-                url = git_commit_checker.dependency_source_details&.fetch(:url)
+                url = git_commit_checker.dependency_source_details&.url
                 source = T.must(Source.from_url(url))
 
                 SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
@@ -224,7 +224,7 @@ module Dependabot
                   SharedHelpers.run_shell_command("git clone --no-recurse-submodules #{url} #{repo_contents_path}")
 
                   Dir.chdir(repo_contents_path) do
-                    ref_branch = find_container_branch(git_commit_checker.dependency_source_details&.fetch(:ref))
+                    ref_branch = find_container_branch(T.must(git_commit_checker.dependency_source_details&.ref))
                     git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
                   end
                 end

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -121,7 +121,7 @@ module Dependabot
             if head_commit_for_ref_sha
               head_commit_for_ref_sha
             else
-              url = git_commit_checker.dependency_source_details&.fetch(:url)
+              url = git_commit_checker.dependency_source_details&.url
               source = T.must(Source.from_url(url))
 
               SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
@@ -130,7 +130,7 @@ module Dependabot
                 SharedHelpers.run_shell_command("git clone --no-recurse-submodules #{url} #{repo_contents_path}")
 
                 Dir.chdir(repo_contents_path) do
-                  ref_branch = find_container_branch(git_commit_checker.dependency_source_details&.fetch(:ref))
+                  ref_branch = find_container_branch(T.must(git_commit_checker.dependency_source_details&.ref))
                   git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
                 end
               end

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -131,7 +131,7 @@ module Dependabot
 
         sig { override.returns(T.nilable(String)) }
         def cooldown_source_url
-          @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
+          @git_helper.git_commit_checker.dependency_source_details&.url
         end
 
         sig { override.returns(T::Array[Dependabot::Credential]) }

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe namespace::LatestVersionFinder do
       branch: nil
     }
   end
+  let(:source_details) { Dependabot::GitCommitChecker::SourceDetails.from_hash(dependency_source) }
   let(:dependency_version) do
     return unless Dependabot::GithubActions::Version.correct?(reference)
 
@@ -557,8 +558,7 @@ RSpec.describe namespace::LatestVersionFinder do
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
-                        ref: "v1", branch: nil })
+          .and_return(source_details)
         allow(finder).to receive_messages(
           latest_version_tag: { tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
                                 commit_sha: "abc123" },
@@ -587,8 +587,7 @@ RSpec.describe namespace::LatestVersionFinder do
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
-                        ref: "v1", branch: nil })
+          .and_return(source_details)
         allow(finder).to receive_messages(
           latest_version_tag: { tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
                                 commit_sha: "abc123" },
@@ -622,8 +621,7 @@ RSpec.describe namespace::LatestVersionFinder do
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
-                        ref: "v1", branch: nil })
+          .and_return(source_details)
         allow(finder).to receive_messages(
           latest_version_tag: { tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
                                 commit_sha: "abc123" },
@@ -651,8 +649,7 @@ RSpec.describe namespace::LatestVersionFinder do
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
-                        ref: "v1", branch: nil })
+          .and_return(source_details)
         allow(finder).to receive(:latest_version_tag)
           .and_return({ tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
                         commit_sha: "abc123" })
@@ -675,8 +672,7 @@ RSpec.describe namespace::LatestVersionFinder do
 
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/actions/setup-node",
-                        ref: "v1", branch: nil })
+          .and_return(source_details)
         allow(finder).to receive_messages(
           latest_version_tag: { tag: "v1.0.0", version: Dependabot::GithubActions::Version.new("1.0.0"),
                                 commit_sha: "abc123" },

--- a/pre_commit/lib/dependabot/pre_commit/package/package_details_fetcher.rb
+++ b/pre_commit/lib/dependabot/pre_commit/package/package_details_fetcher.rb
@@ -208,7 +208,7 @@ module Dependabot
               if head_commit_for_ref_sha
                 head_commit_for_ref_sha
               else
-                url = git_commit_checker.dependency_source_details&.fetch(:url)
+                url = git_commit_checker.dependency_source_details&.url
                 source = T.must(Source.from_url(url))
 
                 SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
@@ -217,7 +217,7 @@ module Dependabot
                   SharedHelpers.run_shell_command("git clone --no-recurse-submodules #{url} #{repo_contents_path}")
 
                   Dir.chdir(repo_contents_path) do
-                    ref_branch = find_container_branch(git_commit_checker.dependency_source_details&.fetch(:ref))
+                    ref_branch = find_container_branch(T.must(git_commit_checker.dependency_source_details&.ref))
                     git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
                   end
                 end

--- a/pre_commit/lib/dependabot/pre_commit/update_checker.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker.rb
@@ -146,7 +146,7 @@ module Dependabot
             if head_commit_for_ref_sha
               head_commit_for_ref_sha
             else
-              url = T.cast(git_commit_checker.dependency_source_details&.fetch(:url), T.nilable(String))
+              url = git_commit_checker.dependency_source_details&.url
               source = T.must(Source.from_url(T.must(url)))
 
               SharedHelpers.in_a_temporary_directory(File.dirname(source.repo)) do |temp_dir|
@@ -155,7 +155,7 @@ module Dependabot
                 SharedHelpers.run_shell_command("git clone --no-recurse-submodules #{url} #{repo_contents_path}")
 
                 Dir.chdir(repo_contents_path) do
-                  ref = T.cast(git_commit_checker.dependency_source_details&.fetch(:ref), T.nilable(String))
+                  ref = git_commit_checker.dependency_source_details&.ref
                   ref_branch = find_container_branch(T.must(ref))
                   git_commit_checker.head_commit_for_local_branch(ref_branch) if ref_branch
                 end

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -103,7 +103,7 @@ module Dependabot
 
         sig { override.returns(T.nilable(String)) }
         def cooldown_source_url
-          @git_helper.git_commit_checker.dependency_source_details&.fetch(:url)
+          @git_helper.git_commit_checker.dependency_source_details&.url
         end
 
         sig { override.returns(T::Array[Dependabot::Credential]) }

--- a/pre_commit/spec/dependabot/pre_commit/helpers/githelper_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/helpers/githelper_spec.rb
@@ -46,17 +46,27 @@ RSpec.describe Dependabot::PreCommit::Helpers::Githelper do
   end
 
   describe "#git_commit_checker_for" do
-    it "preserves nil source details" do
+    it "parses source details" do
       checker = git_helper.git_commit_checker_for(source)
 
-      expect(checker.dependency_source_details).to eq(source)
+      expect(checker.dependency_source_details).to have_attributes(
+        type: "git",
+        url: "https://github.com/pre-commit/pre-commit-hooks",
+        ref: "v4.4.0",
+        branch: nil
+      )
     end
 
-    it "preserves non-string source metadata" do
+    it "ignores unknown source metadata" do
       source_with_metadata = source.merge(metadata: { comment: "# frozen: v4.4.0" })
       checker = git_helper.git_commit_checker_for(source_with_metadata)
 
-      expect(checker.dependency_source_details).to eq(source_with_metadata)
+      expect(checker.dependency_source_details).to have_attributes(
+        type: "git",
+        url: "https://github.com/pre-commit/pre-commit-hooks",
+        ref: "v4.4.0",
+        branch: nil
+      )
     end
   end
 end

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
       branch: nil
     }
   end
+  let(:source_details) { Dependabot::GitCommitChecker::SourceDetails.from_hash(dependency_source) }
   let(:dependency) do
     Dependabot::Dependency.new(
       name: "https://github.com/#{dependency_name}",
@@ -259,8 +260,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_return([latest_tag, older_tag])
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
+          .and_return(source_details)
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -297,8 +297,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_return([latest_tag])
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
+          .and_return(source_details)
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -335,8 +334,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_return([latest_tag, older_tag])
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
+          .and_return(source_details)
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -387,8 +385,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
             .and_return([latest_tag, old_tag])
           allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
             .to receive(:dependency_source_details)
-            .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                          ref: "v4.4.0", branch: nil })
+            .and_return(source_details)
           allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
           allow(Dir).to receive(:chdir).and_yield
           allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -467,8 +464,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_raise("unexpected precision filtering")
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: reference, branch: nil })
+          .and_return(source_details)
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -513,8 +509,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_raise("unexpected precision filtering")
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: reference, branch: nil })
+          .and_return(source_details)
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -556,8 +551,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_return([latest_tag])
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
+          .and_return(source_details)
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -588,8 +582,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_return([latest_tag])
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
+          .and_return(source_details)
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -630,8 +623,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_return([latest_tag, older_tag])
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
+          .and_return(source_details)
         allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
         allow(Dir).to receive(:chdir).and_yield
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
@@ -668,8 +660,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_return([latest_tag])
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
+          .and_return(source_details)
 
         # Mock GitHub Release with recent published_at (in cooldown)
         mock_release = Struct.new(:tag_name, :published_at, :prerelease)
@@ -699,8 +690,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
           .and_return([latest_tag])
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: "v4.4.0", branch: nil })
+          .and_return(source_details)
 
         # No release for this tag
         mock_client = instance_double(Octokit::Client, releases: [])

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
       branch: nil
     }
   end
+  let(:source_details) { Dependabot::GitCommitChecker::SourceDetails.from_hash(dependency_source) }
   let(:dependency_version) do
     return unless Dependabot::PreCommit::Version.correct?(reference)
 
@@ -187,8 +188,7 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
           .and_return([v6_tag])
         allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
           .to receive(:dependency_source_details)
-          .and_return({ type: "git", url: "https://github.com/pre-commit/pre-commit-hooks",
-                        ref: reference, branch: nil })
+          .and_return(source_details)
         # Stub GitHub Releases (empty — forces git clone fallback)
         mock_client = instance_double(Octokit::Client, releases: [])
         allow(Dependabot::Clients::GithubWithRetries).to receive(:for_source).and_return(mock_client)


### PR DESCRIPTION
`GitCommitChecker#dependency_source_details` now returns `SourceDetails`. Ten callers in `github_actions` and `pre_commit` use typed `url` and `ref` readers instead of hash fetches and casts.