### PR TITLE
Type GitHub release metadata

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1149
+# Offense count: 1147
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -286,7 +286,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/clients/gitlab_with_retries.rb"
     - "common/lib/dependabot/dependency.rb"
     - "common/lib/dependabot/file_fetchers/base.rb"
-    - "common/lib/dependabot/git_commit_checker.rb"
     - "common/lib/dependabot/metadata_finders/base/changelog_finder.rb"
     - "common/lib/dependabot/metadata_finders/base/release_finder.rb"
     - "common/lib/dependabot/pull_request_creator/github.rb"

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -15,6 +15,7 @@ require "dependabot/source"
 require "dependabot/dependency"
 require "dependabot/credential"
 require "dependabot/git_metadata_fetcher"
+require "dependabot/git_commit_checker/github_release"
 require "dependabot/git_commit_checker/source_details"
 require "dependabot/git_tag_details"
 require "dependabot/package/package_release"
@@ -737,7 +738,7 @@ module Dependabot
       false
     end
 
-    sig { returns(T::Array[T.untyped]) }
+    sig { returns(T::Array[GitHubRelease]) }
     def github_releases
       @github_releases ||= T.let(
         begin
@@ -752,11 +753,15 @@ module Dependabot
           )
           # The Octokit RBI types this as non-nil, but it can be nil at runtime
           # (e.g. an empty/unexpected registry response), so guard against it.
-          T.unsafe(client.releases(T.must(source).repo, per_page: 100)) || []
+          releases = T.let(
+            client.releases(T.must(source).repo, per_page: 100),
+            T.nilable(T::Array[Sawyer::Resource])
+          )
+          (releases || []).filter_map { |release| GitHubRelease.from_resource(release) }
         rescue Octokit::Error
           []
         end,
-        T.nilable(T::Array[T.untyped])
+        T.nilable(T::Array[GitHubRelease])
       )
     end
 

--- a/common/lib/dependabot/git_commit_checker/github_release.rb
+++ b/common/lib/dependabot/git_commit_checker/github_release.rb
@@ -1,0 +1,26 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sawyer"
+require "sorbet-runtime"
+
+module Dependabot
+  class GitCommitChecker
+    # Typed view over the release fields returned by Octokit.
+    class GitHubRelease < T::ImmutableStruct
+      extend T::Sig
+
+      const :tag_name, String
+      const :prerelease, T::Boolean
+
+      sig { params(resource: Sawyer::Resource).returns(T.nilable(GitHubRelease)) }
+      def self.from_resource(resource)
+        tag_name = T.cast(resource[:tag_name], Object)
+        return unless tag_name.is_a?(String)
+
+        prerelease = T.cast(resource[:prerelease], Object)
+        new(tag_name: tag_name, prerelease: prerelease == true)
+      end
+    end
+  end
+end

--- a/common/spec/dependabot/git_commit_checker/git_hub_release_spec.rb
+++ b/common/spec/dependabot/git_commit_checker/git_hub_release_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/git_commit_checker/github_release"
+
+RSpec.describe Dependabot::GitCommitChecker::GitHubRelease do
+  describe ".from_resource" do
+    subject(:release) { described_class.from_resource(resource) }
+
+    let(:agent) { instance_double(Sawyer::Agent, parse_links: [data, {}]) }
+    let(:resource) { Sawyer::Resource.new(agent, data) }
+
+    context "with a valid release" do
+      let(:data) { { tag_name: "v1.2.3", prerelease: true } }
+
+      it "parses the known fields" do
+        expect(release).to have_attributes(tag_name: "v1.2.3", prerelease: true)
+      end
+    end
+
+    context "without a string tag name" do
+      let(:data) { { tag_name: nil, prerelease: true } }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with a non-boolean prerelease value" do
+      let(:data) { { tag_name: "v1.2.3", prerelease: "true" } }
+
+      it "treats the release as stable" do
+        expect(release).to have_attributes(tag_name: "v1.2.3", prerelease: false)
+      end
+    end
+  end
+end

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -2295,10 +2295,8 @@ RSpec.describe Dependabot::GitCommitChecker do
         it "returns the releases" do
           releases = checker.send(:github_releases)
           expect(releases.length).to eq(2)
-          expect(releases.first[:tag_name]).to eq("v1.0.0")
-          expect(releases.first[:prerelease]).to be(false)
-          expect(releases.last[:tag_name]).to eq("v2.0.0-beta")
-          expect(releases.last[:prerelease]).to be(true)
+          expect(releases.first).to have_attributes(tag_name: "v1.0.0", prerelease: false)
+          expect(releases.last).to have_attributes(tag_name: "v2.0.0-beta", prerelease: true)
         end
 
         it "caches the result" do


### PR DESCRIPTION
`GitCommitChecker` now parses Octokit release resources into a typed `GitHubRelease`. This removes its final explicit `T.untyped` annotations and its `ForbidTUntyped` exclusion.