### PR TITLE
Retry corepack prepare and install on signature metadata errors from private registries

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb
@@ -504,11 +504,11 @@ module Dependabot
       def self.package_manager_install(name, version, env: {})
         return "Corepack does not support #{name}" unless corepack_supported_package_manager?(name)
 
-        Dependabot::SharedHelpers.run_shell_command(
+        run_corepack_command(
           "corepack install #{name}@#{version} --global --cache-only",
           fingerprint: "corepack install <name>@<version> --global --cache-only",
           env: env
-        ).strip
+        )
       end
 
       # Prepare the package manager for use by using corepack
@@ -516,11 +516,11 @@ module Dependabot
       def self.package_manager_activate(name, version, env: {})
         return "Corepack does not support #{name}" unless corepack_supported_package_manager?(name)
 
-        Dependabot::SharedHelpers.run_shell_command(
+        run_corepack_command(
           "corepack prepare #{name}@#{version} --activate",
           fingerprint: "corepack prepare <name>@<version> --activate",
           env: env
-        ).strip
+        )
       end
 
       # Fetch the currently installed version of the package manager directly
@@ -565,12 +565,30 @@ module Dependabot
         output_observer: nil,
         env: nil
       )
-        full_command = T.let("corepack #{name} #{command}", String)
-        command_fingerprint = T.let("corepack #{name} #{fingerprint || command}", String)
+        run_corepack_command(
+          "corepack #{name} #{command}",
+          fingerprint: "corepack #{name} #{fingerprint || command}",
+          output_observer: output_observer,
+          env: env
+        )
+      end
 
+      # Run a corepack shell command, retrying once with signature verification
+      # disabled when a configured private registry strips `dist.signatures`
+      # from its version endpoint (a known Artifactory behaviour that otherwise
+      # aborts the run with COREPACK_SIGNATURE_METADATA_ERROR).
+      sig do
+        params(
+          full_command: String,
+          fingerprint: String,
+          output_observer: CommandHelpers::OutputObserver,
+          env: T.nilable(T::Hash[String, String])
+        ).returns(String)
+      end
+      def self.run_corepack_command(full_command, fingerprint:, output_observer: nil, env: nil)
         run_corepack_shell_command(
           full_command,
-          fingerprint: command_fingerprint,
+          fingerprint: fingerprint,
           output_observer: output_observer,
           env: env
         )
@@ -587,8 +605,8 @@ module Dependabot
           )
 
           return run_corepack_shell_command(
-            T.must(full_command),
-            fingerprint: T.must(command_fingerprint),
+            full_command,
+            fingerprint: fingerprint,
             output_observer: output_observer,
             env: retry_env
           )

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/helpers_spec.rb
@@ -169,6 +169,26 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
       )
       described_class.package_manager_install("npm", "7.0.0")
     end
+
+    it "retries once with COREPACK_INTEGRITY_KEYS when corepack signature verification fails" do
+      env = { "COREPACK_NPM_REGISTRY" => "https://packages.example.com/artifactory/api/npm/npm" }
+
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+        "corepack install npm@11.9.0 --global --cache-only",
+        fingerprint: "corepack install <name>@<version> --global --cache-only",
+        env: env
+      ).ordered.and_raise(
+        StandardError.new("Internal Error: No compatible signature found in package metadata")
+      )
+
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+        "corepack install npm@11.9.0 --global --cache-only",
+        fingerprint: "corepack install <name>@<version> --global --cache-only",
+        env: env.merge("COREPACK_INTEGRITY_KEYS" => "")
+      ).ordered.and_return("")
+
+      described_class.package_manager_install("npm", "11.9.0", env: env)
+    end
   end
 
   describe "::package_manager_activate" do
@@ -180,6 +200,30 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
         env: {}
       )
       described_class.package_manager_activate("npm", "7.0.0")
+    end
+
+    it "retries once with COREPACK_INTEGRITY_KEYS when corepack signature verification fails" do
+      env = { "COREPACK_NPM_REGISTRY" => "https://packages.example.com/artifactory/api/npm/npm" }
+
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+        "corepack prepare npm@11.9.0 --activate",
+        fingerprint: "corepack prepare <name>@<version> --activate",
+        env: env
+      ).ordered.and_raise(
+        StandardError.new(
+          "Preparing npm@11.9.0 for immediate activation...\n" \
+          "Internal Error: No compatible signature found in package metadata"
+        )
+      )
+
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+        "corepack prepare npm@11.9.0 --activate",
+        fingerprint: "corepack prepare <name>@<version> --activate",
+        env: env.merge("COREPACK_INTEGRITY_KEYS" => "")
+      ).ordered.and_return("Preparing npm@11.9.0 for immediate activation...")
+
+      expect(described_class.package_manager_activate("npm", "11.9.0", env: env))
+        .to eq("Preparing npm@11.9.0 for immediate activation...")
     end
   end
 
@@ -356,6 +400,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
 
         # Log expectations
         expect(Dependabot.logger).to receive(:info).with("Installing \"npm@8.0.0\"")
+        allow(Dependabot.logger).to receive(:error)
         expect(Dependabot.logger).to receive(:error).with(
           "Error activating npm@8.0.0: Unexpected error"
         )
@@ -403,6 +448,7 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
 
         # Log expectations
         expect(Dependabot.logger).to receive(:info).with("Installing \"npm@8.0.0\"")
+        allow(Dependabot.logger).to receive(:error)
         expect(Dependabot.logger).to receive(:error).with("Error activating npm@8.0.0: Corepack failed")
         expect(Dependabot.logger).to receive(:info).with(
           "Falling back to activate the currently installed version of npm."
@@ -426,68 +472,43 @@ RSpec.describe Dependabot::NpmAndYarn::Helpers do
         }
       end
 
-      it "passes private registry env vars to fallback activation" do
+      it "retries activation with COREPACK_INTEGRITY_KEYS disabled instead of falling back" do
+        retry_env = private_registry_env.merge("COREPACK_INTEGRITY_KEYS" => "")
+
         # First call: corepack prepare npm@10.0.0 --activate WITH private registry env
-        # Fails with signature error (Artifactory strips signatures)
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+        # Fails with signature error (Artifactory strips signatures from its version endpoint)
+        expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
           "corepack prepare npm@10.0.0 --activate",
           fingerprint: "corepack prepare <name>@<version> --activate",
           env: private_registry_env
-        ).and_raise(
+        ).ordered.and_raise(
           StandardError,
           "Preparing npm@10.0.0 for immediate activation...\n" \
           "Internal Error: No compatible signature found in package metadata"
         )
 
-        # Fallback: npm -v returns the container's installed version
+        # Retry: same command with signature verification disabled succeeds
+        expect(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack prepare npm@10.0.0 --activate",
+          fingerprint: "corepack prepare <name>@<version> --activate",
+          env: retry_env
+        ).ordered.and_return("Preparing npm@10.0.0 for immediate activation...")
+
+        # package_manager_version after successful activation
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
+          "corepack npm -v",
+          fingerprint: "corepack npm -v",
+          env: private_registry_env
+        ).and_return("10.0.0")
+
+        # It must not fall back to the locally installed npm version
+        expect(Dependabot::SharedHelpers).not_to receive(:run_shell_command).with(
           "npm -v",
           fingerprint: "npm -v"
-        ).and_return("11.9.0")
-
-        # Fallback must use the same private registry env vars
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
-          "corepack prepare npm@11.9.0 --activate",
-          fingerprint: "corepack prepare <name>@<version> --activate",
-          env: private_registry_env
-        ).and_return("Preparing npm@11.9.0 for immediate activation...")
-
-        # package_manager_version after fallback
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).with(
-          "corepack npm -v",
-          fingerprint: "corepack npm -v",
-          env: private_registry_env
-        ).and_return("11.9.0")
-
-        # Log expectations
-        expect(Dependabot.logger).to receive(:info).with("Installing \"npm@10.0.0\"")
-        expect(Dependabot.logger).to receive(:error).with(
-          a_string_matching(/Error activating npm@10.0.0:.*No compatible signature found/m)
         )
-        expect(Dependabot.logger).to receive(:info).with(
-          "Falling back to activate the currently installed version of npm."
-        )
-        expect(Dependabot.logger).to receive(:info).with(
-          "Activating currently installed version of npm: 11.9.0"
-        )
-        expect(Dependabot.logger).to receive(:info).with("Fetching version for package manager: npm")
-        expect(Dependabot.logger).to receive(:info).with("Installed version of npm: 11.9.0")
 
         result = described_class.install("npm", "10.0.0", env: private_registry_env)
-        expect(result).to eq("11.9.0")
-
-        # Verify the fallback call received the private registry env
-        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
-          "corepack prepare npm@11.9.0 --activate",
-          fingerprint: "corepack prepare <name>@<version> --activate",
-          env: private_registry_env
-        )
-
-        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
-          "corepack npm -v",
-          fingerprint: "corepack npm -v",
-          env: private_registry_env
-        )
+        expect(result).to eq("10.0.0")
       end
 
       it "passes private registry env vars to fallback on unexpected output" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #14612.

Dependabot aborts file fetching with `Internal Error: No compatible signature found in package metadata` when a private npm registry (e.g. JFrog Artifactory) strips `dist.signatures` from its version-specific endpoint. Since #10944, package managers are provisioned through corepack, whose signature verification fetches that endpoint and fails.

PR #15466 already added a `COREPACK_INTEGRITY_KEYS=""` retry on this error, but only inside the generic `package_manager_run_command` runner. The commands that actually run during file fetching — `corepack prepare … --activate` and `corepack install … --cache-only` — bypassed it, so the retry never fired for the failing case.

This routes `package_manager_activate` and `package_manager_install` through the same guarded retry logic (extracted into a shared `run_corepack_command` helper).

### Anything you want to highlight for special attention from reviewers?

The retry remains narrowly scoped: it only triggers when a non-default `COREPACK_NPM_REGISTRY` is configured and the error is the specific corepack signature-metadata error. Signature verification against the public npm registry is never weakened. This matches corepack's documented escape hatch (`COREPACK_INTEGRITY_KEYS` may be set to an empty string to skip integrity checks).

### How will you know you've accomplished your goal?

Added unit specs asserting `package_manager_activate` and `package_manager_install` each retry once with signatures disabled on the signature error, and updated the private-registry `install` spec to assert it now recovers via retry instead of falling back to the local package manager. Full `rspec`, `rubocop`, and `srb tc` pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
