### PR TITLE
Make Job strongly typed

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1126
+# Offense count: 1110
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -403,9 +403,7 @@ Sorbet/ForbidTUntyped:
     - "terraform/lib/dependabot/terraform/update_checker.rb"
     - "updater/lib/dependabot/api_client.rb"
     - "updater/lib/dependabot/dependency_attribution.rb"
-    - "updater/lib/dependabot/environment.rb"
     - "updater/lib/dependabot/file_fetcher_command.rb"
-    - "updater/lib/dependabot/job.rb"
     - "updater/lib/dependabot/job/allowed_update.rb"
     - "updater/lib/dependabot/job/ignore_condition.rb"
     - "updater/lib/dependabot/job/security_advisory_entry.rb"

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -70,7 +70,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       attr_reader :repo_contents_path
 
-      sig { returns(T::Hash[String, String]) }
+      sig { returns(T::Hash[Symbol, Object]) }
       attr_reader :options
 
       CLIENT_NOT_FOUND_ERRORS = T.let(
@@ -135,7 +135,7 @@ module Dependabot
             source: Dependabot::Source,
             credentials: T::Array[Dependabot::Credential],
             repo_contents_path: T.nilable(String),
-            options: T::Hash[String, String],
+            options: T::Hash[Symbol, Object],
             update_config: T.nilable(Dependabot::Config::UpdateConfig)
           )
           .void

--- a/common/lib/dependabot/package/release_cooldown_options.rb
+++ b/common/lib/dependabot/package/release_cooldown_options.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/github_actions/lib/dependabot/github_actions/file_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/file_fetcher.rb
@@ -29,7 +29,7 @@ module Dependabot
             source: Dependabot::Source,
             credentials: T::Array[Dependabot::Credential],
             repo_contents_path: T.nilable(String),
-            options: T::Hash[String, String],
+            options: T::Hash[Symbol, Object],
             update_config: T.nilable(Dependabot::Config::UpdateConfig)
           )
           .void

--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -41,7 +41,7 @@ module Dependabot
             source: Dependabot::Source,
             credentials: T::Array[Dependabot::Credential],
             repo_contents_path: T.nilable(String),
-            options: T::Hash[String, String],
+            options: T::Hash[Symbol, Object],
             update_config: T.nilable(Dependabot::Config::UpdateConfig)
           )
           .void

--- a/updater/lib/dependabot/environment.rb
+++ b/updater/lib/dependabot/environment.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/updater/lib/dependabot/environment.rb
+++ b/updater/lib/dependabot/environment.rb
@@ -65,9 +65,12 @@ module Dependabot
       @deterministic_updates ||= T.let(b, T.nilable(T::Boolean))
     end
 
-    sig { returns(T::Hash[String, T.untyped]) }
+    sig { returns(T::Hash[String, Object]) }
     def self.job_definition
-      @job_definition ||= T.let(JSON.parse(File.read(job_path)), T.nilable(T::Hash[String, T.untyped]))
+      @job_definition ||= T.let(
+        T.cast(JSON.parse(File.read(job_path)), T::Hash[String, Object]),
+        T.nilable(T::Hash[String, Object])
+      )
     end
 
     sig do
@@ -93,7 +96,10 @@ module Dependabot
 
     sig { returns(T::Boolean) }
     private_class_method def self.job_debug_enabled?
-      !!job_definition.dig("job", "debug")
+      job = job_definition["job"]
+      return false unless job.is_a?(Hash)
+
+      !!T.cast(job["debug"], Object)
     end
 
     sig { returns(T::Boolean) }

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -100,16 +100,24 @@ module Dependabot
       directory_to_use = directory || job.source.directory
 
       job_definition = Environment.job_definition
-      job_credentials_metadata = job_definition.fetch("job", {}).fetch("credentials-metadata", [])
+      job_details = job_definition["job"]
+      job_credentials_metadata =
+        if job_details.is_a?(Hash)
+          T.cast(job_details["credentials-metadata"], Object) || []
+        else
+          []
+        end
 
       # prefer credentials directly from the root of the file (will contain secrets) but if not specified, fall back to
       # the job's credentials-metadata that has no secrets
-      credentials = job_definition.fetch("credentials", job_credentials_metadata)
+      credentials = Job::Definition.credentials_from(
+        job_definition.fetch("credentials", job_credentials_metadata)
+      )
 
       args = {
         source: job.source.clone.tap { |s| s.directory = directory_to_use },
         credentials: credentials,
-        options: T.unsafe(job.experiments)
+        options: job.experiments
       }
       args[:repo_contents_path] = Environment.repo_contents_path if job.clone? || already_cloned?
       args[:update_config] = job.update_config

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -523,19 +523,22 @@ module Dependabot
 
     sig { params(dependency: Dependabot::Dependency).void }
     def log_blocked_versions_for(dependency)
-      entries = matching_blocked_entries(dependency).filter_map do |bv|
-        req = T.must(bv.version_requirement).strip
-        next if req.empty?
+      entries = T.let(
+        matching_blocked_entries(dependency).filter_map do |bv|
+          req = T.must(bv.version_requirement).strip
+          next if req.empty?
 
-        reason = bv.reason&.strip
-        { version_requirement: req, reason: reason&.empty? ? nil : reason }
-      end
+          reason = bv.reason&.strip
+          [req, reason&.empty? ? nil : reason]
+        end,
+        T::Array[[String, T.nilable(String)]]
+      )
       return if entries.empty?
 
       Dependabot.logger.info("Blocked versions (by GitHub Security):")
-      entries.each do |entry|
-        msg = "  #{entry[:version_requirement]}"
-        msg += " - reason: #{entry[:reason]}" if entry[:reason]
+      entries.each do |version_requirement, reason|
+        msg = "  #{version_requirement}"
+        msg += " - reason: #{reason}" if reason
         Dependabot.logger.info(msg)
       end
     end

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -17,6 +17,7 @@ require "dependabot/updater/update_type_helper"
 
 require "dependabot/job/allowed_update"
 require "dependabot/job/blocked_version"
+require "dependabot/job/definition"
 require "dependabot/job/dependency_group_definition"
 require "dependabot/job/existing_group_pull_request"
 require "dependabot/job/ignore_condition"
@@ -184,90 +185,56 @@ module Dependabot
 
     # NOTE: "attributes" are fetched and injected at run time from
     # dependabot-api using the UpdateJobPrivateSerializer
-    sig { params(attributes: T::Hash[Symbol, T.untyped]).void }
+    sig { params(attributes: T::Hash[Symbol, Object]).void }
     def initialize(attributes) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-      @id                             = T.let(attributes.fetch(:id), String)
-      @command                        = T.let(attributes.fetch(:command, ""), String)
-      @allowed_updates                = T.let(
-        attributes.fetch(:allowed_updates).map { |h| AllowedUpdate.from_hash(h) },
-        T::Array[AllowedUpdate]
-      )
+      definition = Definition.from_hash(attributes)
+
+      @id = T.let(definition.id, String)
+      @command = T.let(definition.command, String)
+      @allowed_updates = T.let(definition.allowed_updates, T::Array[AllowedUpdate])
       @commit_message_options = T.let(
-        attributes.fetch(:commit_message_options, {}),
-        T.nilable(T::Hash[String, T.untyped])
+        definition.commit_message_options,
+        T.nilable(T::Hash[String, Object])
       )
-      @credentials = T.let(
-        attributes.fetch(:credentials, []).map do |data|
-          Dependabot::Credential.new(data)
-        end,
-        T::Array[Dependabot::Credential]
-      )
-      @dependencies                   = T.let(attributes.fetch(:dependencies), T.nilable(T::Array[String]))
-      @exclude_paths                  = T.let(attributes.fetch(:exclude_paths, []), T.nilable(T::Array[String]))
-      @existing_pull_requests         = T.let(PullRequest.create_from_job_definition(attributes), T::Array[PullRequest])
-      # TODO: Make this hash required
-      #
-      # We will need to do a pass updating the CLI and smoke tests before this is possible,
-      # so let's consider it optional for now. If we get a nil value, let's force it to be
-      # an array.
+      @credentials = T.let(definition.credentials, T::Array[Dependabot::Credential])
+      @dependencies = T.let(definition.dependencies, T.nilable(T::Array[String]))
+      @exclude_paths = T.let(definition.exclude_paths, T.nilable(T::Array[String]))
+      @existing_pull_requests = T.let(definition.existing_pull_requests, T::Array[PullRequest])
       @existing_group_pull_requests = T.let(
-        (attributes.fetch(:existing_group_pull_requests, []) || []).grep(Hash).map do |pr|
-          ExistingGroupPullRequest.from_hash(pr)
-        end,
+        definition.existing_group_pull_requests,
         T::Array[ExistingGroupPullRequest]
       )
       @experiments = T.let(
-        attributes.fetch(:experiments, {}),
-        T.nilable(T::Hash[String, T.untyped])
+        definition.experiments,
+        T.nilable(T::Hash[String, Object])
       )
-      @ignore_conditions = T.let(
-        attributes.fetch(:ignore_conditions).map { |h| Job::IgnoreCondition.from_hash(h) },
-        T::Array[Job::IgnoreCondition]
-      )
-      @package_manager                =  T.let(attributes.fetch(:package_manager), String)
-      @reject_external_code           =  T.let(attributes.fetch(:reject_external_code, false), T::Boolean)
-      @repo_contents_path             =  T.let(attributes.fetch(:repo_contents_path, nil), T.nilable(String))
-
-      @requirements_update_strategy   = T.let(
+      @ignore_conditions = T.let(definition.ignore_conditions, T::Array[Job::IgnoreCondition])
+      @package_manager = T.let(definition.package_manager, String)
+      @reject_external_code = T.let(definition.reject_external_code, T::Boolean)
+      @repo_contents_path = T.let(definition.repo_contents_path, T.nilable(String))
+      @requirements_update_strategy = T.let(
         build_update_strategy(
-          requirements_update_strategy: attributes.fetch(:requirements_update_strategy),
-          lockfile_only: attributes.fetch(:lockfile_only)
+          requirements_update_strategy: definition.requirements_update_strategy,
+          lockfile_only: definition.lockfile_only
         ),
         T.nilable(Dependabot::RequirementsUpdateStrategy)
       )
-
-      @security_advisories = T.let(
-        attributes.fetch(:security_advisories).map { |h| SecurityAdvisoryEntry.from_hash(h) },
-        T::Array[SecurityAdvisoryEntry]
-      )
-      @security_updates_only          = T.let(attributes.fetch(:security_updates_only), T::Boolean)
-      @source                         = T.let(build_source(attributes.fetch(:source)), Dependabot::Source)
-      @token                          = T.let(attributes.fetch(:token, nil), T.nilable(String))
-      @update_subdependencies         = T.let(attributes.fetch(:update_subdependencies), T::Boolean)
-      @updating_a_pull_request        = T.let(attributes.fetch(:updating_a_pull_request), T::Boolean)
-      @vendor_dependencies            = T.let(attributes.fetch(:vendor_dependencies, false), T::Boolean)
+      @security_advisories = T.let(definition.security_advisories, T::Array[SecurityAdvisoryEntry])
+      @security_updates_only = T.let(definition.security_updates_only, T::Boolean)
+      @source = T.let(definition.source.to_source, Dependabot::Source)
+      @token = T.let(definition.token, T.nilable(String))
+      @update_subdependencies = T.let(definition.update_subdependencies, T::Boolean)
+      @updating_a_pull_request = T.let(definition.updating_a_pull_request, T::Boolean)
+      @vendor_dependencies = T.let(definition.vendor_dependencies, T::Boolean)
       @cooldown = T.let(
-        build_cooldown(attributes.fetch(:cooldown, nil)),
+        build_cooldown(definition.cooldown),
         T.nilable(Dependabot::Package::ReleaseCooldownOptions)
       )
-      @multi_ecosystem_update = T.let(attributes.fetch(:multi_ecosystem_update, false), T::Boolean)
-      # TODO: Make this hash required
-      #
-      # We will need to do a pass updating the CLI and smoke tests before this is possible,
-      # so let's consider it optional for now. If we get a nil value, let's force it to be
-      # an array.
-      @dependency_groups = T.let(
-        (attributes.fetch(:dependency_groups, []) || []).grep(Hash).map do |group|
-          DependencyGroupDefinition.from_hash(group)
-        end,
-        T::Array[DependencyGroupDefinition]
-      )
-      @dependency_group_to_refresh    = T.let(attributes.fetch(:dependency_group_to_refresh, nil), T.nilable(String))
-      @repo_private                   = T.let(attributes.fetch(:repo_private, nil), T.nilable(T::Boolean))
-      @blocked_versions               = T.let(
-        self.class.parse_blocked_versions(attributes.fetch(:blocked_versions, []) || []),
-        T::Array[BlockedVersion]
-      )
+      @multi_ecosystem_update = T.let(definition.multi_ecosystem_update, T::Boolean)
+      @dependency_groups = T.let(definition.dependency_groups, T::Array[DependencyGroupDefinition])
+      @dependency_group_to_refresh = T.let(definition.dependency_group_to_refresh, T.nilable(String))
+      @repo_private = T.let(definition.repo_private, T.nilable(T::Boolean))
+      @blocked_versions = T.let(definition.blocked_versions, T::Array[BlockedVersion])
 
       @update_config = T.let(calculate_update_config, Dependabot::Config::UpdateConfig)
 
@@ -700,11 +667,6 @@ module Dependabot
       end
 
       lockfile_only ? RequirementsUpdateStrategy::LockfileOnly : nil
-    end
-
-    sig { params(source_details: T::Hash[String, Object]).returns(Dependabot::Source) }
-    def build_source(source_details)
-      SourceDefinition.from_hash(source_details).to_source
     end
 
     sig do

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -21,6 +21,7 @@ require "dependabot/job/dependency_group_definition"
 require "dependabot/job/existing_group_pull_request"
 require "dependabot/job/ignore_condition"
 require "dependabot/job/security_advisory_entry"
+require "dependabot/job/source_definition"
 
 # Describes a single Dependabot workload within the GitHub-integrated Service
 #
@@ -701,22 +702,9 @@ module Dependabot
       lockfile_only ? RequirementsUpdateStrategy::LockfileOnly : nil
     end
 
-    sig { params(source_details: T::Hash[String, T.untyped]).returns(Dependabot::Source) }
+    sig { params(source_details: T::Hash[String, Object]).returns(Dependabot::Source) }
     def build_source(source_details)
-      # Immediately normalize the source directory, ensure it starts with a "/"
-      # Uses Pathname#cleanpath to prevent users from maliciously using paths like ../.. to access other directories.
-      directory, directories = clean_directories(source_details)
-
-      Dependabot::Source.new(
-        provider: T.let(source_details["provider"], String),
-        repo: T.let(source_details["repo"], String),
-        directory: directory,
-        directories: directories,
-        branch: T.let(source_details["branch"], T.nilable(String)),
-        commit: T.let(source_details["commit"], T.nilable(String)),
-        hostname: T.let(source_details["hostname"], T.nilable(String)),
-        api_endpoint: T.let(source_details["api-endpoint"], T.nilable(String))
-      )
+      SourceDefinition.from_hash(source_details).to_source
     end
 
     sig do
@@ -749,24 +737,6 @@ module Dependabot
       return DEFAULT_COOLDOWN_DAYS if experiments[:enable_cooldown_default_days]
 
       0
-    end
-
-    sig { params(source_details: T::Hash[String, T.untyped]).returns([T.nilable(String), T.nilable(T::Array[String])]) }
-    def clean_directories(source_details)
-      directory = T.let(source_details["directory"], T.nilable(String))
-      unless directory.nil?
-        directory = Pathname.new(directory).cleanpath.to_s
-        directory = "/#{directory}" unless directory.start_with?("/")
-      end
-      directories = T.let(source_details["directories"], T.nilable(T::Array[String]))
-      unless directories.nil?
-        directories = directories.map do |dir|
-          dir = Pathname.new(dir).cleanpath.to_s
-          dir = "/#{dir}" unless dir.start_with?("/")
-          dir
-        end
-      end
-      [directory, directories]
     end
 
     # Provides a Dependabot::Config::UpdateConfig objected hydrated with

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -134,7 +134,7 @@ module Dependabot
     sig { returns(T::Array[Dependabot::Job::BlockedVersion]) }
     attr_reader :blocked_versions
 
-    sig { params(blocked_versions: T::Array[T::Hash[String, T.untyped]]).void }
+    sig { params(blocked_versions: T::Array[T::Hash[String, Object]]).void }
     def blocked_versions=(blocked_versions)
       @blocked_versions = self.class.parse_blocked_versions(blocked_versions)
     end
@@ -145,13 +145,14 @@ module Dependabot
     sig do
       params(
         job_id: String,
-        job_definition: T::Hash[String, T.untyped],
+        job_definition: T::Hash[String, Object],
         repo_contents_path: T.nilable(String)
       ).returns(Job)
     end
     def self.new_fetch_job(job_id:, job_definition:, repo_contents_path: nil)
-      standardised = standardise_keys(job_definition["job"])
-      attrs = standardised.slice(*T.unsafe(PERMITTED_KEYS))
+      standardised = standardise_keys(job_attributes(job_definition))
+      # Sorbet cannot type a splat from a dynamically-sized key array.
+      attrs = standardised.select { |key, _value| PERMITTED_KEYS.include?(key) } # rubocop:disable Style/HashSlice
 
       new(attrs.merge(id: job_id, repo_contents_path: repo_contents_path))
     end
@@ -159,28 +160,45 @@ module Dependabot
     sig do
       params(
         job_id: String,
-        job_definition: T::Hash[String, T.untyped],
+        job_definition: T::Hash[String, Object],
         repo_contents_path: T.nilable(String)
       ).returns(Job)
     end
     def self.new_update_job(job_id:, job_definition:, repo_contents_path: nil)
-      job_hash = standardise_keys(job_definition["job"])
-      attrs = job_hash.slice(*T.unsafe(PERMITTED_KEYS))
+      job_hash = standardise_keys(job_attributes(job_definition))
+      # Sorbet cannot type a splat from a dynamically-sized key array.
+      attrs = job_hash.select { |key, _value| PERMITTED_KEYS.include?(key) } # rubocop:disable Style/HashSlice
       attrs[:credentials] = job_hash[:credentials_metadata] || []
 
       new(attrs.merge(id: job_id, repo_contents_path: repo_contents_path))
     end
 
-    sig { params(hash: T::Hash[String, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+    sig { params(hash: T::Hash[String, Object]).returns(T::Hash[Symbol, Object]) }
     def self.standardise_keys(hash)
       hash.transform_keys { |key| key.tr("-", "_").to_sym }
     end
 
+    sig { params(job_definition: T::Hash[String, Object]).returns(T::Hash[String, Object]) }
+    def self.job_attributes(job_definition)
+      value = job_definition["job"]
+      raise TypeError, "job must be a hash" unless value.is_a?(Hash)
+
+      result = T.let({}, T::Hash[String, Object])
+      value.each do |raw_key, raw_value|
+        key = T.cast(raw_key, Object)
+        raise TypeError, "job keys must be strings" unless key.is_a?(String)
+
+        result[key] = T.cast(raw_value, Object)
+      end
+      result
+    end
+    private_class_method :job_attributes
+
     # Non-hash entries are dropped rather than raising so that malformed
     # entries are ignored, matching the previous hash-based filtering.
-    sig { params(blocked_versions: T::Array[T::Hash[String, T.untyped]]).returns(T::Array[BlockedVersion]) }
+    sig { params(blocked_versions: T::Array[T::Hash[String, Object]]).returns(T::Array[BlockedVersion]) }
     def self.parse_blocked_versions(blocked_versions)
-      blocked_versions.grep(Hash).map { |bv| BlockedVersion.from_hash(bv) }
+      blocked_versions.map { |blocked_version| BlockedVersion.from_hash(blocked_version) }
     end
 
     # NOTE: "attributes" are fetched and injected at run time from
@@ -413,14 +431,14 @@ module Dependabot
       Dependabot::Dependency.name_normaliser_for_package_manager(package_manager)
     end
 
-    sig { returns(T::Hash[Symbol, T.untyped]) }
+    sig { returns(T::Hash[Symbol, Object]) }
     def experiments
       return {} unless @experiments
 
       self.class.standardise_keys(@experiments)
     end
 
-    sig { returns(T::Hash[Symbol, T.untyped]) }
+    sig { returns(T::Hash[Symbol, Object]) }
     def commit_message_options
       return {} unless @commit_message_options
 
@@ -670,24 +688,13 @@ module Dependabot
     end
 
     sig do
-      params(
-        cooldown: T.nilable(
-          T::Hash[String,
-                  T.untyped]
-        )
-      ).returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions))
+      params(cooldown: T.nilable(CooldownDefinition))
+        .returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions))
     end
     def build_cooldown(cooldown)
       return nil unless cooldown
 
-      Dependabot::Package::ReleaseCooldownOptions.new(
-        default_days: cooldown["default-days"] || default_cooldown_days,
-        semver_major_days: cooldown["semver-major-days"] || 0,
-        semver_minor_days: cooldown["semver-minor-days"] || 0,
-        semver_patch_days: cooldown["semver-patch-days"] || 0,
-        include: cooldown["include"] || [],
-        exclude: cooldown["exclude"] || []
-      )
+      cooldown.to_options(default_days: default_cooldown_days)
     end
 
     # The fallback applied when a cooldown block is present but `default-days`

--- a/updater/lib/dependabot/job/cooldown_definition.rb
+++ b/updater/lib/dependabot/job/cooldown_definition.rb
@@ -1,0 +1,64 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/package/release_cooldown_options"
+
+module Dependabot
+  class Job
+    # Parsed representation of cooldown settings from the job definition.
+    class CooldownDefinition < T::ImmutableStruct
+      extend T::Sig
+
+      const :default_days, T.nilable(Integer)
+      const :semver_major_days, T.nilable(Integer)
+      const :semver_minor_days, T.nilable(Integer)
+      const :semver_patch_days, T.nilable(Integer)
+      const :include, T::Array[String], default: []
+      const :exclude, T::Array[String], default: []
+
+      sig { params(hash: T::Hash[String, Object]).returns(CooldownDefinition) }
+      def self.from_hash(hash)
+        new(
+          default_days: optional_integer(hash["default-days"], "default-days"),
+          semver_major_days: optional_integer(hash["semver-major-days"], "semver-major-days"),
+          semver_minor_days: optional_integer(hash["semver-minor-days"], "semver-minor-days"),
+          semver_patch_days: optional_integer(hash["semver-patch-days"], "semver-patch-days"),
+          include: string_array(hash["include"], "include"),
+          exclude: string_array(hash["exclude"], "exclude")
+        )
+      end
+
+      sig { params(default_days: Integer).returns(Dependabot::Package::ReleaseCooldownOptions) }
+      def to_options(default_days:)
+        Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: self.default_days.nil? ? default_days : self.default_days,
+          semver_major_days: semver_major_days || 0,
+          semver_minor_days: semver_minor_days || 0,
+          semver_patch_days: semver_patch_days || 0,
+          include: include,
+          exclude: exclude
+        )
+      end
+
+      sig { params(value: T.nilable(Object), key: String).returns(T.nilable(Integer)) }
+      def self.optional_integer(value, key)
+        return if value.nil?
+        raise TypeError, "#{key} must be an integer" unless value.is_a?(Integer)
+
+        value
+      end
+      private_class_method :optional_integer
+
+      sig { params(value: T.nilable(Object), key: String).returns(T::Array[String]) }
+      def self.string_array(value, key)
+        return [] if value.nil?
+        raise TypeError, "#{key} must be an array of strings" unless value.is_a?(Array) && value.all?(String)
+
+        value.map { |entry| T.cast(entry, String) }
+      end
+      private_class_method :string_array
+    end
+  end
+end

--- a/updater/lib/dependabot/job/definition.rb
+++ b/updater/lib/dependabot/job/definition.rb
@@ -1,0 +1,311 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/credential"
+require "dependabot/pull_request"
+require "dependabot/job/allowed_update"
+require "dependabot/job/blocked_version"
+require "dependabot/job/dependency_group_definition"
+require "dependabot/job/existing_group_pull_request"
+require "dependabot/job/ignore_condition"
+require "dependabot/job/security_advisory_entry"
+require "dependabot/job/source_definition"
+
+module Dependabot
+  class Job
+    # Parsed representation of the top-level job attributes.
+    class Definition < T::ImmutableStruct
+      extend T::Sig
+
+      const :id, String
+      const :command, String
+      const :allowed_updates, T::Array[AllowedUpdate]
+      const :commit_message_options, T.nilable(T::Hash[String, Object])
+      const :credentials, T::Array[Dependabot::Credential]
+      const :dependencies, T.nilable(T::Array[String])
+      const :exclude_paths, T.nilable(T::Array[String])
+      const :existing_pull_requests, T::Array[Dependabot::PullRequest]
+      const :existing_group_pull_requests, T::Array[ExistingGroupPullRequest]
+      const :experiments, T.nilable(T::Hash[String, Object])
+      const :ignore_conditions, T::Array[IgnoreCondition]
+      const :package_manager, String
+      const :reject_external_code, T::Boolean
+      const :repo_contents_path, T.nilable(String)
+      const :requirements_update_strategy, T.nilable(String)
+      const :lockfile_only, T::Boolean
+      const :security_advisories, T::Array[SecurityAdvisoryEntry]
+      const :security_updates_only, T::Boolean
+      const :source, SourceDefinition
+      const :token, T.nilable(String)
+      const :update_subdependencies, T::Boolean
+      const :updating_a_pull_request, T::Boolean
+      const :vendor_dependencies, T::Boolean
+      const :cooldown, T.nilable(T::Hash[String, Object])
+      const :multi_ecosystem_update, T::Boolean
+      const :dependency_groups, T::Array[DependencyGroupDefinition]
+      const :dependency_group_to_refresh, T.nilable(String)
+      const :repo_private, T.nilable(T::Boolean)
+      const :blocked_versions, T::Array[BlockedVersion]
+
+      # Keep the complete wire-to-model mapping visible in one place so new job fields cannot bypass parsing.
+      # rubocop:disable Metrics/AbcSize
+      sig { params(hash: T::Hash[Symbol, Object]).returns(Definition) }
+      def self.from_hash(hash)
+        new(
+          id: required_string(hash, :id),
+          command: string_with_default(hash, :command, ""),
+          allowed_updates: parsed_allowed_updates(hash),
+          commit_message_options: parsed_commit_message_options(hash),
+          credentials: parsed_credentials(hash),
+          dependencies: optional_string_array(hash.fetch(:dependencies), :dependencies),
+          exclude_paths: optional_string_array(hash.fetch(:exclude_paths, []), :exclude_paths),
+          existing_pull_requests: Dependabot::PullRequest.create_from_job_definition(hash),
+          existing_group_pull_requests: parsed_existing_group_pull_requests(hash),
+          experiments: optional_string_hash(hash.fetch(:experiments, nil), :experiments),
+          ignore_conditions: parsed_ignore_conditions(hash),
+          package_manager: required_string(hash, :package_manager),
+          reject_external_code: boolean_with_default(hash, :reject_external_code, false),
+          repo_contents_path: optional_string(hash.fetch(:repo_contents_path, nil), :repo_contents_path),
+          requirements_update_strategy: parsed_requirements_update_strategy(hash),
+          lockfile_only: required_boolean(hash, :lockfile_only),
+          security_advisories: parsed_security_advisories(hash),
+          security_updates_only: required_boolean(hash, :security_updates_only),
+          source: parsed_source(hash),
+          token: optional_string(hash.fetch(:token, nil), :token),
+          update_subdependencies: required_boolean(hash, :update_subdependencies),
+          updating_a_pull_request: required_boolean(hash, :updating_a_pull_request),
+          vendor_dependencies: boolean_with_default(hash, :vendor_dependencies, false),
+          cooldown: optional_string_hash(hash.fetch(:cooldown, nil), :cooldown),
+          multi_ecosystem_update: boolean_with_default(hash, :multi_ecosystem_update, false),
+          dependency_groups: parsed_dependency_groups(hash),
+          dependency_group_to_refresh: parsed_dependency_group_to_refresh(hash),
+          repo_private: optional_boolean(hash.fetch(:repo_private, nil), :repo_private),
+          blocked_versions: parsed_blocked_versions(hash)
+        )
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T::Array[AllowedUpdate]) }
+      def self.parsed_allowed_updates(hash)
+        strict_hash_array(hash.fetch(:allowed_updates), :allowed_updates)
+          .map { |entry| AllowedUpdate.from_hash(entry) }
+      end
+      private_class_method :parsed_allowed_updates
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T.nilable(T::Hash[String, Object])) }
+      def self.parsed_commit_message_options(hash)
+        optional_string_hash(hash.fetch(:commit_message_options, nil), :commit_message_options)
+      end
+      private_class_method :parsed_commit_message_options
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T::Array[Dependabot::Credential]) }
+      def self.parsed_credentials(hash)
+        credentials(hash.fetch(:credentials, []))
+      end
+      private_class_method :parsed_credentials
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T::Array[ExistingGroupPullRequest]) }
+      def self.parsed_existing_group_pull_requests(hash)
+        tolerant_hash_array(
+          hash.fetch(:existing_group_pull_requests, []) || [],
+          :existing_group_pull_requests
+        ).map { |entry| ExistingGroupPullRequest.from_hash(entry) }
+      end
+      private_class_method :parsed_existing_group_pull_requests
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T::Array[IgnoreCondition]) }
+      def self.parsed_ignore_conditions(hash)
+        strict_hash_array(hash.fetch(:ignore_conditions), :ignore_conditions)
+          .map { |entry| IgnoreCondition.from_hash(entry) }
+      end
+      private_class_method :parsed_ignore_conditions
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T.nilable(String)) }
+      def self.parsed_requirements_update_strategy(hash)
+        optional_string(hash.fetch(:requirements_update_strategy), :requirements_update_strategy)
+      end
+      private_class_method :parsed_requirements_update_strategy
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T::Array[SecurityAdvisoryEntry]) }
+      def self.parsed_security_advisories(hash)
+        strict_hash_array(hash.fetch(:security_advisories), :security_advisories)
+          .map { |entry| SecurityAdvisoryEntry.from_hash(entry) }
+      end
+      private_class_method :parsed_security_advisories
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(SourceDefinition) }
+      def self.parsed_source(hash)
+        SourceDefinition.from_hash(required_string_hash(hash.fetch(:source), :source))
+      end
+      private_class_method :parsed_source
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T::Array[DependencyGroupDefinition]) }
+      def self.parsed_dependency_groups(hash)
+        tolerant_hash_array(
+          hash.fetch(:dependency_groups, []) || [],
+          :dependency_groups
+        ).map { |entry| DependencyGroupDefinition.from_hash(entry) }
+      end
+      private_class_method :parsed_dependency_groups
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T.nilable(String)) }
+      def self.parsed_dependency_group_to_refresh(hash)
+        optional_string(hash.fetch(:dependency_group_to_refresh, nil), :dependency_group_to_refresh)
+      end
+      private_class_method :parsed_dependency_group_to_refresh
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T::Array[BlockedVersion]) }
+      def self.parsed_blocked_versions(hash)
+        tolerant_hash_array(
+          hash.fetch(:blocked_versions, []) || [],
+          :blocked_versions
+        ).map { |entry| BlockedVersion.from_hash(entry) }
+      end
+      private_class_method :parsed_blocked_versions
+
+      sig { params(hash: T::Hash[Symbol, Object], key: Symbol).returns(String) }
+      def self.required_string(hash, key)
+        value = hash.fetch(key)
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :required_string
+
+      sig { params(hash: T::Hash[Symbol, Object], key: Symbol, default: String).returns(String) }
+      def self.string_with_default(hash, key, default)
+        value = hash.fetch(key, default)
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :string_with_default
+
+      sig { params(value: T.nilable(Object), key: Symbol).returns(T.nilable(String)) }
+      def self.optional_string(value, key)
+        return if value.nil?
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :optional_string
+
+      sig { params(hash: T::Hash[Symbol, Object], key: Symbol).returns(T::Boolean) }
+      def self.required_boolean(hash, key)
+        boolean_value(hash.fetch(key), key)
+      end
+      private_class_method :required_boolean
+
+      sig do
+        params(
+          hash: T::Hash[Symbol, Object],
+          key: Symbol,
+          default: T::Boolean
+        ).returns(T::Boolean)
+      end
+      def self.boolean_with_default(hash, key, default)
+        boolean_value(hash.fetch(key, default), key)
+      end
+      private_class_method :boolean_with_default
+
+      sig { params(value: T.nilable(Object), key: Symbol).returns(T.nilable(T::Boolean)) }
+      def self.optional_boolean(value, key)
+        return if value.nil?
+
+        boolean_value(value, key)
+      end
+      private_class_method :optional_boolean
+
+      sig { params(value: Object, key: Symbol).returns(T::Boolean) }
+      def self.boolean_value(value, key)
+        return value if value == true || value == false
+
+        raise TypeError, "#{key} must be a boolean"
+      end
+      private_class_method :boolean_value
+
+      sig { params(value: T.nilable(Object), key: Symbol).returns(T.nilable(T::Array[String])) }
+      def self.optional_string_array(value, key)
+        return if value.nil?
+        raise TypeError, "#{key} must be an array of strings" unless value.is_a?(Array) && value.all?(String)
+
+        value.map { |entry| T.cast(entry, String) }
+      end
+      private_class_method :optional_string_array
+
+      sig { params(value: T.nilable(Object), key: Symbol).returns(T.nilable(T::Hash[String, Object])) }
+      def self.optional_string_hash(value, key)
+        return if value.nil?
+
+        required_string_hash(value, key)
+      end
+      private_class_method :optional_string_hash
+
+      sig { params(value: Object, key: Symbol).returns(T::Hash[String, Object]) }
+      def self.required_string_hash(value, key)
+        raise TypeError, "#{key} must be a hash" unless value.is_a?(Hash)
+
+        result = T.let({}, T::Hash[String, Object])
+        value.each do |raw_key, raw_value|
+          parsed_key = T.cast(raw_key, Object)
+          raise TypeError, "#{key} keys must be strings" unless parsed_key.is_a?(String)
+
+          result[parsed_key] = T.cast(raw_value, Object)
+        end
+        result
+      end
+      private_class_method :required_string_hash
+
+      sig { params(value: Object, key: Symbol).returns(T::Array[T::Hash[String, Object]]) }
+      def self.strict_hash_array(value, key)
+        raise TypeError, "#{key} must be an array" unless value.is_a?(Array)
+
+        value.map { |entry| required_string_hash(T.cast(entry, Object), key) }
+      end
+      private_class_method :strict_hash_array
+
+      sig { params(value: Object, key: Symbol).returns(T::Array[T::Hash[String, Object]]) }
+      def self.tolerant_hash_array(value, key)
+        raise TypeError, "#{key} must be an array" unless value.is_a?(Array)
+
+        value.filter_map do |entry|
+          parsed_entry = T.cast(entry, Object)
+          required_string_hash(parsed_entry, key) if parsed_entry.is_a?(Hash)
+        end
+      end
+      private_class_method :tolerant_hash_array
+
+      sig { params(value: Object).returns(T::Array[Dependabot::Credential]) }
+      def self.credentials(value)
+        strict_hash_array(value, :credentials).map do |entry|
+          Dependabot::Credential.new(credential_hash(entry))
+        end
+      end
+      private_class_method :credentials
+
+      sig do
+        params(hash: T::Hash[String, Object])
+          .returns(T::Hash[String, T.any(T::Boolean, String, T::Array[String])])
+      end
+      def self.credential_hash(hash)
+        hash.to_h do |key, value|
+          parsed_value =
+            case value
+            when String, TrueClass, FalseClass then value
+            when Array
+              raise TypeError, "credential array values must contain strings" unless value.all?(String)
+
+              value.map { |entry| T.cast(entry, String) }
+            else
+              raise TypeError, "credential values must be strings, booleans, or string arrays"
+            end
+
+          [key, parsed_value]
+        end
+      end
+      private_class_method :credential_hash
+    end
+  end
+end

--- a/updater/lib/dependabot/job/definition.rb
+++ b/updater/lib/dependabot/job/definition.rb
@@ -7,6 +7,7 @@ require "dependabot/credential"
 require "dependabot/pull_request"
 require "dependabot/job/allowed_update"
 require "dependabot/job/blocked_version"
+require "dependabot/job/cooldown_definition"
 require "dependabot/job/dependency_group_definition"
 require "dependabot/job/existing_group_pull_request"
 require "dependabot/job/ignore_condition"
@@ -42,7 +43,7 @@ module Dependabot
       const :update_subdependencies, T::Boolean
       const :updating_a_pull_request, T::Boolean
       const :vendor_dependencies, T::Boolean
-      const :cooldown, T.nilable(T::Hash[String, Object])
+      const :cooldown, T.nilable(CooldownDefinition)
       const :multi_ecosystem_update, T::Boolean
       const :dependency_groups, T::Array[DependencyGroupDefinition]
       const :dependency_group_to_refresh, T.nilable(String)
@@ -77,7 +78,7 @@ module Dependabot
           update_subdependencies: required_boolean(hash, :update_subdependencies),
           updating_a_pull_request: required_boolean(hash, :updating_a_pull_request),
           vendor_dependencies: boolean_with_default(hash, :vendor_dependencies, false),
-          cooldown: optional_string_hash(hash.fetch(:cooldown, nil), :cooldown),
+          cooldown: parsed_cooldown(hash),
           multi_ecosystem_update: boolean_with_default(hash, :multi_ecosystem_update, false),
           dependency_groups: parsed_dependency_groups(hash),
           dependency_group_to_refresh: parsed_dependency_group_to_refresh(hash),
@@ -102,7 +103,7 @@ module Dependabot
 
       sig { params(hash: T::Hash[Symbol, Object]).returns(T::Array[Dependabot::Credential]) }
       def self.parsed_credentials(hash)
-        credentials(hash.fetch(:credentials, []))
+        credentials_from(hash.fetch(:credentials, []))
       end
       private_class_method :parsed_credentials
 
@@ -164,6 +165,13 @@ module Dependabot
         ).map { |entry| BlockedVersion.from_hash(entry) }
       end
       private_class_method :parsed_blocked_versions
+
+      sig { params(hash: T::Hash[Symbol, Object]).returns(T.nilable(CooldownDefinition)) }
+      def self.parsed_cooldown(hash)
+        cooldown = optional_string_hash(hash.fetch(:cooldown, nil), :cooldown)
+        CooldownDefinition.from_hash(cooldown) if cooldown
+      end
+      private_class_method :parsed_cooldown
 
       sig { params(hash: T::Hash[Symbol, Object], key: Symbol).returns(String) }
       def self.required_string(hash, key)
@@ -278,12 +286,11 @@ module Dependabot
       private_class_method :tolerant_hash_array
 
       sig { params(value: Object).returns(T::Array[Dependabot::Credential]) }
-      def self.credentials(value)
+      def self.credentials_from(value)
         strict_hash_array(value, :credentials).map do |entry|
           Dependabot::Credential.new(credential_hash(entry))
         end
       end
-      private_class_method :credentials
 
       sig do
         params(hash: T::Hash[String, Object])

--- a/updater/lib/dependabot/job/source_definition.rb
+++ b/updater/lib/dependabot/job/source_definition.rb
@@ -1,0 +1,92 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "pathname"
+require "sorbet-runtime"
+
+require "dependabot/source"
+
+module Dependabot
+  class Job
+    # Parsed representation of the repository source from the job definition.
+    class SourceDefinition < T::ImmutableStruct
+      extend T::Sig
+
+      const :provider, String
+      const :repo, String
+      const :directory, T.nilable(String)
+      const :directories, T.nilable(T::Array[String])
+      const :branch, T.nilable(String)
+      const :commit, T.nilable(String)
+      const :hostname, T.nilable(String)
+      const :api_endpoint, T.nilable(String)
+
+      sig { params(hash: T::Hash[String, Object]).returns(SourceDefinition) }
+      def self.from_hash(hash)
+        new(
+          provider: required_string(hash, "provider"),
+          repo: required_string(hash, "repo"),
+          directory: normalized_directory(hash["directory"]),
+          directories: normalized_directories(hash["directories"]),
+          branch: optional_string(hash["branch"]),
+          commit: optional_string(hash["commit"]),
+          hostname: optional_string(hash["hostname"]),
+          api_endpoint: optional_string(hash["api-endpoint"])
+        )
+      end
+
+      sig { returns(Dependabot::Source) }
+      def to_source
+        Dependabot::Source.new(
+          provider: provider,
+          repo: repo,
+          directory: directory,
+          directories: directories,
+          branch: branch,
+          commit: commit,
+          hostname: hostname,
+          api_endpoint: api_endpoint
+        )
+      end
+
+      sig { params(hash: T::Hash[String, Object], key: String).returns(String) }
+      def self.required_string(hash, key)
+        value = hash.fetch(key)
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :required_string
+
+      sig { params(value: T.nilable(Object)).returns(T.nilable(String)) }
+      def self.optional_string(value)
+        value if value.is_a?(String)
+      end
+      private_class_method :optional_string
+
+      sig { params(value: T.nilable(Object)).returns(T.nilable(String)) }
+      def self.normalized_directory(value)
+        return unless value.is_a?(String)
+
+        normalize_path(value)
+      end
+      private_class_method :normalized_directory
+
+      sig { params(value: T.nilable(Object)).returns(T.nilable(T::Array[String])) }
+      def self.normalized_directories(value)
+        return unless value.is_a?(Array)
+        return unless value.all?(String)
+
+        value.map { |directory| normalize_path(T.cast(directory, String)) }
+      end
+      private_class_method :normalized_directories
+
+      sig { params(directory: String).returns(String) }
+      def self.normalize_path(directory)
+        normalized = Pathname.new(directory).cleanpath.to_s
+        normalized.start_with?("/") ? normalized : "/#{normalized}"
+      end
+      private_class_method :normalize_path
+    end
+  end
+end

--- a/updater/spec/dependabot/job/cooldown_definition_spec.rb
+++ b/updater/spec/dependabot/job/cooldown_definition_spec.rb
@@ -1,0 +1,65 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/job/cooldown_definition"
+
+RSpec.describe Dependabot::Job::CooldownDefinition do
+  describe ".from_hash" do
+    subject(:definition) { described_class.from_hash(cooldown_hash) }
+
+    let(:cooldown_hash) do
+      {
+        "default-days" => 7,
+        "semver-major-days" => 14,
+        "semver-minor-days" => 5,
+        "semver-patch-days" => 2,
+        "include" => ["rails"],
+        "exclude" => ["rack"]
+      }
+    end
+
+    it "parses cooldown fields" do
+      expect(definition).to have_attributes(
+        default_days: 7,
+        semver_major_days: 14,
+        semver_minor_days: 5,
+        semver_patch_days: 2,
+        include: ["rails"],
+        exclude: ["rack"]
+      )
+    end
+
+    context "with malformed fields" do
+      let(:cooldown_hash) { super().merge("default-days" => "7") }
+
+      it "fails fast" do
+        expect { definition }.to raise_error(TypeError, /default-days/)
+      end
+    end
+  end
+
+  describe "#to_options" do
+    it "uses the supplied fallback when default-days is absent" do
+      definition = described_class.from_hash(
+        {
+          "include" => ["rails"],
+          "exclude" => []
+        }
+      )
+
+      expect(definition.to_options(default_days: 3)).to have_attributes(
+        default_days: 3,
+        semver_major_days: 3,
+        semver_minor_days: 3,
+        semver_patch_days: 3
+      )
+    end
+
+    it "preserves an explicit zero default" do
+      definition = described_class.from_hash("default-days" => 0)
+
+      expect(definition.to_options(default_days: 3).default_days).to eq(0)
+    end
+  end
+end

--- a/updater/spec/dependabot/job/definition_spec.rb
+++ b/updater/spec/dependabot/job/definition_spec.rb
@@ -1,0 +1,99 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/job/definition"
+
+RSpec.describe Dependabot::Job::Definition do
+  describe ".from_hash" do
+    subject(:definition) { described_class.from_hash(attributes) }
+
+    let(:attributes) do
+      {
+        id: "job-id",
+        command: "update",
+        allowed_updates: [{ "dependency-type" => "direct" }],
+        commit_message_options: { "prefix" => "deps", "include-scope" => true },
+        credentials: [{ "type" => "git_source", "host" => "github.com" }],
+        dependencies: ["rake"],
+        exclude_paths: ["vendor/**"],
+        existing_pull_requests: [],
+        existing_group_pull_requests: [{ "dependency-group-name" => "group-a" }],
+        experiments: { "feature" => true, "timeout" => 60 },
+        ignore_conditions: [{ "dependency-name" => "rake" }],
+        package_manager: "bundler",
+        reject_external_code: false,
+        repo_contents_path: "/tmp/repo",
+        requirements_update_strategy: nil,
+        lockfile_only: false,
+        security_advisories: [],
+        security_updates_only: false,
+        source: {
+          "provider" => "github",
+          "repo" => "dependabot/dependabot-core",
+          "directory" => "/"
+        },
+        token: "token",
+        update_subdependencies: false,
+        updating_a_pull_request: false,
+        vendor_dependencies: true,
+        cooldown: { "default-days" => 7 },
+        multi_ecosystem_update: false,
+        dependency_groups: [{ "name" => "group-a" }],
+        dependency_group_to_refresh: "group-a",
+        repo_private: true,
+        blocked_versions: [{ "dependency-name" => "rake", "version-requirement" => "< 1" }]
+      }
+    end
+
+    it "parses the final constructor values" do
+      expect(definition).to have_attributes(
+        id: "job-id",
+        command: "update",
+        dependencies: ["rake"],
+        exclude_paths: ["vendor/**"],
+        package_manager: "bundler",
+        repo_contents_path: "/tmp/repo",
+        security_updates_only: false,
+        token: "token",
+        vendor_dependencies: true,
+        dependency_group_to_refresh: "group-a",
+        repo_private: true
+      )
+      expect(definition.allowed_updates).to all(be_a(Dependabot::Job::AllowedUpdate))
+      expect(definition.credentials).to all(be_a(Dependabot::Credential))
+      expect(definition.ignore_conditions).to all(be_a(Dependabot::Job::IgnoreCondition))
+      expect(definition.existing_group_pull_requests)
+        .to all(be_a(Dependabot::Job::ExistingGroupPullRequest))
+      expect(definition.dependency_groups).to all(be_a(Dependabot::Job::DependencyGroupDefinition))
+      expect(definition.blocked_versions).to all(be_a(Dependabot::Job::BlockedVersion))
+      expect(definition.source).to be_a(Dependabot::Job::SourceDefinition)
+      expect(definition.experiments).to eq("feature" => true, "timeout" => 60)
+      expect(definition.commit_message_options).to eq("prefix" => "deps", "include-scope" => true)
+    end
+
+    context "with non-hash entries in tolerant collections" do
+      let(:attributes) do
+        super().merge(
+          existing_group_pull_requests: [nil, { "dependency-group-name" => "group-a" }],
+          dependency_groups: ["invalid", { "name" => "group-a" }],
+          blocked_versions: [false, { "dependency-name" => "rake", "version-requirement" => "< 1" }]
+        )
+      end
+
+      it "ignores them" do
+        expect(definition.existing_group_pull_requests.length).to eq(1)
+        expect(definition.dependency_groups.length).to eq(1)
+        expect(definition.blocked_versions.length).to eq(1)
+      end
+    end
+
+    context "with a malformed required scalar" do
+      let(:attributes) { super().merge(package_manager: nil) }
+
+      it "fails fast" do
+        expect { definition }.to raise_error(TypeError, /package_manager/)
+      end
+    end
+  end
+end

--- a/updater/spec/dependabot/job/source_definition_spec.rb
+++ b/updater/spec/dependabot/job/source_definition_spec.rb
@@ -1,0 +1,117 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/job/source_definition"
+
+RSpec.describe Dependabot::Job::SourceDefinition do
+  describe ".from_hash" do
+    subject(:definition) { described_class.from_hash(source_hash) }
+
+    let(:source_hash) do
+      {
+        "provider" => "github",
+        "repo" => "dependabot/dependabot-core",
+        "directory" => "updater/../common",
+        "directories" => nil,
+        "branch" => "main",
+        "commit" => "abc123",
+        "hostname" => "github.example.com",
+        "api-endpoint" => "https://github.example.com/api/v3"
+      }
+    end
+
+    it "parses and normalizes the source" do
+      expect(definition).to have_attributes(
+        provider: "github",
+        repo: "dependabot/dependabot-core",
+        directory: "/common",
+        directories: nil,
+        branch: "main",
+        commit: "abc123",
+        hostname: "github.example.com",
+        api_endpoint: "https://github.example.com/api/v3"
+      )
+    end
+
+    context "with multiple directories" do
+      let(:source_hash) do
+        super().merge("directory" => nil, "directories" => ["one", "/two/../three"])
+      end
+
+      it "normalizes every directory" do
+        expect(definition).to have_attributes(directory: nil, directories: ["/one", "/three"])
+      end
+    end
+
+    context "with root directory" do
+      let(:source_hash) { super().merge("directory" => "/") }
+
+      it "preserves the root" do
+        expect(definition.directory).to eq("/")
+      end
+    end
+
+    context "with malformed optional fields" do
+      let(:source_hash) do
+        super().merge(
+          "directory" => 1,
+          "directories" => ["one", 2],
+          "branch" => [],
+          "commit" => {},
+          "hostname" => true,
+          "api-endpoint" => 3
+        )
+      end
+
+      it "drops them" do
+        expect(definition).to have_attributes(
+          directory: nil,
+          directories: nil,
+          branch: nil,
+          commit: nil,
+          hostname: nil,
+          api_endpoint: nil
+        )
+      end
+    end
+
+    context "without a provider" do
+      let(:source_hash) { super().except("provider") }
+
+      it "fails fast" do
+        expect { definition }.to raise_error(KeyError)
+      end
+    end
+
+    context "with a malformed repository" do
+      let(:source_hash) { super().merge("repo" => nil) }
+
+      it "fails fast" do
+        expect { definition }.to raise_error(TypeError, /repo/)
+      end
+    end
+  end
+
+  describe "#to_source" do
+    it "builds a Dependabot::Source" do
+      definition = described_class.from_hash(
+        {
+          "provider" => "github",
+          "repo" => "dependabot/dependabot-core",
+          "directory" => "/common",
+          "hostname" => "github.example.com",
+          "api-endpoint" => "https://github.example.com/api/v3"
+        }
+      )
+
+      expect(definition.to_source).to have_attributes(
+        provider: "github",
+        repo: "dependabot/dependabot-core",
+        directory: "/common",
+        hostname: "github.example.com",
+        api_endpoint: "https://github.example.com/api/v3"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Parses job, source, cooldown, credentials, and options at the wire boundary, then moves `Job` and `Environment` to `typed: strong`. `ForbidTUntyped` drops from 1126 to 1110.