### PR TITLE
Type Job wire models

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1110
+# Offense count: 1104
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -404,11 +404,7 @@ Sorbet/ForbidTUntyped:
     - "updater/lib/dependabot/api_client.rb"
     - "updater/lib/dependabot/dependency_attribution.rb"
     - "updater/lib/dependabot/file_fetcher_command.rb"
-    - "updater/lib/dependabot/job/allowed_update.rb"
-    - "updater/lib/dependabot/job/ignore_condition.rb"
-    - "updater/lib/dependabot/job/security_advisory_entry.rb"
     - "updater/lib/dependabot/opentelemetry.rb"
-    - "updater/lib/dependabot/pull_request.rb"
 
     - "updater/lib/dependabot/service.rb"
     - "updater/lib/dependabot/updater/dependency_group_change_batch.rb"

--- a/updater/lib/dependabot/job/allowed_update.rb
+++ b/updater/lib/dependabot/job/allowed_update.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -7,7 +7,7 @@ module Dependabot
   class Job
     # Parsed representation of an allowed update rule from the job definition.
     #
-    # Replaces the raw T::Hash[String, T.untyped] with a typed struct so
+    # Replaces the raw job hash with a typed struct so
     # downstream code gets compile-time checked field access instead of
     # hash key lookups that return T.untyped.
     class AllowedUpdate < T::ImmutableStruct
@@ -18,15 +18,42 @@ module Dependabot
       const :update_type, String, default: "all"
       const :update_types, T::Array[String], default: []
 
-      sig { params(hash: T::Hash[String, T.untyped]).returns(AllowedUpdate) }
+      sig { params(hash: T::Hash[String, Object]).returns(AllowedUpdate) }
       def self.from_hash(hash)
         new(
-          dependency_name: hash["dependency-name"],
-          dependency_type: hash.fetch("dependency-type", "all") || "all",
-          update_type: hash.fetch("update-type", "all") || "all",
-          update_types: hash.fetch("update-types", []) || []
+          dependency_name: optional_string(hash["dependency-name"], "dependency-name"),
+          dependency_type: string_with_default(hash["dependency-type"], "dependency-type", "all"),
+          update_type: string_with_default(hash["update-type"], "update-type", "all"),
+          update_types: string_array_with_default(hash["update-types"], "update-types")
         )
       end
+
+      sig { params(value: T.nilable(Object), key: String).returns(T.nilable(String)) }
+      def self.optional_string(value, key)
+        return if value.nil?
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :optional_string
+
+      sig { params(value: T.nilable(Object), key: String, default: String).returns(String) }
+      def self.string_with_default(value, key, default)
+        return default if value.nil?
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :string_with_default
+
+      sig { params(value: T.nilable(Object), key: String).returns(T::Array[String]) }
+      def self.string_array_with_default(value, key)
+        return [] if value.nil?
+        raise TypeError, "#{key} must be an array of strings" unless value.is_a?(Array) && value.all?(String)
+
+        value.map { |entry| T.cast(entry, String) }
+      end
+      private_class_method :string_array_with_default
     end
   end
 end

--- a/updater/lib/dependabot/job/allowed_update.rb
+++ b/updater/lib/dependabot/job/allowed_update.rb
@@ -9,7 +9,7 @@ module Dependabot
     #
     # Replaces the raw job hash with a typed struct so
     # downstream code gets compile-time checked field access instead of
-    # hash key lookups that return T.untyped.
+    # raw hash key lookups.
     class AllowedUpdate < T::ImmutableStruct
       extend T::Sig
 

--- a/updater/lib/dependabot/job/blocked_version.rb
+++ b/updater/lib/dependabot/job/blocked_version.rb
@@ -12,7 +12,7 @@ module Dependabot
     #
     # Replaces the raw job hash with a typed struct so
     # downstream code gets compile-time checked field access instead of
-    # hash key lookups that return T.untyped.
+    # raw hash key lookups.
     class BlockedVersion < T::ImmutableStruct
       extend T::Sig
 

--- a/updater/lib/dependabot/job/blocked_version.rb
+++ b/updater/lib/dependabot/job/blocked_version.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -10,7 +10,7 @@ module Dependabot
     # Parsed representation of a blocked version entry, either from the job
     # definition or fetched from the service mid-job.
     #
-    # Replaces the raw T::Hash[String, T.untyped] with a typed struct so
+    # Replaces the raw job hash with a typed struct so
     # downstream code gets compile-time checked field access instead of
     # hash key lookups that return T.untyped.
     class BlockedVersion < T::ImmutableStruct
@@ -22,11 +22,7 @@ module Dependabot
 
       # Non-string values are dropped rather than raising so that malformed
       # entries are ignored, matching the previous hash-based filtering.
-      # T.untyped is unavoidable here: this parses a freshly-deserialised
-      # JSON hash at the wire boundary.
-      # rubocop:disable Sorbet/ForbidTUntyped
-      sig { params(hash: T::Hash[String, T.untyped]).returns(BlockedVersion) }
-      # rubocop:enable Sorbet/ForbidTUntyped
+      sig { params(hash: T::Hash[String, Object]).returns(BlockedVersion) }
       def self.from_hash(hash)
         name = hash["dependency-name"]
         requirement = hash["version-requirement"]

--- a/updater/lib/dependabot/job/dependency_group_definition.rb
+++ b/updater/lib/dependabot/job/dependency_group_definition.rb
@@ -9,7 +9,7 @@ module Dependabot
     #
     # Replaces the raw job hash with a typed struct so
     # downstream code gets compile-time checked field access instead of
-    # hash key lookups that return T.untyped.
+    # raw hash key lookups.
     #
     # Named DependencyGroupDefinition to avoid colliding with
     # Dependabot::DependencyGroup, the runtime grouping model this

--- a/updater/lib/dependabot/job/dependency_group_definition.rb
+++ b/updater/lib/dependabot/job/dependency_group_definition.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -7,7 +7,7 @@ module Dependabot
   class Job
     # Parsed representation of a dependency group from the job definition.
     #
-    # Replaces the raw T::Hash[String, T.untyped] with a typed struct so
+    # Replaces the raw job hash with a typed struct so
     # downstream code gets compile-time checked field access instead of
     # hash key lookups that return T.untyped.
     #
@@ -19,19 +19,14 @@ module Dependabot
 
       const :name, T.nilable(String)
       const :applies_to, T.nilable(String)
-      # Rules are open-ended, ecosystem-agnostic configuration, so their
-      # values cannot be typed more precisely than T.untyped.
-      # rubocop:disable Sorbet/ForbidTUntyped
-      const :rules, T.nilable(T::Hash[String, T.untyped])
-      # rubocop:enable Sorbet/ForbidTUntyped
+      RuleValue = T.type_alias { T.any(String, T::Array[String]) }
+
+      const :rules, T.nilable(T::Hash[String, RuleValue])
 
       # Unexpected value types are coerced to nil rather than raising, so a
       # malformed entry degrades gracefully instead of crashing the job at
-      # the parse boundary. T.untyped is unavoidable here: this parses a
-      # freshly-deserialised JSON hash at the wire boundary.
-      # rubocop:disable Sorbet/ForbidTUntyped
-      sig { params(hash: T::Hash[String, T.untyped]).returns(DependencyGroupDefinition) }
-      # rubocop:enable Sorbet/ForbidTUntyped
+      # the parse boundary.
+      sig { params(hash: T::Hash[String, Object]).returns(DependencyGroupDefinition) }
       def self.from_hash(hash)
         name = hash["name"]
         applies_to = hash["applies-to"]
@@ -40,15 +35,13 @@ module Dependabot
         new(
           name: name.is_a?(String) ? name : nil,
           applies_to: applies_to.is_a?(String) ? applies_to : nil,
-          rules: rules.is_a?(Hash) ? rules : nil
+          rules: string_hash(rules)
         )
       end
 
       # The wire format of this group definition, used when reporting job
       # errors back to the service.
-      # rubocop:disable Sorbet/ForbidTUntyped
-      sig { returns(T::Hash[String, T.untyped]) }
-      # rubocop:enable Sorbet/ForbidTUntyped
+      sig { returns(T::Hash[String, Object]) }
       def to_h
         {
           "name" => name,
@@ -56,6 +49,40 @@ module Dependabot
           "rules" => rules
         }.compact
       end
+
+      sig { params(value: T.nilable(Object)).returns(T.nilable(T::Hash[String, RuleValue])) }
+      def self.string_hash(value)
+        return unless value.is_a?(Hash)
+
+        valid = T.let(true, T::Boolean)
+        result = T.let({}, T::Hash[String, RuleValue])
+        value.each do |raw_key, raw_value|
+          key = T.cast(raw_key, Object)
+          unless key.is_a?(String)
+            valid = false
+            next
+          end
+
+          parsed_value = rule_value(T.cast(raw_value, Object))
+          unless parsed_value
+            valid = false
+            next
+          end
+
+          result[key] = parsed_value
+        end
+        result if valid
+      end
+      private_class_method :string_hash
+
+      sig { params(value: Object).returns(T.nilable(RuleValue)) }
+      def self.rule_value(value)
+        return value if value.is_a?(String)
+        return unless value.is_a?(Array) && value.all?(String)
+
+        value.map { |entry| T.cast(entry, String) }
+      end
+      private_class_method :rule_value
     end
   end
 end

--- a/updater/lib/dependabot/job/existing_group_pull_request.rb
+++ b/updater/lib/dependabot/job/existing_group_pull_request.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -8,7 +8,7 @@ module Dependabot
     # Parsed representation of an existing group pull request from the job
     # definition.
     #
-    # Replaces the raw T::Hash[String, T.untyped] with a typed struct so
+    # Replaces the raw job hash with a typed struct so
     # downstream code gets compile-time checked field access instead of
     # hash key lookups that return T.untyped.
     class ExistingGroupPullRequest < T::ImmutableStruct
@@ -29,11 +29,7 @@ module Dependabot
         const :directory, T.nilable(String)
         const :removed, T::Boolean, default: false
 
-        # T.untyped is unavoidable here: this parses a freshly-deserialised
-        # JSON hash at the wire boundary.
-        # rubocop:disable Sorbet/ForbidTUntyped
-        sig { params(hash: T::Hash[String, T.untyped]).returns(Dependency) }
-        # rubocop:enable Sorbet/ForbidTUntyped
+        sig { params(hash: T::Hash[String, Object]).returns(Dependency) }
         def self.from_hash(hash)
           name = hash["dependency-name"]
           version = hash["dependency-version"]
@@ -65,11 +61,7 @@ module Dependabot
       const :pr_number, T.nilable(Integer)
       const :dependencies, T.nilable(T::Array[Dependency])
 
-      # T.untyped is unavoidable here: this parses a freshly-deserialised
-      # JSON hash at the wire boundary.
-      # rubocop:disable Sorbet/ForbidTUntyped
-      sig { params(hash: T::Hash[String, T.untyped]).returns(ExistingGroupPullRequest) }
-      # rubocop:enable Sorbet/ForbidTUntyped
+      sig { params(hash: T::Hash[String, Object]).returns(ExistingGroupPullRequest) }
       def self.from_hash(hash)
         group_name = hash["dependency-group-name"]
         pr_number = hash["pr_number"]
@@ -78,9 +70,33 @@ module Dependabot
         new(
           dependency_group_name: group_name.is_a?(String) ? group_name : nil,
           pr_number: pr_number.is_a?(Integer) ? pr_number : nil,
-          dependencies: dependencies.is_a?(Array) ? dependencies.grep(Hash).map { |d| Dependency.from_hash(d) } : nil
+          dependencies: parsed_dependencies(dependencies)
         )
       end
+
+      sig { params(value: T.nilable(Object)).returns(T.nilable(T::Array[Dependency])) }
+      def self.parsed_dependencies(value)
+        return unless value.is_a?(Array)
+
+        value.filter_map do |dependency|
+          hash = string_hash(T.cast(dependency, Object))
+          Dependency.from_hash(hash) if hash
+        end
+      end
+      private_class_method :parsed_dependencies
+
+      sig { params(value: Object).returns(T.nilable(T::Hash[String, Object])) }
+      def self.string_hash(value)
+        return unless value.is_a?(Hash)
+
+        result = T.let({}, T::Hash[String, Object])
+        value.each do |raw_key, raw_value|
+          key = T.cast(raw_key, Object)
+          result[key] = T.cast(raw_value, Object) if key.is_a?(String)
+        end
+        result
+      end
+      private_class_method :string_hash
     end
   end
 end

--- a/updater/lib/dependabot/job/existing_group_pull_request.rb
+++ b/updater/lib/dependabot/job/existing_group_pull_request.rb
@@ -10,7 +10,7 @@ module Dependabot
     #
     # Replaces the raw job hash with a typed struct so
     # downstream code gets compile-time checked field access instead of
-    # hash key lookups that return T.untyped.
+    # raw hash key lookups.
     class ExistingGroupPullRequest < T::ImmutableStruct
       extend T::Sig
 

--- a/updater/lib/dependabot/job/ignore_condition.rb
+++ b/updater/lib/dependabot/job/ignore_condition.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -19,16 +19,43 @@ module Dependabot
       const :source, T.nilable(String)
       const :updated_at, T.nilable(String)
 
-      sig { params(hash: T::Hash[String, T.untyped]).returns(IgnoreCondition) }
+      sig { params(hash: T::Hash[String, Object]).returns(IgnoreCondition) }
       def self.from_hash(hash)
         new(
-          dependency_name: hash.fetch("dependency-name"),
-          version_requirement: hash["version-requirement"],
-          update_types: hash["update-types"],
-          source: hash["source"],
-          updated_at: hash["updated-at"]
+          dependency_name: required_string(hash, "dependency-name"),
+          version_requirement: optional_string(hash["version-requirement"], "version-requirement"),
+          update_types: optional_string_array(hash["update-types"], "update-types"),
+          source: optional_string(hash["source"], "source"),
+          updated_at: optional_string(hash["updated-at"], "updated-at")
         )
       end
+
+      sig { params(hash: T::Hash[String, Object], key: String).returns(String) }
+      def self.required_string(hash, key)
+        value = hash.fetch(key)
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :required_string
+
+      sig { params(value: T.nilable(Object), key: String).returns(T.nilable(String)) }
+      def self.optional_string(value, key)
+        return if value.nil?
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :optional_string
+
+      sig { params(value: T.nilable(Object), key: String).returns(T.nilable(T::Array[String])) }
+      def self.optional_string_array(value, key)
+        return if value.nil?
+        raise TypeError, "#{key} must be an array of strings" unless value.is_a?(Array) && value.all?(String)
+
+        value.map { |entry| T.cast(entry, String) }
+      end
+      private_class_method :optional_string_array
     end
   end
 end

--- a/updater/lib/dependabot/job/security_advisory_entry.rb
+++ b/updater/lib/dependabot/job/security_advisory_entry.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -14,15 +14,33 @@ module Dependabot
       const :patched_versions, T::Array[String], default: []
       const :unaffected_versions, T::Array[String], default: []
 
-      sig { params(hash: T::Hash[String, T.untyped]).returns(SecurityAdvisoryEntry) }
+      sig { params(hash: T::Hash[String, Object]).returns(SecurityAdvisoryEntry) }
       def self.from_hash(hash)
         new(
-          dependency_name: hash.fetch("dependency-name"),
-          affected_versions: hash.fetch("affected-versions", []) || [],
-          patched_versions: hash.fetch("patched-versions", []) || [],
-          unaffected_versions: hash.fetch("unaffected-versions", []) || []
+          dependency_name: required_string(hash, "dependency-name"),
+          affected_versions: string_array_with_default(hash["affected-versions"], "affected-versions"),
+          patched_versions: string_array_with_default(hash["patched-versions"], "patched-versions"),
+          unaffected_versions: string_array_with_default(hash["unaffected-versions"], "unaffected-versions")
         )
       end
+
+      sig { params(hash: T::Hash[String, Object], key: String).returns(String) }
+      def self.required_string(hash, key)
+        value = hash.fetch(key)
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :required_string
+
+      sig { params(value: T.nilable(Object), key: String).returns(T::Array[String]) }
+      def self.string_array_with_default(value, key)
+        return [] if value.nil?
+        raise TypeError, "#{key} must be an array of strings" unless value.is_a?(Array) && value.all?(String)
+
+        value.map { |entry| T.cast(entry, String) }
+      end
+      private_class_method :string_array_with_default
     end
   end
 end

--- a/updater/lib/dependabot/pull_request.rb
+++ b/updater/lib/dependabot/pull_request.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -37,14 +37,25 @@ module Dependabot
         @directory = T.let(normalize_directory(directory), T.nilable(String))
       end
 
-      sig { returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(hash: T::Hash[String, Object]).returns(Dependency) }
+      def self.from_hash(hash)
+        new(
+          name: required_string(hash, "dependency-name"),
+          version: optional_string(hash["dependency-version"], "dependency-version"),
+          removed: boolean_with_default(hash, "dependency-removed", false),
+          directory: optional_string(hash["directory"], "directory")
+        )
+      end
+
+      sig { returns(T::Hash[Symbol, T.any(String, T::Boolean)]) }
       def to_h
-        {
-          name: name,
-          version: version,
-          removed: removed? || nil,
-          directory: directory
-        }.compact
+        details = T.let({ name: name }, T::Hash[Symbol, T.any(String, T::Boolean)])
+        parsed_version = version
+        details[:version] = parsed_version if parsed_version
+        details[:removed] = true if removed?
+        parsed_directory = directory
+        details[:directory] = parsed_directory if parsed_directory
+        details
       end
 
       sig { returns(T::Boolean) }
@@ -52,7 +63,7 @@ module Dependabot
         removed
       end
 
-      sig { params(other: T.untyped).returns(T::Boolean) }
+      sig { params(other: Object).returns(T::Boolean) }
       def ==(other)
         return false unless other.is_a?(Dependency)
 
@@ -60,6 +71,39 @@ module Dependabot
       end
 
       private
+
+      sig { params(hash: T::Hash[String, Object], key: String).returns(String) }
+      def self.required_string(hash, key)
+        value = hash.fetch(key)
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :required_string
+
+      sig { params(value: T.nilable(Object), key: String).returns(T.nilable(String)) }
+      def self.optional_string(value, key)
+        return if value.nil?
+        raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+        value
+      end
+      private_class_method :optional_string
+
+      sig do
+        params(
+          hash: T::Hash[String, Object],
+          key: String,
+          default: T::Boolean
+        ).returns(T::Boolean)
+      end
+      def self.boolean_with_default(hash, key, default)
+        value = hash.fetch(key, default)
+        return value if value == true || value == false
+
+        raise TypeError, "#{key} must be a boolean"
+      end
+      private_class_method :boolean_with_default
 
       sig { params(directory: T.nilable(String)).returns(T.nilable(String)) }
       def normalize_directory(directory)
@@ -78,29 +122,12 @@ module Dependabot
     sig { returns(T.nilable(Integer)) }
     attr_reader :pr_number
 
-    sig { params(attributes: T::Hash[Symbol, T.untyped]).returns(T::Array[Dependabot::PullRequest]) }
+    sig { params(attributes: T::Hash[Symbol, Object]).returns(T::Array[Dependabot::PullRequest]) }
     def self.create_from_job_definition(attributes)
-      attributes.fetch(:existing_pull_requests).map do |pr|
-        case pr
-        when Array
-          pr_number = pr.first["pr-number"]
-        when Hash
-          pr_number = pr["pr-number"]
-          pr = pr["dependencies"] # now pr becomes the dependencies array from the pr
-        end
+      pull_requests = attributes.fetch(:existing_pull_requests)
+      raise TypeError, "existing pull requests must be an array" unless pull_requests.is_a?(Array)
 
-        dependencies =
-          pr.map do |dep|
-            PullRequest::Dependency.new(
-              name: dep.fetch("dependency-name"),
-              version: dep.fetch("dependency-version", nil),
-              removed: dep.fetch("dependency-removed", false),
-              directory: dep.fetch("directory", nil)
-            )
-          end
-
-        new(dependencies, pr_number: pr_number)
-      end
+      pull_requests.map { |pull_request| from_job_value(T.cast(pull_request, Object)) }
     end
 
     sig { params(updated_dependencies: T::Array[Dependabot::Dependency]).returns(Dependabot::PullRequest) }
@@ -123,8 +150,10 @@ module Dependabot
       @pr_number = pr_number
     end
 
-    sig { params(other: PullRequest).returns(T::Boolean) }
+    sig { params(other: Object).returns(T::Boolean) }
     def ==(other)
+      return false unless other.is_a?(PullRequest)
+
       if using_directory? && other.using_directory?
         dependencies.to_set(&:to_h) == other.dependencies.to_set(&:to_h)
       else
@@ -143,5 +172,63 @@ module Dependabot
     def using_directory?
       dependencies.all? { |dep| !!dep.directory }
     end
+
+    sig { params(value: Object).returns(PullRequest) }
+    def self.from_job_value(value)
+      case value
+      when Array
+        first_dependency = T.cast(value.first, Object)
+        raise TypeError, "pull request dependencies must not be empty" if first_dependency.nil?
+
+        first_hash = string_hash(first_dependency, "pull request dependency")
+        new(
+          dependency_array(value),
+          pr_number: optional_integer(first_hash["pr-number"], "pr-number")
+        )
+      when Hash
+        pull_request = string_hash(value, "pull request")
+        new(
+          dependency_array(pull_request.fetch("dependencies")),
+          pr_number: optional_integer(pull_request["pr-number"], "pr-number")
+        )
+      else
+        raise TypeError, "pull request must be an array or hash"
+      end
+    end
+    private_class_method :from_job_value
+
+    sig { params(value: Object).returns(T::Array[Dependency]) }
+    def self.dependency_array(value)
+      raise TypeError, "pull request dependencies must be an array" unless value.is_a?(Array)
+
+      value.map do |dependency|
+        Dependency.from_hash(string_hash(T.cast(dependency, Object), "pull request dependency"))
+      end
+    end
+    private_class_method :dependency_array
+
+    sig { params(value: Object, name: String).returns(T::Hash[String, Object]) }
+    def self.string_hash(value, name)
+      raise TypeError, "#{name} must be a hash" unless value.is_a?(Hash)
+
+      result = T.let({}, T::Hash[String, Object])
+      value.each do |raw_key, raw_value|
+        key = T.cast(raw_key, Object)
+        raise TypeError, "#{name} keys must be strings" unless key.is_a?(String)
+
+        result[key] = T.cast(raw_value, Object)
+      end
+      result
+    end
+    private_class_method :string_hash
+
+    sig { params(value: T.nilable(Object), name: String).returns(T.nilable(Integer)) }
+    def self.optional_integer(value, name)
+      return if value.nil?
+      raise TypeError, "#{name} must be an integer" unless value.is_a?(Integer)
+
+      value
+    end
+    private_class_method :optional_integer
   end
 end

--- a/updater/spec/dependabot/job/allowed_update_spec.rb
+++ b/updater/spec/dependabot/job/allowed_update_spec.rb
@@ -1,0 +1,50 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/job/allowed_update"
+
+RSpec.describe Dependabot::Job::AllowedUpdate do
+  describe ".from_hash" do
+    it "parses an allowed update" do
+      update = described_class.from_hash(
+        {
+          "dependency-name" => "rails",
+          "dependency-type" => "direct",
+          "update-type" => "security",
+          "update-types" => ["version-update:semver-minor"]
+        }
+      )
+
+      expect(update).to have_attributes(
+        dependency_name: "rails",
+        dependency_type: "direct",
+        update_type: "security",
+        update_types: ["version-update:semver-minor"]
+      )
+    end
+
+    it "uses defaults for absent or nil values" do
+      update = described_class.from_hash(
+        {
+          "dependency-type" => nil,
+          "update-type" => nil,
+          "update-types" => nil
+        }
+      )
+
+      expect(update).to have_attributes(
+        dependency_name: nil,
+        dependency_type: "all",
+        update_type: "all",
+        update_types: []
+      )
+    end
+
+    it "fails for a malformed dependency name" do
+      expect do
+        described_class.from_hash("dependency-name" => 1)
+      end.to raise_error(TypeError, /dependency-name/)
+    end
+  end
+end

--- a/updater/spec/dependabot/job/blocked_version_spec.rb
+++ b/updater/spec/dependabot/job/blocked_version_spec.rb
@@ -1,0 +1,41 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/job/blocked_version"
+
+RSpec.describe Dependabot::Job::BlockedVersion do
+  describe ".from_hash" do
+    it "parses a blocked version" do
+      blocked_version = described_class.from_hash(
+        {
+          "dependency-name" => "rails",
+          "version-requirement" => "< 7",
+          "reason" => "vulnerable"
+        }
+      )
+
+      expect(blocked_version).to have_attributes(
+        dependency_name: "rails",
+        version_requirement: "< 7",
+        reason: "vulnerable"
+      )
+    end
+
+    it "drops malformed fields" do
+      blocked_version = described_class.from_hash(
+        {
+          "dependency-name" => 1,
+          "version-requirement" => [],
+          "reason" => true
+        }
+      )
+
+      expect(blocked_version).to have_attributes(
+        dependency_name: nil,
+        version_requirement: nil,
+        reason: nil
+      )
+    end
+  end
+end

--- a/updater/spec/dependabot/job/dependency_group_definition_spec.rb
+++ b/updater/spec/dependabot/job/dependency_group_definition_spec.rb
@@ -1,0 +1,61 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/job/dependency_group_definition"
+
+RSpec.describe Dependabot::Job::DependencyGroupDefinition do
+  describe ".from_hash" do
+    it "parses a dependency group" do
+      definition = described_class.from_hash(
+        {
+          "name" => "production",
+          "applies-to" => "version-updates",
+          "rules" => {
+            "patterns" => ["*"],
+            "exclude-patterns" => ["rubocop"],
+            "dependency-type" => "production"
+          }
+        }
+      )
+
+      expect(definition).to have_attributes(
+        name: "production",
+        applies_to: "version-updates",
+        rules: {
+          "patterns" => ["*"],
+          "exclude-patterns" => ["rubocop"],
+          "dependency-type" => "production"
+        }
+      )
+    end
+
+    it "drops malformed fields" do
+      definition = described_class.from_hash(
+        {
+          "name" => 1,
+          "applies-to" => [],
+          "rules" => "all"
+        }
+      )
+
+      expect(definition).to have_attributes(name: nil, applies_to: nil, rules: nil)
+    end
+  end
+
+  describe "#to_h" do
+    it "preserves open-ended rule values" do
+      definition = described_class.from_hash(
+        {
+          "name" => "production",
+          "rules" => { "patterns" => ["*"], "dependency-type" => "production" }
+        }
+      )
+
+      expect(definition.to_h).to eq(
+        "name" => "production",
+        "rules" => { "patterns" => ["*"], "dependency-type" => "production" }
+      )
+    end
+  end
+end

--- a/updater/spec/dependabot/job/existing_group_pull_request_spec.rb
+++ b/updater/spec/dependabot/job/existing_group_pull_request_spec.rb
@@ -1,0 +1,71 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/job/existing_group_pull_request"
+
+RSpec.describe Dependabot::Job::ExistingGroupPullRequest do
+  describe ".from_hash" do
+    it "parses an existing group pull request" do
+      pull_request = described_class.from_hash(
+        {
+          "dependency-group-name" => "production",
+          "pr_number" => 123,
+          "dependencies" => [
+            {
+              "dependency-name" => "rails",
+              "dependency-version" => "7.0.8",
+              "directory" => "/app",
+              "dependency-removed" => true
+            }
+          ]
+        }
+      )
+
+      expect(pull_request).to have_attributes(
+        dependency_group_name: "production",
+        pr_number: 123
+      )
+      expect(pull_request.dependencies).to contain_exactly(
+        have_attributes(
+          name: "rails",
+          version: "7.0.8",
+          directory: "/app",
+          removed: true
+        )
+      )
+    end
+
+    it "drops malformed scalars and filters non-hash dependencies" do
+      pull_request = described_class.from_hash(
+        {
+          "dependency-group-name" => 1,
+          "pr_number" => "123",
+          "dependencies" => [
+            nil,
+            {
+              "dependency-name" => 2,
+              "dependency-version" => [],
+              "directory" => false,
+              "dependency-removed" => "true"
+            }
+          ]
+        }
+      )
+
+      expect(pull_request).to have_attributes(
+        dependency_group_name: nil,
+        pr_number: nil
+      )
+      expect(pull_request.dependencies).to contain_exactly(
+        have_attributes(name: nil, version: nil, directory: nil, removed: false)
+      )
+    end
+
+    it "drops malformed dependencies containers" do
+      pull_request = described_class.from_hash("dependencies" => "rails")
+
+      expect(pull_request.dependencies).to be_nil
+    end
+  end
+end

--- a/updater/spec/dependabot/job/ignore_condition_spec.rb
+++ b/updater/spec/dependabot/job/ignore_condition_spec.rb
@@ -1,0 +1,44 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/job/ignore_condition"
+
+RSpec.describe Dependabot::Job::IgnoreCondition do
+  describe ".from_hash" do
+    it "parses an ignore condition" do
+      condition = described_class.from_hash(
+        {
+          "dependency-name" => "rails",
+          "version-requirement" => "< 7",
+          "update-types" => ["version-update:semver-major"],
+          "source" => "@dependabot ignore",
+          "updated-at" => "2026-07-16T00:00:00Z"
+        }
+      )
+
+      expect(condition).to have_attributes(
+        dependency_name: "rails",
+        version_requirement: "< 7",
+        update_types: ["version-update:semver-major"],
+        source: "@dependabot ignore",
+        updated_at: "2026-07-16T00:00:00Z"
+      )
+    end
+
+    it "fails when dependency-name is missing" do
+      expect { described_class.from_hash({}) }.to raise_error(KeyError)
+    end
+
+    it "fails for malformed optional fields" do
+      expect do
+        described_class.from_hash(
+          {
+            "dependency-name" => "rails",
+            "update-types" => "major"
+          }
+        )
+      end.to raise_error(TypeError, /update-types/)
+    end
+  end
+end

--- a/updater/spec/dependabot/job/security_advisory_entry_spec.rb
+++ b/updater/spec/dependabot/job/security_advisory_entry_spec.rb
@@ -1,0 +1,53 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/job/security_advisory_entry"
+
+RSpec.describe Dependabot::Job::SecurityAdvisoryEntry do
+  describe ".from_hash" do
+    it "parses an advisory" do
+      advisory = described_class.from_hash(
+        {
+          "dependency-name" => "rails",
+          "affected-versions" => ["< 7.0.8"],
+          "patched-versions" => [">= 7.0.8"],
+          "unaffected-versions" => ["< 6"]
+        }
+      )
+
+      expect(advisory).to have_attributes(
+        dependency_name: "rails",
+        affected_versions: ["< 7.0.8"],
+        patched_versions: [">= 7.0.8"],
+        unaffected_versions: ["< 6"]
+      )
+    end
+
+    it "defaults nil arrays to empty" do
+      advisory = described_class.from_hash(
+        {
+          "dependency-name" => "rails",
+          "affected-versions" => nil
+        }
+      )
+
+      expect(advisory).to have_attributes(
+        affected_versions: [],
+        patched_versions: [],
+        unaffected_versions: []
+      )
+    end
+
+    it "fails for a malformed array" do
+      expect do
+        described_class.from_hash(
+          {
+            "dependency-name" => "rails",
+            "patched-versions" => ">= 7"
+          }
+        )
+      end.to raise_error(TypeError, /patched-versions/)
+    end
+  end
+end

--- a/updater/spec/dependabot/pull_request_spec.rb
+++ b/updater/spec/dependabot/pull_request_spec.rb
@@ -5,6 +5,59 @@ require "spec_helper"
 require "dependabot/pull_request"
 
 RSpec.describe Dependabot::PullRequest do
+  describe Dependabot::PullRequest::Dependency do
+    describe ".from_hash" do
+      it "parses a dependency" do
+        dependency = described_class.from_hash(
+          {
+            "dependency-name" => "foo",
+            "dependency-version" => "1.0.0",
+            "dependency-removed" => true,
+            "directory" => "/foo"
+          }
+        )
+
+        expect(dependency).to have_attributes(
+          name: "foo",
+          version: "1.0.0",
+          removed: true,
+          directory: "/foo"
+        )
+      end
+
+      it "fails when the dependency name is missing" do
+        expect { described_class.from_hash({}) }.to raise_error(KeyError)
+      end
+
+      it "fails when an optional field has the wrong type" do
+        expect do
+          described_class.from_hash(
+            {
+              "dependency-name" => "foo",
+              "dependency-version" => 1
+            }
+          )
+        end.to raise_error(TypeError, /dependency-version/)
+      end
+    end
+
+    describe "#to_h" do
+      it "omits nil and false values" do
+        dependency = described_class.new(name: "foo", version: nil)
+
+        expect(dependency.to_h).to eq(name: "foo")
+      end
+    end
+
+    describe "==" do
+      it "returns false for another object type" do
+        dependency = described_class.new(name: "foo", version: nil)
+
+        expect(dependency).not_to eq("foo")
+      end
+    end
+  end
+
   context "when there are different formats from the job" do
     let(:existing_pull_requests) do
       [[{ "dependency-name" => "foo", "dependency-version" => "1.0.0", "directory" => "/", "pr-number" => 123 }]]
@@ -58,6 +111,12 @@ RSpec.describe Dependabot::PullRequest do
       )
 
       expect(pr2).to eq(pr1)
+    end
+
+    it "fails fast for an unsupported pull request shape" do
+      expect do
+        described_class.create_from_job_definition(existing_pull_requests: ["invalid"])
+      end.to raise_error(TypeError, /pull request/)
     end
   end
 


### PR DESCRIPTION
Parses existing pull requests and the remaining nested Job wire models through `Object` boundaries. All seven files move to `typed: strong`, and `ForbidTUntyped` drops from 1110 to 1104.