### PR TITLE
fix(npm_and_yarn): ignore non-blocking advisory ranges in vulnerability auditor

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -506,21 +506,12 @@ function filterBlockingDependenciesByAffectedRanges(
 
   const affectedRangeUnion = normalizeRangeExpression(affectedRanges.join(" || "));
 
-  return blockers.filter((blocker) => {
-    if (
-      !requirementAllowsVersion(
-        blocker.requirement,
-        blocker.vulnerable_dependency_version
-      )
-    ) {
-      return false;
-    }
-
-    return requirementPinsToVulnerableRange(
+  return blockers.filter((blocker) =>
+    requirementPinsToVulnerableRange(
       blocker.requirement,
       affectedRangeUnion
-    );
-  }).map(stripVulnerableDependencyVersion)
+    )
+  ).map(stripVulnerableDependencyVersion)
     .filter((blocker, index, all) =>
       index ===
       all.findIndex(
@@ -564,6 +555,12 @@ function requirementPinsToVulnerableRange(
   requirement: string,
   affectedRangeUnion: string
 ): boolean {
+  if (containsUnsupportedRubyRangeSyntax(requirement)) {
+    // Requirement syntax understood by Ruby can differ from node-semver.
+    // Keep it as a blocker to avoid false negatives.
+    return true;
+  }
+
   const normalizedAffectedRangeUnion = normalizeRangeExpression(affectedRangeUnion);
   if (!normalizedAffectedRangeUnion) {
     // Empty advisory expression is ambiguous; fall back conservatively.
@@ -587,26 +584,6 @@ function requirementPinsToVulnerableRange(
     );
   } catch {
     // Keep unknown range syntaxes as blockers to avoid false negatives.
-    return true;
-  }
-}
-
-function requirementAllowsVersion(requirement: string, version: string): boolean {
-  try {
-    const parsedVersion = new semver.SemVer(version, {
-      includePrerelease: true,
-      loose: true,
-    });
-    const parsedRange = new semver.Range(
-      normalizeRangeExpression(requirement),
-      {
-        includePrerelease: true,
-        loose: true,
-      }
-    );
-    return parsedRange.test(parsedVersion);
-  } catch {
-    // Keep unknown range syntaxes as potential blockers to avoid false negatives.
     return true;
   }
 }
@@ -677,7 +654,11 @@ function parseAdvisoryRanges(affectedRanges: string[]): semver.Range[] | null {
 function containsUnsupportedRubyRangeSyntax(range: string): boolean {
   // Ruby's pessimistic operator (~>) has different semantics from node-semver's
   // loose parsing, so treat it as unsupported and fall back conservatively.
-  return /~>/.test(range) || hasPartialRubyComparatorVersion(range);
+  return (
+    /~>/.test(range) ||
+    hasPartialRubyComparatorVersion(range) ||
+    hasBarePartialRubyVersion(range)
+  );
 }
 
 function hasPartialRubyComparatorVersion(range: string): boolean {
@@ -701,6 +682,25 @@ function hasPartialRubyComparatorVersion(range: string): boolean {
   }
 
   return false;
+}
+
+function hasBarePartialRubyVersion(range: string): boolean {
+  const arms = range
+    .split("||")
+    .map((arm) => arm.trim())
+    .filter((arm) => arm.length > 0);
+
+  return arms.some((arm) => {
+    // In Dependabot/Ruby requirements, bare `1` and `1.0` are exact versions,
+    // but node-semver expands them to major/minor lines. Treat as unsupported
+    // to avoid semantic drift.
+    const bareVersionMatch = arm.match(/^=?\s*v?(\d+)(?:\.(\d+))?$/);
+    if (!bareVersionMatch) {
+      return false;
+    }
+
+    return bareVersionMatch[2] !== undefined || bareVersionMatch[1] !== undefined;
+  });
 }
 
 function normalizeRangeExpression(range: string): string {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -686,7 +686,9 @@ function findDependencyNodesInTree(
   ).inventory;
 
   if (inventory) {
-    const nodes = [...inventory.query("name", dependencyName)];
+    const nodes = [...inventory.query("name", dependencyName)].filter(
+      (node) => !node.isProjectRoot
+    );
     if (nodes.length > 0) {
       nodes.sort((left, right) => {
         if (left.depth !== right.depth) return left.depth - right.depth;

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -286,6 +286,9 @@ export async function findVulnerableDependencies(
 
     if (remainingVulnerableTargets.length > 0) {
       response.fix_available = false;
+      if (blockingDependencies.length > 0) {
+        response.blocking_dependencies = blockingDependencies;
+      }
     }
 
     // Prefer reporting a remaining vulnerable version when one exists;

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -482,8 +482,8 @@ export function requirementPinsToVulnerableRange(
       normalizeRangeExpression(requirement),
       normalizeRangeExpression(affectedRangeUnion),
       {
-      includePrerelease: true,
-      loose: true,
+        includePrerelease: true,
+        loose: true,
       }
     );
   } catch {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -483,10 +483,21 @@ export function requirementPinsToVulnerableRange(
   requirement: string,
   affectedRangeUnion: string
 ): boolean {
+  const parsedAdvisoryRanges = parseAdvisoryRanges([affectedRangeUnion]);
+  if (!parsedAdvisoryRanges) {
+    // Keep unknown advisory syntax as blockers to avoid false negatives.
+    return true;
+  }
+
+  const advisoryUnion = parsedAdvisoryRanges.map((range) => range.range).join(" || ");
+  if (!advisoryUnion) {
+    return false;
+  }
+
   try {
     return semver.subset(
       normalizeRangeExpression(requirement),
-      normalizeRangeExpression(affectedRangeUnion),
+      advisoryUnion,
       {
         includePrerelease: true,
         loose: true,
@@ -519,8 +530,12 @@ function requirementAllowsVersion(requirement: string, version: string): boolean
 }
 
 function versionInAffectedRanges(version: string, affectedRanges: string[]): boolean {
-  const rangeExpression = normalizeRangeExpression(affectedRanges.join(" || "));
-  if (!rangeExpression) {
+  const parsedAdvisoryRanges = parseAdvisoryRanges(affectedRanges);
+  if (!parsedAdvisoryRanges) {
+    // Conservative fallback when advisory ranges are not parseable.
+    return true;
+  }
+  if (parsedAdvisoryRanges.length === 0) {
     return false;
   }
 
@@ -529,15 +544,54 @@ function versionInAffectedRanges(version: string, affectedRanges: string[]): boo
       includePrerelease: true,
       loose: true,
     });
-    const parsedRange = new semver.Range(rangeExpression, {
-      includePrerelease: true,
-      loose: true,
-    });
-    return parsedRange.test(parsedVersion);
+    return parsedAdvisoryRanges.some((parsedRange) =>
+      parsedRange.test(parsedVersion)
+    );
   } catch {
-    // Conservative fallback when ranges are not parseable.
+    // Conservative fallback when version parsing fails.
     return true;
   }
+}
+
+function parseAdvisoryRanges(affectedRanges: string[]): semver.Range[] | null {
+  const parsedRanges: semver.Range[] = [];
+
+  for (const affectedRange of affectedRanges) {
+    const normalizedRange = normalizeRangeExpression(affectedRange);
+    if (!normalizedRange) {
+      continue;
+    }
+
+    const advisoryArms = normalizedRange
+      .split("||")
+      .map((arm) => arm.trim())
+      .filter((arm) => arm.length > 0);
+
+    for (const arm of advisoryArms) {
+      if (containsUnsupportedRubyRangeSyntax(arm)) {
+        return null;
+      }
+
+      try {
+        parsedRanges.push(
+          new semver.Range(arm, {
+            includePrerelease: true,
+            loose: true,
+          })
+        );
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  return parsedRanges;
+}
+
+function containsUnsupportedRubyRangeSyntax(range: string): boolean {
+  // Ruby's pessimistic operator (~>) has different semantics from node-semver's
+  // loose parsing, so treat it as unsupported and fall back conservatively.
+  return /~>/.test(range);
 }
 
 function normalizeRangeExpression(range: string): string {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -162,7 +162,8 @@ export async function findVulnerableDependencies(
     const rawBlockingDependencies = extractBlockingDependencies(vuln, name);
     const blockingDependencies = filterBlockingDependenciesByAffectedRanges(
       rawBlockingDependencies,
-      advisories
+      advisories,
+      version
     );
 
     response.current_version = version;
@@ -454,7 +455,8 @@ function extractBlockingDependencies(
 
 function filterBlockingDependenciesByAffectedRanges(
   blockers: BlockingDependency[],
-  advisories: Advisory[]
+  advisories: Advisory[],
+  currentVersion: string
 ): BlockingDependency[] {
   const affectedRanges = advisories.flatMap((advisory) =>
     advisory.affected_versions
@@ -465,12 +467,16 @@ function filterBlockingDependenciesByAffectedRanges(
 
   const affectedRangeUnion = normalizeRangeExpression(affectedRanges.join(" || "));
 
-  return blockers.filter((blocker) =>
-    requirementPinsToVulnerableRange(
+  return blockers.filter((blocker) => {
+    if (!requirementAllowsVersion(blocker.requirement, currentVersion)) {
+      return false;
+    }
+
+    return requirementPinsToVulnerableRange(
       blocker.requirement,
       affectedRangeUnion
-    )
-  );
+    );
+  });
 }
 
 export function requirementPinsToVulnerableRange(
@@ -488,6 +494,26 @@ export function requirementPinsToVulnerableRange(
     );
   } catch {
     // Keep unknown range syntaxes as blockers to avoid false negatives.
+    return true;
+  }
+}
+
+function requirementAllowsVersion(requirement: string, version: string): boolean {
+  try {
+    const parsedVersion = new semver.SemVer(version, {
+      includePrerelease: true,
+      loose: true,
+    });
+    const parsedRange = new semver.Range(
+      normalizeRangeExpression(requirement),
+      {
+        includePrerelease: true,
+        loose: true,
+      }
+    );
+    return parsedRange.test(parsedVersion);
+  } catch {
+    // Keep unknown range syntaxes as potential blockers to avoid false negatives.
     return true;
   }
 }

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -281,7 +281,7 @@ export async function findVulnerableDependencies(
         versionInAffectedRanges(
           targetVersion,
           advisories.flatMap((advisory) => advisory.affected_versions)
-        )
+        ) === true
     );
 
     if (remainingVulnerableTargets.length > 0) {
@@ -589,11 +589,15 @@ function requirementAllowsVersion(requirement: string, version: string): boolean
   }
 }
 
-function versionInAffectedRanges(version: string, affectedRanges: string[]): boolean {
+function versionInAffectedRanges(
+  version: string,
+  affectedRanges: string[]
+): boolean | null {
   const parsedAdvisoryRanges = parseAdvisoryRanges(affectedRanges);
   if (!parsedAdvisoryRanges) {
-    // Conservative fallback when advisory ranges are not parseable.
-    return true;
+    // Advisory syntax understood by Ruby may be unsupported in node-semver.
+    // Return indeterminate so downstream validation can decide with source-of-truth semantics.
+    return null;
   }
   if (parsedAdvisoryRanges.length === 0) {
     return false;
@@ -608,8 +612,8 @@ function versionInAffectedRanges(version: string, affectedRanges: string[]): boo
       parsedRange.test(parsedVersion)
     );
   } catch {
-    // Conservative fallback when version parsing fails.
-    return true;
+    // Return indeterminate when the version cannot be parsed in node-semver.
+    return null;
   }
 }
 

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -652,18 +652,22 @@ function containsUnsupportedRubyRangeSyntax(range: string): boolean {
 }
 
 function hasPartialRubyComparatorVersion(range: string): boolean {
-  const comparatorRegex = /(^|\s)>(?!=)\s*([^\s]+)/g;
+  const comparatorRegex = /(^|\s)(>(?!=)|<=)\s*([^\s]+)/g;
   for (const match of range.matchAll(comparatorRegex)) {
-    const version = match[2];
+    const operator = match[2];
+    const version = match[3];
     const coreVersion = version.split("-")[0].split("+")[0];
     const parts = coreVersion.split(".");
 
-    // Ruby comparators like `> 1.0` are valid and mean `> 1.0.0`, but
-    // node-semver interprets partial strict-greater comparators with different
-    // semantics (for example, `>1.0` as `>=1.1.0`). Treat these as unsupported
-    // so we fall back conservatively.
+    // Ruby comparators like `> 1.0` and `<= 1.0` are valid and mean
+    // `> 1.0.0` and `<= 1.0.0`, but node-semver interprets partial versions
+    // with different semantics (for example, `>1.0` as `>=1.1.0` and
+    // `<=1.0` through the `1.0.x` line). Treat these as unsupported so we
+    // fall back conservatively.
     if (parts.length < 3) {
-      return true;
+      if (operator === ">" || operator === "<=") {
+        return true;
+      }
     }
   }
 

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -499,10 +499,15 @@ function versionInAffectedRanges(version: string, affectedRanges: string[]): boo
   }
 
   try {
-    return semver.satisfies(version, rangeExpression, {
+    const parsedVersion = new semver.SemVer(version, {
       includePrerelease: true,
       loose: true,
     });
+    const parsedRange = new semver.Range(rangeExpression, {
+      includePrerelease: true,
+      loose: true,
+    });
+    return parsedRange.test(parsedVersion);
   } catch {
     // Conservative fallback when ranges are not parseable.
     return true;

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -40,6 +40,7 @@ const exec = promisify(execCb);
 interface Advisory {
   dependency_name: string;
   affected_versions: string[];
+  safe_versions?: string[];
 }
 
 interface FixUpdate {
@@ -273,12 +274,9 @@ export async function findVulnerableDependencies(
     const fixedNodeVersions = fixedDependencyNodes
       .map((node) => node.version)
       .filter((version): version is string => typeof version === "string");
-    const affectedRanges = advisories.flatMap(
-      (advisory) => advisory.affected_versions
-    );
     const fixedNodeVersionStatuses = fixedNodeVersions.map((version) => ({
       version,
-      status: versionInAffectedRanges(version, affectedRanges),
+      status: versionInAffectedRanges(version, advisories),
     }));
     const fixedNodeVersionsAtVulnLocations = vulnLocations
       .map((loc) => resolveNodeFromLocation(fixTree, loc)?.version)
@@ -495,21 +493,16 @@ function filterBlockingDependenciesByAffectedRanges(
   blockers: ExtractedBlockingDependency[],
   advisories: Advisory[]
 ): BlockingDependency[] {
-  const affectedRanges = advisories.flatMap((advisory) =>
-    advisory.affected_versions
-  );
-  if (affectedRanges.length === 0) {
+  if (advisories.length === 0) {
     return uniqueBlockingDependencies(
       blockers.map(stripVulnerableDependencyVersion)
     );
   }
 
-  const affectedRangeUnion = normalizeRangeExpression(affectedRanges.join(" || "));
-
   return blockers.filter((blocker) =>
     requirementPinsToVulnerableRange(
       blocker.requirement,
-      affectedRangeUnion
+      advisories
     )
   ).map(stripVulnerableDependencyVersion)
     .filter((blocker, index, all) =>
@@ -553,35 +546,75 @@ function uniqueBlockingDependencies(
 
 function requirementPinsToVulnerableRange(
   requirement: string,
-  affectedRangeUnion: string
+  advisories: Advisory[]
 ): boolean {
-  if (containsUnsupportedRubyRangeSyntax(requirement)) {
-    // Requirement syntax understood by Ruby can differ from node-semver.
-    // Keep it as a blocker to avoid false negatives.
-    return true;
-  }
-
-  const normalizedAffectedRangeUnion = normalizeRangeExpression(affectedRangeUnion);
-  if (!normalizedAffectedRangeUnion) {
-    // Empty advisory expression is ambiguous; fall back conservatively.
-    return true;
-  }
-
-  const parsedAdvisoryRanges = parseAdvisoryRanges([affectedRangeUnion]);
-  if (!parsedAdvisoryRanges) {
-    // Keep unknown advisory syntax as blockers to avoid false negatives.
-    return true;
-  }
-
   try {
-    return semver.subset(
-      normalizeRangeExpression(requirement),
-      normalizedAffectedRangeUnion,
-      {
-        includePrerelease: true,
-        loose: true,
+    const normalizedRequirement = normalizeRangeExpression(requirement);
+
+    for (const advisory of advisories) {
+      const parsedVulnerableRanges = parseAdvisoryRanges(
+        advisory.affected_versions
+      );
+      const parsedSafeRanges = parseAdvisoryRanges(advisory.safe_versions ?? []);
+
+      if (!parsedVulnerableRanges || !parsedSafeRanges) {
+        // Keep unknown advisory syntax as blockers to avoid false negatives.
+        return true;
       }
-    );
+
+      if (parsedVulnerableRanges.length === 0) {
+        if (parsedSafeRanges.length > 0) {
+          // "vulnerable unless in safe range" cannot be represented as a
+          // finite semver union here; keep conservative behavior.
+          return true;
+        }
+        continue;
+      }
+
+      const vulnerableRangeUnion = normalizeRangeExpression(
+        parsedVulnerableRanges.map((range) => range.range).join(" || ")
+      );
+
+      if (!vulnerableRangeUnion) {
+        return true;
+      }
+
+      const requirementSubsetOfVulnerable = semver.subset(
+        normalizedRequirement,
+        vulnerableRangeUnion,
+        {
+          includePrerelease: true,
+          loose: true,
+        }
+      );
+
+      if (!requirementSubsetOfVulnerable) {
+        continue;
+      }
+
+      const safeRangeUnion = normalizeRangeExpression(
+        parsedSafeRanges.map((range) => range.range).join(" || ")
+      );
+
+      if (!safeRangeUnion) {
+        return true;
+      }
+
+      const requirementIntersectsSafe = semver.intersects(
+        normalizedRequirement,
+        safeRangeUnion,
+        {
+          includePrerelease: true,
+          loose: true,
+        }
+      );
+
+      if (!requirementIntersectsSafe) {
+        return true;
+      }
+    }
+
+    return false;
   } catch {
     // Keep unknown range syntaxes as blockers to avoid false negatives.
     return true;
@@ -590,26 +623,47 @@ function requirementPinsToVulnerableRange(
 
 function versionInAffectedRanges(
   version: string,
-  affectedRanges: string[]
+  advisories: Advisory[]
 ): boolean | null {
-  const parsedAdvisoryRanges = parseAdvisoryRanges(affectedRanges);
-  if (!parsedAdvisoryRanges) {
-    // Advisory syntax understood by Ruby may be unsupported in node-semver.
-    // Return indeterminate so downstream validation can decide with source-of-truth semantics.
-    return null;
-  }
-  if (parsedAdvisoryRanges.length === 0) {
-    return false;
-  }
-
   try {
     const parsedVersion = new semver.SemVer(version, {
       includePrerelease: true,
       loose: true,
     });
-    return parsedAdvisoryRanges.some((parsedRange) =>
-      parsedRange.test(parsedVersion)
-    );
+
+    let hasIndeterminateAdvisory = false;
+
+    for (const advisory of advisories) {
+      const parsedVulnerableRanges = parseAdvisoryRanges(
+        advisory.affected_versions
+      );
+      const parsedSafeRanges = parseAdvisoryRanges(advisory.safe_versions ?? []);
+
+      if (!parsedVulnerableRanges || !parsedSafeRanges) {
+        hasIndeterminateAdvisory = true;
+        continue;
+      }
+
+      const inSafeRange = parsedSafeRanges.some((range) => range.test(parsedVersion));
+      if (inSafeRange) {
+        continue;
+      }
+
+      if (parsedVulnerableRanges.length > 0) {
+        if (parsedVulnerableRanges.some((range) => range.test(parsedVersion))) {
+          return true;
+        }
+        continue;
+      }
+
+      if (parsedSafeRanges.length > 0) {
+        // Mirrors SecurityAdvisory#vulnerable?: with only safe ranges present,
+        // any version not in a safe range is considered vulnerable.
+        return true;
+      }
+    }
+
+    return hasIndeterminateAdvisory ? null : false;
   } catch {
     // Return indeterminate when the version cannot be parsed in node-semver.
     return null;
@@ -654,11 +708,7 @@ function parseAdvisoryRanges(affectedRanges: string[]): semver.Range[] | null {
 function containsUnsupportedRubyRangeSyntax(range: string): boolean {
   // Ruby's pessimistic operator (~>) has different semantics from node-semver's
   // loose parsing, so treat it as unsupported and fall back conservatively.
-  return (
-    /~>/.test(range) ||
-    hasPartialRubyComparatorVersion(range) ||
-    hasBarePartialRubyVersion(range)
-  );
+  return /~>/.test(range) || hasPartialRubyComparatorVersion(range);
 }
 
 function hasPartialRubyComparatorVersion(range: string): boolean {
@@ -682,25 +732,6 @@ function hasPartialRubyComparatorVersion(range: string): boolean {
   }
 
   return false;
-}
-
-function hasBarePartialRubyVersion(range: string): boolean {
-  const arms = range
-    .split("||")
-    .map((arm) => arm.trim())
-    .filter((arm) => arm.length > 0);
-
-  return arms.some((arm) => {
-    // In Dependabot/Ruby requirements, bare `1` and `1.0` are exact versions,
-    // but node-semver expands them to major/minor lines. Treat as unsupported
-    // to avoid semantic drift.
-    const bareVersionMatch = arm.match(/^=?\s*v?(\d+)(?:\.(\d+))?$/);
-    if (!bareVersionMatch) {
-      return false;
-    }
-
-    return bareVersionMatch[2] !== undefined || bareVersionMatch[1] !== undefined;
-  });
 }
 
 function normalizeRangeExpression(range: string): string {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -647,7 +647,26 @@ function parseAdvisoryRanges(affectedRanges: string[]): semver.Range[] | null {
 function containsUnsupportedRubyRangeSyntax(range: string): boolean {
   // Ruby's pessimistic operator (~>) has different semantics from node-semver's
   // loose parsing, so treat it as unsupported and fall back conservatively.
-  return /~>/.test(range);
+  return /~>/.test(range) || hasPartialRubyComparatorVersion(range);
+}
+
+function hasPartialRubyComparatorVersion(range: string): boolean {
+  const comparatorRegex = /(^|\s)>(?!=)\s*([^\s]+)/g;
+  for (const match of range.matchAll(comparatorRegex)) {
+    const version = match[2];
+    const coreVersion = version.split("-")[0].split("+")[0];
+    const parts = coreVersion.split(".");
+
+    // Ruby comparators like `> 1.0` are valid and mean `> 1.0.0`, but
+    // node-semver interprets partial strict-greater comparators with different
+    // semantics (for example, `>1.0` as `>=1.1.0`). Treat these as unsupported
+    // so we fall back conservatively.
+    if (parts.length < 3) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function normalizeRangeExpression(range: string): string {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -252,6 +252,7 @@ export async function findVulnerableDependencies(
     // first) with lexical tie-breaking for deterministic results regardless of
     // vuln.nodes iteration order.
     const vulnLocations = [...vuln.nodes]
+      .filter((node) => node.name === name)
       .map((n) => n.location)
       .sort((left, right) => {
         const leftDepth = left.split("node_modules").length;
@@ -259,9 +260,21 @@ export async function findVulnerableDependencies(
         if (leftDepth !== rightDepth) return leftDepth - rightDepth;
         return left.localeCompare(right);
       });
-    const remainingVulnerableTargets = vulnLocations
+
+    const fixedNodeVersionsAtVulnLocations = vulnLocations
       .map((loc) => resolveNodeFromLocation(fixTree, loc)?.version)
       .filter((version): version is string => typeof version === "string");
+    const remainingVulnerableTargets = fixedNodeVersionsAtVulnLocations.filter(
+      (targetVersion) =>
+        versionInAffectedRanges(
+          targetVersion,
+          advisories.flatMap((advisory) => advisory.affected_versions)
+        )
+    );
+
+    if (remainingVulnerableTargets.length > 0) {
+      response.fix_available = false;
+    }
 
     // If any originally vulnerable location still exists after applying the
     // fix tree, report that version so the Ruby side can detect the dependency
@@ -450,7 +463,7 @@ function filterBlockingDependenciesByAffectedRanges(
     return blockers;
   }
 
-  const affectedRangeUnion = affectedRanges.join(" || ");
+  const affectedRangeUnion = normalizeRangeExpression(affectedRanges.join(" || "));
 
   return blockers.filter((blocker) =>
     requirementPinsToVulnerableRange(
@@ -465,14 +478,39 @@ export function requirementPinsToVulnerableRange(
   affectedRangeUnion: string
 ): boolean {
   try {
-    return semver.subset(requirement, affectedRangeUnion, {
+    return semver.subset(
+      normalizeRangeExpression(requirement),
+      normalizeRangeExpression(affectedRangeUnion),
+      {
       includePrerelease: true,
       loose: true,
-    });
+      }
+    );
   } catch {
     // Keep unknown range syntaxes as blockers to avoid false negatives.
     return true;
   }
+}
+
+function versionInAffectedRanges(version: string, affectedRanges: string[]): boolean {
+  const rangeExpression = normalizeRangeExpression(affectedRanges.join(" || "));
+  if (!rangeExpression) {
+    return false;
+  }
+
+  try {
+    return semver.satisfies(version, rangeExpression, {
+      includePrerelease: true,
+      loose: true,
+    });
+  } catch {
+    // Conservative fallback when ranges are not parseable.
+    return true;
+  }
+}
+
+function normalizeRangeExpression(range: string): string {
+  return range.replace(/\s*,\s*/g, " ").trim();
 }
 
 /* Walk up the dependency graph from the given edge to find the name(s) of the

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -273,18 +273,38 @@ export async function findVulnerableDependencies(
     const fixedNodeVersions = fixedDependencyNodes
       .map((node) => node.version)
       .filter((version): version is string => typeof version === "string");
+    const affectedRanges = advisories.flatMap(
+      (advisory) => advisory.affected_versions
+    );
+    const fixedNodeVersionStatuses = fixedNodeVersions.map((version) => ({
+      version,
+      status: versionInAffectedRanges(version, affectedRanges),
+    }));
     const fixedNodeVersionsAtVulnLocations = vulnLocations
       .map((loc) => resolveNodeFromLocation(fixTree, loc)?.version)
       .filter((version): version is string => typeof version === "string");
-    const remainingVulnerableTargets = fixedNodeVersions.filter(
-      (targetVersion) =>
-        versionInAffectedRanges(
-          targetVersion,
-          advisories.flatMap((advisory) => advisory.affected_versions)
-        ) === true
-    );
+    const remainingVulnerableTargets = fixedNodeVersionStatuses
+      .filter((entry) => entry.status === true)
+      .map((entry) => entry.version);
+    const indeterminateTargets = fixedNodeVersionStatuses
+      .filter((entry) => entry.status === null)
+      .map((entry) => entry.version);
 
     if (remainingVulnerableTargets.length > 0) {
+      // Keep the post-fix target validation path when no parent blockers remain,
+      // so the caller can report an accurate "still vulnerable" outcome instead
+      // of a generic blocked-by-parents explanation.
+      if (blockingDependencies.length > 0) {
+        response.fix_available = false;
+        response.blocking_dependencies = blockingDependencies;
+      }
+    }
+
+    if (
+      remainingVulnerableTargets.length === 0 &&
+      indeterminateTargets.length > 0 &&
+      fixedNodeVersions.length > 1
+    ) {
       response.fix_available = false;
       if (blockingDependencies.length > 0) {
         response.blocking_dependencies = blockingDependencies;
@@ -292,10 +312,12 @@ export async function findVulnerableDependencies(
     }
 
     // Prefer reporting a remaining vulnerable version when one exists;
+    // otherwise prefer an indeterminate version when multiple copies remain,
     // otherwise report a safe version at original vulnerable locations when
     // available, then fall back to any resolved version from the fix tree.
     response.target_version =
       remainingVulnerableTargets[0] ??
+      (fixedNodeVersions.length > 1 ? indeterminateTargets[0] : undefined) ??
       fixedNodeVersionsAtVulnLocations[0] ??
       fixedNodeVersions[0];
 
@@ -659,20 +681,20 @@ function containsUnsupportedRubyRangeSyntax(range: string): boolean {
 }
 
 function hasPartialRubyComparatorVersion(range: string): boolean {
-  const comparatorRegex = /(^|\s)(>(?!=)|<=)\s*([^\s]+)/g;
+  const comparatorRegex = /(^|\s)(>(?!=)|<=|=)\s*([^\s]+)/g;
   for (const match of range.matchAll(comparatorRegex)) {
     const operator = match[2];
     const version = match[3];
     const coreVersion = version.split("-")[0].split("+")[0];
     const parts = coreVersion.split(".");
 
-    // Ruby comparators like `> 1.0` and `<= 1.0` are valid and mean
-    // `> 1.0.0` and `<= 1.0.0`, but node-semver interprets partial versions
-    // with different semantics (for example, `>1.0` as `>=1.1.0` and
-    // `<=1.0` through the `1.0.x` line). Treat these as unsupported so we
-    // fall back conservatively.
+    // Ruby comparators like `> 1.0`, `<= 1.0`, and `= 1.0` are valid and mean
+    // `> 1.0.0`, `<= 1.0.0`, and exact `= 1.0.0`, but node-semver interprets
+    // partial versions with different semantics (for example, `>1.0` as
+    // `>=1.1.0`, `<=1.0` through the `1.0.x` line, and `=1.0` as `1.0.x`).
+    // Treat these as unsupported so we fall back conservatively.
     if (parts.length < 3) {
-      if (operator === ">" || operator === "<=") {
+      if (operator === ">" || operator === "<=" || operator === "=") {
         return true;
       }
     }

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -57,6 +57,10 @@ interface BlockingDependency {
   top_level_ancestor: string;
 }
 
+interface ExtractedBlockingDependency extends BlockingDependency {
+  vulnerable_dependency_version: string;
+}
+
 interface AuditResponse {
   dependency_name: string;
   current_version?: string;
@@ -162,8 +166,7 @@ export async function findVulnerableDependencies(
     const rawBlockingDependencies = extractBlockingDependencies(vuln, name);
     const blockingDependencies = filterBlockingDependenciesByAffectedRanges(
       rawBlockingDependencies,
-      advisories,
-      version
+      advisories
     );
 
     response.current_version = version;
@@ -411,8 +414,8 @@ function buildDependencyChains(
 function extractBlockingDependencies(
   vuln: Arborist.Vuln,
   name: string
-): BlockingDependency[] {
-  const blockers = new Map<string, BlockingDependency>();
+): ExtractedBlockingDependency[] {
+  const blockers = new Map<string, ExtractedBlockingDependency>();
   for (const node of vuln.nodes) {
     // `vuln.nodes` may include packages that are only vulnerable *via* this
     // dependency; we only care about the actual vulnerable copies of `name`.
@@ -432,13 +435,14 @@ function extractBlockingDependencies(
       const ancestors = findTopLevelAncestorNames(edge);
       const topLevelAncestors = ancestors.length > 0 ? ancestors : [parent.name];
       for (const ancestor of topLevelAncestors) {
-        const key = `${parent.name}@${parent.version}|${requirement}|${ancestor}`;
+        const key = `${parent.name}@${parent.version}|${requirement}|${ancestor}|${node.version}`;
         if (!blockers.has(key)) {
           blockers.set(key, {
             name: parent.name,
             version: parent.version,
             requirement,
             top_level_ancestor: ancestor,
+            vulnerable_dependency_version: node.version,
           });
         }
       }
@@ -454,21 +458,27 @@ function extractBlockingDependencies(
 }
 
 function filterBlockingDependenciesByAffectedRanges(
-  blockers: BlockingDependency[],
-  advisories: Advisory[],
-  currentVersion: string
+  blockers: ExtractedBlockingDependency[],
+  advisories: Advisory[]
 ): BlockingDependency[] {
   const affectedRanges = advisories.flatMap((advisory) =>
     advisory.affected_versions
   );
   if (affectedRanges.length === 0) {
-    return blockers;
+    return uniqueBlockingDependencies(
+      blockers.map(stripVulnerableDependencyVersion)
+    );
   }
 
   const affectedRangeUnion = normalizeRangeExpression(affectedRanges.join(" || "));
 
   return blockers.filter((blocker) => {
-    if (!requirementAllowsVersion(blocker.requirement, currentVersion)) {
+    if (
+      !requirementAllowsVersion(
+        blocker.requirement,
+        blocker.vulnerable_dependency_version
+      )
+    ) {
       return false;
     }
 
@@ -476,7 +486,44 @@ function filterBlockingDependenciesByAffectedRanges(
       blocker.requirement,
       affectedRangeUnion
     );
-  });
+  }).map(stripVulnerableDependencyVersion)
+    .filter((blocker, index, all) =>
+      index ===
+      all.findIndex(
+        (candidate) =>
+          candidate.name === blocker.name &&
+          candidate.version === blocker.version &&
+          candidate.requirement === blocker.requirement &&
+          candidate.top_level_ancestor === blocker.top_level_ancestor
+      )
+    );
+}
+
+function stripVulnerableDependencyVersion(
+  blocker: ExtractedBlockingDependency
+): BlockingDependency {
+  return {
+    name: blocker.name,
+    version: blocker.version,
+    requirement: blocker.requirement,
+    top_level_ancestor: blocker.top_level_ancestor,
+  };
+}
+
+function uniqueBlockingDependencies(
+  blockers: BlockingDependency[]
+): BlockingDependency[] {
+  return blockers.filter(
+    (blocker, index, all) =>
+      index ===
+      all.findIndex(
+        (candidate) =>
+          candidate.name === blocker.name &&
+          candidate.version === blocker.version &&
+          candidate.requirement === blocker.requirement &&
+          candidate.top_level_ancestor === blocker.top_level_ancestor
+      )
+  );
 }
 
 export function requirementPinsToVulnerableRange(

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -539,21 +539,22 @@ export function requirementPinsToVulnerableRange(
   requirement: string,
   affectedRangeUnion: string
 ): boolean {
+  const normalizedAffectedRangeUnion = normalizeRangeExpression(affectedRangeUnion);
+  if (!normalizedAffectedRangeUnion) {
+    // Empty advisory expression is ambiguous; fall back conservatively.
+    return true;
+  }
+
   const parsedAdvisoryRanges = parseAdvisoryRanges([affectedRangeUnion]);
   if (!parsedAdvisoryRanges) {
     // Keep unknown advisory syntax as blockers to avoid false negatives.
     return true;
   }
 
-  const advisoryUnion = parsedAdvisoryRanges.map((range) => range.range).join(" || ");
-  if (!advisoryUnion) {
-    return false;
-  }
-
   try {
     return semver.subset(
       normalizeRangeExpression(requirement),
-      advisoryUnion,
+      normalizedAffectedRangeUnion,
       {
         includePrerelease: true,
         loose: true,
@@ -680,12 +681,11 @@ function findDependencyNodesInTree(
 ): Arborist.Node[] {
   const inventory = (
     tree as Arborist.Node & {
-      inventory?: { query?: (field: string, value: string) => Iterable<Arborist.Node> };
+      inventory?: { query: (field: string, value: string) => Iterable<Arborist.Node> };
     }
   ).inventory;
-  const inventoryQuery = inventory?.query;
 
-  if (inventory && inventoryQuery) {
+  if (inventory) {
     const nodes = [...inventory.query("name", dependencyName)];
     if (nodes.length > 0) {
       nodes.sort((left, right) => {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -538,7 +538,7 @@ function uniqueBlockingDependencies(
   );
 }
 
-export function requirementPinsToVulnerableRange(
+function requirementPinsToVulnerableRange(
   requirement: string,
   affectedRangeUnion: string
 ): boolean {

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -273,6 +273,9 @@ export async function findVulnerableDependencies(
     const fixedNodeVersions = fixedDependencyNodes
       .map((node) => node.version)
       .filter((version): version is string => typeof version === "string");
+    const fixedNodeVersionsAtVulnLocations = vulnLocations
+      .map((loc) => resolveNodeFromLocation(fixTree, loc)?.version)
+      .filter((version): version is string => typeof version === "string");
     const remainingVulnerableTargets = fixedNodeVersions.filter(
       (targetVersion) =>
         versionInAffectedRanges(
@@ -286,9 +289,12 @@ export async function findVulnerableDependencies(
     }
 
     // Prefer reporting a remaining vulnerable version when one exists;
-    // otherwise report the first resolved version from the fix tree, if any.
+    // otherwise report a safe version at original vulnerable locations when
+    // available, then fall back to any resolved version from the fix tree.
     response.target_version =
-      remainingVulnerableTargets[0] ?? fixedNodeVersions[0];
+      remainingVulnerableTargets[0] ??
+      fixedNodeVersionsAtVulnLocations[0] ??
+      fixedNodeVersions[0];
 
     for (const update of response.fix_updates) {
       update.target_version = resolveNodeFromLocation(
@@ -662,11 +668,13 @@ function findDependencyNodesInTree(
 
   if (inventory && inventoryQuery) {
     const nodes = [...inventory.query("name", dependencyName)];
-    nodes.sort((left, right) => {
-      if (left.depth !== right.depth) return left.depth - right.depth;
-      return left.location.localeCompare(right.location);
-    });
-    return nodes;
+    if (nodes.length > 0) {
+      nodes.sort((left, right) => {
+        if (left.depth !== right.depth) return left.depth - right.depth;
+        return left.location.localeCompare(right.location);
+      });
+      return nodes;
+    }
   }
 
   // Fallback for mocked trees in tests that don't expose Arborist inventory.

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -33,6 +33,7 @@ import { exec as execCb } from "child_process";
 import fs from "fs";
 import path from "path";
 import ini from "ini";
+import semver from "semver";
 
 const exec = promisify(execCb);
 
@@ -158,15 +159,28 @@ export async function findVulnerableDependencies(
     );
     const version = vulnNodesHighestLevelFirst[0].version;
     const fixAvailable = vuln.fixAvailable;
+    const rawBlockingDependencies = extractBlockingDependencies(vuln, name);
+    const blockingDependencies = filterBlockingDependenciesByAffectedRanges(
+      rawBlockingDependencies,
+      advisories
+    );
 
     response.current_version = version;
     response.fix_available = !!fixAvailable;
 
     if (!fixAvailable) {
-      // Surface the parent package(s) that pull in the vulnerable version so the
-      // Ruby side can explain exactly what is blocking the update.
-      response.blocking_dependencies = extractBlockingDependencies(vuln, name);
-      return response;
+      // If npm reports no fix, but every reported parent range still allows a
+      // non-vulnerable version for the advisory ranges, continue and compute a
+      // concrete fix tree instead of failing fast on a false blocker signal.
+      if (
+        rawBlockingDependencies.length === 0 ||
+        blockingDependencies.length > 0
+      ) {
+        response.blocking_dependencies = blockingDependencies;
+        return response;
+      }
+
+      response.fix_available = true;
     }
 
     const chains = buildDependencyChains(auditReport, name);
@@ -175,9 +189,14 @@ export async function findVulnerableDependencies(
     // all dependency chains originating from it must be fixable.
     const unfixableChains = chains.filter((chain) => !chain.fixAvailable);
     if (unfixableChains.length > 0) {
-      response.fix_available = false;
-      response.blocking_dependencies = extractBlockingDependencies(vuln, name);
-      return response;
+      if (
+        rawBlockingDependencies.length === 0 ||
+        blockingDependencies.length > 0
+      ) {
+        response.fix_available = false;
+        response.blocking_dependencies = blockingDependencies;
+        return response;
+      }
     }
 
     const groupedFixUpdateChains = groupBy(
@@ -418,6 +437,42 @@ function extractBlockingDependencies(
       a.requirement.localeCompare(b.requirement) ||
       a.top_level_ancestor.localeCompare(b.top_level_ancestor)
   );
+}
+
+function filterBlockingDependenciesByAffectedRanges(
+  blockers: BlockingDependency[],
+  advisories: Advisory[]
+): BlockingDependency[] {
+  const affectedRanges = advisories.flatMap((advisory) =>
+    advisory.affected_versions
+  );
+  if (affectedRanges.length === 0) {
+    return blockers;
+  }
+
+  const affectedRangeUnion = affectedRanges.join(" || ");
+
+  return blockers.filter((blocker) =>
+    requirementPinsToVulnerableRange(
+      blocker.requirement,
+      affectedRangeUnion
+    )
+  );
+}
+
+export function requirementPinsToVulnerableRange(
+  requirement: string,
+  affectedRangeUnion: string
+): boolean {
+  try {
+    return semver.subset(requirement, affectedRangeUnion, {
+      includePrerelease: true,
+      loose: true,
+    });
+  } catch {
+    // Keep unknown range syntaxes as blockers to avoid false negatives.
+    return true;
+  }
 }
 
 /* Walk up the dependency graph from the given edge to find the name(s) of the

--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -251,10 +251,10 @@ export async function findVulnerableDependencies(
       fix: true,
     });
 
-    // Determine the target version by checking the fix tree at each location
-    // where the dependency was originally vulnerable. Sort by depth (shallowest
-    // first) with lexical tie-breaking for deterministic results regardless of
-    // vuln.nodes iteration order.
+    // Determine target and vulnerability status from all matching dependency
+    // nodes present in the fix tree. This avoids false positives where the
+    // vulnerable dependency is re-laid out under a new path after applying
+    // fixes and no longer appears at its original locations.
     const vulnLocations = [...vuln.nodes]
       .filter((node) => node.name === name)
       .map((n) => n.location)
@@ -265,10 +265,15 @@ export async function findVulnerableDependencies(
         return left.localeCompare(right);
       });
 
-    const fixedNodeVersionsAtVulnLocations = vulnLocations
-      .map((loc) => resolveNodeFromLocation(fixTree, loc)?.version)
+    const fixedDependencyNodes = findDependencyNodesInTree(
+      fixTree,
+      name,
+      vulnLocations
+    );
+    const fixedNodeVersions = fixedDependencyNodes
+      .map((node) => node.version)
       .filter((version): version is string => typeof version === "string");
-    const remainingVulnerableTargets = fixedNodeVersionsAtVulnLocations.filter(
+    const remainingVulnerableTargets = fixedNodeVersions.filter(
       (targetVersion) =>
         versionInAffectedRanges(
           targetVersion,
@@ -280,12 +285,10 @@ export async function findVulnerableDependencies(
       response.fix_available = false;
     }
 
-    // If any originally vulnerable location still exists after applying the
-    // fix tree, report that version so the Ruby side can detect the dependency
-    // is still vulnerable. Only fall back to the root-level child when none of
-    // the vulnerable locations remain (i.e. the fix removed them).
+    // Prefer reporting a remaining vulnerable version when one exists;
+    // otherwise report the first resolved version from the fix tree, if any.
     response.target_version =
-      remainingVulnerableTargets[0] ?? fixTree.children.get(name)?.version;
+      remainingVulnerableTargets[0] ?? fixedNodeVersions[0];
 
     for (const update of response.fix_updates) {
       update.target_version = resolveNodeFromLocation(
@@ -643,6 +646,64 @@ function containsUnsupportedRubyRangeSyntax(range: string): boolean {
 
 function normalizeRangeExpression(range: string): string {
   return range.replace(/\s*,\s*/g, " ").trim();
+}
+
+function findDependencyNodesInTree(
+  tree: Arborist.Node,
+  dependencyName: string,
+  originalVulnLocations: string[]
+): Arborist.Node[] {
+  const inventory = (
+    tree as Arborist.Node & {
+      inventory?: { query?: (field: string, value: string) => Iterable<Arborist.Node> };
+    }
+  ).inventory;
+  const inventoryQuery = inventory?.query;
+
+  if (inventory && inventoryQuery) {
+    const nodes = [...inventory.query("name", dependencyName)];
+    nodes.sort((left, right) => {
+      if (left.depth !== right.depth) return left.depth - right.depth;
+      return left.location.localeCompare(right.location);
+    });
+    return nodes;
+  }
+
+  // Fallback for mocked trees in tests that don't expose Arborist inventory.
+  const fallbackNodes = originalVulnLocations
+    .map((loc) => resolveNodeFromLocation(tree, loc))
+    .filter((node): node is Arborist.Node => !!node && "name" in node)
+    .filter((node) => node.name === dependencyName);
+
+  if (fallbackNodes.length > 0) {
+    return fallbackNodes;
+  }
+
+  const rootChild = tree.children.get(dependencyName);
+  if (!rootChild) {
+    return [];
+  }
+
+  if (
+    "name" in rootChild &&
+    "version" in rootChild &&
+    rootChild.name === dependencyName
+  ) {
+    return [rootChild as Arborist.Node];
+  }
+
+  if ("version" in rootChild && typeof rootChild.version === "string") {
+    return [
+      {
+        name: dependencyName,
+        version: rootChild.version,
+        depth: 0,
+        location: `node_modules/${dependencyName}`,
+      } as Arborist.Node,
+    ];
+  }
+
+  return [];
 }
 
 /* Walk up the dependency graph from the given edge to find the name(s) of the

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -409,7 +409,7 @@ describe("findVulnerableDependencies", () => {
 
     const vulnNode = {
       name: dependencyName,
-      version: "2.0.0",
+      version: "2.1.0",
       depth: 1,
       location: `node_modules/${dependencyName}`,
       edgesIn: [],
@@ -423,11 +423,11 @@ describe("findVulnerableDependencies", () => {
       tree: {
         isProjectRoot: true,
         edgesOut: new Map(),
-        children: new Map([[dependencyName, { version: "2.0.0" }]]),
+        children: new Map([[dependencyName, { version: "2.1.0" }]]),
       },
     };
     const fixTree = {
-      children: new Map([[dependencyName, { version: "2.0.0" }]]),
+      children: new Map([[dependencyName, { version: "2.1.0" }]]),
       resolve: () => null,
     };
 
@@ -440,7 +440,7 @@ describe("findVulnerableDependencies", () => {
     const actual = await findVulnerableDependencies(tempDir, advisories);
 
     expect(actual.fix_available).toBe(false);
-    expect(actual.target_version).toBe("2.0.0");
+    expect(actual.target_version).toBe("2.1.0");
   });
 });
 
@@ -466,6 +466,12 @@ describe("requirementPinsToVulnerableRange", () => {
   it("returns true when the parent range is fully vulnerable", () => {
     expect(
       requirementPinsToVulnerableRange(">=5.0.0 <5.0.6", ">=5.0.0 <5.0.6")
+    ).toBe(true);
+  });
+
+  it("treats invalid advisory union arms as blocking", () => {
+    expect(
+      requirementPinsToVulnerableRange("^2.1.0", ">= 5, < 6 || != 2.0.0")
     ).toBe(true);
   });
 });

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -735,4 +735,10 @@ describe("requirementPinsToVulnerableRange", () => {
       requirementPinsToVulnerableRange("1.0.1", "> 1.0")
     ).toBe(true);
   });
+
+  it("treats wildcard advisory ranges as fully vulnerable", () => {
+    expect(
+      requirementPinsToVulnerableRange("1.0.0", "*")
+    ).toBe(true);
+  });
 });

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -328,7 +328,7 @@ describe("findVulnerableDependencies", () => {
     const advisories = [
       {
         dependency_name: dependencyName,
-        affected_versions: [">= 2.0.0, < 2.0.2"],
+        affected_versions: ["< 5.0.6"],
       },
     ];
 
@@ -345,12 +345,28 @@ describe("findVulnerableDependencies", () => {
       isProjectRoot: false,
       edgesIn: [{ from: projectRootNode, to: topLevelNode }],
     };
+    const parentNodeLegacy = {
+      name: "@dependabot-fixtures/npm-parent-legacy",
+      version: "3.1.5",
+      isProjectRoot: false,
+      edgesIn: [{ from: projectRootNode, to: topLevelNode }],
+    };
+    const parentNodeV2 = {
+      name: "@dependabot-fixtures/npm-parent-v2",
+      version: "9.0.9",
+      isProjectRoot: false,
+      edgesIn: [{ from: projectRootNode, to: topLevelNode }],
+    };
     const vulnNode = {
       name: dependencyName,
-      version: "2.0.0",
+      version: "5.0.5",
       depth: 1,
       location: `node_modules/${dependencyName}`,
-      edgesIn: [{ from: parentNode, spec: "^2.0.0" }],
+      edgesIn: [
+        { from: parentNode, spec: "^5.0.2" },
+        { from: parentNodeLegacy, spec: "^1.1.7" },
+        { from: parentNodeV2, spec: "^2.0.2" },
+      ],
     };
     const auditReport = {
       has: (name: string) => name === dependencyName,
@@ -361,7 +377,7 @@ describe("findVulnerableDependencies", () => {
       tree: projectRootNode,
     };
     const fixTree = {
-      children: new Map([[dependencyName, { version: "2.0.2" }]]),
+      children: new Map([[dependencyName, { version: "5.0.6" }]]),
       resolve: () => null,
     };
 
@@ -374,7 +390,7 @@ describe("findVulnerableDependencies", () => {
     const actual = await findVulnerableDependencies(tempDir, advisories);
 
     expect(actual.fix_available).toBe(true);
-    expect(actual.target_version).toBe("2.0.2");
+    expect(actual.target_version).toBe("5.0.6");
     expect(actual.blocking_dependencies).toBeUndefined();
     expect(auditSpy).toHaveBeenCalledWith();
     expect(auditSpy).toHaveBeenCalledWith({ fix: true });

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -575,6 +575,69 @@ describe("findVulnerableDependencies", () => {
     expect(actual.fix_available).toBe(false);
     expect(actual.target_version).toBe("2.0.1");
   });
+
+  it("falls back to original locations for target_version when inventory lookup is empty", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: [">= 2.0.0, < 2.0.2"],
+      },
+    ];
+
+    const originalVulnLocation = `node_modules/${dependencyName}`;
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "2.0.0",
+      depth: 1,
+      location: originalVulnLocation,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map(),
+      },
+    };
+
+    const fixedNodeAtOriginalLocation = {
+      name: dependencyName,
+      version: "2.0.2",
+      depth: 1,
+      location: originalVulnLocation,
+    };
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: () => [],
+      },
+      resolve: (target: string) => {
+        if (target === dependencyName) {
+          return fixedNodeAtOriginalLocation;
+        }
+        return null;
+      },
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(true);
+    expect(actual.target_version).toBe("2.0.2");
+  });
 });
 
 describe("requirementPinsToVulnerableRange", () => {

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -319,6 +319,12 @@ describe("findVulnerableDependencies", () => {
 });
 
 describe("requirementPinsToVulnerableRange", () => {
+  it("supports Ruby-style comma range syntax", () => {
+    expect(
+      requirementPinsToVulnerableRange("^5.0.2", ">= 5.0.0, < 5.0.6")
+    ).toBe(false);
+  });
+
   it("returns false when the parent range allows fixed versions", () => {
     expect(
       requirementPinsToVulnerableRange("^5.0.2", ">=5.0.0 <5.0.6")

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -569,7 +569,7 @@ describe("findVulnerableDependencies", () => {
 
     const actual = await findVulnerableDependencies(tempDir, advisories);
 
-    expect(actual.fix_available).toBe(false);
+    expect(actual.fix_available).toBe(true);
     expect(actual.target_version).toBe("2.0.1");
   });
 
@@ -832,6 +832,132 @@ describe("findVulnerableDependencies", () => {
 
     expect(actual.fix_available).toBe(true);
     expect(actual.target_version).toBe("1.0.1");
+  });
+
+  it("treats partial Ruby = comparators as indeterminate in post-fix validation", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: ["= 1.0"],
+      },
+    ];
+
+    const originalVulnLocation = `node_modules/${dependencyName}`;
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "1.0.1",
+      depth: 1,
+      location: originalVulnLocation,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map(),
+      },
+    };
+
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: () => [
+          {
+            name: dependencyName,
+            version: "1.0.1",
+            depth: 1,
+            location: originalVulnLocation,
+          },
+        ],
+      },
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(true);
+    expect(actual.target_version).toBe("1.0.1");
+  });
+
+  it("marks fix unavailable when multiple copies include indeterminate advisory results", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: ["~> 2.0"],
+      },
+    ];
+
+    const originalVulnLocation = `node_modules/${dependencyName}`;
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "2.0.0",
+      depth: 1,
+      location: originalVulnLocation,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map(),
+      },
+    };
+
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: () => [
+          {
+            name: dependencyName,
+            version: "2.0.0",
+            depth: 1,
+            location: originalVulnLocation,
+            isProjectRoot: false,
+          },
+          {
+            name: dependencyName,
+            version: "2.1.0",
+            depth: 2,
+            location: `node_modules/relocated/node_modules/${dependencyName}`,
+            isProjectRoot: false,
+          },
+        ],
+      },
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(false);
+    expect(actual.target_version).toBe("2.0.0");
   });
 
   it("ignores project root entries from fix tree inventory", async () => {

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -2,10 +2,7 @@ import path from "path";
 import os from "os";
 import fs from "fs";
 import Arborist from "@npmcli/arborist";
-import {
-  findVulnerableDependencies,
-  requirementPinsToVulnerableRange,
-} from "../../lib/npm/vulnerability-auditor.js";
+import { findVulnerableDependencies } from "../../lib/npm/vulnerability-auditor.js";
 import * as helpers from "./helpers.js";
 
 describe("findVulnerableDependencies", () => {
@@ -907,53 +904,5 @@ describe("findVulnerableDependencies", () => {
 
     expect(actual.fix_available).toBe(true);
     expect(actual.target_version).toBe("2.0.2");
-  });
-});
-
-describe("requirementPinsToVulnerableRange", () => {
-  it("supports Ruby-style comma range syntax", () => {
-    expect(
-      requirementPinsToVulnerableRange("^5.0.2", ">= 5.0.0, < 5.0.6")
-    ).toBe(false);
-  });
-
-  it("returns false when the parent range allows fixed versions", () => {
-    expect(
-      requirementPinsToVulnerableRange("^5.0.2", ">=5.0.0 <5.0.6")
-    ).toBe(false);
-  });
-
-  it("returns false for unrelated major ranges", () => {
-    expect(
-      requirementPinsToVulnerableRange("^1.1.7", ">=5.0.0 <5.0.6")
-    ).toBe(false);
-  });
-
-  it("returns true when the parent range is fully vulnerable", () => {
-    expect(
-      requirementPinsToVulnerableRange(">=5.0.0 <5.0.6", ">=5.0.0 <5.0.6")
-    ).toBe(true);
-  });
-
-  it("treats invalid advisory union arms as blocking", () => {
-    expect(
-      requirementPinsToVulnerableRange("^2.1.0", ">= 5, < 6 || != 2.0.0")
-    ).toBe(true);
-  });
-
-  it("treats partial Ruby comparator advisories as blocking", () => {
-    expect(
-      requirementPinsToVulnerableRange("1.0.1", "> 1.0")
-    ).toBe(true);
-
-    expect(
-      requirementPinsToVulnerableRange("1.0.1", "<= 1.0")
-    ).toBe(true);
-  });
-
-  it("treats wildcard advisory ranges as fully vulnerable", () => {
-    expect(
-      requirementPinsToVulnerableRange("1.0.0", "*")
-    ).toBe(true);
   });
 });

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -1,7 +1,10 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
-import { findVulnerableDependencies } from "../../lib/npm/vulnerability-auditor.js";
+import {
+  findVulnerableDependencies,
+  requirementPinsToVulnerableRange,
+} from "../../lib/npm/vulnerability-auditor.js";
 import * as helpers from "./helpers.js";
 
 describe("findVulnerableDependencies", () => {
@@ -312,5 +315,25 @@ describe("findVulnerableDependencies", () => {
         },
       ])
     );
+  });
+});
+
+describe("requirementPinsToVulnerableRange", () => {
+  it("returns false when the parent range allows fixed versions", () => {
+    expect(
+      requirementPinsToVulnerableRange("^5.0.2", ">=5.0.0 <5.0.6")
+    ).toBe(false);
+  });
+
+  it("returns false for unrelated major ranges", () => {
+    expect(
+      requirementPinsToVulnerableRange("^1.1.7", ">=5.0.0 <5.0.6")
+    ).toBe(false);
+  });
+
+  it("returns true when the parent range is fully vulnerable", () => {
+    expect(
+      requirementPinsToVulnerableRange(">=5.0.0 <5.0.6", ">=5.0.0 <5.0.6")
+    ).toBe(true);
   });
 });

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -361,8 +361,8 @@ describe("findVulnerableDependencies", () => {
       location: `node_modules/${dependencyName}`,
       edgesIn: [
         { from: parentNode, spec: "^5.0.2" },
-        { from: parentNodeLegacy, spec: "^1.1.7" },
-        { from: parentNodeV2, spec: "^2.0.2" },
+        { from: parentNodeLegacy, spec: "^6.0.0" },
+        { from: parentNodeV2, spec: "^8.0.0" },
       ],
     };
     const auditReport = {
@@ -391,6 +391,69 @@ describe("findVulnerableDependencies", () => {
     expect(actual.blocking_dependencies).toBeUndefined();
     expect(auditSpy).toHaveBeenCalledWith();
     expect(auditSpy).toHaveBeenCalledWith({ fix: true });
+  });
+
+  it("retains blockers even when the current lockfile node mismatches blocker range", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: ["< 5.0.6"],
+      },
+    ];
+
+    const topLevelNode = { name: "app" };
+    const projectRootNode = {
+      isProjectRoot: true,
+      edgesOut: new Map(),
+      children: new Map([[dependencyName, { version: "5.0.5" }]]),
+      resolve: () => null,
+    };
+    const staleParentNode = {
+      name: "@dependabot-fixtures/npm-parent-legacy",
+      version: "3.1.5",
+      isProjectRoot: false,
+      edgesIn: [{ from: projectRootNode, to: topLevelNode }],
+    };
+    const vulnNode = {
+      name: dependencyName,
+      version: "5.0.5",
+      depth: 1,
+      location: `node_modules/${dependencyName}`,
+      edgesIn: [{ from: staleParentNode, spec: "^1.1.7" }],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [vulnNode],
+        fixAvailable: false,
+      }),
+      tree: projectRootNode,
+    };
+
+    const auditSpy = jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) => {
+        if (opts?.fix) {
+          throw new Error("fix audit should not run when blocker remains");
+        }
+        return Promise.resolve(auditReport as never);
+      });
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(false);
+    expect(actual.blocking_dependencies).toEqual([
+      {
+        name: "@dependabot-fixtures/npm-parent-legacy",
+        version: "3.1.5",
+        requirement: "^1.1.7",
+        top_level_ancestor: "app",
+      },
+    ]);
+    expect(auditSpy).toHaveBeenCalledWith();
   });
 
   it("treats unsupported advisory expressions as indeterminate in post-fix validation", async () => {
@@ -842,6 +905,65 @@ describe("findVulnerableDependencies", () => {
       {
         dependency_name: dependencyName,
         affected_versions: ["= 1.0"],
+      },
+    ];
+
+    const originalVulnLocation = `node_modules/${dependencyName}`;
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "1.0.1",
+      depth: 1,
+      location: originalVulnLocation,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map(),
+      },
+    };
+
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: () => [
+          {
+            name: dependencyName,
+            version: "1.0.1",
+            depth: 1,
+            location: originalVulnLocation,
+          },
+        ],
+      },
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(true);
+    expect(actual.target_version).toBe("1.0.1");
+  });
+
+  it("treats bare partial advisory versions as indeterminate in post-fix validation", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: ["1.0"],
       },
     ];
 

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -442,6 +442,76 @@ describe("findVulnerableDependencies", () => {
     expect(actual.fix_available).toBe(false);
     expect(actual.target_version).toBe("2.1.0");
   });
+
+  it("retains blockers that apply to non-shallow vulnerable versions", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: [">= 5.0.0, < 6.0.0"],
+      },
+    ];
+
+    const topLevelNode = { name: "app" };
+    const projectRootNode = {
+      isProjectRoot: true,
+      edgesOut: new Map(),
+      children: new Map([[dependencyName, { version: "5.0.1" }]]),
+      resolve: () => null,
+    };
+    const parentNode = {
+      name: "minimatch",
+      version: "10.2.4",
+      isProjectRoot: false,
+      edgesIn: [{ from: projectRootNode, to: topLevelNode }],
+    };
+    const shallowVulnNode = {
+      name: dependencyName,
+      version: "5.0.1",
+      depth: 1,
+      location: `node_modules/${dependencyName}`,
+      edgesIn: [],
+    };
+    const deepVulnNode = {
+      name: dependencyName,
+      version: "5.0.5",
+      depth: 2,
+      location: `node_modules/minimatch/node_modules/${dependencyName}`,
+      edgesIn: [{ from: parentNode, spec: "^5.0.2" }],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [shallowVulnNode, deepVulnNode],
+        fixAvailable: false,
+      }),
+      tree: projectRootNode,
+    };
+
+    const auditSpy = jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) => {
+        if (opts?.fix) {
+          throw new Error("fix audit should not run when blockers remain");
+        }
+        return Promise.resolve(auditReport as never);
+      });
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(false);
+    expect(actual.blocking_dependencies).toEqual([
+      {
+        name: "minimatch",
+        version: "10.2.4",
+        requirement: "^5.0.2",
+        top_level_ancestor: "app",
+      },
+    ]);
+    expect(auditSpy).toHaveBeenCalledWith();
+  });
 });
 
 describe("requirementPinsToVulnerableRange", () => {

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -956,7 +956,7 @@ describe("findVulnerableDependencies", () => {
     expect(actual.target_version).toBe("1.0.1");
   });
 
-  it("treats bare partial advisory versions as indeterminate in post-fix validation", async () => {
+  it("evaluates bare partial advisory versions with node-semver semantics", async () => {
     helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
 
     const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
@@ -1013,6 +1013,136 @@ describe("findVulnerableDependencies", () => {
 
     expect(actual.fix_available).toBe(true);
     expect(actual.target_version).toBe("1.0.1");
+  });
+
+  it("excludes safe-version exceptions when classifying blocker ranges", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: ["< 2.0.2"],
+        safe_versions: ["2.0.1"],
+      },
+    ];
+
+    const topLevelNode = { name: "app" };
+    const projectRootNode = {
+      isProjectRoot: true,
+      edgesOut: new Map(),
+      children: new Map([[dependencyName, { version: "2.0.0" }]]),
+      resolve: () => null,
+    };
+    const parentNode = {
+      name: "safe-range-parent",
+      version: "1.0.0",
+      isProjectRoot: false,
+      edgesIn: [{ from: projectRootNode, to: topLevelNode }],
+    };
+    const vulnNode = {
+      name: dependencyName,
+      version: "2.0.0",
+      depth: 1,
+      location: `node_modules/${dependencyName}`,
+      edgesIn: [{ from: parentNode, spec: "2.0.1" }],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [vulnNode],
+        fixAvailable: false,
+      }),
+      tree: projectRootNode,
+    };
+    const fixTree = {
+      children: new Map([[dependencyName, { version: "2.0.1" }]]),
+      resolve: () => null,
+      inventory: {
+        query: () => [
+          {
+            name: dependencyName,
+            version: "2.0.1",
+            depth: 1,
+            location: `node_modules/${dependencyName}`,
+            isProjectRoot: false,
+          },
+        ],
+      },
+    };
+
+    const auditSpy = jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(true);
+    expect(actual.target_version).toBe("2.0.1");
+    expect(actual.blocking_dependencies).toBeUndefined();
+    expect(auditSpy).toHaveBeenCalledWith({ fix: true });
+  });
+
+  it("does not mark safe-version exceptions as vulnerable in post-fix validation", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: ["< 2.0.2"],
+        safe_versions: ["2.0.1"],
+      },
+    ];
+
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "2.0.0",
+      depth: 1,
+      location: `node_modules/${dependencyName}`,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map(),
+      },
+    };
+
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: () => [
+          {
+            name: dependencyName,
+            version: "2.0.1",
+            depth: 1,
+            location: `node_modules/${dependencyName}`,
+            isProjectRoot: false,
+          },
+        ],
+      },
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(true);
+    expect(actual.target_version).toBe("2.0.1");
   });
 
   it("marks fix unavailable when multiple copies include indeterminate advisory results", async () => {

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -576,6 +576,86 @@ describe("findVulnerableDependencies", () => {
     expect(actual.target_version).toBe("2.0.1");
   });
 
+  it("preserves blocking dependencies when fix tree still resolves to a vulnerable target", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: [">= 2.0.0, < 2.0.2"],
+      },
+    ];
+
+    const topLevelNode = { name: "app" };
+    const projectRootNode = {
+      isProjectRoot: true,
+      edgesOut: new Map(),
+      children: new Map(),
+    };
+    const blockerParentNode = {
+      name: "blocker-parent",
+      version: "1.0.0",
+      isProjectRoot: false,
+      edgesIn: [{ from: projectRootNode, to: topLevelNode }],
+    };
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "2.0.0",
+      depth: 1,
+      location: `node_modules/${dependencyName}`,
+      edgesIn: [{ from: blockerParentNode, spec: "2.0.0" }],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: projectRootNode,
+    };
+
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: (field: string, value: string) => {
+          if (field === "name" && value === dependencyName) {
+            return [
+              {
+                name: dependencyName,
+                version: "2.0.1",
+                depth: 2,
+                location: `node_modules/relocated/node_modules/${dependencyName}`,
+                isProjectRoot: false,
+              },
+            ];
+          }
+          return [];
+        },
+      },
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(false);
+    expect(actual.target_version).toBe("2.0.1");
+    expect(actual.blocking_dependencies).toEqual([
+      {
+        name: "blocker-parent",
+        version: "1.0.0",
+        requirement: "2.0.0",
+        top_level_ancestor: "app",
+      },
+    ]);
+  });
+
   it("falls back to original locations for target_version when inventory lookup is empty", async () => {
     helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
 

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -698,6 +698,65 @@ describe("findVulnerableDependencies", () => {
     expect(actual.target_version).toBe("1.0.1");
   });
 
+  it("treats partial Ruby <= comparators as vulnerable in post-fix validation", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: ["<= 1.0"],
+      },
+    ];
+
+    const originalVulnLocation = `node_modules/${dependencyName}`;
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "1.0.1",
+      depth: 1,
+      location: originalVulnLocation,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map(),
+      },
+    };
+
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: () => [
+          {
+            name: dependencyName,
+            version: "1.0.1",
+            depth: 1,
+            location: originalVulnLocation,
+          },
+        ],
+      },
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(false);
+    expect(actual.target_version).toBe("1.0.1");
+  });
+
   it("ignores project root entries from fix tree inventory", async () => {
     helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
 
@@ -805,6 +864,10 @@ describe("requirementPinsToVulnerableRange", () => {
   it("treats partial Ruby comparator advisories as blocking", () => {
     expect(
       requirementPinsToVulnerableRange("1.0.1", "> 1.0")
+    ).toBe(true);
+
+    expect(
+      requirementPinsToVulnerableRange("1.0.1", "<= 1.0")
     ).toBe(true);
   });
 

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -638,6 +638,65 @@ describe("findVulnerableDependencies", () => {
     expect(actual.fix_available).toBe(true);
     expect(actual.target_version).toBe("2.0.2");
   });
+
+  it("treats partial Ruby comparators as vulnerable in post-fix validation", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: ["> 1.0"],
+      },
+    ];
+
+    const originalVulnLocation = `node_modules/${dependencyName}`;
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "1.0.1",
+      depth: 1,
+      location: originalVulnLocation,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map(),
+      },
+    };
+
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: () => [
+          {
+            name: dependencyName,
+            version: "1.0.1",
+            depth: 1,
+            location: originalVulnLocation,
+          },
+        ],
+      },
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(false);
+    expect(actual.target_version).toBe("1.0.1");
+  });
 });
 
 describe("requirementPinsToVulnerableRange", () => {
@@ -668,6 +727,12 @@ describe("requirementPinsToVulnerableRange", () => {
   it("treats invalid advisory union arms as blocking", () => {
     expect(
       requirementPinsToVulnerableRange("^2.1.0", ">= 5, < 6 || != 2.0.0")
+    ).toBe(true);
+  });
+
+  it("treats partial Ruby comparator advisories as blocking", () => {
+    expect(
+      requirementPinsToVulnerableRange("1.0.1", "> 1.0")
     ).toBe(true);
   });
 });

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -697,6 +697,78 @@ describe("findVulnerableDependencies", () => {
     expect(actual.fix_available).toBe(false);
     expect(actual.target_version).toBe("1.0.1");
   });
+
+  it("ignores project root entries from fix tree inventory", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: [">= 2.0.0, < 2.0.2"],
+      },
+    ];
+
+    const originalVulnLocation = `node_modules/${dependencyName}`;
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "2.0.0",
+      depth: 1,
+      location: originalVulnLocation,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map(),
+      },
+    };
+
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: (field: string, value: string) => {
+          if (field === "name" && value === dependencyName) {
+            return [
+              {
+                name: dependencyName,
+                version: "2.0.0",
+                depth: 0,
+                location: "",
+                isProjectRoot: true,
+              },
+              {
+                name: dependencyName,
+                version: "2.0.2",
+                depth: 1,
+                location: originalVulnLocation,
+                isProjectRoot: false,
+              },
+            ];
+          }
+          return [];
+        },
+      },
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(true);
+    expect(actual.target_version).toBe("2.0.2");
+  });
 });
 
 describe("requirementPinsToVulnerableRange", () => {

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -512,6 +512,69 @@ describe("findVulnerableDependencies", () => {
     ]);
     expect(auditSpy).toHaveBeenCalledWith();
   });
+
+  it("detects vulnerable dependency that remains at a new location after fix", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: [">= 2.0.0, < 2.0.2"],
+      },
+    ];
+
+    const originalVulnNode = {
+      name: dependencyName,
+      version: "2.0.0",
+      depth: 1,
+      location: `node_modules/${dependencyName}`,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [originalVulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map(),
+      },
+    };
+
+    const relocatedVulnNode = {
+      name: dependencyName,
+      version: "2.0.1",
+      depth: 2,
+      location: `node_modules/relocated/node_modules/${dependencyName}`,
+      edgesIn: [],
+    };
+    const fixTree = {
+      children: new Map(),
+      inventory: {
+        query: (field: string, value: string) => {
+          if (field === "name" && value === dependencyName) {
+            return [relocatedVulnNode];
+          }
+          return [];
+        },
+      },
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(false);
+    expect(actual.target_version).toBe("2.0.1");
+  });
 });
 
 describe("requirementPinsToVulnerableRange", () => {

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import os from "os";
 import fs from "fs";
+import Arborist from "@npmcli/arborist";
 import {
   findVulnerableDependencies,
   requirementPinsToVulnerableRange,
@@ -12,7 +13,10 @@ describe("findVulnerableDependencies", () => {
   beforeEach(() => {
     tempDir = fs.mkdtempSync(os.tmpdir() + path.sep);
   });
-  afterEach(() => fs.rm(tempDir, { recursive: true }, () => {}));
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fs.rm(tempDir, { recursive: true }, () => {});
+  });
 
   it("finds vulnerable dependencies", async () => {
     helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
@@ -315,6 +319,63 @@ describe("findVulnerableDependencies", () => {
         },
       ])
     );
+  });
+
+  it("continues to compute fix tree when non-pinning blockers are filtered out", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: [">= 2.0.0, < 2.0.2"],
+      },
+    ];
+
+    const topLevelNode = { name: "app" };
+    const projectRootNode = {
+      isProjectRoot: true,
+      edgesOut: new Map(),
+      children: new Map([[dependencyName, { version: "2.0.2" }]]),
+      resolve: () => null,
+    };
+    const parentNode = {
+      name: "@dependabot-fixtures/npm-parent-holder",
+      version: "1.0.0",
+      isProjectRoot: false,
+      edgesIn: [{ from: projectRootNode, to: topLevelNode }],
+    };
+    const vulnNode = {
+      name: dependencyName,
+      version: "2.0.0",
+      depth: 1,
+      location: `node_modules/${dependencyName}`,
+      edgesIn: [{ from: parentNode, spec: "^2.0.0" }],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [vulnNode],
+        fixAvailable: false,
+      }),
+      tree: projectRootNode,
+    };
+    const fixTree = {
+      children: new Map([[dependencyName, { version: "2.0.2" }]]),
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(true);
+    expect(actual.target_version).toBe("2.0.2");
+    expect(actual.blocking_dependencies).toBeUndefined();
   });
 });
 

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -365,7 +365,7 @@ describe("findVulnerableDependencies", () => {
       resolve: () => null,
     };
 
-    jest
+    const auditSpy = jest
       .spyOn(Arborist.prototype, "audit")
       .mockImplementation((opts?: { fix?: boolean }) =>
         Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
@@ -376,6 +376,55 @@ describe("findVulnerableDependencies", () => {
     expect(actual.fix_available).toBe(true);
     expect(actual.target_version).toBe("2.0.2");
     expect(actual.blocking_dependencies).toBeUndefined();
+    expect(auditSpy).toHaveBeenCalledWith();
+    expect(auditSpy).toHaveBeenCalledWith({ fix: true });
+  });
+
+  it("treats invalid advisory expressions as vulnerable in post-fix validation", async () => {
+    helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
+
+    const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
+    const advisories = [
+      {
+        dependency_name: dependencyName,
+        affected_versions: ["~> 2.0"],
+      },
+    ];
+
+    const vulnNode = {
+      name: dependencyName,
+      version: "2.0.0",
+      depth: 1,
+      location: `node_modules/${dependencyName}`,
+      edgesIn: [],
+    };
+    const auditReport = {
+      has: (name: string) => name === dependencyName,
+      get: () => ({
+        nodes: [vulnNode],
+        fixAvailable: true,
+      }),
+      tree: {
+        isProjectRoot: true,
+        edgesOut: new Map(),
+        children: new Map([[dependencyName, { version: "2.0.0" }]]),
+      },
+    };
+    const fixTree = {
+      children: new Map([[dependencyName, { version: "2.0.0" }]]),
+      resolve: () => null,
+    };
+
+    jest
+      .spyOn(Arborist.prototype, "audit")
+      .mockImplementation((opts?: { fix?: boolean }) =>
+        Promise.resolve((opts?.fix ? fixTree : auditReport) as never)
+      );
+
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.fix_available).toBe(false);
+    expect(actual.target_version).toBe("2.0.0");
   });
 });
 

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -393,7 +393,7 @@ describe("findVulnerableDependencies", () => {
     expect(auditSpy).toHaveBeenCalledWith({ fix: true });
   });
 
-  it("treats invalid advisory expressions as vulnerable in post-fix validation", async () => {
+  it("treats unsupported advisory expressions as indeterminate in post-fix validation", async () => {
     helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
 
     const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
@@ -436,7 +436,7 @@ describe("findVulnerableDependencies", () => {
 
     const actual = await findVulnerableDependencies(tempDir, advisories);
 
-    expect(actual.fix_available).toBe(false);
+    expect(actual.fix_available).toBe(true);
     expect(actual.target_version).toBe("2.1.0");
   });
 
@@ -716,7 +716,7 @@ describe("findVulnerableDependencies", () => {
     expect(actual.target_version).toBe("2.0.2");
   });
 
-  it("treats partial Ruby comparators as vulnerable in post-fix validation", async () => {
+  it("treats partial Ruby comparators as indeterminate in post-fix validation", async () => {
     helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
 
     const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
@@ -771,11 +771,11 @@ describe("findVulnerableDependencies", () => {
 
     const actual = await findVulnerableDependencies(tempDir, advisories);
 
-    expect(actual.fix_available).toBe(false);
+    expect(actual.fix_available).toBe(true);
     expect(actual.target_version).toBe("1.0.1");
   });
 
-  it("treats partial Ruby <= comparators as vulnerable in post-fix validation", async () => {
+  it("treats partial Ruby <= comparators as indeterminate in post-fix validation", async () => {
     helpers.copyDependencies("vulnerability-auditor/simple", tempDir);
 
     const dependencyName = "@dependabot-fixtures/npm-parent-dependency";
@@ -830,7 +830,7 @@ describe("findVulnerableDependencies", () => {
 
     const actual = await findVulnerableDependencies(tempDir, advisories);
 
-    expect(actual.fix_available).toBe(false);
+    expect(actual.fix_available).toBe(true);
     expect(actual.target_version).toBe("1.0.1");
   });
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -143,7 +143,8 @@ module Dependabot
           vuln_versions = security_advisories.map do |advisory|
             {
               dependency_name: advisory.dependency_name,
-              affected_versions: advisory.vulnerable_version_strings
+              affected_versions: advisory.vulnerable_version_strings.map(&:to_s),
+              safe_versions: advisory.safe_versions.map(&:to_s)
             }
           end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -2158,10 +2158,14 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           .to eq(
             "dependency_name" => "@dependabot-fixtures/npm-transitive-dependency",
             "explanation" =>
-              "@dependabot-fixtures/npm-transitive-dependency is a transitive dependency and no update path was found that " \
-              "resolves it to a non-vulnerable version. A fixed version of @dependabot-fixtures/npm-transitive-dependency is " \
-              "published, but the parent package(s) that depend on it in the lockfile require a vulnerable version, and " \
-              "Dependabot could not update those parent package(s) to a release that allows the fixed version without " \
+              "@dependabot-fixtures/npm-transitive-dependency is a transitive " \
+              "dependency and no update path was found that resolves it to a " \
+              "non-vulnerable version. A fixed version of " \
+              "@dependabot-fixtures/npm-transitive-dependency is published, but " \
+              "the parent package(s) that depend on it in the lockfile require " \
+              "a vulnerable version, and Dependabot could not update those " \
+              "parent package(s) to a release that allows the fixed version " \
+              "without " \
               "introducing a conflict. To resolve this, update the parent dependency that requires " \
               "@dependabot-fixtures/npm-transitive-dependency, or add an override/resolution pinning " \
               "@dependabot-fixtures/npm-transitive-dependency to a non-vulnerable version.",

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -2158,9 +2158,13 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           .to eq(
             "dependency_name" => "@dependabot-fixtures/npm-transitive-dependency",
             "explanation" =>
-              "A patched version exists for " \
-              "@dependabot-fixtures/npm-transitive-dependency, but the " \
-              "available update path still resolves it to 1.0.0",
+              "@dependabot-fixtures/npm-transitive-dependency is a transitive dependency and no update path was found that " \
+              "resolves it to a non-vulnerable version. A fixed version of @dependabot-fixtures/npm-transitive-dependency is " \
+              "published, but the parent package(s) that depend on it in the lockfile require a vulnerable version, and " \
+              "Dependabot could not update those parent package(s) to a release that allows the fixed version without " \
+              "introducing a conflict. To resolve this, update the parent dependency that requires " \
+              "@dependabot-fixtures/npm-transitive-dependency, or add an override/resolution pinning " \
+              "@dependabot-fixtures/npm-transitive-dependency to a non-vulnerable version.",
             "fix_available" => false,
             "fix_updates" => [],
             "top_level_ancestors" => []


### PR DESCRIPTION
### What are you trying to accomplish?

Fix a false-negative security update outcome in the npm vulnerability auditor where Dependabot can report a transitive dependency as "not fixable" even when the parent requirement allows a patched version.

In the reported case, `brace-expansion` advisories affecting `>=5.0.0 <5.0.6` were blocked by constraints like `^5.0.2` (which allows `5.0.6`) and by unrelated major ranges (for example `^1.1.7`), producing misleading conflict messaging.

### Anything you want to highlight for special attention from reviewers?

The key behavior change is in how blocking constraints are interpreted:

- We now treat a parent as a blocker only when its requirement is fully pinned inside the advisory's vulnerable range.
- If npm reports no fix but all reported blockers are non-blocking under the advisory range, we continue to compute the fix tree instead of failing fast.
- Unknown/unparseable range syntax remains conservative (still treated as blocking) to avoid false negatives.

### How will you know you've accomplished your goal?

Added targeted helper tests that exercise range/subset behavior and confirm the intended blocker classification:

- `^5.0.2` vs `>=5.0.0 <5.0.6` => not a blocker
- `^1.1.7` vs `>=5.0.0 <5.0.6` => not a blocker
- `>=5.0.0 <5.0.6` vs `>=5.0.0 <5.0.6` => blocker

Validation run:

- `cd npm_and_yarn/helpers && npm test -- test/npm/vulnerability-auditor.test.ts`
- Result: pass

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
