### PR TITLE
Type Service and ApiClient

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1104
+# Offense count: 1079
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -401,12 +401,9 @@ Sorbet/ForbidTUntyped:
     - "terraform/lib/dependabot/terraform/file_updater/provider_cli_config_builder.rb"
     - "terraform/lib/dependabot/terraform/package/package_details_fetcher.rb"
     - "terraform/lib/dependabot/terraform/update_checker.rb"
-    - "updater/lib/dependabot/api_client.rb"
     - "updater/lib/dependabot/dependency_attribution.rb"
     - "updater/lib/dependabot/file_fetcher_command.rb"
     - "updater/lib/dependabot/opentelemetry.rb"
-
-    - "updater/lib/dependabot/service.rb"
     - "updater/lib/dependabot/updater/dependency_group_change_batch.rb"
     - "updater/lib/dependabot/updater/error_handler.rb"
     - "updater/lib/dependabot/updater/group_dependency_selector.rb"

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -198,7 +198,7 @@ module Dependabot
       end
     end
 
-    sig { params(base_commit_sha: String).void }
+    sig { params(base_commit_sha: T.nilable(String)).void }
     def mark_job_as_processed(base_commit_sha)
       ::Dependabot::OpenTelemetry.tracer.in_span("mark_job_as_processed", kind: :internal) do |span|
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::BASE_COMMIT_SHA, base_commit_sha)
@@ -282,7 +282,7 @@ module Dependabot
       end
     end
 
-    sig { params(metric: String, tags: T::Hash[String, String]).void }
+    sig { params(metric: String, tags: T::Hash[Symbol, Object]).void }
     def increment_metric(metric, tags:)
       ::Dependabot::OpenTelemetry.tracer.in_span("increment_metric", kind: :internal) do |span|
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID.to_s, job_id.to_s)
@@ -389,7 +389,7 @@ module Dependabot
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
-    sig { params(package_manager: String).returns(T::Array[T::Hash[String, T.untyped]]) }
+    sig { params(package_manager: String).returns(T::Array[T::Hash[String, Object]]) }
     def fetch_blocked_versions(package_manager)
       ::Dependabot::OpenTelemetry.tracer.in_span("fetch_blocked_versions", kind: :internal) do |span|
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id.to_s)

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"
@@ -44,7 +44,7 @@ module Dependabot
 
         api_url = "#{api_path}/update_jobs/#{job_id}/create_pull_request"
         data = create_pull_request_data(dependency_change, base_commit_sha)
-        response = http_client.post(path: api_url, body: { data: data }.to_json)
+        response = post(path: api_url, body: { data: data }.to_json)
         if response.status >= 400 && dependency_file_not_supported_error?(response.body.to_s)
           raise Dependabot::DependencyFileNotSupported, response.body.to_s
         elsif response.status >= 400
@@ -77,7 +77,7 @@ module Dependabot
           "pr-title": dependency_change.pr_message.pr_name,
           "pr-body": dependency_change.pr_message.pr_message
         }
-        response = http_client.post(path: api_url, body: { data: data }.to_json)
+        response = post(path: api_url, body: { data: data }.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0
@@ -97,7 +97,7 @@ module Dependabot
 
         api_url = "#{api_path}/update_jobs/#{job_id}/close_pull_request"
         body = { data: { "dependency-names": dependency_names, reason: reason } }
-        response = http_client.post(path: api_url, body: body.to_json)
+        response = post(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0
@@ -124,7 +124,7 @@ module Dependabot
             "error-details": error_details
           }
         }
-        response = http_client.post(path: api_url, body: body.to_json)
+        response = post(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0
@@ -159,7 +159,7 @@ module Dependabot
             "warn-description": warn_description
           }
         }
-        response = http_client.post(path: api_url, body: body.to_json)
+        response = post(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0
@@ -188,7 +188,7 @@ module Dependabot
             "error-details": error_details
           }
         }
-        response = http_client.post(path: api_url, body: body.to_json)
+        response = post(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0
@@ -208,7 +208,7 @@ module Dependabot
 
         api_url = "#{api_path}/update_jobs/#{job_id}/mark_as_processed"
         body = { data: { "base-commit-sha": base_commit_sha } }
-        response = http_client.patch(path: api_url, body: body.to_json)
+        response = patch(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0
@@ -232,7 +232,7 @@ module Dependabot
             dependency_files: dependency_files
           }
         }
-        response = http_client.post(path: api_url, body: body.to_json)
+        response = post(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0
@@ -253,7 +253,7 @@ module Dependabot
         body = {
           data: dependency_submission
         }
-        response = http_client.post(path: api_url, body: body.to_json)
+        response = post(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0
@@ -272,7 +272,7 @@ module Dependabot
         body = {
           data: { ecosystem_versions: ecosystem_versions }
         }
-        response = http_client.post(path: api_url, body: body.to_json)
+        response = post(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
         retry_count ||= 0
@@ -300,7 +300,7 @@ module Dependabot
             tags: tags
           }
         }
-        response = http_client.post(path: api_url, body: body.to_json)
+        response = post(path: api_url, body: body.to_json)
         # We treat metrics as fire-and-forget, so just warn if they fail.
         Dependabot.logger.debug("Unable to report metric '#{metric}'.") if response.status >= 400
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError
@@ -327,7 +327,7 @@ module Dependabot
           ]
         }
 
-        response = http_client.post(path: api_url, body: body.to_json)
+        response = post(path: api_url, body: body.to_json)
         if response.status >= 400
           Dependabot.logger.error(
             "Failed to record ecosystem meta. Status: #{response.status}, body: #{response.body}"
@@ -369,7 +369,7 @@ module Dependabot
           retry_count = 0
 
           begin
-            response = http_client.post(path: api_url, body: body.to_json)
+            response = post(path: api_url, body: body.to_json)
             raise ApiError, response.body if response.status >= 400
           rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError, ApiError => e
             retry_count += 1
@@ -395,7 +395,7 @@ module Dependabot
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id.to_s)
 
         api_url = "#{api_path}/update_jobs/#{job_id}/blocked_versions"
-        response = http_client.get(path: api_url, query: { "package-manager": package_manager })
+        response = get(path: api_url, query: { "package-manager" => package_manager })
 
         if response.status >= 400
           Dependabot.logger.warn("Failed to fetch blocked versions (HTTP #{response.status}), continuing without them")
@@ -412,6 +412,21 @@ module Dependabot
     end
 
     private
+
+    sig { params(path: String, body: String).returns(Excon::Response) }
+    def post(path:, body:)
+      T.cast(http_client.post(path: path, body: body), Excon::Response)
+    end
+
+    sig { params(path: String, body: String).returns(Excon::Response) }
+    def patch(path:, body:)
+      T.cast(http_client.patch(path: path, body: body), Excon::Response)
+    end
+
+    sig { params(path: String, query: T::Hash[String, String]).returns(Excon::Response) }
+    def get(path:, query:)
+      T.cast(http_client.get(path: path, query: query), Excon::Response)
+    end
 
     sig { params(body: String).returns(T::Array[T::Hash[String, Object]]) }
     def parse_blocked_versions_response(body)
@@ -462,7 +477,8 @@ module Dependabot
 
     sig { returns(String) }
     def api_path
-      T.cast(http_client.params[:path], String)
+      params = T.cast(http_client.params, T::Hash[Symbol, Object])
+      T.cast(params[:path], String)
     end
 
     # Update return type to allow returning a Hash or nil
@@ -517,18 +533,22 @@ module Dependabot
         if ENV.key?("HTTPS_PROXY")
           ENV.fetch("HTTPS_PROXY")
         else
-          URI(base_url).find_proxy&.to_s
+          proxy_uri = T.cast(URI(base_url).find_proxy, T.nilable(URI::Generic))
+          proxy_uri&.to_s
         end
 
-      Excon.new(
-        base_url,
-        proxy: proxy,
-        **Dependabot::SharedHelpers.excon_defaults(
-          headers: {
-            "Authorization" => job_token,
-            "Content-Type" => "application/json"
-          }
-        )
+      T.cast(
+        Excon.new(
+          base_url,
+          proxy: proxy,
+          **Dependabot::SharedHelpers.excon_defaults(
+            headers: {
+              "Authorization" => job_token,
+              "Content-Type" => "application/json"
+            }
+          )
+        ),
+        Excon::Connection
       )
     end
 

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -22,6 +22,8 @@ module Dependabot
   class ApiClient # rubocop:disable Metrics/ClassLength
     extend T::Sig
 
+    ErrorDetails = T.type_alias { T::Hash[T.any(String, Symbol), T.anything] }
+
     MAX_REQUEST_RETRIES = 3
     INVALID_REQUEST_MSG = /The request contains invalid or unauthorized changes/
 
@@ -40,7 +42,7 @@ module Dependabot
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::BASE_COMMIT_SHA, base_commit_sha)
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::DEPENDENCY_NAMES, dependency_change.humanized)
 
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/create_pull_request"
+        api_url = "#{api_path}/update_jobs/#{job_id}/create_pull_request"
         data = create_pull_request_data(dependency_change, base_commit_sha)
         response = http_client.post(path: api_url, body: { data: data }.to_json)
         if response.status >= 400 && dependency_file_not_supported_error?(response.body.to_s)
@@ -66,7 +68,7 @@ module Dependabot
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::BASE_COMMIT_SHA, base_commit_sha)
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::DEPENDENCY_NAMES, dependency_change.humanized)
 
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/update_pull_request"
+        api_url = "#{api_path}/update_jobs/#{job_id}/update_pull_request"
         data = {
           "dependency-names": dependency_change.updated_dependencies.map(&:name),
           "updated-dependency-files": dependency_change.updated_dependency_files_hash,
@@ -93,7 +95,7 @@ module Dependabot
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id.to_s)
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::PR_CLOSE_REASON, reason.to_s)
 
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/close_pull_request"
+        api_url = "#{api_path}/update_jobs/#{job_id}/close_pull_request"
         body = { data: { "dependency-names": dependency_names, reason: reason } }
         response = http_client.post(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
@@ -107,7 +109,7 @@ module Dependabot
       end
     end
 
-    sig { params(error_type: T.any(String, Symbol), error_details: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+    sig { params(error_type: T.any(String, Symbol), error_details: T.nilable(ErrorDetails)).void }
     def record_update_job_error(error_type:, error_details:)
       ::Dependabot::OpenTelemetry.tracer.in_span("record_update_job_error", kind: :internal) do |_span|
         ::Dependabot::OpenTelemetry.record_update_job_error(
@@ -115,7 +117,7 @@ module Dependabot
           error_type: error_type,
           error_details: error_details
         )
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/record_update_job_error"
+        api_url = "#{api_path}/update_jobs/#{job_id}/record_update_job_error"
         body = {
           data: {
             "error-type": error_type,
@@ -149,7 +151,7 @@ module Dependabot
           warn_title: warn_title,
           warn_description: warn_description
         )
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/record_update_job_warning"
+        api_url = "#{api_path}/update_jobs/#{job_id}/record_update_job_warning"
         body = {
           data: {
             "warn-type": warn_type,
@@ -169,7 +171,7 @@ module Dependabot
       end
     end
 
-    sig { params(error_type: T.any(Symbol, String), error_details: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+    sig { params(error_type: T.any(Symbol, String), error_details: T.nilable(ErrorDetails)).void }
     def record_update_job_unknown_error(error_type:, error_details:)
       error_type = "unknown_error" if error_type.nil?
       ::Dependabot::OpenTelemetry.tracer.in_span("record_update_job_unknown_error", kind: :internal) do |_span|
@@ -179,7 +181,7 @@ module Dependabot
           error_details: error_details
         )
 
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/record_update_job_unknown_error"
+        api_url = "#{api_path}/update_jobs/#{job_id}/record_update_job_unknown_error"
         body = {
           data: {
             "error-type": error_type,
@@ -204,7 +206,7 @@ module Dependabot
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::BASE_COMMIT_SHA, base_commit_sha)
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id.to_s)
 
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/mark_as_processed"
+        api_url = "#{api_path}/update_jobs/#{job_id}/mark_as_processed"
         body = { data: { "base-commit-sha": base_commit_sha } }
         response = http_client.patch(path: api_url, body: body.to_json)
         raise ApiError, response.body if response.status >= 400
@@ -218,12 +220,12 @@ module Dependabot
       end
     end
 
-    sig { params(dependencies: T::Array[T::Hash[Symbol, T.untyped]], dependency_files: T::Array[String]).void }
+    sig { params(dependencies: T::Array[T::Hash[Symbol, Object]], dependency_files: T::Array[String]).void }
     def update_dependency_list(dependencies, dependency_files)
       ::Dependabot::OpenTelemetry.tracer.in_span("update_dependency_list", kind: :internal) do |span|
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id.to_s)
 
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/update_dependency_list"
+        api_url = "#{api_path}/update_jobs/#{job_id}/update_dependency_list"
         body = {
           data: {
             dependencies: dependencies,
@@ -242,12 +244,12 @@ module Dependabot
       end
     end
 
-    sig { params(dependency_submission: T::Hash[Symbol, T.untyped]).void }
+    sig { params(dependency_submission: T::Hash[Symbol, Object]).void }
     def create_dependency_submission(dependency_submission)
       ::Dependabot::OpenTelemetry.tracer.in_span("create_dependency_submission", kind: :internal) do |span|
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id.to_s)
 
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/create_dependency_submission"
+        api_url = "#{api_path}/update_jobs/#{job_id}/create_dependency_submission"
         body = {
           data: dependency_submission
         }
@@ -263,10 +265,10 @@ module Dependabot
       end
     end
 
-    sig { params(ecosystem_versions: T::Hash[Symbol, T.untyped]).void }
+    sig { params(ecosystem_versions: T::Hash[Symbol, Object]).void }
     def record_ecosystem_versions(ecosystem_versions)
       ::Dependabot::OpenTelemetry.tracer.in_span("record_ecosystem_versions", kind: :internal) do |_span|
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/record_ecosystem_versions"
+        api_url = "#{api_path}/update_jobs/#{job_id}/record_ecosystem_versions"
         body = {
           data: { ecosystem_versions: ecosystem_versions }
         }
@@ -291,7 +293,7 @@ module Dependabot
           span.set_attribute(key.to_s, value.to_s)
         end
 
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/increment_metric"
+        api_url = "#{api_path}/update_jobs/#{job_id}/increment_metric"
         body = {
           data: {
             metric: metric,
@@ -311,7 +313,7 @@ module Dependabot
       return if ecosystem.nil?
 
       ::Dependabot::OpenTelemetry.tracer.in_span("record_ecosystem_meta", kind: :internal) do |_span|
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/record_ecosystem_meta"
+        api_url = "#{api_path}/update_jobs/#{job_id}/record_ecosystem_meta"
 
         body = {
           data: [
@@ -337,7 +339,6 @@ module Dependabot
     end
 
     # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     sig { params(job: T.nilable(Dependabot::Job)).void }
     def record_cooldown_meta(job)
       return if job&.cooldown.nil?
@@ -346,7 +347,7 @@ module Dependabot
 
       begin
         ::Dependabot::OpenTelemetry.tracer.in_span("record_cooldown_meta", kind: :internal) do |_span|
-          api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/record_cooldown_meta"
+          api_url = "#{api_path}/update_jobs/#{job_id}/record_cooldown_meta"
 
           body = {
             data: [
@@ -386,7 +387,6 @@ module Dependabot
         Dependabot.logger.error("Failed to record cooldown meta: #{e.message}")
       end
     end
-    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
     sig { params(package_manager: String).returns(T::Array[T::Hash[String, Object]]) }
@@ -394,7 +394,7 @@ module Dependabot
       ::Dependabot::OpenTelemetry.tracer.in_span("fetch_blocked_versions", kind: :internal) do |span|
         span.set_attribute(::Dependabot::OpenTelemetry::Attributes::JOB_ID, job_id.to_s)
 
-        api_url = "#{http_client.params[:path]}/update_jobs/#{job_id}/blocked_versions"
+        api_url = "#{api_path}/update_jobs/#{job_id}/blocked_versions"
         response = http_client.get(path: api_url, query: { "package-manager": package_manager })
 
         if response.status >= 400
@@ -424,10 +424,15 @@ module Dependabot
 
     private
 
+    sig { returns(String) }
+    def api_path
+      T.cast(http_client.params[:path], String)
+    end
+
     # Update return type to allow returning a Hash or nil
     sig do
       params(version_manager: T.nilable(Dependabot::Ecosystem::VersionManager))
-        .returns(T.nilable(T::Hash[String, T.untyped]))
+        .returns(T.nilable(T::Hash[Symbol, Object]))
     end
     def version_manager_json(version_manager)
       return nil unless version_manager
@@ -446,7 +451,7 @@ module Dependabot
     # Update return type to allow returning a Hash or nil
     sig do
       params(version_manager: Dependabot::Ecosystem::VersionManager)
-        .returns(T.nilable(T::Hash[String, T.untyped]))
+        .returns(T.nilable(T::Hash[Symbol, String]))
     end
     def version_manager_requirement_json(version_manager)
       requirement = version_manager.requirement
@@ -491,39 +496,42 @@ module Dependabot
       )
     end
 
-    sig { params(dependency_change: Dependabot::DependencyChange).returns(T::Hash[String, T.untyped]) }
+    sig { params(dependency_change: Dependabot::DependencyChange).returns(T::Hash[String, Object]) }
     def dependency_group_hash(dependency_change)
       return {} unless dependency_change.grouped_update?
 
       # FIXME: We currently assumpt that _an attempt_ to send a DependencyGroup#id should
       # result in the `grouped-update` flag being set, regardless of whether the
       # DependencyGroup actually exists.
-      { "dependency-group": dependency_change.dependency_group.to_h }.compact
+      { "dependency-group" => dependency_change.dependency_group.to_h }.compact
     end
 
     sig do
       params(
         dependency_change: Dependabot::DependencyChange,
         base_commit_sha: String
-      ).returns(T::Hash[String, T.untyped])
+      ).returns(T::Hash[String, Object])
     end
     def create_pull_request_data(dependency_change, base_commit_sha)
-      data = {
-        dependencies: dependency_change.updated_dependencies.map do |dep|
-          {
-            name: dep.name,
-            "previous-version": dep.previous_version,
-            requirements: dep.requirements,
-            "previous-requirements": dep.previous_requirements,
-            directory: dep.directory
-          }.merge({
-            version: dep.version,
-            removed: dep.removed? || nil
-          }.compact)
-        end,
-        "updated-dependency-files": dependency_change.updated_dependency_files_hash,
-        "base-commit-sha": base_commit_sha
-      }.merge(dependency_group_hash(dependency_change))
+      data = T.let(
+        {
+          "dependencies" => dependency_change.updated_dependencies.map do |dep|
+            {
+              "name" => dep.name,
+              "previous-version" => dep.previous_version,
+              "requirements" => dep.requirements,
+              "previous-requirements" => dep.previous_requirements,
+              "directory" => dep.directory
+            }.merge({
+              "version" => dep.version,
+              "removed" => dep.removed? || nil
+            }.compact)
+          end,
+          "updated-dependency-files" => dependency_change.updated_dependency_files_hash,
+          "base-commit-sha" => base_commit_sha
+        }.merge(dependency_group_hash(dependency_change)),
+        T::Hash[String, Object]
+      )
 
       data["commit-message"] = dependency_change.pr_message.commit_message
       data["pr-title"] = dependency_change.pr_message.pr_name

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -402,20 +402,9 @@ module Dependabot
           return []
         end
 
-        parsed = JSON.parse(response.body.to_s)
-        unless parsed.is_a?(Hash)
-          Dependabot.logger.warn("Unexpected blocked versions format, continuing without them")
-          return []
-        end
-        data = parsed.fetch("data", [])
-        unless data.is_a?(Array) && data.all?(Hash)
-          Dependabot.logger.warn("Unexpected blocked versions format, continuing without them")
-          return []
-        end
-        data
+        parse_blocked_versions_response(response.body.to_s)
       rescue JSON::ParserError, TypeError => e
-        Dependabot.logger.warn("Failed to parse blocked versions response: #{e.message}, continuing without them")
-        []
+        raise ApiError, "Malformed blocked versions response: #{e.message}"
       rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError => e
         Dependabot.logger.warn("Failed to fetch blocked versions: #{e.message}, continuing without them")
         []
@@ -423,6 +412,53 @@ module Dependabot
     end
 
     private
+
+    sig { params(body: String).returns(T::Array[T::Hash[String, Object]]) }
+    def parse_blocked_versions_response(body)
+      parsed = T.cast(JSON.parse(body), Object)
+      raise TypeError, "expected an object" unless parsed.is_a?(Hash)
+
+      data = T.cast(parsed["data"], Object)
+      raise TypeError, "data must be an array" unless data.is_a?(Array)
+
+      data.map do |entry|
+        blocked_version = string_hash(T.cast(entry, Object), "blocked version")
+        required_string(blocked_version, "dependency-name")
+        required_string(blocked_version, "version-requirement")
+        optional_string(blocked_version["reason"], "reason")
+        blocked_version
+      end
+    end
+
+    sig { params(value: Object, name: String).returns(T::Hash[String, Object]) }
+    def string_hash(value, name)
+      raise TypeError, "#{name} must be an object" unless value.is_a?(Hash)
+
+      result = T.let({}, T::Hash[String, Object])
+      value.each do |raw_key, raw_value|
+        key = T.cast(raw_key, Object)
+        raise TypeError, "#{name} keys must be strings" unless key.is_a?(String)
+
+        result[key] = T.cast(raw_value, Object)
+      end
+      result
+    end
+
+    sig { params(hash: T::Hash[String, Object], key: String).returns(String) }
+    def required_string(hash, key)
+      value = hash.fetch(key)
+      raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+      value
+    end
+
+    sig { params(value: T.nilable(Object), key: String).returns(T.nilable(String)) }
+    def optional_string(value, key)
+      return if value.nil?
+      raise TypeError, "#{key} must be a string" unless value.is_a?(String)
+
+      value
+    end
 
     sig { returns(String) }
     def api_path
@@ -541,12 +577,22 @@ module Dependabot
 
     sig { params(response: String).returns(T::Boolean) }
     def dependency_file_not_supported_error?(response)
-      body = JSON.parse(response)
-
+      body = T.cast(JSON.parse(response), Object)
       return false unless body.is_a?(Hash)
-      return false unless body["errors"]
 
-      INVALID_REQUEST_MSG.match? body["errors"].first["detail"]
+      errors = T.cast(body["errors"], Object)
+      return false if errors.nil?
+      raise TypeError, "errors must be an array" unless errors.is_a?(Array)
+
+      first_error = T.cast(errors.first, Object)
+      raise TypeError, "errors must contain objects" unless first_error.is_a?(Hash)
+
+      detail = T.cast(first_error["detail"], Object)
+      raise TypeError, "error detail must be a string" unless detail.is_a?(String)
+
+      INVALID_REQUEST_MSG.match?(detail)
+    rescue JSON::ParserError, TypeError => e
+      raise ApiError, "Malformed API error response: #{e.message}"
     end
   end
 end

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sentry-ruby"
@@ -10,6 +10,7 @@ require "dependabot/errors"
 require "dependabot/opentelemetry"
 require "dependabot/experiments"
 require "dependabot/workflow_summary"
+require "github_api/dependency_submission"
 
 # This class provides an output adapter for the Dependabot Service which manages
 # communication with the private API as well as consolidated error handling.
@@ -20,13 +21,34 @@ require "dependabot/workflow_summary"
 module Dependabot
   class Service
     extend T::Sig
-    extend Forwardable
 
-    sig { returns(T::Array[T.untyped]) }
+    ErrorDetails = T.type_alias { T::Hash[T.any(String, Symbol), T.anything] }
+    PullRequestResult = T.type_alias { [String, T.any(String, Symbol)] }
+    LegacyErrorResult = T.type_alias { [String, T.nilable(Dependabot::Dependency)] }
+    EnhancedErrorResult = T.type_alias do
+      [String, T.nilable(ErrorDetails), T.nilable(Dependabot::Dependency)]
+    end
+    ErrorResult = T.type_alias { T.any(LegacyErrorResult, EnhancedErrorResult) }
+
+    class ErrorRecord < T::ImmutableStruct
+      extend T::Sig
+
+      const :error_type, String
+      const :error_details, T.nilable(ErrorDetails)
+      const :dependency, T.nilable(Dependabot::Dependency)
+
+      sig { params(enhanced: T::Boolean).returns(ErrorResult) }
+      def to_result(enhanced:)
+        if enhanced
+          [error_type, error_details, dependency]
+        else
+          [error_type, dependency]
+        end
+      end
+    end
+
+    sig { returns(T::Array[PullRequestResult]) }
     attr_reader :pull_requests
-
-    sig { returns(T::Array[T::Array[T.untyped]]) }
-    attr_reader :errors
 
     sig { returns(Dependabot::WorkflowSummary) }
     attr_reader :workflow_summary
@@ -34,19 +56,47 @@ module Dependabot
     sig { params(client: Dependabot::ApiClient).void }
     def initialize(client:)
       @client = client
-      @pull_requests = T.let([], T::Array[T.untyped])
-      @errors = T.let([], T::Array[T.untyped])
-      @threads = T.let([], T::Array[T.untyped])
+      @pull_requests = T.let([], T::Array[PullRequestResult])
+      @error_records = T.let([], T::Array[ErrorRecord])
+      @threads = T.let([], T::Array[Thread])
       @workflow_summary = T.let(Dependabot::WorkflowSummary.new, Dependabot::WorkflowSummary)
     end
 
-    def_delegators :client,
-                   :mark_job_as_processed,
-                   :record_ecosystem_versions,
-                   :increment_metric,
-                   :record_ecosystem_meta,
-                   :record_cooldown_meta,
-                   :fetch_blocked_versions
+    sig { returns(T::Array[ErrorResult]) }
+    def errors
+      enhanced = Dependabot::Experiments.enabled?(:enable_enhanced_error_details_for_updater)
+      @error_records.map { |record| record.to_result(enhanced: enhanced) }
+    end
+
+    sig { params(base_commit_sha: T.nilable(String)).void }
+    def mark_job_as_processed(base_commit_sha)
+      client.mark_job_as_processed(base_commit_sha)
+    end
+
+    sig { params(ecosystem_versions: T::Hash[Symbol, Object]).void }
+    def record_ecosystem_versions(ecosystem_versions)
+      client.record_ecosystem_versions(ecosystem_versions)
+    end
+
+    sig { params(metric: String, tags: T::Hash[Symbol, Object]).void }
+    def increment_metric(metric, tags:)
+      client.increment_metric(metric, tags: tags)
+    end
+
+    sig { params(ecosystem: T.nilable(Dependabot::Ecosystem)).void }
+    def record_ecosystem_meta(ecosystem)
+      client.record_ecosystem_meta(ecosystem)
+    end
+
+    sig { params(job: T.nilable(Dependabot::Job)).void }
+    def record_cooldown_meta(job)
+      client.record_cooldown_meta(job)
+    end
+
+    sig { params(package_manager: String).returns(T::Array[T::Hash[String, Object]]) }
+    def fetch_blocked_versions(package_manager)
+      client.fetch_blocked_versions(package_manager)
+    end
 
     sig { void }
     def wait_for_calls_to_finish
@@ -83,16 +133,16 @@ module Dependabot
     sig do
       params(
         error_type: T.any(String, Symbol),
-        error_details: T.nilable(T::Hash[T.untyped, T.untyped]),
+        error_details: T.nilable(ErrorDetails),
         dependency: T.nilable(Dependabot::Dependency)
       ).void
     end
     def record_update_job_error(error_type:, error_details:, dependency: nil)
-      errors << if Dependabot::Experiments.enabled?(:enable_enhanced_error_details_for_updater)
-                  [error_type.to_s, error_details, dependency]
-                else
-                  [error_type.to_s, dependency]
-                end
+      @error_records << ErrorRecord.new(
+        error_type: error_type.to_s,
+        error_details: error_details,
+        dependency: dependency
+      )
       client.record_update_job_error(error_type: error_type, error_details: error_details)
     end
 
@@ -111,7 +161,7 @@ module Dependabot
       )
     end
 
-    sig { params(error_type: T.any(String, Symbol), error_details: T.nilable(T::Hash[T.untyped, T.untyped])).void }
+    sig { params(error_type: T.any(String, Symbol), error_details: T.nilable(ErrorDetails)).void }
     def record_update_job_unknown_error(error_type:, error_details:)
       client.record_update_job_unknown_error(error_type: error_type, error_details: error_details)
     end
@@ -157,10 +207,10 @@ module Dependabot
     sig do
       params(
         error: StandardError,
-        job: T.untyped,
+        job: T.nilable(Dependabot::Job),
         dependency: T.nilable(Dependabot::Dependency),
         dependency_group: T.nilable(Dependabot::DependencyGroup),
-        tags: T::Hash[String, T.untyped]
+        tags: T::Hash[String, Object]
       ).void
     end
     def capture_exception(error:, job: nil, dependency: nil, dependency_group: nil, tags: {})
@@ -190,7 +240,7 @@ module Dependabot
 
     sig { returns(T::Boolean) }
     def failure?
-      errors.any?
+      @error_records.any?
     end
 
     # Example output:
@@ -221,7 +271,7 @@ module Dependabot
     sig { returns(Dependabot::ApiClient) }
     attr_reader :client
 
-    sig { params(job: T.untyped).returns(T.nilable(T::Array[T::Hash[String, T.untyped]])) }
+    sig { params(job: T.nilable(Dependabot::Job)).returns(T.nilable(T::Array[T::Hash[String, Object]])) }
     def job_dependency_groups(job)
       job&.dependency_groups&.map(&:to_h)
     end
@@ -255,8 +305,8 @@ module Dependabot
     sig { returns(T.nilable(Terminal::Table)) }
     def job_errors_summary
       if Dependabot::Experiments.enabled?(:enable_enhanced_error_details_for_updater)
-        job_errors = errors.filter_map do |error_type, error_details, dependency|
-          [error_type, JSON.pretty_generate(error_details)] if dependency.nil?
+        job_errors = @error_records.filter_map do |record|
+          [record.error_type, JSON.pretty_generate(record.error_details)] if record.dependency.nil?
         end
         return if job_errors.none?
 
@@ -266,8 +316,8 @@ module Dependabot
           t.rows = job_errors
         end
       else
-        job_error_types = errors.filter_map do |error_type, dependency|
-          [error_type] if dependency.nil?
+        job_error_types = @error_records.filter_map do |record|
+          [record.error_type] if record.dependency.nil?
         end
         return if job_error_types.none?
 
@@ -290,8 +340,9 @@ module Dependabot
     sig { returns(T.nilable(Terminal::Table)) }
     def dependency_error_summary
       if Dependabot::Experiments.enabled?(:enable_enhanced_error_details_for_updater)
-        dependency_errors = errors.filter_map do |error_type, error_details, dependency|
-          [dependency.name, error_type, JSON.pretty_generate(error_details)] unless dependency.nil?
+        dependency_errors = @error_records.filter_map do |record|
+          dependency = record.dependency
+          [dependency.name, record.error_type, JSON.pretty_generate(record.error_details)] if dependency
         end
         return if dependency_errors.none?
 
@@ -301,8 +352,9 @@ module Dependabot
           t.rows = dependency_errors
         end
       else
-        dependency_errors = errors.filter_map do |error_type, dependency|
-          [dependency.name, error_type] unless dependency.nil?
+        dependency_errors = @error_records.filter_map do |record|
+          dependency = record.dependency
+          [dependency.name, record.error_type] if dependency
         end
         return if dependency_errors.none?
 

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "base64"

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -883,10 +883,9 @@ RSpec.describe Dependabot::ApiClient do
           .to_return(status: 200, body: "not json", headers: headers)
       end
 
-      it "returns an empty array and logs a warning" do
-        expect(Dependabot.logger).to receive(:warn).with(/Failed to parse blocked versions/)
-        result = client.fetch_blocked_versions("npm_and_yarn")
-        expect(result).to eq([])
+      it "raises an API error" do
+        expect { client.fetch_blocked_versions("npm_and_yarn") }
+          .to raise_error(Dependabot::ApiError, /blocked versions response/)
       end
     end
 
@@ -901,10 +900,9 @@ RSpec.describe Dependabot::ApiClient do
           )
       end
 
-      it "returns an empty array and logs a warning" do
-        expect(Dependabot.logger).to receive(:warn).with(/Unexpected blocked versions format/)
-        result = client.fetch_blocked_versions("npm_and_yarn")
-        expect(result).to eq([])
+      it "raises an API error" do
+        expect { client.fetch_blocked_versions("npm_and_yarn") }
+          .to raise_error(Dependabot::ApiError, /blocked versions response/)
       end
     end
 
@@ -915,10 +913,9 @@ RSpec.describe Dependabot::ApiClient do
           .to_return(status: 200, body: "[]", headers: headers)
       end
 
-      it "returns an empty array and logs a warning" do
-        expect(Dependabot.logger).to receive(:warn).with(/Unexpected blocked versions format/)
-        result = client.fetch_blocked_versions("npm_and_yarn")
-        expect(result).to eq([])
+      it "raises an API error" do
+        expect { client.fetch_blocked_versions("npm_and_yarn") }
+          .to raise_error(Dependabot::ApiError, /blocked versions response/)
       end
     end
 
@@ -933,10 +930,41 @@ RSpec.describe Dependabot::ApiClient do
           )
       end
 
-      it "returns an empty array and logs a warning" do
-        expect(Dependabot.logger).to receive(:warn).with(/Unexpected blocked versions format/)
-        result = client.fetch_blocked_versions("npm_and_yarn")
-        expect(result).to eq([])
+      it "raises an API error" do
+        expect { client.fetch_blocked_versions("npm_and_yarn") }
+          .to raise_error(Dependabot::ApiError, /blocked versions response/)
+      end
+    end
+
+    context "when the API omits data" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_return(status: 200, body: {}.to_json, headers: headers)
+      end
+
+      it "raises an API error" do
+        expect { client.fetch_blocked_versions("npm_and_yarn") }
+          .to raise_error(Dependabot::ApiError, /blocked versions response/)
+      end
+    end
+
+    context "when an entry has malformed fields" do
+      before do
+        stub_request(:get, blocked_versions_url)
+          .with(query: { "package-manager": "npm_and_yarn" })
+          .to_return(
+            status: 200,
+            body: {
+              data: [{ "dependency-name" => 1, "version-requirement" => [], "reason" => true }]
+            }.to_json,
+            headers: headers
+          )
+      end
+
+      it "raises an API error" do
+        expect { client.fetch_blocked_versions("npm_and_yarn") }
+          .to raise_error(Dependabot::ApiError, /blocked versions response/)
       end
     end
   end

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Dependabot::Service do
   describe "Instance methods delegated to @client" do
     {
       mark_job_as_processed: %w(mock_sha),
-      record_ecosystem_versions: %w(mock_ecosystem_versions)
+      record_ecosystem_versions: [{ bundler: "2.6.0" }]
     }.each do |method, arguments|
       before { allow(mock_client).to receive(method) }
 


### PR DESCRIPTION
Types Service state and ApiClient payloads, and makes malformed blocked-version response bodies fail fast. `Service`, `ApiClient`, and `UpdateFilesCommand` move to `typed: strong`; `ForbidTUntyped` drops from 1104 to 1079.