### PR TITLE
Type error reporting

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1079
+# Offense count: 1066
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -402,10 +402,7 @@ Sorbet/ForbidTUntyped:
     - "terraform/lib/dependabot/terraform/package/package_details_fetcher.rb"
     - "terraform/lib/dependabot/terraform/update_checker.rb"
     - "updater/lib/dependabot/dependency_attribution.rb"
-    - "updater/lib/dependabot/file_fetcher_command.rb"
-    - "updater/lib/dependabot/opentelemetry.rb"
     - "updater/lib/dependabot/updater/dependency_group_change_batch.rb"
-    - "updater/lib/dependabot/updater/error_handler.rb"
     - "updater/lib/dependabot/updater/group_dependency_selector.rb"
     - "updater/lib/dependabot/updater/update_type_helper.rb"
     - "uv/lib/dependabot/uv.rb"

--- a/bin/dry-run.rb
+++ b/bin/dry-run.rb
@@ -572,8 +572,8 @@ begin
     error_details = Dependabot.fetcher_error_details(e)
     raise unless error_details
 
-    puts " => handled error whilst fetching dependencies: #{error_details.fetch(:"error-type")} " \
-         "#{error_details.fetch(:"error-detail")}"
+    puts " => handled error whilst fetching dependencies: #{error_details.error_type} " \
+         "#{error_details.error_detail}"
 
     []
   end
@@ -584,8 +584,8 @@ begin
     error_details = Dependabot.parser_error_details(e)
     raise unless error_details
 
-    puts " => handled error whilst parsing dependencies: #{error_details.fetch(:"error-type")} " \
-         "#{error_details.fetch(:"error-detail")}"
+    puts " => handled error whilst parsing dependencies: #{error_details.error_type} " \
+         "#{error_details.error_detail}"
 
     []
   end
@@ -950,8 +950,8 @@ begin
     error_details = Dependabot.updater_error_details(e)
     raise unless error_details
 
-    puts " => handled error whilst updating #{dep.name}: #{error_details.fetch(:"error-type")} " \
-         "#{error_details.fetch(:"error-detail")}"
+    puts " => handled error whilst updating #{dep.name}: #{error_details.error_type} " \
+         "#{error_details.error_detail}"
   end
 
   StackProf.stop if $options[:profile]

--- a/common/lib/dependabot/error_details.rb
+++ b/common/lib/dependabot/error_details.rb
@@ -7,7 +7,7 @@ module Dependabot
   class ErrorDetails < T::ImmutableStruct
     extend T::Sig
 
-    DetailHash = T.type_alias { T::Hash[Symbol, Object] }
+    DetailHash = T.type_alias { T::Hash[T.any(String, Symbol), T.anything] }
     Detail = T.type_alias { T.any(String, DetailHash) }
 
     const :error_type, String
@@ -40,7 +40,7 @@ module Dependabot
       result = T.let({}, DetailHash)
       value.each do |raw_key, raw_value|
         key = T.cast(raw_key, Object)
-        raise TypeError, "error-detail keys must be symbols" unless key.is_a?(Symbol)
+        raise TypeError, "error-detail keys must be strings or symbols" unless key.is_a?(String) || key.is_a?(Symbol)
 
         result[key] = T.cast(raw_value, Object)
       end

--- a/common/lib/dependabot/error_details.rb
+++ b/common/lib/dependabot/error_details.rb
@@ -1,0 +1,51 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  class ErrorDetails < T::ImmutableStruct
+    extend T::Sig
+
+    DetailHash = T.type_alias { T::Hash[Symbol, Object] }
+    Detail = T.type_alias { T.any(String, DetailHash) }
+
+    const :error_type, String
+    const :error_detail, T.nilable(Detail)
+
+    sig { params(hash: T::Hash[Symbol, T.anything]).returns(ErrorDetails) }
+    def self.from_hash(hash)
+      raw_type = T.cast(hash[:"error-type"], Object)
+      raise TypeError, "error-type must be a string" unless raw_type.is_a?(String)
+
+      new(
+        error_type: raw_type,
+        error_detail: parse_detail(T.cast(hash[:"error-detail"], T.nilable(Object)))
+      )
+    end
+
+    sig { returns(T::Hash[Symbol, Object]) }
+    def to_h
+      result = T.let({ "error-type": error_type }, T::Hash[Symbol, Object])
+      result[:"error-detail"] = error_detail if error_detail
+      result
+    end
+
+    sig { params(value: T.nilable(Object)).returns(T.nilable(Detail)) }
+    def self.parse_detail(value)
+      return if value.nil?
+      return value if value.is_a?(String)
+      raise TypeError, "error-detail must be a string or hash" unless value.is_a?(Hash)
+
+      result = T.let({}, DetailHash)
+      value.each do |raw_key, raw_value|
+        key = T.cast(raw_key, Object)
+        raise TypeError, "error-detail keys must be symbols" unless key.is_a?(Symbol)
+
+        result[key] = T.cast(raw_value, Object)
+      end
+      result
+    end
+    private_class_method :parse_detail
+  end
+end

--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/error_details"
 require "dependabot/utils"
 
 # rubocop:disable Metrics/ModuleLength
@@ -23,7 +24,7 @@ module Dependabot
 
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/CyclomaticComplexity
-  sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.anything])) }
+  sig { params(error: StandardError).returns(T.nilable(Dependabot::ErrorDetails)) }
   def self.fetcher_error_details(error)
     case error
     when Dependabot::ToolVersionNotSupported
@@ -138,11 +139,12 @@ module Dependabot
           "rate-limit-reset": T.cast(error, Octokit::Error).response_headers["X-RateLimit-Reset"]
         }
       }
-    end
+    end => details
+    Dependabot::ErrorDetails.from_hash(details) if details
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
-  sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.anything])) }
+  sig { params(error: StandardError).returns(T.nilable(Dependabot::ErrorDetails)) }
   def self.parser_error_details(error)
     case error
     when Dependabot::ToolFeatureNotSupported
@@ -220,13 +222,14 @@ module Dependabot
       # and responsibility for fixing it is on them, not us. As a result we
       # quietly log these as errors
       { "error-type": "server_error" }
-    end
+    end => details
+    Dependabot::ErrorDetails.from_hash(details) if details
   end
 
   # rubocop:disable Lint/RedundantCopDisableDirective
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/AbcSize
-  sig { params(error: StandardError).returns(T.nilable(T::Hash[Symbol, T.anything])) }
+  sig { params(error: StandardError).returns(T.nilable(Dependabot::ErrorDetails)) }
   def self.updater_error_details(error)
     case error
     when Dependabot::ToolFeatureNotSupported
@@ -400,7 +403,8 @@ module Dependabot
           "rate-limit-reset": T.cast(error, Octokit::Error).response_headers["X-RateLimit-Reset"]
         }
       }
-    end
+    end => details
+    Dependabot::ErrorDetails.from_hash(details) if details
   end
 
   # rubocop:enable Metrics/MethodLength

--- a/common/spec/dependabot/error_details_spec.rb
+++ b/common/spec/dependabot/error_details_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/error_details"
+
+RSpec.describe Dependabot::ErrorDetails do
+  it "parses and serializes hash details" do
+    details = described_class.from_hash(
+      {
+        "error-type": "dependency_file_not_found",
+        "error-detail": { message: "missing" }
+      }
+    )
+
+    expect(details).to have_attributes(
+      error_type: "dependency_file_not_found",
+      error_detail: { message: "missing" }
+    )
+    expect(details.to_h).to eq(
+      "error-type": "dependency_file_not_found",
+      "error-detail": { message: "missing" }
+    )
+  end
+
+  it "supports string and nil details" do
+    expect(
+      described_class.from_hash("error-type": "unknown", "error-detail": "boom").error_detail
+    ).to eq("boom")
+    expect(described_class.from_hash("error-type": "unknown").error_detail).to be_nil
+  end
+
+  it "rejects malformed error types" do
+    expect { described_class.from_hash("error-type": 1) }.to raise_error(TypeError)
+  end
+end

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -22,7 +22,7 @@ module Dependabot
   class ApiClient # rubocop:disable Metrics/ClassLength
     extend T::Sig
 
-    ErrorDetails = T.type_alias { T::Hash[T.any(String, Symbol), T.anything] }
+    ErrorDetails = T.type_alias { Dependabot::ErrorDetails::Detail }
 
     MAX_REQUEST_RETRIES = 3
     INVALID_REQUEST_MSG = /The request contains invalid or unauthorized changes/

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/base_command"
@@ -114,8 +114,10 @@ module Dependabot
         job_definition.fetch("credentials", job_credentials_metadata)
       )
 
+      source = job.source.clone
+      source.directory = directory_to_use
       args = {
-        source: job.source.clone.tap { |s| s.directory = directory_to_use },
+        source: source,
         credentials: credentials,
         options: job.experiments
       }
@@ -225,7 +227,14 @@ module Dependabot
       api_client.record_ecosystem_versions(ecosystem_versions) unless ecosystem_versions.nil?
     end
 
-    sig { params(max_retries: Integer, _block: T.proc.returns(T.untyped)).returns(T.untyped) }
+    sig do
+      type_parameters(:U)
+        .params(
+          max_retries: Integer,
+          _block: T.proc.returns(T.type_parameter(:U))
+        )
+        .returns(T.type_parameter(:U))
+    end
     def with_retries(max_retries: 2, &_block)
       retries ||= 0
       begin
@@ -309,8 +318,8 @@ module Dependabot
     end
 
     sig { params(error: StandardError).void }
-    def handle_file_fetcher_error(error) # rubocop:disable Metrics/AbcSize
-      error_details = T.let(Dependabot.fetcher_error_details(error), T.nilable(T::Hash[Symbol, T.untyped]))
+    def handle_file_fetcher_error(error)
+      error_details = Dependabot.fetcher_error_details(error)
 
       if error_details.nil?
         log_error(error)
@@ -329,24 +338,21 @@ module Dependabot
             ErrorAttributes::DEPENDENCIES => job.dependencies,
             ErrorAttributes::DEPENDENCY_GROUPS => job.dependency_groups.map(&:to_h)
           }.compact,
-          T::Hash[Symbol, T.untyped]
+          Dependabot::ErrorDetails::DetailHash
         )
 
-        error_details = T.let(
-          {
-            "error-type": "file_fetcher_error",
-            "error-detail": unknown_error_details
-          },
-          T::Hash[Symbol, T.untyped]
+        error_details = Dependabot::ErrorDetails.new(
+          error_type: "file_fetcher_error",
+          error_detail: unknown_error_details
         )
       end
 
       service.record_update_job_error(
-        error_type: error_details.fetch(:"error-type"),
-        error_details: error_details[:"error-detail"]
+        error_type: error_details.error_type,
+        error_details: error_details.error_detail
       )
 
-      return unless error_details.fetch(:"error-type") == "file_fetcher_error"
+      return unless error_details.error_type == "file_fetcher_error"
 
       service.capture_exception(error: error, job: job)
     end
@@ -354,9 +360,10 @@ module Dependabot
     sig { params(error: StandardError).returns(T.any(Integer, Float)) }
     def rate_limit_error_remaining(error)
       # Time at which the current rate limit window resets in UTC epoch secs.
-      expires_at = T.unsafe(error).response_headers["X-RateLimit-Reset"].to_i
+      headers = T.cast(T.cast(error, Octokit::Error).response_headers, T::Hash[String, Object])
+      expires_at = headers["X-RateLimit-Reset"].to_s.to_i
       remaining = Time.at(expires_at) - Time.now
-      remaining.positive? ? remaining : 0
+      [remaining, 0].max
     end
 
     sig { params(error: StandardError).void }
@@ -365,20 +372,20 @@ module Dependabot
       error.backtrace&.each { |line| Dependabot.logger.error line }
     end
 
-    sig { params(error_details: T::Hash[Symbol, T.untyped]).void }
+    sig { params(error_details: Dependabot::ErrorDetails).void }
     def record_error(error_details)
       service.record_update_job_error(
-        error_type: error_details.fetch(:"error-type"),
-        error_details: error_details[:"error-detail"]
+        error_type: error_details.error_type,
+        error_details: error_details.error_detail
       )
 
       # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
       return unless Experiments.enabled?(:record_update_job_unknown_error)
-      return unless error_details.fetch(:"error-type") == "file_fetcher_error"
+      return unless error_details.error_type == "file_fetcher_error"
 
       service.record_update_job_unknown_error(
-        error_type: error_details.fetch(:"error-type"),
-        error_details: error_details[:"error-detail"]
+        error_type: error_details.error_type,
+        error_details: error_details.error_detail
       )
     end
 

--- a/updater/lib/dependabot/opentelemetry.rb
+++ b/updater/lib/dependabot/opentelemetry.rb
@@ -1,10 +1,12 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
 require "opentelemetry/sdk"
 require "opentelemetry-logs-sdk"
 require "opentelemetry-metrics-sdk"
+require "dependabot/error_details"
+require "dependabot/job"
 
 module Dependabot
   module OpenTelemetry
@@ -78,7 +80,7 @@ module Dependabot
       params(
         job_id: T.any(String, Integer),
         error_type: T.any(String, Symbol),
-        error_details: T.nilable(T::Hash[T.untyped, T.untyped])
+        error_details: T.nilable(Dependabot::ErrorDetails::Detail)
       ).void
     end
     def self.record_update_job_error(job_id:, error_type:, error_details:)
@@ -89,8 +91,13 @@ module Dependabot
         Attributes::ERROR_TYPE => error_type
       }
 
-      error_details&.each do |key, value|
-        attributes.store("#{Attributes::ERROR_DETAILS}.#{key}", value)
+      case error_details
+      when Hash
+        error_details.each do |key, value|
+          attributes.store("#{Attributes::ERROR_DETAILS}.#{key}", value)
+        end
+      when String
+        attributes.store(Attributes::ERROR_DETAILS, error_details)
       end
 
       current_span.add_event(error_type, attributes: attributes)
@@ -119,8 +126,8 @@ module Dependabot
     sig do
       params(
         error: StandardError,
-        job: T.untyped,
-        tags: T::Hash[String, T.untyped]
+        job: T.nilable(Dependabot::Job),
+        tags: T::Hash[String, Object]
       ).void
     end
     def self.record_exception(error:, job: nil, tags: {})

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -22,7 +22,7 @@ module Dependabot
   class Service
     extend T::Sig
 
-    ErrorDetails = T.type_alias { T::Hash[T.any(String, Symbol), T.anything] }
+    ErrorDetails = T.type_alias { Dependabot::ErrorDetails::Detail }
     PullRequestResult = T.type_alias { [String, T.any(String, Symbol)] }
     LegacyErrorResult = T.type_alias { [String, T.nilable(Dependabot::Dependency)] }
     EnhancedErrorResult = T.type_alias do

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -107,17 +107,17 @@ module Dependabot
       error_details ||=
         # Check if the error is a known "run halting" state we should handle
         if (error_type = Updater::ErrorHandler::RUN_HALTING_ERRORS[error.class])
-          { "error-type": error_type }
+          Dependabot::ErrorDetails.new(error_type: error_type)
         elsif error.is_a?(ToolVersionNotSupported)
           Dependabot.logger.error(error.message)
-          {
-            "error-type": "tool_version_not_supported",
-            "error-detail": {
+          Dependabot::ErrorDetails.new(
+            error_type: "tool_version_not_supported",
+            error_detail: {
               "tool-name": error.tool_name,
               "detected-version": error.detected_version,
               "supported-versions": error.supported_versions
             }
-          }
+          )
         else
           # If it isn't, then log all the details and let the application error
           # tracker know about it
@@ -137,14 +137,14 @@ module Dependabot
           service.capture_exception(error: error, job: job)
 
           # Set an unknown error type as update_files_error to be added to the job
-          {
-            "error-type": "update_files_error",
-            "error-detail": unknown_error_details
-          }
+          Dependabot::ErrorDetails.new(
+            error_type: "update_files_error",
+            error_detail: unknown_error_details
+          )
         end
 
-      error_type = T.cast(error_details.fetch(:"error-type"), T.any(String, Symbol))
-      error_detail = T.cast(error_details[:"error-detail"], T.nilable(T::Hash[Symbol, T.anything]))
+      error_type = error_details.error_type
+      error_detail = error_details.error_detail
 
       service.record_update_job_error(
         error_type: error_type,
@@ -164,8 +164,8 @@ module Dependabot
     sig { params(error: Dependabot::DependencyFileNotParseable).void }
     def handle_dependency_file_not_parseable_error(error)
       error_details = T.must(Dependabot.updater_error_details(error))
-      error_type = T.cast(error_details.fetch(:"error-type"), T.any(String, Symbol))
-      error_detail = T.cast(error_details[:"error-detail"], T.nilable(T::Hash[Symbol, T.anything]))
+      error_type = error_details.error_type
+      error_detail = error_details.error_detail
 
       service.record_update_job_error(
         error_type: error_type,

--- a/updater/lib/dependabot/update_graph_command.rb
+++ b/updater/lib/dependabot/update_graph_command.rb
@@ -71,7 +71,7 @@ module Dependabot
       error_details ||=
         # Check if the error is a known "run halting" state we should handle
         if (error_type = Updater::ErrorHandler::RUN_HALTING_ERRORS[error.class])
-          { "error-type": error_type }
+          Dependabot::ErrorDetails.new(error_type: error_type)
         else
           # If it isn't, then log all the details and let the application error
           # tracker know about it
@@ -93,14 +93,14 @@ module Dependabot
           service.capture_exception(error: error, job: job)
 
           # Set an unknown error type as update_files_error to be added to the job
-          {
-            "error-type": ERROR_TYPE_LABEL,
-            "error-detail": unknown_error_details
-          }
+          Dependabot::ErrorDetails.new(
+            error_type: ERROR_TYPE_LABEL,
+            error_detail: unknown_error_details
+          )
         end
 
-      error_type = T.cast(error_details.fetch(:"error-type"), T.any(String, Symbol))
-      error_detail = T.cast(error_details[:"error-detail"], T.nilable(T::Hash[Symbol, T.anything]))
+      error_type = error_details.error_type
+      error_detail = error_details.error_detail
 
       service.record_update_job_error(
         error_type: error_type,

--- a/updater/lib/dependabot/update_graph_processor.rb
+++ b/updater/lib/dependabot/update_graph_processor.rb
@@ -183,9 +183,12 @@ module Dependabot
       # If we are not running in Actions, there's nothing more to do.
       return unless Dependabot::Environment.github_actions?
 
-      error_details = Dependabot.updater_error_details(e) || { "error-type": "unknown_error" }
-      error_detail = T.cast(error_details[:"error-detail"], T.nilable(T::Hash[Symbol, T.anything]))
-      detail_message = T.cast(error_detail&.dig(:message), T.nilable(Object))
+      error_details =
+        Dependabot.updater_error_details(e) ||
+        Dependabot::ErrorDetails.new(error_type: "unknown_error", error_detail: nil)
+      error_detail = error_details.error_detail
+      detail_message =
+        (T.cast(error_detail[:message], T.nilable(Object)) if error_detail.is_a?(Hash))
       record_workflow_result(
         directory,
         GithubApi::DependencySubmission::SnapshotStatus::FAILED,
@@ -197,7 +200,7 @@ module Dependabot
         branch,
         T.must(directory_source),
         GithubApi::DependencySubmission::SnapshotStatus::FAILED,
-        T.cast(error_details.fetch(:"error-type"), String)
+        error_details.error_type
       )
       service.create_dependency_submission(dependency_submission: empty_submission)
     end

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/errors"
@@ -86,21 +86,21 @@ module Dependabot
 
         error_details = error_details_for(error, dependency: dependency, dependency_group: dependency_group)
         service.record_update_job_error(
-          error_type: error_details.fetch(:"error-type"),
-          error_details: error_details[:"error-detail"],
+          error_type: error_details.error_type,
+          error_details: error_details.error_detail,
           dependency: dependency
         )
         # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
         if Experiments.enabled?(:record_update_job_unknown_error) &&
-           error_details.fetch(:"error-type") == "unknown_error"
+           error_details.error_type == "unknown_error"
           log_unknown_error_with_backtrace(error)
         end
 
         log_dependency_error(
           dependency: dependency,
           error: error,
-          error_type: error_details.fetch(:"error-type"),
-          error_detail: error_details.fetch(:"error-detail", nil)
+          error_type: error_details.error_type,
+          error_detail: error_details.error_detail
         )
       end
 
@@ -110,7 +110,7 @@ module Dependabot
           dependency: T.nilable(Dependabot::Dependency),
           error: StandardError,
           error_type: String,
-          error_detail: T.nilable(T.any(T::Hash[Symbol, T.untyped], String))
+          error_detail: T.nilable(Dependabot::ErrorDetails::Detail)
         ).void
       end
       def log_dependency_error(dependency:, error:, error_type:, error_detail: nil)
@@ -143,19 +143,19 @@ module Dependabot
 
         error_details = error_details_for(error, dependency_group: dependency_group)
         service.record_update_job_error(
-          error_type: error_details.fetch(:"error-type"),
-          error_details: error_details[:"error-detail"]
+          error_type: error_details.error_type,
+          error_details: error_details.error_detail
         )
         # We don't set this flag in GHES because there older GHES version does not support reporting unknown errors.
         if Experiments.enabled?(:record_update_job_unknown_error) &&
-           error_details.fetch(:"error-type") == "unknown_error"
+           error_details.error_type == "unknown_error"
           log_unknown_error_with_backtrace(error)
         end
 
         log_job_error(
           error: error,
-          error_type: error_details.fetch(:"error-type"),
-          error_detail: error_details.fetch(:"error-detail", nil)
+          error_type: error_details.error_type,
+          error_detail: error_details.error_detail
         )
       end
 
@@ -164,7 +164,7 @@ module Dependabot
         params(
           error: StandardError,
           error_type: String,
-          error_detail: T.nilable(T.any(T::Hash[Symbol, T.untyped], String))
+          error_detail: T.nilable(Dependabot::ErrorDetails::Detail)
         ).void
       end
       def log_job_error(error:, error_type:, error_detail: nil)
@@ -218,7 +218,7 @@ module Dependabot
           error: StandardError,
           dependency: T.nilable(Dependabot::Dependency),
           dependency_group: T.nilable(Dependabot::DependencyGroup)
-        ).returns(T::Hash[Symbol, T.untyped])
+        ).returns(Dependabot::ErrorDetails)
       end
       def error_details_for(error, dependency: nil, dependency_group: nil)
         error_details = Dependabot.updater_error_details(error)
@@ -243,7 +243,7 @@ module Dependabot
           )
         end
 
-        { "error-type": "unknown_error" }
+        Dependabot::ErrorDetails.new(error_type: "unknown_error", error_detail: nil)
       end
 
       sig { params(error: StandardError).void }
@@ -273,7 +273,8 @@ module Dependabot
       def extract_fingerprint(error)
         if error.respond_to?(:sentry_context)
           context = T.cast(error, Dependabot::HasSentryContext).sentry_context
-          return context[:fingerprint] if context.is_a?(Hash)
+          fingerprint = T.cast(context[:fingerprint], Object)
+          return fingerprint.map { |value| T.cast(value, Object).to_s } if fingerprint.is_a?(Array)
         end
 
         nil

--- a/updater/spec/dependabot/open_telemetry_spec.rb
+++ b/updater/spec/dependabot/open_telemetry_spec.rb
@@ -1,0 +1,83 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/opentelemetry"
+
+RSpec.describe Dependabot::OpenTelemetry do
+  let(:span) { instance_double(OpenTelemetry::Trace::Span) }
+
+  before do
+    allow(OpenTelemetry::Trace).to receive(:current_span).and_return(span)
+  end
+
+  describe ".record_update_job_error" do
+    it "records hash details as individual attributes" do
+      expect(span).to receive(:add_event).with(
+        "update_error",
+        attributes: {
+          "dependabot.job.id" => "123",
+          "dependabot.job.error_type" => "update_error",
+          "dependabot.job.error_details.package-manager" => "bundler"
+        }
+      )
+
+      described_class.record_update_job_error(
+        job_id: "123",
+        error_type: "update_error",
+        error_details: { "package-manager": "bundler" }
+      )
+    end
+
+    it "records string details under the base detail attribute" do
+      expect(span).to receive(:add_event).with(
+        :update_error,
+        attributes: {
+          "dependabot.job.id" => 123,
+          "dependabot.job.error_type" => :update_error,
+          "dependabot.job.error_details" => "details"
+        }
+      )
+
+      described_class.record_update_job_error(
+        job_id: 123,
+        error_type: :update_error,
+        error_details: "details"
+      )
+    end
+
+    it "omits nil details" do
+      expect(span).to receive(:add_event).with(
+        "update_error",
+        attributes: {
+          "dependabot.job.id" => "123",
+          "dependabot.job.error_type" => "update_error"
+        }
+      )
+
+      described_class.record_update_job_error(
+        job_id: "123",
+        error_type: "update_error",
+        error_details: nil
+      )
+    end
+  end
+
+  describe ".record_exception" do
+    let(:error) { StandardError.new("boom") }
+    let(:job) { instance_double(Dependabot::Job, id: "123") }
+
+    it "records the job, tags, status, and exception" do
+      expect(span).to receive(:set_attribute).with("dependabot.job.id", "123")
+      expect(span).to receive(:add_attributes).with({ "package-manager" => "bundler" })
+      expect(span).to receive(:status=).with(instance_of(OpenTelemetry::Trace::Status))
+      expect(span).to receive(:record_exception).with(error)
+
+      described_class.record_exception(
+        error: error,
+        job: job,
+        tags: { "package-manager" => "bundler" }
+      )
+    end
+  end
+end


### PR DESCRIPTION
Replace error hashes with a typed model and make updater error handling strongly typed.