### PR TITLE
Type updater dependency helpers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1066
+# Offense count: 1054
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -401,10 +401,6 @@ Sorbet/ForbidTUntyped:
     - "terraform/lib/dependabot/terraform/file_updater/provider_cli_config_builder.rb"
     - "terraform/lib/dependabot/terraform/package/package_details_fetcher.rb"
     - "terraform/lib/dependabot/terraform/update_checker.rb"
-    - "updater/lib/dependabot/dependency_attribution.rb"
-    - "updater/lib/dependabot/updater/dependency_group_change_batch.rb"
-    - "updater/lib/dependabot/updater/group_dependency_selector.rb"
-    - "updater/lib/dependabot/updater/update_type_helper.rb"
     - "uv/lib/dependabot/uv.rb"
     - "uv/lib/dependabot/uv/dependency_grapher.rb"
     - "uv/lib/dependabot/uv/file_fetcher/workspace_fetcher.rb"

--- a/cargo/lib/dependabot/cargo/version.rb
+++ b/cargo/lib/dependabot/cargo/version.rb
@@ -104,7 +104,14 @@ module Dependabot
 
       # Determines the correct update type for a version change according to Cargo's semantic versioning rules
       # For pre-1.0 versions, Cargo treats changes in the leftmost non-zero component as breaking
-      sig { params(from_version: T.any(String, Dependabot::Cargo::Version), to_version: T.any(String, Dependabot::Cargo::Version)).returns(String) }
+      sig do
+        override
+          .params(
+            from_version: T.any(String, Dependabot::Cargo::Version),
+            to_version: T.any(String, Dependabot::Cargo::Version)
+          )
+          .returns(String)
+      end
       def self.update_type(from_version, to_version)
         from_v, to_v = normalize_versions(from_version, to_version)
         from_major, from_minor, from_patch, to_major, to_minor, to_patch = extract_version_parts(from_v, to_v)

--- a/common/lib/dependabot/version.rb
+++ b/common/lib/dependabot/version.rb
@@ -24,6 +24,15 @@ module Dependabot
       T.cast(super, Dependabot::Version)
     end
 
+    sig do
+      overridable
+        .params(_from_version: String, _to_version: String)
+        .returns(T.nilable(String))
+    end
+    def self.update_type(_from_version, _to_version)
+      nil
+    end
+
     # Opt-in to Rubygems 4 behavior
     sig { override.overridable.params(version: VersionParameter).returns(T::Boolean) }
     def self.correct?(version)

--- a/common/spec/dependabot/version_spec.rb
+++ b/common/spec/dependabot/version_spec.rb
@@ -7,6 +7,12 @@ require "dependabot/version"
 RSpec.describe Dependabot::Version do
   subject(:version) { described_class.new(version_string) }
 
+  describe ".update_type" do
+    it "does not override the generic update classification" do
+      expect(described_class.update_type("1.0.0", "2.0.0")).to be_nil
+    end
+  end
+
   describe "#lowest_prerelease_suffix" do
     subject(:ignored_versions) { version.lowest_prerelease_suffix }
 

--- a/updater/lib/dependabot/dependency_attribution.rb
+++ b/updater/lib/dependabot/dependency_attribution.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/updater/lib/dependabot/dependency_attribution.rb
+++ b/updater/lib/dependabot/dependency_attribution.rb
@@ -10,7 +10,23 @@ module Dependabot
   module DependencyAttribution
     extend T::Sig
 
-    # Selection reasons for why a dependency was included in a group update
+    class SelectionReason < T::Enum
+      enums do
+        DIRECT = new("direct")
+        ALREADY_UPDATED = new("already_updated")
+        DEPENDENCY_DRIFT = new("dependency_drift")
+        NOT_IN_GROUP = new("not_in_group")
+        FILTERED_BY_CONFIG = new("filtered_by_config")
+        BELONGS_TO_MORE_SPECIFIC_GROUP = new("belongs_to_more_specific_group")
+        UNKNOWN = new("unknown")
+      end
+
+      sig { returns(Symbol) }
+      def to_sym
+        serialize.to_sym
+      end
+    end
+
     SELECTION_REASONS = T.let(
       %i(
         direct
@@ -18,85 +34,165 @@ module Dependabot
         dependency_drift
         not_in_group
         filtered_by_config
+        belongs_to_more_specific_group
         unknown
       ).freeze,
       T::Array[Symbol]
     )
 
-    # Add attribution metadata to a dependency
+    class Attribution < T::ImmutableStruct
+      extend T::Sig
+
+      const :source_group, String
+      const :selection_reason, SelectionReason
+      const :directory, String
+      const :timestamp, Time
+
+      sig { returns(T::Hash[Symbol, Object]) }
+      def to_h
+        {
+          source_group: source_group,
+          selection_reason: selection_reason.to_sym,
+          directory: directory,
+          timestamp: timestamp
+        }
+      end
+    end
+
+    class AttributedDependency < T::ImmutableStruct
+      extend T::Sig
+
+      const :name, String
+      const :version, T.nilable(String)
+      const :previous_version, T.nilable(String)
+      const :attribution, Attribution
+
+      sig { returns(T::Hash[Symbol, Object]) }
+      def to_h
+        result = T.let(
+          {
+            name: name,
+            version: version,
+            previous_version: previous_version
+          },
+          T::Hash[Symbol, Object]
+        )
+        result.merge(attribution.to_h)
+      end
+    end
+
+    class TelemetrySummary < T::ImmutableStruct
+      extend T::Sig
+
+      const :total_dependencies, Integer
+      const :attributed_dependencies, Integer
+      const :attribution_coverage, Float
+      const :selection_reasons, T::Hash[String, Integer]
+      const :source_groups, T::Hash[String, Integer]
+      const :directories, T::Hash[String, Integer]
+
+      sig { returns(T::Hash[Symbol, Object]) }
+      def to_h
+        {
+          total_dependencies: total_dependencies,
+          attributed_dependencies: attributed_dependencies,
+          attribution_coverage: attribution_coverage,
+          selection_reasons: selection_reasons,
+          source_groups: source_groups,
+          directories: directories
+        }
+      end
+    end
+
     sig do
       params(dependency: Dependabot::Dependency, source_group: String, selection_reason: Symbol, directory: String).void
     end
     def self.annotate_dependency(dependency, source_group:, selection_reason:, directory:)
-      return unless SELECTION_REASONS.include?(selection_reason)
+      reason = SelectionReason.try_deserialize(selection_reason.to_s)
+      return unless reason
 
       dependency.attribution_source_group = source_group
-      dependency.attribution_selection_reason = selection_reason
+      dependency.attribution_selection_reason = reason.to_sym
       dependency.attribution_directory = directory
       dependency.attribution_timestamp = Time.now.utc
     end
 
-    # Get attribution metadata from a dependency
-    sig { params(dependency: Dependabot::Dependency).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    sig { params(dependency: Dependabot::Dependency).returns(T.nilable(Attribution)) }
     def self.get_attribution(dependency)
-      return nil unless dependency.attribution_source_group
+      source_group = dependency.attribution_source_group
+      selection_reason = dependency.attribution_selection_reason
+      directory = dependency.attribution_directory
+      timestamp = dependency.attribution_timestamp
+      return unless source_group && selection_reason && directory && timestamp
 
-      {
-        source_group: dependency.attribution_source_group,
-        selection_reason: dependency.attribution_selection_reason,
-        directory: dependency.attribution_directory,
-        timestamp: dependency.attribution_timestamp
-      }
+      reason = SelectionReason.try_deserialize(selection_reason.to_s)
+      return unless reason
+
+      Attribution.new(
+        source_group: source_group,
+        selection_reason: reason,
+        directory: directory,
+        timestamp: timestamp
+      )
     end
 
-    # Check if a dependency has attribution metadata
     sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
     def self.attributed?(dependency)
-      !dependency.attribution_source_group.nil?
+      !get_attribution(dependency).nil?
     end
 
-    # Get all attributed dependencies from a collection with their metadata
-    sig { params(dependencies: T::Array[Dependabot::Dependency]).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+    sig do
+      params(dependencies: T::Array[Dependabot::Dependency])
+        .returns(T::Array[AttributedDependency])
+    end
     def self.extract_attribution_data(dependencies)
       dependencies.filter_map do |dep|
         attribution = get_attribution(dep)
         next unless attribution
 
-        {
+        AttributedDependency.new(
           name: dep.name,
           version: dep.version,
           previous_version: dep.previous_version,
-          **attribution
-        }
+          attribution: attribution
+        )
       end
     end
 
-    # Generate telemetry summary for attributed dependencies
-    sig { params(dependencies: T::Array[Dependabot::Dependency]).returns(T::Hash[Symbol, T.untyped]) }
+    sig { params(dependencies: T::Array[Dependabot::Dependency]).returns(TelemetrySummary) }
     def self.telemetry_summary(dependencies)
       attributed_deps = dependencies.select { |dep| attributed?(dep) }
       total_count = dependencies.length
       attributed_count = attributed_deps.length
 
-      summary = {
-        total_dependencies: total_count,
-        attributed_dependencies: attributed_count,
-        attribution_coverage: total_count.zero? ? 0.0 : attributed_count.to_f / total_count,
-        selection_reasons: Hash.new(0),
-        source_groups: Hash.new(0),
-        directories: Hash.new(0)
-      }
+      selection_reasons = T.let(Hash.new(0), T::Hash[String, Integer])
+      source_groups = T.let(Hash.new(0), T::Hash[String, Integer])
+      directories = T.let(Hash.new(0), T::Hash[String, Integer])
 
       attributed_deps.each do |dep|
         attribution = get_attribution(dep)
         next unless attribution
 
-        summary[:selection_reasons][attribution[:selection_reason].to_s] += 1
-        summary[:source_groups][attribution[:source_group]] += 1
-        summary[:directories][attribution[:directory]] += 1
+        reason = attribution.selection_reason.serialize
+        increment(selection_reasons, reason)
+        increment(source_groups, attribution.source_group)
+        increment(directories, attribution.directory)
       end
 
-      summary
+      TelemetrySummary.new(
+        total_dependencies: total_count,
+        attributed_dependencies: attributed_count,
+        attribution_coverage: total_count.zero? ? 0.0 : attributed_count.to_f / total_count,
+        selection_reasons: selection_reasons,
+        source_groups: source_groups,
+        directories: directories
+      )
     end
+
+    sig { params(counts: T::Hash[String, Integer], key: String).void }
+    def self.increment(counts, key)
+      counts[key] = counts.fetch(key, 0) + 1
+    end
+    private_class_method :increment
   end
 end

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "pathname"

--- a/updater/lib/dependabot/updater/dependency_group_change_batch.rb
+++ b/updater/lib/dependabot/updater/dependency_group_change_batch.rb
@@ -11,6 +11,14 @@ module Dependabot
     class DependencyGroupChangeBatch
       extend T::Sig
 
+      class FileState < T::ImmutableStruct
+        const :file, Dependabot::DependencyFile
+        const :changed, T::Boolean
+        const :changes, Integer
+      end
+
+      FileBatch = T.type_alias { T::Hash[String, FileState] }
+
       sig { returns(T::Array[Dependabot::Dependency]) }
       attr_reader :updated_dependencies
 
@@ -20,12 +28,12 @@ module Dependabot
 
         @dependency_file_batch = T.let(
           initial_dependency_files.to_h do |file|
-            [file.path, { file: file, changed: false, changes: 0 }]
+            [file.path, FileState.new(file: file, changed: false, changes: 0)]
           end,
-          T::Hash[String, T::Hash[Symbol, T.untyped]]
+          FileBatch
         )
 
-        @vendored_dependency_batch = T.let({}, T::Hash[String, T::Hash[Symbol, T.untyped]])
+        @vendored_dependency_batch = T.let({}, FileBatch)
 
         Dependabot.logger.debug("Starting with '#{@dependency_file_batch.count}' dependency files:")
         debug_current_file_state
@@ -37,7 +45,7 @@ module Dependabot
         directory = Pathname.new(job.source.directory).cleanpath.to_s
 
         files = @dependency_file_batch.filter_map do |_path, data|
-          data[:file] if Pathname.new(data[:file].directory).cleanpath.to_s == directory
+          data.file if Pathname.new(data.file.directory).cleanpath.to_s == directory
         end
         # This should be prevented in the FileFetcher, but possible due to directory cleaning
         # that all files are filtered out.
@@ -50,8 +58,8 @@ module Dependabot
       # and changes we've collected to vendored dependencies
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def updated_dependency_files
-        @dependency_file_batch.filter_map { |_path, data| data[:file] if data[:changed] } +
-          @vendored_dependency_batch.map { |_path, data| data[:file] }
+        @dependency_file_batch.filter_map { |_path, data| data.file if data.changed } +
+          @vendored_dependency_batch.map { |_path, data| data.file }
       end
 
       sig { params(dependency_change: Dependabot::DependencyChange).void }
@@ -97,17 +105,16 @@ module Dependabot
         end
       end
 
-      sig { params(file: Dependabot::DependencyFile, batch: T::Hash[String, T::Hash[Symbol, T.untyped]]).void }
+      sig { params(file: Dependabot::DependencyFile, batch: FileBatch).void }
       def merge_file_to_batch(file, batch)
-        change_count = if (existing_file = batch[file.path])
-                         existing_file.fetch(:change_count, 0)
-                       else
-                         # The file is newly encountered
-                         Dependabot.logger.debug("File #{file.operation}d: '#{file.path}'")
-                         0
-                       end
+        existing_state = batch[file.path]
+        Dependabot.logger.debug("File #{file.operation}d: '#{file.path}'") unless existing_state
 
-        batch[file.path] = { file: file, changed: true, changes: change_count + 1 }
+        batch[file.path] = FileState.new(
+          file: file,
+          changed: true,
+          changes: existing_state ? existing_state.changes + 1 : 1
+        )
       end
 
       sig { void }
@@ -132,9 +139,9 @@ module Dependabot
         @vendored_dependency_batch.each { |path, data| debug_file_hash(path, data) }
       end
 
-      sig { params(path: String, data: T::Hash[Symbol, T.untyped]).void }
+      sig { params(path: String, data: FileState).void }
       def debug_file_hash(path, data)
-        changed_string = data[:changed] ? "( Changed #{data[:changes]} times )" : ""
+        changed_string = data.changed ? "( Changed #{data.changes} times )" : ""
         Dependabot.logger.debug("  - #{path} #{changed_string}")
       end
     end

--- a/updater/lib/dependabot/updater/group_dependency_selector.rb
+++ b/updater/lib/dependabot/updater/group_dependency_selector.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -167,13 +167,17 @@ module Dependabot
       end
 
       sig do
-        params(
-          changes_by_dir: T::Array[Dependabot::DependencyChange],
-          _blk: T.proc.params(directory: String, dep: Dependabot::Dependency).returns(T.untyped)
-        ).returns(T::Array[Dependabot::Dependency])
+        type_parameters(:Key)
+          .params(
+            changes_by_dir: T::Array[Dependabot::DependencyChange],
+            _blk: T.proc
+                  .params(directory: String, dep: Dependabot::Dependency)
+                   .returns(T.type_parameter(:Key))
+          )
+          .returns(T::Array[Dependabot::Dependency])
       end
       def deduplicate_dependencies_with_key(changes_by_dir, &_blk)
-        seen_keys = T.let(Set.new, T::Set[T.untyped])
+        seen_keys = T.let(Set.new, T::Set[T.type_parameter(:Key)])
         merged_dependencies = T.let([], T::Array[Dependabot::Dependency])
 
         changes_by_dir.each do |change|
@@ -193,7 +197,9 @@ module Dependabot
       end
 
       sig do
-        params(dependency_change: Dependabot::DependencyChange)
+        params(
+          dependency_change: Dependabot::DependencyChange
+        )
           .returns([T::Array[Dependabot::Dependency], T::Array[Dependabot::Dependency]])
       end
       def partition_dependencies(dependency_change)
@@ -229,19 +235,20 @@ module Dependabot
         :unknown
       end
 
-      sig { params(dep: Dependabot::Dependency, directory: String).returns(T::Boolean) }
-      def group_contains_dependency?(dep, directory)
-        if @group.respond_to?(:contains_dependency?)
-          T.unsafe(@group).contains_dependency?(dep, directory: directory)
-        else
-          @group.contains?(dep)
-        end
+      sig { params(dep: Dependabot::Dependency, _directory: String).returns(T::Boolean) }
+      def group_contains_dependency?(dep, _directory)
+        @group.contains?(dep)
       end
 
       sig { params(dep: Dependabot::Dependency, directory: String).returns(T::Boolean) }
       def dependency_belongs_to_more_specific_group?(dep, directory)
         contains_checker = T.let(
-          proc { |group, dependency, dir| group_contains_dependency_for_group?(group, dependency, dir) },
+          proc do |raw_group, raw_dependency, raw_directory|
+            group = T.cast(raw_group, Dependabot::DependencyGroup)
+            dependency = T.cast(raw_dependency, Dependabot::Dependency)
+            checked_directory = T.cast(raw_directory, T.nilable(String))
+            group_contains_dependency_for_group?(group, dependency, checked_directory)
+          end,
           T.proc.params(
             group: Dependabot::DependencyGroup,
             dep: Dependabot::Dependency,
@@ -258,21 +265,19 @@ module Dependabot
       end
 
       sig do
-        params(group: Dependabot::DependencyGroup, dep: Dependabot::Dependency, directory: String).returns(T::Boolean)
+        params(
+          group: Dependabot::DependencyGroup,
+          dep: Dependabot::Dependency,
+          _directory: T.nilable(String)
+        ).returns(T::Boolean)
       end
-      def group_contains_dependency_for_group?(group, dep, directory)
-        if group.respond_to?(:contains_dependency?)
-          T.unsafe(group).contains_dependency?(dep, directory: directory)
-        else
-          group.contains?(dep)
-        end
+      def group_contains_dependency_for_group?(group, dep, _directory)
+        group.contains?(dep)
       end
 
       sig { returns(T.nilable(String)) }
       def group_applies_to
-        return nil unless @group.respond_to?(:applies_to)
-
-        T.unsafe(@group).applies_to
+        @group.applies_to
       end
 
       sig { params(dep: Dependabot::Dependency, job: Dependabot::Job).returns(T::Boolean) }
@@ -313,7 +318,7 @@ module Dependabot
         updated_dep_names = updated_deps.to_set(&:name)
 
         file_dependencies = @snapshot.dependencies.select do |dep|
-          dep.requirements.any? { |req| req[:file] == file.name }
+          dep.requirements.any? { |req| req.file == file.name }
         end
 
         file_dependencies.filter_map do |dep|
@@ -367,24 +372,27 @@ module Dependabot
 
       sig { params(filtered_deps: T::Array[Dependabot::Dependency]).returns(T::Hash[Symbol, T::Array[String]]) }
       def group_dependencies_by_reason(filtered_deps)
-        grouped = {
-          not_in_group: T.let([], T::Array[String]),
-          filtered_by_config: T.let([], T::Array[String]),
-          belongs_to_more_specific_group: T.let([], T::Array[String]),
-          other: T.let([], T::Array[String])
-        }
+        grouped = T.let(
+          {
+            not_in_group: [],
+            filtered_by_config: [],
+            belongs_to_more_specific_group: [],
+            other: []
+          },
+          T::Hash[Symbol, T::Array[String]]
+        )
 
         filtered_deps.each do |dep|
           attribution = DependencyAttribution.get_attribution(dep)
           case attribution&.selection_reason
           when DependencyAttribution::SelectionReason::NOT_IN_GROUP
-            grouped[:not_in_group] << dep.name
+            grouped.fetch(:not_in_group) << dep.name
           when DependencyAttribution::SelectionReason::FILTERED_BY_CONFIG
-            grouped[:filtered_by_config] << dep.name
+            grouped.fetch(:filtered_by_config) << dep.name
           when DependencyAttribution::SelectionReason::BELONGS_TO_MORE_SPECIFIC_GROUP
-            grouped[:belongs_to_more_specific_group] << dep.name
+            grouped.fetch(:belongs_to_more_specific_group) << dep.name
           else
-            grouped[:other] << dep.name
+            grouped.fetch(:other) << dep.name
           end
         end
 

--- a/updater/lib/dependabot/updater/group_dependency_selector.rb
+++ b/updater/lib/dependabot/updater/group_dependency_selector.rb
@@ -376,12 +376,12 @@ module Dependabot
 
         filtered_deps.each do |dep|
           attribution = DependencyAttribution.get_attribution(dep)
-          case attribution&.dig(:selection_reason)
-          when :not_in_group
+          case attribution&.selection_reason
+          when DependencyAttribution::SelectionReason::NOT_IN_GROUP
             grouped[:not_in_group] << dep.name
-          when :filtered_by_config
+          when DependencyAttribution::SelectionReason::FILTERED_BY_CONFIG
             grouped[:filtered_by_config] << dep.name
-          when :belongs_to_more_specific_group
+          when DependencyAttribution::SelectionReason::BELONGS_TO_MORE_SPECIFIC_GROUP
             grouped[:belongs_to_more_specific_group] << dep.name
           else
             grouped[:other] << dep.name

--- a/updater/lib/dependabot/updater/update_type_helper.rb
+++ b/updater/lib/dependabot/updater/update_type_helper.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/updater/lib/dependabot/updater/update_type_helper.rb
+++ b/updater/lib/dependabot/updater/update_type_helper.rb
@@ -35,15 +35,17 @@ module Dependabot
 
       sig { params(dep: Dependabot::Dependency).returns(T.nilable(T.class_of(Dependabot::Version))) }
       def version_class_for(dep)
-        return nil unless dep.respond_to?(:package_manager)
-
         Dependabot::Utils.version_class_for_package_manager(dep.package_manager)
       end
 
-      sig { params(version_class: T.untyped, prev_str: String, curr_str: String).returns(T.nilable(String)) }
+      sig do
+        params(
+          version_class: T.class_of(Dependabot::Version),
+          prev_str: String,
+          curr_str: String
+        ).returns(T.nilable(String))
+      end
       def update_type_from_class(version_class, prev_str, curr_str)
-        return unless version_class.respond_to?(:update_type)
-
         result = version_class.update_type(prev_str, curr_str)
         if result.nil?
           Dependabot.logger.info(
@@ -54,11 +56,10 @@ module Dependabot
       end
 
       sig do
-        params(version_class: T.untyped, prev_str: String, curr_str: String)
+        params(version_class: T.class_of(Dependabot::Version), prev_str: String, curr_str: String)
           .returns(T.nilable([Dependabot::Version, Dependabot::Version]))
       end
       def build_versions(version_class, prev_str, curr_str)
-        return nil unless version_class.respond_to?(:correct?)
         return nil unless version_class.correct?(prev_str) && version_class.correct?(curr_str)
 
         [version_class.new(prev_str), version_class.new(curr_str)]
@@ -85,12 +86,12 @@ module Dependabot
         nil
       end
 
-      sig { params(version: T.untyped).returns(T.nilable(SemverParts)) }
+      sig { params(version: Gem::Version).returns(T.nilable(SemverParts)) }
       def semver_parts(version)
         # Normalize the version string by stripping any 'v' prefix
         normalized_version = version.to_s.delete_prefix("v")
 
-        if version.respond_to?(:semver_parts)
+        if version.is_a?(Dependabot::Version)
           parts = version.semver_parts
           return SemverParts.new(major: parts[0], minor: parts[1], patch: parts[2]) if parts
         end
@@ -117,8 +118,8 @@ module Dependabot
       # by comparing its previous and current versions. Returns nil if it cannot be determined.
       sig { params(dep: Dependabot::Dependency).returns(T.nilable(String)) }
       def update_type_for_dependency(dep)
-        prev_str = dep.respond_to?(:previous_version) ? dep.previous_version&.to_s : nil
-        curr_str = dep.respond_to?(:version) ? dep.version&.to_s : nil
+        prev_str = dep.previous_version&.to_s
+        curr_str = dep.version&.to_s
         return nil unless prev_str && curr_str
 
         version_class = version_class_for(dep)

--- a/updater/spec/dependabot/dependency_attribution_spec.rb
+++ b/updater/spec/dependabot/dependency_attribution_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe Dependabot::DependencyAttribution do
 
       # Check that attribution metadata is properly set
       attribution = described_class.get_attribution(dependency)
-      expect(attribution).to include(
+      expect(attribution.to_h).to include(
         source_group: "backend",
         selection_reason: :direct,
         directory: "/api"
       )
-      expect(attribution[:timestamp]).to be_a(Time)
+      expect(attribution.timestamp).to be_a(Time)
     end
 
     it "validates selection reason" do
@@ -70,14 +70,14 @@ RSpec.describe Dependabot::DependencyAttribution do
         )
       end
 
-      it "returns attribution hash" do
+      it "returns attribution details" do
         attribution = described_class.get_attribution(dependency)
-        expect(attribution).to include(
+        expect(attribution.to_h).to include(
           source_group: "backend",
           selection_reason: :direct,
           directory: "/api"
         )
-        expect(attribution[:timestamp]).to be_a(Time)
+        expect(attribution.timestamp).to be_a(Time)
       end
     end
 
@@ -86,9 +86,9 @@ RSpec.describe Dependabot::DependencyAttribution do
         expect(described_class.extract_attribution_data([])).to eq([])
 
         summary = described_class.telemetry_summary([])
-        expect(summary[:total_dependencies]).to eq(0)
-        expect(summary[:attributed_dependencies]).to eq(0)
-        expect(summary[:attribution_coverage]).to eq(0.0)
+        expect(summary.total_dependencies).to eq(0)
+        expect(summary.attributed_dependencies).to eq(0)
+        expect(summary.attribution_coverage).to eq(0.0)
       end
     end
   end
@@ -147,7 +147,7 @@ RSpec.describe Dependabot::DependencyAttribution do
     it "extracts attribution data from attributed dependencies" do
       data = described_class.extract_attribution_data(dependencies)
       expect(data.length).to eq(1)
-      expect(data[0]).to include(
+      expect(data[0].to_h).to include(
         name: "attributed-dep",
         version: "1.0.0",
         previous_version: "0.9.0",
@@ -185,20 +185,20 @@ RSpec.describe Dependabot::DependencyAttribution do
 
     it "generates telemetry summary" do
       summary = described_class.telemetry_summary(dependencies)
-      expect(summary).to include(
+      expect(summary.to_h).to include(
         total_dependencies: 3,
         attributed_dependencies: 2,
         attribution_coverage: 2.0 / 3
       )
-      expect(summary[:selection_reasons]).to include(
+      expect(summary.selection_reasons).to include(
         "direct" => 1,
         "already_updated" => 1
       )
-      expect(summary[:source_groups]).to include(
+      expect(summary.source_groups).to include(
         "backend" => 1,
         "frontend" => 1
       )
-      expect(summary[:directories]).to include(
+      expect(summary.directories).to include(
         "/api" => 1,
         "/web" => 1
       )
@@ -213,6 +213,7 @@ RSpec.describe Dependabot::DependencyAttribution do
         :dependency_drift,
         :not_in_group,
         :filtered_by_config,
+        :belongs_to_more_specific_group,
         :unknown
       )
     end

--- a/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
+++ b/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
@@ -9,6 +9,63 @@ require "dependabot/updater/operations"
 require "spec_helper"
 
 RSpec.describe Dependabot::Updater::DependencyGroupChangeBatch do
+  describe "#merge" do
+    let(:initial_file) do
+      Dependabot::DependencyFile.new(name: "Gemfile.lock", content: "initial", directory: "/")
+    end
+    let(:updated_file) do
+      Dependabot::DependencyFile.new(name: "Gemfile.lock", content: "first update", directory: "/")
+    end
+    let(:second_update) do
+      Dependabot::DependencyFile.new(name: "Gemfile.lock", content: "second update", directory: "/")
+    end
+    let(:vendored_file) do
+      Dependabot::DependencyFile.new(
+        name: "vendor/cache/example.gem",
+        content: "vendored",
+        directory: "/",
+        vendored_file: true
+      )
+    end
+    let(:batch) { described_class.new(initial_dependency_files: [initial_file]) }
+    let(:logger) { instance_double(Logger, debug?: true, debug: nil) }
+
+    before do
+      allow(Dependabot).to receive(:logger).and_return(logger)
+    end
+
+    it "tracks changed and vendored files" do
+      change = instance_double(
+        Dependabot::DependencyChange,
+        updated_dependencies: [],
+        updated_dependency_files: [updated_file, vendored_file]
+      )
+
+      batch.merge(change)
+
+      expect(batch.updated_dependency_files).to contain_exactly(updated_file, vendored_file)
+    end
+
+    it "increments repeated changes and retains the newest file" do
+      first_change = instance_double(
+        Dependabot::DependencyChange,
+        updated_dependencies: [],
+        updated_dependency_files: [updated_file]
+      )
+      second_change = instance_double(
+        Dependabot::DependencyChange,
+        updated_dependencies: [],
+        updated_dependency_files: [second_update]
+      )
+
+      batch.merge(first_change)
+      expect(logger).to receive(:debug).with("  - /Gemfile.lock ( Changed 2 times )")
+      batch.merge(second_change)
+
+      expect(batch.updated_dependency_files).to eq([second_update])
+    end
+  end
+
   describe "current_dependency_files" do
     let(:files) do
       [

--- a/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
+++ b/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
@@ -13,14 +13,18 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
   # double matches how DependencyGroup parses its rules. A nil reader means the
   # rule is absent, mirroring DependencyGroup#string_array_rule.
   def group_double(rules:, **attrs)
-    instance_double(
+    applies_to = attrs.delete(:applies_to) || "version-updates"
+    group = instance_double(
       Dependabot::DependencyGroup,
       rules: rules,
+      applies_to: applies_to,
       patterns: rules.key?("patterns") ? Array(rules["patterns"]) : nil,
       exclude_patterns: rules.key?("exclude-patterns") ? Array(rules["exclude-patterns"]) : nil,
       update_types: rules.key?("update-types") ? Array(rules["update-types"]) : nil,
       **attrs
     )
+    allow(group).to receive(:respond_to?).and_return(false)
+    group
   end
 
   let(:group_name) { "backend-dependencies" }
@@ -491,7 +495,7 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
           snapshot_with_multiple_groups.groups,
           instance_of(Proc),
           "/api",
-          applies_to: nil,
+          applies_to: "version-updates",
           update_type: "minor"
         )
       end

--- a/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
+++ b/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
@@ -625,20 +625,16 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       end
 
       it "includes specificity filtering in group dependencies by reason" do
-        allow(Dependabot::DependencyAttribution).to receive(:get_attribution) do |dep|
-          if %w(docker-compose nginx).include?(dep.name)
-            { selection_reason: :belongs_to_more_specific_group }
-          else
-            { selection_reason: :direct }
-          end
-        end
+        generic_selector.filter_to_group!(dependency_change)
 
-        filtered_deps = [docker_dep, nginx_dep]
-        grouped = generic_selector.send(:group_dependencies_by_reason, filtered_deps)
-
-        expect(grouped[:belongs_to_more_specific_group]).to contain_exactly("docker-compose", "nginx")
-        expect(grouped[:not_in_group]).to be_empty
-        expect(grouped[:filtered_by_config]).to be_empty
+        expect(Dependabot::DependencyAttribution.get_attribution(docker_dep).selection_reason)
+          .to eq(Dependabot::DependencyAttribution::SelectionReason::BELONGS_TO_MORE_SPECIFIC_GROUP)
+        expect(Dependabot::DependencyAttribution.get_attribution(nginx_dep).selection_reason)
+          .to eq(Dependabot::DependencyAttribution::SelectionReason::BELONGS_TO_MORE_SPECIFIC_GROUP)
+        expect(Dependabot.logger).to have_received(:info).with(
+          "Filtered dependencies belongs to more specific group: docker-compose, nginx " \
+          "[group=all-dependencies, ecosystem=bundler, count=2]"
+        )
       end
     end
 
@@ -1424,16 +1420,19 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
   end
 
   def stub_attribution_methods(dep)
-    allow(dep).to receive(:attribution_source_group=)
-    allow(dep).to receive(:attribution_selection_reason=)
-    allow(dep).to receive(:attribution_directory=)
-    allow(dep).to receive(:attribution_timestamp=)
-    allow(dep).to receive_messages(
-      attribution_source_group: nil,
-      attribution_selection_reason: nil,
-      attribution_directory: nil,
-      attribution_timestamp: nil
-    )
+    source_group = nil
+    selection_reason = nil
+    directory = nil
+    timestamp = nil
+
+    allow(dep).to receive(:attribution_source_group=) { |value| source_group = value }
+    allow(dep).to receive(:attribution_selection_reason=) { |value| selection_reason = value }
+    allow(dep).to receive(:attribution_directory=) { |value| directory = value }
+    allow(dep).to receive(:attribution_timestamp=) { |value| timestamp = value }
+    allow(dep).to receive(:attribution_source_group) { source_group }
+    allow(dep).to receive(:attribution_selection_reason) { selection_reason }
+    allow(dep).to receive(:attribution_directory) { directory }
+    allow(dep).to receive(:attribution_timestamp) { timestamp }
   end
 
   def create_dependency_change(job:, dependencies:, files:)

--- a/updater/spec/dependabot/updater/update_type_helper_spec.rb
+++ b/updater/spec/dependabot/updater/update_type_helper_spec.rb
@@ -15,15 +15,30 @@ RSpec.describe Dependabot::Updater::UpdateTypeHelper do
 
   let(:helper) { helper_class.new }
 
-  # Simple test version class that supports semver_parts
   let(:version_with_semver_parts) do
-    Struct.new(:semver_parts, :to_s)
+    Class.new(Dependabot::Version) do
+      def semver_parts
+        [1, 2, 3]
+      end
+    end
+  end
+
+  let(:version_without_semver_parts) do
+    Class.new(Dependabot::Version) do
+      def semver_parts
+        nil
+      end
+
+      def to_s
+        "invalid"
+      end
+    end
   end
 
   describe "#semver_parts" do
     context "when version responds to semver_parts" do
       it "returns SemverParts from the version's semver_parts method" do
-        version = version_with_semver_parts.new([1, 2, 3], "1.2.3")
+        version = version_with_semver_parts.new("1.2.3")
 
         result = helper.semver_parts(version)
 
@@ -34,7 +49,7 @@ RSpec.describe Dependabot::Updater::UpdateTypeHelper do
       end
 
       it "returns nil when semver_parts returns nil" do
-        version = version_with_semver_parts.new(nil, "invalid")
+        version = version_without_semver_parts.new("1.0.0")
 
         result = helper.semver_parts(version)
 


### PR DESCRIPTION
Replace untyped updater helper state with typed models and move four files to `typed: strong`.