### PR TITLE
docker: Allow suffix to start with a number

### DIFF
--- a/docker/lib/dependabot/docker/tag.rb
+++ b/docker/lib/dependabot/docker/tag.rb
@@ -12,9 +12,9 @@ module Dependabot
 
       WORDS_WITH_BUILD = /(?:(?:-[a-z]+)+-[0-9]+)+/
       VERSION_REGEX = /v?(?<version>[0-9]+(?:[_.][0-9]+)*(?:\.[a-z0-9]+|#{WORDS_WITH_BUILD}|-(?:kb)?[0-9]+)*)/i
-      VERSION_WITH_SFX = /^(?<operator>[~^<>=]*)#{VERSION_REGEX}(?<suffix>-[a-z][a-z0-9.\-]*)?$/i
+      VERSION_WITH_SFX = /^(?<operator>[~^<>=]*)#{VERSION_REGEX}(?<suffix>-(?:[a-z][a-z0-9.\-]*|[0-9a-f]{9}))?$/i
       VERSION_WITH_PFX = /^(?<prefix>[a-z][a-z0-9.\-_]*-)?#{VERSION_REGEX}$/i
-      VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-_]+-)?#{VERSION_REGEX}(?<suffix>-[a-z\-]+)?$/i
+      VERSION_WITH_PFX_AND_SFX = /^(?<prefix>[a-z\-_]+-)#{VERSION_REGEX}(?<suffix>-[a-z0-9\-]+)?$/i
       NAME_WITH_VERSION =
         /
           #{VERSION_WITH_PFX}|

--- a/docker/spec/dependabot/docker/tag_spec.rb
+++ b/docker/spec/dependabot/docker/tag_spec.rb
@@ -226,5 +226,27 @@ RSpec.describe Dependabot::Docker::Tag do
       expect(described_class.new("17.10").numeric_version).to eq("17.10")
       expect(described_class.new("2.4.0-slim").numeric_version).to eq("2.4.0")
     end
+
+    it "parses numeric-leading hash suffix tags as comparable versions" do
+      current = described_class.new("1.43.1.10611-1e34174b1")
+      newer = described_class.new("1.43.3.10828-00f62d37d")
+
+      expect(current.comparable?).to be true
+      expect(newer.comparable?).to be true
+      expect(current.format).to eq(:sha_suffixed)
+      expect(newer.format).to eq(:sha_suffixed)
+      expect(current.version).to eq("1.43.1.10611")
+      expect(newer.version).to eq("1.43.3.10828")
+      expect(current.suffix).to eq("-1e34174b1")
+      expect(newer.suffix).to eq("-00f62d37d")
+      expect(current.comparable_to?(newer)).to be true
+      expect(newer.comparable_to?(current)).to be true
+    end
+
+    it "does not treat complex date-plus-hash suffixes as comparable" do
+      tag = described_class.new("3.2025.123.4567-123abc-20250305t1309")
+
+      expect(tag.comparable?).to be false
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide both a what and a _why_ for the change. -->
Allows Dependabot to parse versions like `1.43.1.10611-1e34174b1` as something that can be compared, i.e. suffixes may start with a number if they appear to be a short hash. 

<!-- What issues does this affect or fix? -->
Solves [#15624](https://github.com/dependabot/dependabot-core/issues/15624)

### Anything you want to highlight for special attention from reviewers?

This is mentioned in in more detail in the linked issue, but I am not sure about the consequences since there are two commits which mentions explicitly that suffixes should start with a letter:

- [Version suffixes should always start with a letter.](https://github.com/dependabot/dependabot-core/commit/c8271c8cfe87070ce16483af8d7076ab74b7abe5)
- [Fix inconsistent docker updates with - suffixed images](https://github.com/dependabot/dependabot-core/pull/6173/changes)

However, at the same time I suppose a short hash is something that should be supported?

Also, the `VERSION_WITH_SFX` and the `VERSION_WITH_PFX_AND_SFX` regex differ, do we want to align them in some way or is it intentional?

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
  - There are some questions that need to be resolved since regex is not entirely trivial to begin with. 
