### PR TITLE
npm_and_yarn: group vulnerability auditor blocking-dependency messages by top-level ancestor

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -271,23 +271,31 @@ module Dependabot
           blockers = audit_result["blocking_dependencies"]
           return generic_fix_unavailable_message(dependency) if blockers.nil? || blockers.empty?
 
-          conflicts = blockers.map do |blocker|
-            blocker_name = blocker["name"]
-            blocker_version = blocker["version"]
-            blocker_requirement = blocker["requirement"]
-            detail = "#{blocker_name}@#{blocker_version} requires " \
-                     "#{dependency.name}@#{blocker_requirement}"
-            ancestor = blocker["top_level_ancestor"]
+          # Group by the top-level dependency a customer would actually need to act on, rather than
+          # listing one line per (parent, version, requirement) tuple. A single top-level package
+          # (e.g. jest) commonly pulls in the vulnerable dependency via several different parents/
+          # versions, and repeating each of those separately buries the actionable information.
+          grouped_by_ancestor = blockers.group_by { |blocker| blocker["top_level_ancestor"] }
 
-            detail += " (pulled in via #{ancestor})" if ancestor && ancestor != blocker_name
-            detail
-          end.join("; ")
+          ancestor_lines = grouped_by_ancestor.sort.map do |ancestor, group|
+            requirements = group.map do |blocker|
+              blocker_name = blocker["name"]
+              detail = "#{dependency.name}@#{blocker['requirement']}"
+              detail += " (via #{blocker_name}@#{blocker['version']})" if blocker_name != ancestor
+              detail
+            end.uniq.join(" and ")
 
-          "#{dependency.name} can't be updated to a non-vulnerable version because the npm helper identified parent " \
-            "package constraints in the dependency tree that still require a vulnerable version: #{conflicts}. To " \
-            "resolve this, update the parent " \
-            "package(s) listed above to a release that allows a non-vulnerable #{dependency.name}, or add an " \
-            "override/resolution pinning #{dependency.name} to a non-vulnerable version."
+            "  - #{ancestor}: requires #{requirements}"
+          end.join("\n")
+
+          ancestors = grouped_by_ancestor.keys.sort.join(", ")
+
+          "#{dependency.name} can't be automatically updated to a non-vulnerable version. The following " \
+            "top-level dependencies still require a vulnerable #{dependency.name} and need to be updated:\n" \
+            "#{ancestor_lines}\n\n" \
+            "To resolve this, update #{ancestors} to a release that depends on a non-vulnerable " \
+            "#{dependency.name}, or add an override/resolution pinning #{dependency.name} to a non-vulnerable " \
+            "version."
         end
 
         sig { params(dependency: Dependabot::Dependency).returns(String) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -227,12 +227,13 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
           .to include(
             "fix_available" => false,
             "explanation" =>
-              "#{dependency.name} can't be updated to a non-vulnerable version because the npm helper identified " \
-              "parent package constraints in the dependency tree that still require a vulnerable version: " \
-              "@dependabot-fixtures/npm-parent-dependency@2.0.0 requires #{dependency.name}@1.0.0 " \
-              "(pulled in via @dependabot-fixtures/npm-top-level). To resolve this, update the parent " \
-              "package(s) listed above to a release that allows a non-vulnerable #{dependency.name}, or add an " \
-              "override/resolution pinning #{dependency.name} to a non-vulnerable version.",
+              "#{dependency.name} can't be automatically updated to a non-vulnerable version. The following " \
+              "top-level dependencies still require a vulnerable #{dependency.name} and need to be updated:\n" \
+              "  - @dependabot-fixtures/npm-top-level: requires #{dependency.name}@1.0.0 " \
+              "(via @dependabot-fixtures/npm-parent-dependency@2.0.0)\n\n" \
+              "To resolve this, update @dependabot-fixtures/npm-top-level to a release that depends on a " \
+              "non-vulnerable #{dependency.name}, or add an override/resolution pinning #{dependency.name} to a " \
+              "non-vulnerable version.",
             "blocking_dependencies" => [{
               "name" => "@dependabot-fixtures/npm-parent-dependency",
               "version" => "2.0.0",

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -242,6 +242,69 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             }]
           )
       end
+
+      it "groups blockers by top-level ancestor and deduplicates repeated entries within a group" do
+        security_advisories = [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: dependency.name,
+            package_manager: "npm_and_yarn",
+            vulnerable_versions: ["<1.0.1"],
+            safe_versions: ["1.0.1"]
+          )
+        ]
+
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_helper_subprocess)
+          .and_return({
+            "dependency_name" => dependency.name,
+            "fix_available" => false,
+            "current_version" => "1.0.0",
+            "fix_updates" => [],
+            "top_level_ancestors" => [],
+            "blocking_dependencies" => [
+              {
+                "name" => "minimatch",
+                "version" => "10.2.4",
+                "requirement" => "^5.0.2",
+                "top_level_ancestor" => "ancestor-a"
+              },
+              {
+                "name" => "minimatch",
+                "version" => "3.1.5",
+                "requirement" => "^1.1.7",
+                "top_level_ancestor" => "ancestor-a"
+              },
+              # Duplicate of the entry above (e.g. two separate vulnerable locations pulled in by the
+              # same parent/version/requirement combination) - should be collapsed to a single line.
+              {
+                "name" => "minimatch",
+                "version" => "3.1.5",
+                "requirement" => "^1.1.7",
+                "top_level_ancestor" => "ancestor-a"
+              },
+              {
+                "name" => "minimatch",
+                "version" => "3.1.5",
+                "requirement" => "^1.1.7",
+                "top_level_ancestor" => "ancestor-b"
+              }
+            ]
+          })
+
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+          .to include(
+            "fix_available" => false,
+            "explanation" =>
+              "#{dependency.name} can't be automatically updated to a non-vulnerable version. The following " \
+              "top-level dependencies still require a vulnerable #{dependency.name} and need to be updated:\n" \
+              "  - ancestor-a: requires #{dependency.name}@^5.0.2 (via minimatch@10.2.4) and " \
+              "#{dependency.name}@^1.1.7 (via minimatch@3.1.5)\n" \
+              "  - ancestor-b: requires #{dependency.name}@^1.1.7 (via minimatch@3.1.5)\n\n" \
+              "To resolve this, update ancestor-a, ancestor-b to a release that depends on a non-vulnerable " \
+              "#{dependency.name}, or add an override/resolution pinning #{dependency.name} to a non-vulnerable " \
+              "version."
+          )
+      end
     end
 
     context "when no fix is available and no blocking dependencies are known" do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -2086,15 +2086,16 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
           .to eq(
             "dependency_name" => "@dependabot-fixtures/npm-transitive-dependency",
             "explanation" =>
-              "@dependabot-fixtures/npm-transitive-dependency can't be updated to a non-vulnerable version " \
-              "because the npm helper identified parent package constraints in the dependency tree that still " \
-              "require a vulnerable version: " \
-              "@dependabot-fixtures/npm-intermediate-dependency@0.0.1 requires " \
+              "@dependabot-fixtures/npm-transitive-dependency can't be automatically updated to a " \
+              "non-vulnerable version. The following top-level dependencies still require a vulnerable " \
+              "@dependabot-fixtures/npm-transitive-dependency and need to be updated:\n" \
+              "  - @dependabot-fixtures/npm-parent-dependency-5: requires " \
               "@dependabot-fixtures/npm-transitive-dependency@1.0.0 " \
-              "(pulled in via @dependabot-fixtures/npm-parent-dependency-5). To resolve this, update the " \
-              "parent package(s) listed above to a release that allows a non-vulnerable " \
-              "@dependabot-fixtures/npm-transitive-dependency, or add an override/resolution pinning " \
-              "@dependabot-fixtures/npm-transitive-dependency to a non-vulnerable version.",
+              "(via @dependabot-fixtures/npm-intermediate-dependency@0.0.1)\n\n" \
+              "To resolve this, update @dependabot-fixtures/npm-parent-dependency-5 to a release that depends " \
+              "on a non-vulnerable @dependabot-fixtures/npm-transitive-dependency, or add an " \
+              "override/resolution pinning @dependabot-fixtures/npm-transitive-dependency to a non-vulnerable " \
+              "version.",
             "fix_available" => false,
             "fix_updates" => [],
             "top_level_ancestors" => [],


### PR DESCRIPTION
### What are you trying to accomplish?

When the same transitive dependency (e.g. `brace-expansion`) is pulled in multiple times by different parent packages requiring incompatible version ranges, Dependabot can't safely bump it to a single non-vulnerable version.

Dependabot's VulnerabilityAuditor uses npm's own dependency resolution engine (the same one behind `npm audit fix`) to check this, and it correctly determines no full fix is possible here. However, the resulting log message was hard to act on — it repeated the same blocking package multiple times without making clear which top-level dependency actually needs updating.

This change improves that message by grouping the blocking dependencies by top-level ancestor, so customers can see exactly which packages (e.g. `jest`, `eslint-config-next`) they need to update or override to resolve the vulnerability, instead of a flat, repetitive list.

### Anything you want to highlight for special attention from reviewers?

Group blocking_dependencies by top-level ancestor instead of emitting one flat sentence per (parent, version, requirement) tuple, so the explanation names the exact packages a user needs to update (e.g. `jest`, `eslint-config-next`) rather than repeating the same intermediate dependency multiple times.

Update specs in `vulnerability_auditor_spec.rb` and `update_checker_spec.rb` to match the new message format.

### How will you know you've accomplished your goal?

Error message:

Before: 
Ref: https://github.com/dsp-testing/npm-transitive-dependency-security-update-failure-FR-13807/actions/runs/29822966340/job/88609662294
```
updater | 2026/06/18 08:38:33 INFO <job_1420896546> The latest possible version that can be installed is 5.0.5 because of the following conflicting dependency:

  brace-expansion can't be updated to a non-vulnerable version because the npm helper identified parent package constraints in the dependency tree that still require a vulnerable version: minimatch@10.2.4 requires brace-expansion@^5.0.2 (pulled in via eslint-config-next); minimatch@3.1.5 requires brace-expansion@^1.1.7 (pulled in via eslint-config-next); minimatch@3.1.5 requires brace-expansion@^1.1.7 (pulled in via jest); minimatch@3.1.5 requires brace-expansion@^1.1.7 (pulled in via license-checker); minimatch@3.1.5 requires brace-expansion@^1.1.7 (pulled in via npm-build-zip); minimatch@9.0.9 requires brace-expansion@^2.0.2 (pulled in via jest). To resolve this, update the parent package(s) listed above to a release that allows a non-vulnerable brace-expansion, or add an override/resolution pinning brace-expansion to a non-vulnerable version.
2026/06/18 08:38:33 INFO <job_1420896546> The earliest fixed version is 5.0.6.
```

After this update:
```
2026/07/20 15:03:39 INFO The latest possible version that can be installed is 5.0.5 because of the following conflicting dependency:

  brace-expansion can't be automatically updated to a non-vulnerable version. The following top-level dependencies still require a vulnerable brace-expansion and need to be updated:
  - eslint-config-next: requires brace-expansion@^5.0.2 (via minimatch@10.2.4) and brace-expansion@^1.1.7 (via minimatch@3.1.5)
  - jest: requires brace-expansion@^1.1.7 (via minimatch@3.1.5) and brace-expansion@^2.0.2 (via minimatch@9.0.9)
  - license-checker: requires brace-expansion@^1.1.7 (via minimatch@3.1.5)
  - npm-build-zip: requires brace-expansion@^1.1.7 (via minimatch@3.1.5)

To resolve this, update eslint-config-next, jest, license-checker, npm-build-zip to a release that depends on a non-vulnerable brace-expansion, or add an override/resolution pinning brace-expansion to a non-vulnerable version.
2026/07/20 15:03:39 INFO The earliest fixed version is 5.0.6.
```

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
