### PR TITLE
ensure proper formatting when patching element attributes

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
@@ -79,6 +79,27 @@ public class SpecialFilePatcherTests
             """
         ];
 
+        // one-off test to verify no whitespace before end tag is supported
+        yield return
+        [
+            // fileContent
+            """
+            <Project>
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets"/>
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """,
+            // expectedPatchedContent
+            """
+            <Project>
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" Condition="false" />
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """
+        ];
+
         // one-off test to verify existing conditions are restored
         yield return
         [
@@ -87,6 +108,28 @@ public class SpecialFilePatcherTests
             <Project>
               <Import Project="Unrelated.One.targets" />
               <Import Project="Some\Path\Microsoft.WebApplication.targets" Condition="existing condition" />
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """,
+            // expectedPatchedContent
+            """
+            <Project>
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" Condition="false" />
+              <Import Project="Unrelated.Two.targets" />
+            </Project>
+            """
+        ];
+
+        // one-off test to verify existing conditions are restored when on a different line
+        yield return
+        [
+            // fileContent
+            """
+            <Project>
+              <Import Project="Unrelated.One.targets" />
+              <Import Project="Some\Path\Microsoft.WebApplication.targets"
+                      Condition="existing condition on a different line" />
               <Import Project="Unrelated.Two.targets" />
             </Project>
             """,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
@@ -54,6 +54,44 @@ public class SpecialFilePatcherTests
         Assert.Equal(restoredContent.Replace("\r", ""), fileContent.Replace("\r", ""));
     }
 
+    [Fact]
+    public async Task ModifiedAttributesAreRetainedThroughConditionPatching()
+    {
+        // it's possible that an operation updated a `<Import Project="..." />` element after we patched it with `Condition="false"`
+        // this test ensures that if that did happen, we don't lose the updated attributes when we restore the original content
+
+        // arrange
+        var projectFileName = "project.csproj";
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync((projectFileName, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" />
+            </Project>
+            """));
+        var projectPath = Path.Join(tempDir.DirectoryPath, projectFileName);
+
+        // act
+        using (var patcher = new SpecialImportsConditionPatcher(projectPath))
+        {
+            var initialPatchedContent = await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken);
+            Assert.Contains("Condition=\"false\"", initialPatchedContent);
+
+            // this simulates an operation that updated the `<Import Project="..."` attribute that we still want to be present when we're all done
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <Import Project="UPDATED\Path\Microsoft.WebApplication.targets" Condition="false" />
+                </Project>
+                """, TestContext.Current.CancellationToken);
+        }
+
+        // assert
+        var restoredAndUpdatedContent = await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken);
+        Assert.Equal("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <Import Project="UPDATED\Path\Microsoft.WebApplication.targets" />
+            </Project>
+            """.Replace("\r", ""), restoredAndUpdatedContent.Replace("\r", ""));
+    }
+
     public static IEnumerable<object[]> SpecialImportsConditionPatcherTestData()
     {
         // magic file names

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/SpecialFilePatcherTests.cs
@@ -92,6 +92,82 @@ public class SpecialFilePatcherTests
             """.Replace("\r", ""), restoredAndUpdatedContent.Replace("\r", ""));
     }
 
+    [Fact]
+    public async Task NewAttributesAreRetainedThroughConditionPatching()
+    {
+        // it's possible that an operation updated a `<Import Project="..." />` element after we patched it with `Condition="false"`
+        // this test ensures that if that did happen, we don't lose any attributes that were added
+
+        // arrange
+        var projectFileName = "project.csproj";
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync((projectFileName, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" />
+            </Project>
+            """));
+        var projectPath = Path.Join(tempDir.DirectoryPath, projectFileName);
+
+        // act
+        using (var patcher = new SpecialImportsConditionPatcher(projectPath))
+        {
+            var initialPatchedContent = await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken);
+            Assert.Contains("Condition=\"false\"", initialPatchedContent);
+
+            // this simulates an operation that added the `NewAttribute="..."` attribute that we still want to be present when we're all done
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <Import Project="Some\Path\Microsoft.WebApplication.targets" NewAttribute="NewValue" Condition="false" />
+                </Project>
+                """, TestContext.Current.CancellationToken);
+        }
+
+        // assert
+        var restoredAndUpdatedContent = await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken);
+        Assert.Equal("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" NewAttribute="NewValue" />
+            </Project>
+            """.Replace("\r", ""), restoredAndUpdatedContent.Replace("\r", ""));
+    }
+
+    [Fact]
+    public async Task RemovedAttributesAreNotReAddedThroughConditionPatching()
+    {
+        // it's possible that an operation updated a `<Import Project="..." />` element after we patched it with `Condition="false"`
+        // this test ensures that if that did happen, we don't re-add any attributes that were removed
+
+        // arrange
+        var projectFileName = "project.csproj";
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync((projectFileName, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" UnrelatedAttribute="UnrelatedValue" />
+            </Project>
+            """));
+        var projectPath = Path.Join(tempDir.DirectoryPath, projectFileName);
+
+        // act
+        using (var patcher = new SpecialImportsConditionPatcher(projectPath))
+        {
+            var initialPatchedContent = await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken);
+            Assert.Contains("Condition=\"false\"", initialPatchedContent);
+
+            // this simulates an operation that removed the `UnrelatedAttribute="..."` attribute that should remain absent when we're all done
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <Import Project="Some\Path\Microsoft.WebApplication.targets" Condition="false" />
+                </Project>
+                """, TestContext.Current.CancellationToken);
+        }
+
+        // assert
+        var restoredAndUpdatedContent = await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken);
+        Assert.Equal("""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <Import Project="Some\Path\Microsoft.WebApplication.targets" />
+            </Project>
+            """.Replace("\r", ""), restoredAndUpdatedContent.Replace("\r", ""));
+    }
+
     public static IEnumerable<object[]> SpecialImportsConditionPatcherTestData()
     {
         // magic file names

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SpecialImportsConditionPatcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SpecialImportsConditionPatcher.cs
@@ -76,12 +76,29 @@ namespace NuGetUpdater.Core.Updater
                         if (attributeName == "Condition" && attributeValue == "false")
                         {
                             // this was the attribute we manually patched so it shouldn't be copied over
+                            // note that if the update operation change the Condition value, then we _will_ copy it over, which is what we want
                             continue;
                         }
 
                         var oldAttribute = originalRestoredElement.GetAttribute(attributeName);
-                        var updatedAttribute = oldAttribute.WithValue(updatedAttributeValues[attributeName]);
-                        originalRestoredElement = originalRestoredElement.ReplaceAttribute(oldAttribute, updatedAttribute);
+                        if (oldAttribute is null)
+                        {
+                            // the attribute was added by an operation and just needs to be added
+                            originalRestoredElement = originalRestoredElement.WithAttribute(attributeName, attributeValue);
+                        }
+                        else
+                        {
+                            // the attribute was updated by an operation and needs to be maintained
+                            var updatedAttribute = oldAttribute.WithValue(updatedAttributeValues[attributeName]);
+                            originalRestoredElement = originalRestoredElement.ReplaceAttribute(oldAttribute, updatedAttribute);
+                        }
+                    }
+
+                    // remove attributes not present in the updated element
+                    var attributeNamesToRemove = originalRestoredElement.Attributes.Select(a => a.Name).Except(updatedAttributeValues.Keys);
+                    foreach (var attributeNameToRemove in attributeNamesToRemove)
+                    {
+                        originalRestoredElement = originalRestoredElement.RemoveAttributeByName(attributeNameToRemove);
                     }
 
                     return (XmlNodeSyntax)originalRestoredElement;

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SpecialImportsConditionPatcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SpecialImportsConditionPatcher.cs
@@ -8,7 +8,7 @@ namespace NuGetUpdater.Core.Updater
 {
     internal class SpecialImportsConditionPatcher : IDisposable
     {
-        private readonly List<string?> _capturedConditions = new List<string?>();
+        private readonly List<IXmlElementSyntax> _capturedElements = [];
         private readonly XmlFilePreAndPostProcessor _processor;
 
         // These files only ship with a full Visual Studio install
@@ -60,20 +60,14 @@ namespace NuGetUpdater.Core.Updater
                 preProcessor: (i, n) =>
                 {
                     var element = (IXmlElementSyntax)n;
-                    _capturedConditions.Add(element.GetAttributeValue("Condition"));
+                    _capturedElements.Add(element);
                     return (XmlNodeSyntax)element.RemoveAttributeByName("Condition").WithAttribute("Condition", "false");
                 },
                 postProcessor: (i, n) =>
                 {
                     var element = (IXmlElementSyntax)n;
-                    var newElement = element.RemoveAttributeByName("Condition");
-                    var capturedCondition = _capturedConditions[i];
-                    if (capturedCondition is not null)
-                    {
-                        newElement = newElement.WithAttribute("Condition", capturedCondition);
-                    }
-
-                    return (XmlNodeSyntax)newElement;
+                    var originalElement = _capturedElements[i];
+                    return (XmlNodeSyntax)originalElement;
                 }
             );
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SpecialImportsConditionPatcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/SpecialImportsConditionPatcher.cs
@@ -67,7 +67,24 @@ namespace NuGetUpdater.Core.Updater
                 {
                     var element = (IXmlElementSyntax)n;
                     var originalElement = _capturedElements[i];
-                    return (XmlNodeSyntax)originalElement;
+
+                    // copy over attribute values from the potentially updated element EXCEPT for `Condition="false"`
+                    var updatedAttributeValues = element.Attributes.ToDictionary(e => e.Name, e => e.Value);
+                    var originalRestoredElement = originalElement;
+                    foreach (var (attributeName, attributeValue) in updatedAttributeValues)
+                    {
+                        if (attributeName == "Condition" && attributeValue == "false")
+                        {
+                            // this was the attribute we manually patched so it shouldn't be copied over
+                            continue;
+                        }
+
+                        var oldAttribute = originalRestoredElement.GetAttribute(attributeName);
+                        var updatedAttribute = oldAttribute.WithValue(updatedAttributeValues[attributeName]);
+                        originalRestoredElement = originalRestoredElement.ReplaceAttribute(oldAttribute, updatedAttribute);
+                    }
+
+                    return (XmlNodeSyntax)originalRestoredElement;
                 }
             );
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/XmlExtensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/XmlExtensions.cs
@@ -66,15 +66,25 @@ public static class XmlExtensions
 
     public static IXmlElementSyntax WithAttribute(this IXmlElementSyntax parent, string name, string value)
     {
-        var singleSpanceTrivia = SyntaxFactory.WhitespaceTrivia(" ");
-
-        return parent.AddAttribute(SyntaxFactory.XmlAttribute(
+        var singleSpaceTrivia = SyntaxFactory.WhitespaceTrivia(" ");
+        var newAttribute = SyntaxFactory.XmlAttribute(
             SyntaxFactory.XmlName(null, SyntaxFactory.XmlNameToken(name, null, null)),
             SyntaxFactory.Punctuation(SyntaxKind.EqualsToken, "=", null, null),
             SyntaxFactory.XmlString(
                 SyntaxFactory.Punctuation(SyntaxKind.SingleQuoteToken, "\"", null, null),
                 SyntaxFactory.XmlTextLiteralToken(value, null, null),
-                SyntaxFactory.Punctuation(SyntaxKind.SingleQuoteToken, "\"", null, singleSpanceTrivia))));
+                SyntaxFactory.Punctuation(SyntaxKind.SingleQuoteToken, "\"", null, singleSpaceTrivia)));
+        var lastAttribute = parent.Attributes.LastOrDefault();
+        if (lastAttribute is not null &&
+            string.IsNullOrEmpty(lastAttribute.GetTrailingTrivia().ToFullString()))
+        {
+            // ensure there's a space at the end of the previous attribute so we don't end up with this:
+            //   <Element ExistingAttribute="ExistingValue"NewAttribute="NewValue" />
+            parent = parent.RemoveAttribute(lastAttribute)
+                .AddAttribute(lastAttribute.WithTrailingTrivia(singleSpaceTrivia));
+        }
+
+        return parent.AddAttribute(newAttribute);
     }
 
     public static XmlElementSyntax CreateOpenCloseXmlElementSyntax(string name, int indentation = 2, bool spaces = true)


### PR DESCRIPTION
Before update operations are performed, certain `<Import Project="..." ... />` elements are patched with a `Condition="false"` attribute.  If the `Project` attribute doesn't have trailing whitespace on the same line like one of the below:

``` xml
<Import Project="..."/>
<!-- or -->
<Import Project"..."
        Condition="..." />
```

then the new `Condition` attribute will cause bad formatting resulting in something like this:

``` xml
<Import Project="..."Condition="false" />
<!-- missing space  ^^ -->
```

The fix is to ensure the previous attribute has a trailing space if necessary.

Part of this also simplified the `Condition` patcher so instead of capturing that attribute and restoring it, just capture and restore the entire `<Import>` element; it's cleaner and less error-prone.  Also fixes a variable typo.