### PR TITLE
julia: don't propose compat updates for workspace packages or synthesize member compat entries

### DIFF
--- a/julia/lib/dependabot/julia/file_parser.rb
+++ b/julia/lib/dependabot/julia/file_parser.rb
@@ -105,9 +105,36 @@ module Dependabot
       def project_file_dependencies
         dependencies_map = T.let({}, T::Hash[String, Dependabot::Dependency])
 
-        # Parse all project files in the workspace
-        all_project_files.each do |proj_file|
-          parse_single_project_file(proj_file, dependencies_map)
+        parsed_projects = all_project_files.filter_map do |proj_file|
+          result = parse_project_file(proj_file)
+          [proj_file, result] if result
+        end
+
+        # Packages that are themselves workspace projects (the root package or
+        # a sibling member) resolve by path within the workspace, never from a
+        # registry, so they must not be treated as updatable dependencies.
+        workspace_package_uuids = parsed_projects.filter_map do |_, result|
+          T.cast(result["uuid"], T.nilable(String))
+        end
+
+        parsed_projects.each do |proj_file, result|
+          parsed_deps = T.cast(result["dependencies"] || [], T::Array[T.untyped])
+          merge_dependencies_from_list(
+            parsed_deps,
+            ["deps"],
+            proj_file.name,
+            dependencies_map,
+            workspace_package_uuids
+          )
+
+          parsed_weak_deps = T.cast(result["weak_dependencies"] || [], T::Array[T.untyped])
+          merge_dependencies_from_list(
+            parsed_weak_deps,
+            ["weakdeps"],
+            proj_file.name,
+            dependencies_map,
+            workspace_package_uuids
+          )
         end
 
         apply_manifest_versions(dependencies_map)
@@ -181,8 +208,8 @@ module Dependabot
         end
       end
 
-      sig { params(proj_file: Dependabot::DependencyFile, dependencies_map: T::Hash[String, Dependabot::Dependency]).void }
-      def parse_single_project_file(proj_file, dependencies_map)
+      sig { params(proj_file: Dependabot::DependencyFile).returns(T.nilable(T::Hash[String, T.untyped])) }
+      def parse_project_file(proj_file)
         temp_dir = Dir.mktmpdir("julia_project")
         # File names like "../Project.toml" (a workspace root fetched from a
         # member directory) must not escape the temp dir; fall back to the
@@ -197,15 +224,9 @@ module Dependabot
         begin
           result = registry_client.parse_project(project_path: project_path)
 
-          return if result["error"]
+          return nil if result["error"]
 
-          # Process dependencies
-          parsed_deps = T.cast(result["dependencies"] || [], T::Array[T.untyped])
-          merge_dependencies_from_list(parsed_deps, ["deps"], proj_file.name, dependencies_map)
-
-          # Process weak dependencies
-          parsed_weak_deps = T.cast(result["weak_dependencies"] || [], T::Array[T.untyped])
-          merge_dependencies_from_list(parsed_weak_deps, ["weakdeps"], proj_file.name, dependencies_map)
+          result
         ensure
           FileUtils.rm_rf(temp_dir)
         end
@@ -216,10 +237,11 @@ module Dependabot
           dep_list: T::Array[T.untyped],
           groups: T::Array[String],
           file_name: String,
-          dependencies_map: T::Hash[String, Dependabot::Dependency]
+          dependencies_map: T::Hash[String, Dependabot::Dependency],
+          workspace_package_uuids: T::Array[String]
         ).void
       end
-      def merge_dependencies_from_list(dep_list, groups, file_name, dependencies_map)
+      def merge_dependencies_from_list(dep_list, groups, file_name, dependencies_map, workspace_package_uuids)
         dep_list.each do |dep_info|
           dep_hash = T.cast(dep_info, T::Hash[String, T.untyped])
           name = T.cast(dep_hash["name"], String)
@@ -227,6 +249,8 @@ module Dependabot
 
           uuid = T.cast(dep_hash["uuid"], T.nilable(String))
           requirement_string = T.cast(dep_hash["requirement"], T.nilable(String))
+
+          next if skip_dependency?(uuid, requirement_string, file_name, workspace_package_uuids)
 
           new_requirement = {
             requirement: requirement_string,
@@ -285,6 +309,32 @@ module Dependabot
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def all_project_files
         dependency_files.select { |f| f.name.match?(/Project\.toml$/i) }
+      end
+
+      sig do
+        params(
+          uuid: T.nilable(String),
+          requirement_string: T.nilable(String),
+          file_name: String,
+          workspace_package_uuids: T::Array[String]
+        ).returns(T::Boolean)
+      end
+      def skip_dependency?(uuid, requirement_string, file_name, workspace_package_uuids)
+        return true if uuid && workspace_package_uuids.include?(uuid)
+
+        # A dep with no compat entry in a workspace member file (test/,
+        # docs/, ...) must not get one synthesized: Julia convention
+        # (CompatHelper) only adds compat bounds to the package's own
+        # Project.toml. Existing member compat entries are still updated.
+        requirement_string.nil? && workspace_member_file?(file_name)
+      end
+
+      # Anything outside the target directory ("test/Project.toml", or
+      # "../Project.toml" when Dependabot targets a member directory) was
+      # discovered via workspace membership rather than requested directly.
+      sig { params(file_name: String).returns(T::Boolean) }
+      def workspace_member_file?(file_name)
+        file_name.include?("/")
       end
 
       sig { returns(T.nilable(Dependabot::DependencyFile)) }

--- a/julia/spec/dependabot/julia/file_parser_spec.rb
+++ b/julia/spec/dependabot/julia/file_parser_spec.rb
@@ -222,12 +222,173 @@ RSpec.describe Dependabot::Julia::FileParser do
         expect(documenter_dep.requirements.first[:file]).to eq("docs/Project.toml")
         expect(documenter_dep.requirements.first[:requirement]).to eq("1")
 
-        # Test should only be in test/Project.toml (but has no compat entry)
+        # Test is only in test/Project.toml and has no compat entry there.
+        # Compat-less deps in workspace member files are skipped so Dependabot
+        # doesn't synthesize new compat entries in test/docs environments.
         test_dep = dependencies.find { |d| d.name == "Test" }
-        expect(test_dep).not_to be_nil
-        expect(test_dep.requirements.length).to eq(1)
-        expect(test_dep.requirements.first[:file]).to eq("test/Project.toml")
-        expect(test_dep.requirements.first[:requirement]).to be_nil # No compat entry
+        expect(test_dep).to be_nil
+      end
+    end
+
+    context "when a workspace member depends on workspace packages" do
+      let(:main_project_file) do
+        Dependabot::DependencyFile.new(
+          name: "Project.toml",
+          content: <<~TOML
+            name = "MainPackage"
+            uuid = "11111111-1111-1111-1111-111111111111"
+            version = "1.0.0"
+
+            [workspace]
+            projects = ["test", "lib/SubPackage"]
+
+            [deps]
+            JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+            [compat]
+            JSON = "0.21.4"
+            julia = "1.10"
+          TOML
+        )
+      end
+
+      let(:sub_package_file) do
+        Dependabot::DependencyFile.new(
+          name: "lib/SubPackage/Project.toml",
+          content: <<~TOML
+            name = "SubPackage"
+            uuid = "22222222-2222-2222-2222-222222222222"
+            version = "0.1.0"
+
+            [deps]
+            JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+            [compat]
+            JSON = "0.21"
+            julia = "1.10"
+          TOML
+        )
+      end
+
+      let(:test_project_file) do
+        Dependabot::DependencyFile.new(
+          name: "test/Project.toml",
+          content: <<~TOML
+            [deps]
+            MainPackage = "11111111-1111-1111-1111-111111111111"
+            SubPackage = "22222222-2222-2222-2222-222222222222"
+            JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+            [compat]
+            JSON = "0.21"
+            MainPackage = "1"
+          TOML
+        )
+      end
+
+      let(:dependency_files) { [main_project_file, sub_package_file, test_project_file] }
+
+      it "does not treat workspace packages as updatable dependencies" do
+        # MainPackage and SubPackage resolve by path within the workspace,
+        # never from a registry (even with a compat entry present)
+        expect(dependencies.map(&:name)).to contain_exactly("JSON")
+      end
+
+      it "still merges registry dependency requirements from all files" do
+        json_dep = dependencies.find { |d| d.name == "JSON" }
+        expect(json_dep.requirements.map { |r| r[:file] })
+          .to contain_exactly("Project.toml", "lib/SubPackage/Project.toml", "test/Project.toml")
+      end
+    end
+
+    context "when Dependabot targets a workspace member directory" do
+      let(:member_project_file) do
+        Dependabot::DependencyFile.new(
+          name: "Project.toml",
+          directory: "/test",
+          content: <<~TOML
+            [deps]
+            MainPackage = "11111111-1111-1111-1111-111111111111"
+            JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+            Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+            [compat]
+            JSON = "0.21"
+          TOML
+        )
+      end
+
+      let(:workspace_root_file) do
+        Dependabot::DependencyFile.new(
+          name: "../Project.toml",
+          directory: "/test",
+          content: <<~TOML
+            name = "MainPackage"
+            uuid = "11111111-1111-1111-1111-111111111111"
+            version = "1.0.0"
+
+            [workspace]
+            projects = ["test"]
+
+            [deps]
+            JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+            Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+            [compat]
+            JSON = "0.21.4"
+            julia = "1.10"
+          TOML
+        )
+      end
+
+      let(:dependency_files) { [member_project_file, workspace_root_file] }
+
+      it "excludes the workspace root package discovered via ../Project.toml" do
+        expect(dependencies.map(&:name)).not_to include("MainPackage")
+      end
+
+      it "keeps compat-less deps of the targeted directory's own Project.toml" do
+        # The user pointed Dependabot at this directory, so adding a compat
+        # entry for Example here is intended behavior
+        example_dep = dependencies.find { |d| d.name == "Example" }
+        expect(example_dep).not_to be_nil
+        expect(example_dep.requirements.first[:file]).to eq("Project.toml")
+        expect(example_dep.requirements.first[:requirement]).to be_nil
+      end
+
+      it "does not synthesize requirements for compat-less deps of the workspace root file" do
+        # Example has no compat entry in ../Project.toml, which was only
+        # discovered via workspace membership — no requirement recorded for it
+        example_dep = dependencies.find { |d| d.name == "Example" }
+        expect(example_dep.requirements.map { |r| r[:file] }).to contain_exactly("Project.toml")
+
+        # JSON has compat entries in both files, so both are tracked
+        json_dep = dependencies.find { |d| d.name == "JSON" }
+        expect(json_dep.requirements.map { |r| r[:file] })
+          .to contain_exactly("Project.toml", "../Project.toml")
+      end
+    end
+
+    context "when the root project has a dependency without a compat entry" do
+      let(:dependency_files) { [root_without_compat] }
+      let(:root_without_compat) do
+        Dependabot::DependencyFile.new(
+          name: "Project.toml",
+          content: <<~TOML
+            name = "MainPackage"
+            uuid = "11111111-1111-1111-1111-111111111111"
+            version = "1.0.0"
+
+            [deps]
+            Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+          TOML
+        )
+      end
+
+      it "keeps the dependency so a compat entry can be added" do
+        example_dep = dependencies.find { |d| d.name == "Example" }
+        expect(example_dep).not_to be_nil
+        expect(example_dep.requirements.first[:requirement]).to be_nil
       end
     end
   end


### PR DESCRIPTION
Addresses the bugs reported in https://github.com/dependabot/dependabot-core/pull/15549#issuecomment-5031942442

@maleadt would you mind taking a look at this.

Claude:

---

### What are you trying to accomplish?

After #15549 enabled workspace member discovery without a committed manifest, Dependabot opened noise PRs against Julia workspace repos (e.g. JuliaLLVM/LLVM.jl#578, JuliaGPU/CUDA.jl#3209/#3210, JuliaIO/VideoIO.jl#458-462). This fixes the two file parser defects behind them:

1. Packages that are themselves workspace projects (the root package or a sibling member) were treated as registry dependencies. Each `Project.toml` is parsed in isolation in a temp dir, losing workspace context, and the `[sources]` filter doesn't cover implicit workspace-path resolution. Now the parser collects each project file's own UUID and skips deps matching any of them.

2. Deps with no compat entry in workspace member files (`test/`, `docs/`, ...) had a requirement synthesized from the target version, causing brand-new `[compat]` entries to be added there. Per Julia convention (CompatHelper), compat bounds are only added to the package's own `Project.toml`; member files now only get updates to existing compat entries. Compat-less deps in the directly-targeted `Project.toml` are still tracked so missing compat can be added there.

### Anything you want to highlight for special attention from reviewers?

- Both fixes live in the Ruby parser rather than the Julia helper: workspace context can only be reconstructed where all the fetched project files are visible together, since each file is parsed in an isolated temp dir.
- Workspace packages are skipped even when they *do* have a compat entry (they always resolve by path, never from a registry).
- Behavior change: a dep that appears only in member files with no compat entry anywhere (e.g. StatsBase in VideoIO's test env) now gets no update PRs at all — matching pre-#15549 behavior and CompatHelper convention. Deps with existing compat entries in member files are still updated.
- "Member file" is determined by the file name containing `/`, which also covers `../Project.toml` (a workspace root discovered when Dependabot targets a member directory) — compat entries are only ever added to the `Project.toml` of the directory the user pointed Dependabot at.

### How will you know you've accomplished your goal?

Each of the three reported failure modes is reproduced in new parser specs:

- a workspace member depending on the root package or a sibling member (LLVM.jl#578, CUDA.jl#3209) → excluded
- a compat-less dep in a member file (CUDA.jl#3210, VideoIO.jl#458-462) → no requirement synthesized, so no compat entry is added
- Dependabot targeting a member directory with the workspace root fetched as `../Project.toml` → root package excluded, no compat added to the root file

Plus regression coverage that legitimate updates survive: registry deps are still merged across all workspace files, and compat-less deps in the targeted `Project.toml` still get entries added.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.