### PR TITLE
Paginate Docker tag listing and classify registry error responses

### DIFF
--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -80,6 +80,14 @@ module Dependabot
       # so we cap the attempts to avoid rate limiting or excessive latency.
       MAX_PLATFORM_VALIDATION_ATTEMPTS = T.let(5, Integer)
 
+      # Page size used when listing tags from a registry. Without an explicit page
+      # size, registries such as Docker Hub try to return every tag in a single
+      # response, which times out (HTTP 504) for images with very large tag counts
+      # (e.g. hexpm/elixir has ~1M tags). Requesting a bounded page keeps each
+      # request fast; the client then follows the registry's pagination links to
+      # collect the remaining tags.
+      TAGS_PAGE_SIZE = T.let(100, Integer)
+
       DockerSource = T.type_alias do
         T::Hash[Symbol, T.nilable(String)]
       end
@@ -491,6 +499,7 @@ module Dependabot
         )
       rescue *transient_docker_errors,
              DockerRegistry2::RegistryAuthenticationException,
+             DockerRegistry2::RegistryAuthorizationException,
              RestClient::Forbidden,
              RestClient::TooManyRequests => e
         Dependabot.logger.warn(
@@ -700,20 +709,11 @@ module Dependabot
       sig { returns(T::Array[Dependabot::Docker::Tag]) }
       def tags_from_registry
         @tags_from_registry ||= T.let(
-          begin
-            client = docker_registry_client
-
-            client.tags(docker_repo_name, auto_paginate: true).fetch("tags").map { |name| Tag.new(name) }
-          rescue *transient_docker_errors
-            attempt ||= 1
-            attempt += 1
-            raise if attempt > 3
-
-            retry
-          end,
+          fetch_tags_from_registry,
           T.nilable(T::Array[Dependabot::Docker::Tag])
         )
       rescue DockerRegistry2::RegistryAuthenticationException,
+             DockerRegistry2::RegistryAuthorizationException,
              RestClient::Forbidden
         raise PrivateSourceAuthenticationFailure, registry_hostname
       rescue RestClient::Exceptions::OpenTimeout,
@@ -722,7 +722,8 @@ module Dependabot
 
         raise PrivateSourceTimedOut, T.must(registry_hostname)
       rescue RestClient::ServerBrokeConnection,
-             RestClient::TooManyRequests
+             RestClient::TooManyRequests,
+             DockerRegistry2::RegistryHTTPException
         raise PrivateSourceBadResponse, registry_hostname
       rescue JSON::ParserError => e
         if e.message.include?("unexpected token")
@@ -730,6 +731,33 @@ module Dependabot
         end
 
         raise
+      end
+
+      # Registries such as Docker Hub time out (HTTP 504) when asked to return the
+      # full tag list for images with very large tag counts (e.g. hexpm/elixir has
+      # ~1M tags). Request the list without a page size first — a single efficient
+      # call for the common case — and fall back to a paginated request when the
+      # registry can't return everything at once.
+      sig { params(page_size: T.nilable(Integer)).returns(T::Array[Dependabot::Docker::Tag]) }
+      def fetch_tags_from_registry(page_size: nil)
+        client = docker_registry_client
+        response =
+          if page_size
+            client.tags(docker_repo_name, page_size, "", false, auto_paginate: true)
+          else
+            client.tags(docker_repo_name, auto_paginate: true)
+          end
+        response.fetch("tags").map { |name| Tag.new(name) }
+      rescue *transient_docker_errors
+        attempt ||= 1
+        attempt += 1
+        raise if attempt > 3
+
+        retry
+      rescue DockerRegistry2::RegistryHTTPException
+        raise if page_size
+
+        fetch_tags_from_registry(page_size: TAGS_PAGE_SIZE)
       end
 
       sig { returns(T.nilable(String)) }
@@ -758,6 +786,7 @@ module Dependabot
 
         retry
       rescue DockerRegistry2::RegistryAuthenticationException,
+             DockerRegistry2::RegistryAuthorizationException,
              RestClient::Forbidden
         raise PrivateSourceAuthenticationFailure, registry_hostname
       rescue RestClient::ServerBrokeConnection,
@@ -1120,6 +1149,7 @@ module Dependabot
         config_created_timestamps[tag_name] = created
         created
       rescue *transient_docker_errors, DockerRegistry2::RegistryAuthenticationException,
+             DockerRegistry2::RegistryAuthorizationException,
              RestClient::Forbidden, JSON::ParserError => e
         Dependabot.logger.info(
           "Failed to fetch config created timestamp for #{docker_repo_name}:#{tag_name}: #{e.message}"
@@ -1417,6 +1447,7 @@ module Dependabot
         platform_digests_cache[tag_name] = digests
         digests
       rescue *transient_docker_errors, DockerRegistry2::RegistryAuthenticationException,
+             DockerRegistry2::RegistryAuthorizationException,
              RestClient::Forbidden, RestClient::TooManyRequests, JSON::ParserError => e
         Dependabot.logger.info(
           "Failed to fetch platform digests for #{docker_repo_name}:#{tag_name}: #{e.message}"
@@ -1460,6 +1491,7 @@ module Dependabot
         manifest_platforms_cache[tag_name] = platforms
         platforms
       rescue *transient_docker_errors, DockerRegistry2::RegistryAuthenticationException,
+             DockerRegistry2::RegistryAuthorizationException,
              RestClient::Forbidden, JSON::ParserError => e
         Dependabot.logger.info(
           "Failed to fetch manifest platforms for #{docker_repo_name}:#{tag_name}: #{e.message}"
@@ -1524,6 +1556,7 @@ module Dependabot
         platform_timestamps_cache[tag_name] = timestamps
         timestamps
       rescue *transient_docker_errors, DockerRegistry2::RegistryAuthenticationException,
+             DockerRegistry2::RegistryAuthorizationException,
              RestClient::Forbidden, JSON::ParserError => e
         Dependabot.logger.info(
           "Failed to fetch platform timestamps for #{docker_repo_name}:#{tag_name}: #{e.message}"

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1051,6 +1051,59 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
             end
         end
       end
+
+      context "when the registry returns a 403 status" do
+        before do
+          tags_url = "https://registry.hub.docker.com/v2/moj/ruby/tags/list"
+          stub_request(:get, tags_url)
+            .and_return(status: 403, body: "")
+        end
+
+        it "raises a PrivateSourceAuthenticationFailure error" do
+          error_class = Dependabot::PrivateSourceAuthenticationFailure
+          expect { checker.latest_version }
+            .to raise_error(error_class) do |error|
+              expect(error.source).to eq("registry.hub.docker.com")
+            end
+        end
+      end
+
+      context "when listing the full tag list times out (504)" do
+        let(:tags_url) { "https://registry.hub.docker.com/v2/moj/ruby/tags/list" }
+
+        before do
+          # Registries such as Docker Hub 504 when asked for the full tag list of
+          # images with huge tag counts; the request must be retried paginated.
+          stub_request(:get, tags_url)
+            .and_return(status: 504, body: "")
+          stub_request(:get, tags_url + "?n=100")
+            .and_return(status: 200, body: registry_tags)
+        end
+
+        it "falls back to a paginated request and resolves the latest version" do
+          expect(checker.latest_version).to eq("2.4.2")
+          expect(WebMock).to have_requested(:get, tags_url + "?n=100")
+        end
+      end
+
+      context "when the tag list request keeps returning a 504" do
+        let(:tags_url) { "https://registry.hub.docker.com/v2/moj/ruby/tags/list" }
+
+        before do
+          stub_request(:get, tags_url)
+            .and_return(status: 504, body: "")
+          stub_request(:get, tags_url + "?n=100")
+            .and_return(status: 504, body: "")
+        end
+
+        it "raises a PrivateSourceBadResponse error" do
+          error_class = Dependabot::PrivateSourceBadResponse
+          expect { checker.latest_version }
+            .to raise_error(error_class) do |error|
+              expect(error.source).to eq("registry.hub.docker.com")
+            end
+        end
+      end
     end
 
     context "when the latest version is a pre-release" do


### PR DESCRIPTION
### Summary

Docker/`docker_compose` update jobs fail with `unknown_error` for images whose registry can't return the full tag list in one response. The clearest case is images with very large tag counts — e.g. `hexpm/elixir` has **~993k tags**, so Docker Hub's `GET /v2/hexpm/elixir/tags/list` (requested unpaginated) times out with an **HTTP 504** after 30s on every run.

Root cause: `Dependabot::Docker::UpdateChecker#tags_from_registry` requests the tag list without a page size, and the `docker_registry2` gem wraps the resulting 504 in `DockerRegistry2::RegistryHTTPException`, which wasn't rescued — so it surfaced as `unknown_error`. Separately, a **403** raises `RegistryAuthorizationException` (sibling of the already-handled `RegistryAuthenticationException`), which was also unclassified.

### Changes

- **Paginate on demand.** `tags_from_registry` now makes a single unpaginated request for the common case, and **falls back to a paginated request (`?n=100`)** when the registry can't return the full list at once, following the registry's pagination links. This keeps the efficient single call for normal images while avoiding the 504 for large ones.
- **Classify registry 5xx.** `RegistryHTTPException` (incl. 504) now raises `PrivateSourceBadResponse` instead of `unknown_error`.
- **Classify 403.** `RegistryAuthorizationException` now raises `PrivateSourceAuthenticationFailure` alongside the existing 401 handling, at every registry-touching rescue site.

This also fixes the `docker_compose` ecosystem, which reuses `Dependabot::Docker::UpdateChecker`.

### Tests

- 504 → paginated fallback resolves the latest version (asserts the `?n=100` request is made).
- Persistent 504 → `PrivateSourceBadResponse`.
- 403 → `PrivateSourceAuthenticationFailure`.

Full docker suite: **573 examples, 0 failures**; RuboCop clean; Sorbet `No errors!`.

### Note

Pagination resolves the general class of failure. For pathological tag counts like `hexpm/elixir` (~1M tags), paginating at 100/page is many round-trips; a follow-up could cap the number of pages/tags fetched, but that's out of scope here.
