### PR TITLE
fix(npm_and_yarn): directory was not set properly on credential-generated .npmrc

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -242,7 +242,8 @@ module Dependabot
 
         Dependabot::DependencyFile.new(
           name: ".npmrc",
-          content: content
+          content: content,
+          directory: directory
         )
       end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -2687,6 +2687,41 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
   end
 
+  context "when generating .npmrc from credential scope for a nested package directory" do
+    let(:directory) { "/packages/nested-app" }
+    let(:credentials) do
+      [Dependabot::Credential.new(
+        {
+          "type" => "git_source",
+          "host" => "github.com",
+          "username" => "x-access-token",
+          "password" => "token"
+        }
+      ), Dependabot::Credential.new(
+        {
+          "type" => "npm_registry",
+          "registry" => "npm.pkg.github.com",
+          "token" => "my_token",
+          "scope" => "@my-company"
+        }
+      )]
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_npmrc_credential_generation, true)
+    end
+
+    after { Dependabot::Experiments.reset! }
+
+    it "sets the generated .npmrc directory to the package directory" do
+      npmrc = file_fetcher_instance.send(:generate_npmrc_from_credentials)
+
+      expect(npmrc).not_to be_nil
+      expect(npmrc.content).to eq("@my-company:registry=https://npm.pkg.github.com")
+      expect(npmrc.directory).to eq(directory)
+    end
+  end
+
   context "with no .npmrc, lockfile inference fails, but credentials have replaces-base" do
     let(:credentials) do
       [Dependabot::Credential.new(


### PR DESCRIPTION
### What are you trying to accomplish?

Fix credential-generated `.npmrc` files so they inherit the package directory being fetched, instead of defaulting to `"/"`.

Observed when trying to adapt my codebase to the [2026-06-30 change](https://github.blog/changelog/2026-06-30-dependabot-no-longer-infers-npmrc/) that requires an explicit `scope` (or committed `.npmrc`) for private registries, `FileFetcher#generate_npmrc_from_credentials` builds a synthetic `.npmrc` when credentials include a scope. That `DependencyFile` was created without `directory:`, so it defaulted to `"/"`.

In multi-directory jobs, `DependencySnapshot` rewrites `job.source.directories` from the unique `directory` values on fetched files. The root-scoped synthetic `.npmrc` injects `"/"` into that list even when the job only targeted nested package directories. If the repo has no root `package.json`, the update/parse phase fails with `dependency_file_not_found` / `package.json not found.` / `file-path: null` - even though fetch for the nested packages succeeded.

This shows up for any multi-directory npm job that uses registry credentials with `scope` and has no root `package.json`. In my case, a GitHub Actions monorepo with multiple sibling directories, some containing JavaScript actions (with a `package.json`) and some containing Composite actions (with none), and no root `package.json`.

A smoke-test that exercises the failure path that affected me, is here: https://github.com/dependabot/smoke-tests/pull/551 (currently, it fails, because the behavior is not patched)

### Anything you want to highlight for special attention from reviewers?

The fix is intentionally minimal: pass `directory: directory` when constructing the credential-generated `.npmrc` in `generate_npmrc_from_credentials`, matching how other fetched files are scoped to the package root.

I considered broader changes (filtering `"/"` out of the snapshot rewrite, skipping synthetic config files when collecting directories) but those paper over incorrect file metadata. Setting `directory` on the generated file is the correct ownership for the file itself.

### How will you know you've accomplished your goal?

**Reproduction (pre-fix):** A multi-directory npm job with scoped registry credentials and no root `package.json` fetches nested packages successfully, then fails during parse with `package.json not found` because `"/"` was injected into `job.source.directories` via the synthetic `.npmrc`.

**Regression test:** `spec/dependabot/npm_and_yarn/file_fetcher_spec.rb` - context `when generating .npmrc from credential scope for a nested package directory` asserts the generated `.npmrc` has `directory` equal to the nested package directory (not `"/"`).

**Verification:**

(on my M4 mac):

```bash
docker run --rm --platform linux/amd64 \
  -v "$PWD/npm_and_yarn:/home/dependabot/npm_and_yarn" \
  -v "$PWD/common:/home/dependabot/common" \
  -w /home/dependabot/npm_and_yarn \
  -e BUNDLE_GEMFILE=/home/dependabot/dependabot-updater/Gemfile \
  ghcr.io/dependabot/dependabot-updater-npm:latest \
  bash -lc 'bundle exec rspec'
```

Results:

on my checkout of `main`:

```
Finished in 23 minutes 9 seconds (files took 2.49 seconds to load)
1905 examples, 146 failures, 4 pending
```

On this branch:

```
Finished in 23 minutes 9 seconds (files took 2.16 seconds to load)
1906 examples, 146 failures, 4 pending
```

So, not all passing to begin with, but our 1 new example DID pass and didn't regress anything.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
    - they didn't, but they didn't regress; see above
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
