### PR TITLE
Add support for python 3.13.14 and 3.14.6

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,8 +3,8 @@
 # python/lib/dependabot/python/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # python/spec/dependabot/python/file_fetcher_spec.rb: exposes the expected ecosystem_versions metric spec
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.5
-ARG PY_3_13=3.13.13
+ARG PY_3_14=3.14.6
+ARG PY_3_13=3.13.14
 ARG PY_3_12=3.12.13
 ARG PY_3_11=3.11.15
 ARG PY_3_10=3.10.20

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ Updating the list of known versions might be tricky, here are the steps:
 
 1. Update the `pyenv` version in the [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile), you may use a commit hash if a new `pyenv` version is not released yet.
 2. Update the `pyenv global` version in the `Dockerfile`. We always use the latest (and greatest) Python version.
-3. Update the list of known Python versions in [`language_version_manager.rb`](https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/language_version_manager.rb).
+3. Update the list of known Python versions in [`language.rb`](https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/language.rb).
 4. Fix any broken tests.
 
 [Example PR](https://github.com/dependabot/dependabot-core/pull/13321) that does all these things.

--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -16,8 +16,8 @@ module Dependabot
       # e.g. ARG PY_3_13=3.13.x
       # Note: uv ecosystem aliases this class, so updates here apply to both ecosystems.
       PRE_INSTALLED_PYTHON_VERSIONS_RAW = %w(
-        3.14.5
-        3.13.13
+        3.14.6
+        3.13.14
         3.12.13
         3.11.15
         3.10.20

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -3,13 +3,13 @@
 # python/lib/dependabot/python/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # (`uv/lib/dependabot/uv/language.rb` aliases `Dependabot::Python::Language`).
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.5
-ARG PY_3_13=3.13.13
+ARG PY_3_14=3.14.6
+ARG PY_3_13=3.13.14
 ARG PY_3_12=3.12.13
 ARG PY_3_11=3.11.15
 ARG PY_3_10=3.10.20
 # https://github.com/pyenv/pyenv/releases
-ARG PYENV_VERSION=v2.6.16
+ARG PYENV_VERSION=v2.7.2
 
 # This cannot be inlined below (e.g., COPY --from=...) because Dependabot does not support that syntax yet
 FROM ghcr.io/astral-sh/uv:0.11.12 AS uv

--- a/uv/README.md
+++ b/uv/README.md
@@ -10,7 +10,7 @@ Updating the list of known versions might be tricky, here are the steps:
 
 1. Update the `pyenv` version in the [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile), you may use a commit hash if a new `pyenv` version is not released yet.
 2. Update the `pyenv global` version in the `Dockerfile`. We always use the latest (and greatest) Python version.
-3. Update the list of known Python versions in [`language_version_manager.rb`](https://github.com/dependabot/dependabot-core/blob/main/uv/lib/dependabot/uv/language_version_manager.rb).
+3. Follow the steps to update the (supported Python versions for Python)[https://github.com/dependabot/dependabot-core/blob/main/python/README.md].
 4. Fix any broken tests.
 
 [Example PR](https://github.com/dependabot/dependabot-core/pull/13321) that does all these things

--- a/uv/README.md
+++ b/uv/README.md
@@ -10,7 +10,7 @@ Updating the list of known versions might be tricky, here are the steps:
 
 1. Update the `pyenv` version in the [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile), you may use a commit hash if a new `pyenv` version is not released yet.
 2. Update the `pyenv global` version in the `Dockerfile`. We always use the latest (and greatest) Python version.
-3. Follow the steps to update the (supported Python versions for Python)[https://github.com/dependabot/dependabot-core/blob/main/python/README.md].
+3. Follow the steps to update the [supported Python versions for Python](https://github.com/dependabot/dependabot-core/blob/main/python/README.md).
 4. Fix any broken tests.
 
 [Example PR](https://github.com/dependabot/dependabot-core/pull/13321) that does all these things


### PR DESCRIPTION
### What are you trying to accomplish?
Add support for python 3.13.14 and 3.14.6


### How will you know you've accomplished your goal?
- Existing tests pass
- Projects using Python 3.14.6 and 3.13.14 are now supported

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
