### PR TITLE
Helm: skip non-chart OCI tags and classify chart download failures

### DIFF
--- a/helm/lib/dependabot/helm/file_updater/lock_file_generator.rb
+++ b/helm/lib/dependabot/helm/file_updater/lock_file_generator.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/errors"
 require "dependabot/shared_helpers"
 require "dependabot/dependency"
 require "dependabot/shared/shared_file_updater"
@@ -40,9 +41,23 @@ module Dependabot
               File.read(chart_lock.name)
             end
           end
+        rescue SharedHelpers::HelperSubprocessFailed => e
+          raise unless chart_download_failure?(e.message)
+
+          # `helm dependency update` failed to download a chart dependency (e.g.
+          # the resolved version isn't a pullable chart in the registry). Surface
+          # a precise, classified error instead of a generic unknown_error.
+          raise Dependabot::DependencyFileNotResolvable, e.message
         end
 
         private
+
+        # Matches Helm's chart download failures, e.g.
+        #   "could not download oci://.../frontierchart:...: ...: not found"
+        sig { params(message: String).returns(T::Boolean) }
+        def chart_download_failure?(message)
+          message.include?("could not download") || message.match?(/not found/i)
+        end
 
         sig { returns(T::Array[Dependabot::Dependency]) }
         attr_reader :dependencies

--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -367,12 +367,12 @@ module Dependabot
         tags = fetch_oci_tags(chart_name, repo_url)
         return nil unless tags && !tags.empty?
 
+        oci_repo_ref = "#{repo_url.gsub('oci://', '').chomp('/')}/#{chart_name}"
+
         valid_tags = filter_valid_versions(tags)
         if cooldown_enabled?
           # Filter out versions that are in cooldown period
-          repo_url = repo_url.gsub("oci://", "")
-          repo_url = repo_url + "/" + chart_name
-          tags_with_release_date = fetch_tags_with_release_date_using_oci(valid_tags, repo_url)
+          tags_with_release_date = fetch_tags_with_release_date_using_oci(valid_tags, oci_repo_ref)
           valid_tags = latest_version_resolver.filter_versions_in_cooldown_period_using_oci(
             valid_tags,
             tags_with_release_date
@@ -380,9 +380,44 @@ module Dependabot
         end
         return nil if valid_tags.empty?
 
-        highest_tag = valid_tags.map { |v| version_class.new(v) }.max
-        Dependabot.logger.info("Highest valid OCI tag for #{chart_name} is #{highest_tag}")
-        highest_tag
+        select_highest_chart_tag(oci_repo_ref, valid_tags)
+      end
+
+      # Selects the highest tag that is an actual Helm chart. `oras repo tags`
+      # can return non-chart artifacts (e.g. SBOMs, signatures, or partial
+      # publishes) that pass version parsing but can't be pulled as a chart,
+      # which previously caused `helm dependency update` to fail with a 404.
+      # Tags are only skipped when their OCI manifest positively proves they are
+      # not a chart; if a manifest can't be fetched or parsed we keep the tag
+      # (fail open) so a transient registry issue never silently stops updates.
+      sig { params(oci_repo_ref: String, valid_tags: T::Array[String]).returns(T.nilable(Gem::Version)) }
+      def select_highest_chart_tag(oci_repo_ref, valid_tags)
+        sorted_tags = valid_tags.map { |v| version_class.new(v) }.sort.reverse
+        chosen = sorted_tags.find { |tag| !non_chart_oci_tag?(oci_repo_ref, tag.to_s) } || sorted_tags.first
+        Dependabot.logger.info("Highest valid OCI tag for #{oci_repo_ref} is #{chosen}")
+        chosen
+      end
+
+      # Returns true only when the tag's OCI manifest can be fetched and parsed
+      # and none of its media types identify it as a Helm chart. Helm chart
+      # manifests always reference the "helm" media types
+      # (application/vnd.cncf.helm.*), so anything without "helm" is a non-chart
+      # artifact we should not try to update to.
+      sig { params(oci_repo_ref: String, tag: String).returns(T::Boolean) }
+      def non_chart_oci_tag?(oci_repo_ref, tag)
+        # OCI tags use "_" where semver build metadata uses "+".
+        oci_tag = tag.tr("+", "_")
+        manifest = Helpers.fetch_tags_with_release_date_using_oci(oci_repo_ref, oci_tag)
+        parsed = JSON.parse(manifest)
+        media_types = [parsed.dig("config", "mediaType")]
+        media_types += Array(parsed["layers"]).map { |layer| layer["mediaType"] }
+        media_types = media_types.compact
+        return false if media_types.empty?
+
+        media_types.none? { |media_type| media_type.to_s.include?("helm") }
+      rescue Dependabot::SharedHelpers::HelperSubprocessFailed, JSON::ParserError => e
+        Dependabot.logger.info("Could not validate OCI manifest for #{oci_repo_ref}:#{oci_tag}: #{e.message}")
+        false
       end
 
       sig { params(chart_name: String, repo_url: String).returns(T.nilable(T::Array[String])) }

--- a/helm/spec/dependabot/helm/file_updater/lock_file_generator_spec.rb
+++ b/helm/spec/dependabot/helm/file_updater/lock_file_generator_spec.rb
@@ -191,5 +191,42 @@ RSpec.describe Dependabot::Helm::FileUpdater::LockFileGenerator do
         expect(Dependabot::SharedHelpers).to have_received(:with_git_configured).with(credentials: credentials)
       end
     end
+
+    context "when helm fails to download a chart dependency" do
+      let(:download_error) do
+        Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+          message: "could not download oci://registry.sweet.security/helm/frontierchart: " \
+                   "registry.sweet.security/helm/frontierchart:1.0.259257_abc.0: not found",
+          error_context: {}
+        )
+      end
+
+      before do
+        allow(Dependabot::Helm::Helpers).to receive(:update_lock).and_raise(download_error)
+      end
+
+      it "raises a DependencyFileNotResolvable error instead of an unknown error" do
+        expect { generator.updated_chart_lock(chart_lock, updated_chart_yaml_content) }
+          .to raise_error(Dependabot::DependencyFileNotResolvable, /could not download/)
+      end
+    end
+
+    context "when helm fails for an unrelated reason" do
+      let(:other_error) do
+        Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+          message: "Error: context deadline exceeded",
+          error_context: {}
+        )
+      end
+
+      before do
+        allow(Dependabot::Helm::Helpers).to receive(:update_lock).and_raise(other_error)
+      end
+
+      it "re-raises the original error" do
+        expect { generator.updated_chart_lock(chart_lock, updated_chart_yaml_content) }
+          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+      end
+    end
   end
 end

--- a/helm/spec/dependabot/helm/update_checker_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker_spec.rb
@@ -127,6 +127,8 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
           .and_return(
             "1.0.119807+c2277fddd003556d4982b86ef4e77fc84a41ed79\n1.0.124446+3123f85bdf6d8309d3d601938564a996f5cad238"
           )
+        allow(Dependabot::Helm::Helpers).to receive(:fetch_tags_with_release_date_using_oci)
+          .and_return({ config: { mediaType: "application/vnd.cncf.helm.config.v1+json" } }.to_json)
       end
 
       let(:credentials) { [] }
@@ -159,6 +161,76 @@ RSpec.describe Dependabot::Helm::UpdateChecker do
         it "filters out non-version tags and returns the latest valid version" do
           expect(checker.latest_version).to eq(
             Dependabot::Helm::Version.new("1.1.0")
+          )
+        end
+      end
+    end
+
+    context "when resolving OCI chart tags where the highest tag is not a pullable chart" do
+      let(:credentials) { [] }
+      let(:version) { "1.0.119807+c2277fddd003556d4982b86ef4e77fc84a41ed79" }
+      let(:dependency_name) { "frontierchart" }
+      let(:repo_url) { "oci://registry.sweet.security/helm" }
+      let(:source) { { tag: version, registry: "oci://registry.sweet.security/helm" } }
+
+      let(:chart_manifest) do
+        {
+          config: { mediaType: "application/vnd.cncf.helm.config.v1+json" },
+          layers: [{ mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip" }]
+        }.to_json
+      end
+      let(:non_chart_manifest) do
+        {
+          config: { mediaType: "application/vnd.oci.image.config.v1+json" },
+          layers: [{ mediaType: "application/vnd.dev.cosign.simplesigning.v1+json" }]
+        }.to_json
+      end
+
+      before do
+        allow(checker).to receive(:fetch_releases_with_helm_cli).and_return(nil)
+        allow(Dependabot::Helm::Helpers).to receive(:fetch_oci_tags)
+          .with("registry.sweet.security/helm/frontierchart")
+          .and_return(
+            "1.0.119807+c2277fddd003556d4982b86ef4e77fc84a41ed79\n" \
+            "1.0.124446+3123f85bdf6d8309d3d601938564a996f5cad238\n" \
+            "1.0.259257+999869104425869d064e81ab142da02642554db0.0"
+          )
+      end
+
+      context "when the non-chart tag's manifest can be fetched" do
+        before do
+          allow(Dependabot::Helm::Helpers).to receive(:fetch_tags_with_release_date_using_oci)
+            .with(
+              "registry.sweet.security/helm/frontierchart",
+              "1.0.259257_999869104425869d064e81ab142da02642554db0.0"
+            )
+            .and_return(non_chart_manifest)
+          allow(Dependabot::Helm::Helpers).to receive(:fetch_tags_with_release_date_using_oci)
+            .with(
+              "registry.sweet.security/helm/frontierchart",
+              "1.0.124446_3123f85bdf6d8309d3d601938564a996f5cad238"
+            )
+            .and_return(chart_manifest)
+        end
+
+        it "skips the non-chart tag and returns the highest chart version" do
+          expect(checker.latest_version).to eq(
+            Dependabot::Helm::Version.new("1.0.124446+3123f85bdf6d8309d3d601938564a996f5cad238")
+          )
+        end
+      end
+
+      context "when the OCI manifest cannot be fetched" do
+        before do
+          allow(Dependabot::Helm::Helpers).to receive(:fetch_tags_with_release_date_using_oci)
+            .and_raise(
+              Dependabot::SharedHelpers::HelperSubprocessFailed.new(message: "boom", error_context: {})
+            )
+        end
+
+        it "fails open and keeps the highest tag" do
+          expect(checker.latest_version).to eq(
+            Dependabot::Helm::Version.new("1.0.259257+999869104425869d064e81ab142da02642554db0.0")
           )
         end
       end


### PR DESCRIPTION
### Summary

Helm `docker_compose`-style OCI chart updates fail with `unknown_error` when the resolver picks a tag that isn't a pullable chart. Observed on `frontierchart` (`oci://registry.sweet.security/helm`): `oras repo tags` returns a tag `1.0.259257_…db0.0` that Dependabot writes to `Chart.yaml`, and `helm dependency update` then fails:

```
could not download oci://registry.sweet.security/helm/frontierchart:
  registry.sweet.security/helm/frontierchart:1.0.259257_…db0.0: not found
Error processing frontierchart (Dependabot::SharedHelpers::HelperSubprocessFailed)
```

which surfaces as `unknown_error`.

Root cause: `oras repo tags` also lists non-chart OCI artifacts (SBOMs, signatures, partial/broken publishes) that pass version parsing. The resolver took the highest such tag without checking it's a chart. (The version string itself is **not** mangled — the `Helm::Version` round-trip is faithful; the selected tag simply isn't a pullable chart.)

### Changes

- **`UpdateChecker` – skip non-chart OCI tags.** Select the highest tag whose OCI manifest is actually a Helm chart (config/layer media types reference `application/vnd.cncf.helm.*`). Tags are skipped **only** when their manifest positively proves they're non-chart; if a manifest can't be fetched or parsed the tag is **kept (fail open)**, so a transient registry issue never silently stops updates. Also removes an in-place `repo_url` mutation in favour of a computed `oci_repo_ref`.
- **`LockFileGenerator` – classify download failures.** Rescue the `helm dependency update` "could not download / not found" failure and raise `DependencyFileNotResolvable` instead of leaking `HelperSubprocessFailed` as `unknown_error`.

### Tests

- Non-chart highest tag is skipped; the highest actual chart version is returned.
- Fail-open: when the manifest can't be fetched, the highest tag is kept.
- Download failure → `DependencyFileNotResolvable`; unrelated helm failures are re-raised unchanged.

Full helm suite: **287 examples, 0 failures**; RuboCop clean; Sorbet `No errors!`.

### Notes

- The two fixes are complementary: media-type validation handles non-chart artifact tags; error classification handles the residual case (a broken-but-real chart tag that lists but can't be pulled).
- The happy path now makes one extra `oras manifest fetch` (for the highest tag) per update check.
