### PR TITLE
Preserve original absence of the bundler self-checksum on lockfile updates

### DIFF
--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -29,9 +29,7 @@ module Dependabot
         # No `/m`: it would let the greedy `.*` in `entries` match newlines and
         # swallow the trailing `BUNDLED WITH` section. `^` is line-anchored anyway.
         CHECKSUMS_SECTION = /(^CHECKSUMS\n)(?<entries>(?:^  .*\n)+)/
-        BUNDLED_WITH_VERSION_REGEX = /BUNDLED WITH\s+(?<version>\d+\.\d+\.\d+)/m
         BUNDLER_CHECKSUM_ENTRY_REGEX = /^  bundler \([^)]+\).*\n?$/
-        MIN_BUNDLER_CHECKSUM_VERSION = Gem::Version.new("4.0.11")
 
         sig do
           params(
@@ -250,14 +248,17 @@ module Dependabot
           lockfile_content = T.must(lockfile).content
           return false unless lockfile_content&.include?("CHECKSUMS\n")
 
+          # Strip a bundler self-checksum only when the original CHECKSUMS
+          # section did not contain one. If the original pins one,
+          # restore_bundler_checksum separately swaps a generated entry back to
+          # the original when present. Dependabot must not introduce a missing
+          # entry: the runner's regular-gem install can calculate a checksum that
+          # a default-gem install cannot (ruby/rubygems#9512), and its runtime
+          # bundler version need not match BUNDLED WITH because Dependabot does
+          # not manage that version. This can add unrelated or mismatched
+          # metadata and cause lockfile churn.
           checksums_section = lockfile_content.match(CHECKSUMS_SECTION)
-          return false if checksums_section && T.must(checksums_section[:entries]).match?(BUNDLER_CHECKSUM_ENTRY_REGEX)
-
-          bundled_with = lockfile_content.match(BUNDLED_WITH_VERSION_REGEX)&.[](:version)
-          return false unless bundled_with
-
-          bundled_with_version = Gem::Version.new(bundled_with)
-          bundled_with_version >= Gem::Version.new("4.0.0") && bundled_with_version < MIN_BUNDLER_CHECKSUM_VERSION
+          !(checksums_section && T.must(checksums_section[:entries]).match?(BUNDLER_CHECKSUM_ENTRY_REGEX))
         end
 
         sig { params(lockfile_body: String).returns(String) }

--- a/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
@@ -60,7 +60,36 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
         .and_return(generated_lockfile)
     end
 
-    context "when original lockfile uses Bundler 4.0.10 (in the [4.0.0, 4.0.11) strip range)" do
+    context "when original lockfile uses Bundler 2.7.2 with no bundler checksum" do
+      let(:project_name) { "checksums_bundler_2_7_2" }
+      let(:generated_lockfile) do
+        <<~LOCKFILE
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              business (1.5.0)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            business (~> 1.5)
+
+          CHECKSUMS
+            business (1.5.0) sha256=123
+            bundler (2.7.2) sha256=runner272
+
+          BUNDLED WITH
+             2.7.2
+        LOCKFILE
+      end
+
+      it "strips the runner-injected bundler checksum regardless of version" do
+        expect(updated_lockfile_content).not_to include("bundler (2.7.2)")
+      end
+    end
+
+    context "when original lockfile uses Bundler 4.0.10 with no bundler checksum" do
       let(:project_name) { "checksums_bundler_4_0_10" }
 
       it "removes newly added bundler checksums" do
@@ -72,11 +101,49 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
       end
     end
 
-    context "when original lockfile uses Bundler 4.0.11 (at the strip-range upper bound)" do
+    context "when original lockfile uses Bundler 4.0.11 with no bundler checksum" do
       let(:project_name) { "checksums_bundler_4_0_11" }
 
-      it "keeps bundler checksums" do
-        expect(updated_lockfile_content).to include("bundler (4.0.11)")
+      it "strips the runner-injected bundler checksum, preserving the original's absence" do
+        expect(updated_lockfile_content).not_to include("bundler (4.0.11)")
+      end
+    end
+
+    context "when original lockfile uses Bundler 4.0.15 (>= 4.0.11) with no bundler checksum" do
+      # Regression for the default-gem install case (ruby/rubygems#9512,
+      # dependabot-core#15215): the runner's bundler adds an entry for its own
+      # version (4.0.17) that need not match BUNDLED WITH (4.0.15). Dependabot
+      # must not persist it, or the lockfile churns on the next local install.
+      let(:project_name) { "checksums_bundler_4_0_15" }
+      let(:generated_lockfile) do
+        <<~LOCKFILE
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              business (1.5.0)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            business (~> 1.5)
+
+          CHECKSUMS
+            business (1.5.0) sha256=123
+            bundler (4.0.17) sha256=runner17
+
+          BUNDLED WITH
+             4.0.15
+        LOCKFILE
+      end
+
+      it "strips the runner-injected bundler checksum" do
+        expect(updated_lockfile_content).not_to include("bundler (4.0.17)")
+        expect(updated_lockfile_content).not_to match(/^  bundler \(/)
+      end
+
+      it "preserves the CHECKSUMS header and other entries" do
+        expect(updated_lockfile_content).to match(/^CHECKSUMS\n  business \(1\.5\.0\)/)
       end
     end
 
@@ -142,6 +209,37 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
       end
     end
 
+    context "when the project pins bundler but the original CHECKSUMS section omits it" do
+      let(:project_name) { "checksums_bundler_dep_pinned_no_checksum" }
+      let(:generated_lockfile) do
+        <<~LOCKFILE
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              business (1.5.0)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            bundler (~> 4.0)
+            business (~> 1.5)
+
+          CHECKSUMS
+            business (1.5.0) sha256=123
+            bundler (4.0.17) sha256=runner17
+
+          BUNDLED WITH
+             4.0.17
+        LOCKFILE
+      end
+
+      it "strips the checksum without touching the DEPENDENCIES entry" do
+        expect(updated_lockfile_content).to include("  bundler (~> 4.0)\n")
+        expect(updated_lockfile_content).not_to include("bundler (4.0.17) sha256=runner17")
+      end
+    end
+
     context "when the generated lockfile has no CHECKSUMS section" do
       let(:project_name) { "checksums_bundler_4_0_12" }
       let(:generated_lockfile) do
@@ -168,6 +266,36 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
       end
     end
 
+    context "when the generated CHECKSUMS section contains only the bundler entry" do
+      let(:project_name) { "checksums_bundler_4_0_15" }
+      let(:generated_lockfile) do
+        <<~LOCKFILE
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              business (1.5.0)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            business (~> 1.5)
+
+          CHECKSUMS
+            bundler (4.0.17) sha256=runner17
+
+          BUNDLED WITH
+             4.0.17
+        LOCKFILE
+      end
+
+      it "preserves a parseable empty CHECKSUMS section after stripping" do
+        expect(updated_lockfile_content).to include("CHECKSUMS\n\nBUNDLED WITH")
+        expect(updated_lockfile_content).not_to include("bundler (4.0.17)")
+        expect { ::Bundler::LockfileParser.new(updated_lockfile_content) }.not_to raise_error
+      end
+    end
+
     context "when the generated lockfile has CHECKSUMS but no bundler entry" do
       let(:project_name) { "checksums_bundler_4_0_12" }
       let(:generated_lockfile) do
@@ -191,13 +319,16 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
         LOCKFILE
       end
 
-      it "does not inject the original bundler checksum" do
+      it "does not re-add the original bundler checksum" do
+        original_lockfile = files.find { |file| file.name == "Gemfile.lock" }
+
+        expect(original_lockfile&.content).to include("bundler (4.0.12) sha256=old12")
         expect(updated_lockfile_content).not_to include("bundler (4.0.12)")
         expect(updated_lockfile_content).not_to include("bundler (4.0.13)")
       end
     end
 
-    context "when original lockfile uses Bundler 4.0.12 (outside the strip range — control)" do
+    context "when original lockfile already pins a bundler checksum (control)" do
       let(:project_name) { "checksums_bundler_4_0_12" }
 
       it "preserves the CHECKSUMS header" do

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_2_7_2/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_2_7_2/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4"

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_2_7_2/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_2_7_2/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4)
+
+CHECKSUMS
+  business (1.4.0) sha256=0000000000000000000000000000000000000000000000000000000000000000
+
+BUNDLED WITH
+   2.7.2

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_15/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_15/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "business", "~> 1.4"

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_15/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_4_0_15/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  business (~> 1.4)
+
+CHECKSUMS
+  business (1.4.0) sha256=456
+
+BUNDLED WITH
+   4.0.15

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_dep_pinned_no_checksum/Gemfile
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_dep_pinned_no_checksum/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "bundler", "~> 4.0"
+gem "business", "~> 1.4"

--- a/bundler/spec/fixtures/projects/bundler2/checksums_bundler_dep_pinned_no_checksum/Gemfile.lock
+++ b/bundler/spec/fixtures/projects/bundler2/checksums_bundler_dep_pinned_no_checksum/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    business (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 4.0)
+  business (~> 1.4)
+
+CHECKSUMS
+  business (1.4.0) sha256=0000000000000000000000000000000000000000000000000000000000000000
+
+BUNDLED WITH
+   4.0.15


### PR DESCRIPTION
### What are you trying to accomplish?

Stops Dependabot from introducing a `bundler (...)` self-checksum into lockfiles whose `CHECKSUMS` section never had one, by deciding from the original lockfile's state instead of the `BUNDLED WITH` version. The invariant is now: if the original lockfile pins a bundler self-checksum, the existing restoration path keeps it (#15249); if it doesn't, Dependabot must not add one, regardless of the `BUNDLED WITH` version.

The native helper installs Bundler as a regular gem, so it always has the published `.gem` bytes and always records a self-checksum for its own runtime version. A Bundler installed as a default gem cannot compute one (ruby/rubygems#9512), so those users legitimately have a `CHECKSUMS` section with no bundler entry. Persisting the runner's entry records a version that need not match the restored `BUNDLED WITH`, and the user's next `bundle install` removes it again — either way churning the lockfile on every PR. This is the shape reported in #14913, #15045, and #15215; the earlier fixes (#15164, #15229, #15249) covered the 4.0.0–4.0.10 strip range and the preserve-an-existing-entry case, but any lockfile with `BUNDLED WITH` ≥ 4.0.11 and no original entry still had the runner's entry injected.

Upstream, ruby/rubygems#9658 makes Bundler fall back to an already-locked self-checksum when it can't recompute one — it only preserves existing entries and never adds an absent one, so the injection side is Dependabot's to fix (ruby/rubygems#9622).

### Anything you want to highlight for special attention from reviewers?

The `checksums_bundler_4_0_11` expectation deliberately flips from keeping the runner's entry to preserving the original's absence: original presence now controls the output, not the version gate, and the gate's constants (`BUNDLED_WITH_VERSION_REGEX`, `MIN_BUNDLER_CHECKSUM_VERSION`) are removed with no remaining references.

Two semantics worth confirming intent on: restoration stays replace-only, so an original self-checksum is deliberately not re-added when the generated lockfile omits it (pre-existing #15249 behaviour, now pinned explicitly by a spec), and `BUNDLER_CHECKSUM_ENTRY_REGEX` is only ever applied to the captured `CHECKSUMS` entries, so a `bundler (~> 4.0)` requirement in `DEPENDENCIES` is untouched — a new spec proves that on the strip path, which previously only the restore path exercised.

### How will you know you've accomplished your goal?

The flipped 4.0.11 expectation and the new 4.0.15 regression fail on `main` (the version gate keeps the runner's entry) and pass with this change. The new specs also cover a Bundler 2.x lockfile, a pinned bundler dependency surviving the strip, a generated section containing only the bundler entry — the emptied section is fed through `Bundler::LockfileParser` to prove it still parses — and the deliberate non-restoration case. All 14 checksum/`CHECKSUMS_SECTION` examples pass; RuboCop and `srb tc` are clean.

One honest caveat: the full `lockfile_updater_spec.rb` locally shows 4 failures in unrelated contexts (path gems, vendored gemspecs) that shell out to the real native helper at its Docker-only path and die with `JSON::ParserError`; those fail identically without this change and are untouched by it.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

-----

AI was used to generate or assist with generating this PR. AI tooling assisted with the implementation, regression tests, and review; I reviewed the diff and the local verification results.
