### PR TITLE
Support security updates for vcpkg ports

### DIFF
--- a/vcpkg/README.md
+++ b/vcpkg/README.md
@@ -7,24 +7,46 @@ VCPKG support for [`dependabot-core`][core-repo].
 1. Start a development shell
 
   ```
-  $ bin/docker-dev-shell vcpkg
+  bin/docker-dev-shell vcpkg
   ```
 
-2. Run tests
+1. Run tests
+
    ```
    [dependabot-core-dev] ~ $ cd vcpkg && rspec
    ```
 
 ### Supported scenarios
 
-Dependabot currently only supports updating [the `builtin-baseline` property in the `vcpkg.json` file][builtin-baseline].
+- Updating [the `builtin-baseline` property in the `vcpkg.json` file][builtin-baseline].
+- Updating [the `default-registry` and `registries` properties in the `vcpkg-configuration.json` file][default-registry].
+- Updating a port's [`version>=` constraint][version-gte].
+- Security updates for ports, driven by advisories under the `vcpkg` OSV ecosystem.
+
+### Security updates
+
+A port's version comes from its `version>=` constraint, from the registry baseline, or from both. vcpkg installs the lowest version that satisfies every constraint, so Dependabot works out the effective version by reading `versions/baseline.json` at the commit the manifest pins. That is what gives a bare string dependency a version to test an advisory against.
+
+There are three ways to move a vulnerable port, and Dependabot takes the first one that works:
+
+1. Raise the baseline to the oldest vcpkg release tag whose version floor for the port is safe. Where the baseline is what picks the version, that is the whole fix.
+2. Raise the `version>=` constraint. This covers the case where no release carries the fix yet. A port declared as a bare string becomes an object so it can hold the constraint.
+3. Add an `overrides` entry. [vcpkg refuses to compare versions across schemes][version-schemes], so if every safe version was published under a different scheme than the one in use, pinning the port outright is the only option left.
+
+The versions database and the release tags both come from the vcpkg checkout at `VCPKG_ROOT` (`/opt/vcpkg` in the updater image). Dependabot fetches it first, so a version published since the image was built is still visible.
+
+#### Limitations
+
+- Transitive ports are left alone. Dependabot can only edit what the manifest declares.
+- Dependabot skips ports that come from any registry other than the built-in one, because the shipped versions database says nothing about them.
+- A port pinned to a bare commit SHA does not count as versioned, which keeps a registry baseline recognizable as a git SHA. That affects a handful of pre-2018 `version-string` entries.
 
 ### Future work
 
-- Support updating [the `default-registry` property in the `vcpkg-configuration.json` file][default-registry].
-- Support updating [the `registries` property in the `vcpkg-configuration.json` file][registries].
+- Handle transitive ports, most likely by reading a `vcpkg install --dry-run` plan.
 
 [core-repo]: https://github.com/dependabot/dependabot-core
 [builtin-baseline]: https://learn.microsoft.com/vcpkg/reference/vcpkg-json#builtin-baseline
 [default-registry]: https://learn.microsoft.com/vcpkg/reference/vcpkg-configuration-json#default-registry
-[registries]: https://learn.microsoft.com/vcpkg/reference/vcpkg-configuration-json#registries
+[version-gte]: https://learn.microsoft.com/vcpkg/users/versioning#version-gte
+[version-schemes]: https://learn.microsoft.com/vcpkg/users/versioning#version-schemes

--- a/vcpkg/lib/dependabot/vcpkg.rb
+++ b/vcpkg/lib/dependabot/vcpkg.rb
@@ -1,6 +1,8 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "sorbet-runtime"
+
 # These all need to be required so the various classes can be registered in a
 # lookup table of package manager names to concrete classes.
 require "dependabot/vcpkg/language"
@@ -22,6 +24,8 @@ Dependabot::Dependency.register_production_check("vcpkg", ->(_) { true })
 
 module Dependabot
   module Vcpkg
+    extend T::Sig
+
     ECOSYSTEM = "vcpkg"
 
     PACKAGE_MANAGER = "vcpkg"
@@ -44,5 +48,32 @@ module Dependabot
     VCPKG_DEFAULT_BASELINE_DEFAULT_BRANCH = "master"
 
     VCPKG_SUPPORTED_REGISTRY_TYPES = %w(git builtin).freeze
+
+    # Manifest keys. See https://learn.microsoft.com/vcpkg/reference/vcpkg-json
+    VCPKG_BUILTIN_BASELINE_KEY = "builtin-baseline"
+
+    VCPKG_DEPENDENCIES_KEY = "dependencies"
+
+    VCPKG_OVERRIDES_KEY = "overrides"
+
+    VCPKG_VERSION_CONSTRAINT_KEY = "version>="
+
+    # The vcpkg checkout the updater image ships, holding the ports tree and versions database.
+    VCPKG_DEFAULT_REPOSITORY_PATH = "/opt/vcpkg"
+
+    # See https://learn.microsoft.com/vcpkg/users/versioning#version-schemes
+    VCPKG_VERSION_SCHEME_KEYS = %w(version version-semver version-date version-string).freeze
+
+    VCPKG_BASELINE_DATABASE_PATH = "versions/baseline.json"
+
+    VCPKG_VERSIONS_DIRECTORY = "versions"
+
+    # vcpkg publishes releases as date tags such as `2025.06.13`.
+    VCPKG_RELEASE_TAG_PATTERN = /\Av?\d{4}\.\d{2}\.\d{2}\z/
+
+    sig { returns(String) }
+    def self.repository_path
+      ENV.fetch("VCPKG_ROOT", VCPKG_DEFAULT_REPOSITORY_PATH)
+    end
   end
 end

--- a/vcpkg/lib/dependabot/vcpkg/file_parser.rb
+++ b/vcpkg/lib/dependabot/vcpkg/file_parser.rb
@@ -10,7 +10,10 @@ require "dependabot/logger"
 
 require "dependabot/vcpkg"
 require "dependabot/vcpkg/language"
+require "dependabot/vcpkg/manifest_baseline"
+require "dependabot/vcpkg/package/versions_database"
 require "dependabot/vcpkg/package_manager"
+require "dependabot/vcpkg/version"
 
 module Dependabot
   module Vcpkg
@@ -124,7 +127,7 @@ module Dependabot
 
       sig do
         params(
-          dep: T.untyped,
+          dep: Object,
           dependency_file: Dependabot::DependencyFile
         )
           .returns(T.nilable(Dependabot::Dependency))
@@ -132,38 +135,93 @@ module Dependabot
       def parse_port_dependency(dep:, dependency_file:)
         case dep
         when String
-          # Simple string dependency like "curl" - log and skip
-          Dependabot.logger.warn("Skipping vcpkg dependency '#{dep}' without version>= constraint")
-          nil
+          build_port_dependency(name: dep, constraint: nil, dependency_file:)
         when Hash
           name = dep["name"]
-          version_constraint = dep["version>="]
-
           return nil unless name.is_a?(String)
 
-          unless version_constraint
-            Dependabot.logger.warn("Skipping vcpkg dependency '#{name}' without version>= constraint")
-            return nil
-          end
-
-          # Parse version and optional port-version
-          version, _port_version = parse_version_with_port(version_constraint)
-
-          Dependabot::Dependency.new(
-            name:,
-            version:,
-            package_manager: "vcpkg",
-            requirements: [{
-              requirement: ">=#{version_constraint}",
-              groups: [],
-              source: nil,
-              file: dependency_file.name
-            }]
-          )
+          constraint = dep[VCPKG_VERSION_CONSTRAINT_KEY]
+          build_port_dependency(name:, constraint: constraint.is_a?(String) ? constraint : nil, dependency_file:)
         else
           Dependabot.logger.warn("Skipping unknown vcpkg dependency format: #{dep.inspect}")
           nil
         end
+      end
+
+      # A port's version comes from its `version>=` constraint, the registry baseline, or both.
+      # vcpkg installs the lowest version satisfying every constraint, so where both are present
+      # the effective version is the higher of the two.
+      sig do
+        params(
+          name: String,
+          constraint: T.nilable(String),
+          dependency_file: Dependabot::DependencyFile
+        )
+          .returns(T.nilable(Dependabot::Dependency))
+      end
+      def build_port_dependency(name:, constraint:, dependency_file:)
+        version = effective_port_version(name:, constraint:)
+
+        unless version
+          Dependabot.logger.warn("Skipping vcpkg dependency '#{name}' without version>= constraint")
+          return nil
+        end
+
+        Dependabot::Dependency.new(
+          name:,
+          version: version.to_s,
+          package_manager: "vcpkg",
+          requirements: [{
+            requirement: constraint && ">=#{constraint}",
+            groups: [],
+            source: nil,
+            file: dependency_file.name
+          }]
+        )
+      end
+
+      sig { params(name: String, constraint: T.nilable(String)).returns(T.nilable(Dependabot::Vcpkg::Version)) }
+      def effective_port_version(name:, constraint:)
+        constraint_version = constraint && Version.correct?(constraint) ? Version.new(constraint) : nil
+        baseline_version = baseline_port_version(name)
+
+        return constraint_version unless baseline_version
+        return baseline_version unless constraint_version
+        return constraint_version unless constraint_version.comparable_with?(baseline_version)
+
+        [constraint_version, baseline_version].max
+      end
+
+      sig { params(name: String).returns(T.nilable(Dependabot::Vcpkg::Version)) }
+      def baseline_port_version(name)
+        ref = builtin_baseline_ref
+        return nil unless ref
+
+        versions_database.baseline_version_for(port: name, ref:)
+      end
+
+      # The commit the manifest pins the built-in registry to. Ports resolved from any other
+      # registry are left alone, because the versions database shipped with the image only
+      # describes the built-in one.
+      sig { returns(T.nilable(String)) }
+      def builtin_baseline_ref
+        manifest_baseline.ref
+      end
+
+      sig { returns(Dependabot::Vcpkg::ManifestBaseline) }
+      def manifest_baseline
+        @manifest_baseline ||= T.let(
+          Dependabot::Vcpkg::ManifestBaseline.new(dependency_files:),
+          T.nilable(Dependabot::Vcpkg::ManifestBaseline)
+        )
+      end
+
+      sig { returns(Dependabot::Vcpkg::Package::VersionsDatabase) }
+      def versions_database
+        @versions_database ||= T.let(
+          Dependabot::Vcpkg::Package::VersionsDatabase.new,
+          T.nilable(Dependabot::Vcpkg::Package::VersionsDatabase)
+        )
       end
 
       sig do
@@ -227,15 +285,6 @@ module Dependabot
               default: is_default
             }
           )
-        end
-      end
-
-      sig { params(version_string: String).returns([String, T.nilable(String)]) }
-      def parse_version_with_port(version_string)
-        if version_string.include?("#")
-          version_string.split("#", 2).then { |parts| [parts[0] || "", parts[1]] }
-        else
-          [version_string, nil]
         end
       end
 

--- a/vcpkg/lib/dependabot/vcpkg/file_updater.rb
+++ b/vcpkg/lib/dependabot/vcpkg/file_updater.rb
@@ -145,12 +145,13 @@ module Dependabot
       end
 
       # vcpkg cannot compare versions across schemes, so when no safe version shares the current
-      # one's scheme, the only way to move the port is to pin it outright.
+      # one's scheme, the only way to move the port is to pin it outright. `version` is the
+      # scheme-agnostic key, and the port version belongs in it as a `#N` suffix: the separate
+      # `port-version` key and the scheme-specific keys are both deprecated.
+      # See https://learn.microsoft.com/vcpkg/reference/vcpkg-json#overrides
       sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency).void }
       def apply_override(content, dependency)
-        version = Dependabot::Vcpkg::Version.new(T.must(dependency.version))
-        entry = { "name" => dependency.name, "version" => version.text }
-        entry["port-version"] = version.port_version unless version.port_version.zero?
+        entry = { "name" => dependency.name, "version" => dependency.version }
 
         overrides = content[VCPKG_OVERRIDES_KEY]
         unless overrides.is_a?(Array)

--- a/vcpkg/lib/dependabot/vcpkg/file_updater.rb
+++ b/vcpkg/lib/dependabot/vcpkg/file_updater.rb
@@ -7,6 +7,8 @@ require "sorbet-runtime"
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 require "dependabot/vcpkg"
+require "dependabot/vcpkg/manifest_baseline"
+require "dependabot/vcpkg/version"
 
 module Dependabot
   module Vcpkg
@@ -19,7 +21,7 @@ module Dependabot
 
         # Handle vcpkg.json
         vcpkg_json_file = get_original_file(VCPKG_JSON_FILENAME)
-        if vcpkg_json_file&.then { |file| file_changed?(file) }
+        if vcpkg_json_file && rewrite?(vcpkg_json_file)
           updated_files << updated_file(
             file: vcpkg_json_file,
             content: updated_vcpkg_json_content(vcpkg_json_file)
@@ -28,7 +30,7 @@ module Dependabot
 
         # Handle vcpkg-configuration.json
         vcpkg_config_file = get_original_file(VCPKG_CONFIGURATION_JSON_FILENAME)
-        if vcpkg_config_file&.then { |file| file_changed?(file) }
+        if vcpkg_config_file && rewrite?(vcpkg_config_file)
           updated_files << updated_file(
             file: vcpkg_config_file,
             content: updated_vcpkg_configuration_json_content(vcpkg_config_file)
@@ -39,6 +41,14 @@ module Dependabot
       end
 
       private
+
+      # A security fix can move the baseline in a file that none of the updated dependencies
+      # declare a requirement against, so that file needs rewriting even though `file_changed?`
+      # says otherwise.
+      sig { params(file: Dependabot::DependencyFile).returns(T::Boolean) }
+      def rewrite?(file)
+        file_changed?(file) || security_baseline&.fetch(:file) == file.name
+      end
 
       sig { override.void }
       def check_required_files
@@ -57,6 +67,8 @@ module Dependabot
           .select { |_, requirement| requirement }
           .each { |dependency, _| update_dependency_in_content(parsed_content, dependency, file.name) }
 
+        apply_security_baseline(parsed_content, file.name)
+
         JSON.pretty_generate(parsed_content)
       rescue JSON::ParserError
         raise Dependabot::DependencyFileNotParseable, file.path
@@ -72,6 +84,8 @@ module Dependabot
           .select { |_, requirement| requirement }
           .each { |dependency, _| update_registry_dependency_in_content(parsed_content, dependency, file.name) }
 
+        apply_security_baseline(parsed_content, file.name)
+
         JSON.pretty_generate(parsed_content)
       rescue JSON::ParserError
         raise Dependabot::DependencyFileNotParseable, file.path
@@ -83,24 +97,124 @@ module Dependabot
         when VCPKG_DEFAULT_BASELINE_DEPENDENCY_NAME
           update_baseline_in_content(content, dependency, filename)
         else
-          update_port_dependency_in_content(content, dependency)
+          update_port_dependency_in_content(content, dependency, filename)
         end
       end
 
       sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency, filename: String).void }
       def update_baseline_in_content(content, dependency, filename)
-        update_baseline_field(content, dependency, filename, "builtin-baseline")
+        update_baseline_field(content, dependency, filename, VCPKG_BUILTIN_BASELINE_KEY)
+      end
+
+      sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency, filename: String).void }
+      def update_port_dependency_in_content(content, dependency, filename)
+        case remediation_for(dependency, filename)
+        when :override then apply_override(content, dependency)
+        # A baseline bump moves the port's version floor, so the port entry needs no change.
+        when :baseline then nil
+        else update_version_constraint(content, dependency)
+        end
+      end
+
+      sig do
+        params(dependency: Dependabot::Dependency, filename: String).returns(T.nilable(Symbol))
+      end
+      def remediation_for(dependency, filename)
+        requirement = dependency.requirements.find { |r| r[:file] == filename }
+        metadata = requirement&.dig(:metadata)
+        return nil unless metadata.is_a?(Hash)
+
+        metadata[:security_remediation]
       end
 
       sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency).void }
-      def update_port_dependency_in_content(content, dependency)
-        # Update the dependencies array
-        dependencies_array = content["dependencies"]
-        return unless dependencies_array.is_a?(Array)
+      def update_version_constraint(content, dependency)
+        entries = content[VCPKG_DEPENDENCIES_KEY]
+        return unless entries.is_a?(Array)
 
-        # Find and update the specific dependency using more functional approach
-        target_dep = dependencies_array.find { _1.is_a?(Hash) && _1["name"] == dependency.name }
-        target_dep&.[]=("version>=", dependency.version)
+        index = entries.index { |entry| port_entry_name(entry) == dependency.name }
+        return unless index
+
+        entry = entries[index]
+        # A port declared as a bare string has to become an object to carry a constraint.
+        entry = { "name" => entry } if entry.is_a?(String)
+        return unless entry.is_a?(Hash)
+
+        entry[VCPKG_VERSION_CONSTRAINT_KEY] = dependency.version
+        entries[index] = entry
+      end
+
+      # vcpkg cannot compare versions across schemes, so when no safe version shares the current
+      # one's scheme, the only way to move the port is to pin it outright.
+      sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency).void }
+      def apply_override(content, dependency)
+        version = Dependabot::Vcpkg::Version.new(T.must(dependency.version))
+        entry = { "name" => dependency.name, "version" => version.text }
+        entry["port-version"] = version.port_version unless version.port_version.zero?
+
+        overrides = content[VCPKG_OVERRIDES_KEY]
+        unless overrides.is_a?(Array)
+          overrides = []
+          content[VCPKG_OVERRIDES_KEY] = overrides
+        end
+
+        index = overrides.index { |override| override.is_a?(Hash) && override["name"] == dependency.name }
+        index ? overrides[index] = entry : overrides << entry
+      end
+
+      sig { params(entry: T.untyped).returns(T.nilable(String)) }
+      def port_entry_name(entry)
+        return entry if entry.is_a?(String)
+        return nil unless entry.is_a?(Hash)
+
+        name = entry["name"]
+        name.is_a?(String) ? name : nil
+      end
+
+      # Where the fix wants the registry baseline moved to, if anywhere.
+      sig { returns(T.nilable(T::Hash[Symbol, String])) }
+      def security_baseline
+        return @security_baseline if @looked_up_security_baseline
+
+        @looked_up_security_baseline = T.let(true, T.nilable(T::Boolean))
+        @security_baseline = T.let(build_security_baseline, T.nilable(T::Hash[Symbol, String]))
+      end
+
+      sig { returns(T.nilable(T::Hash[Symbol, String])) }
+      def build_security_baseline
+        commit_sha = dependencies
+                     .flat_map(&:requirements)
+                     .filter_map { |requirement| requirement.dig(:metadata, :baseline_commit_sha) }
+                     .first
+        return nil unless commit_sha.is_a?(String)
+
+        location = manifest_baseline.location
+        return nil unless location
+
+        { file: location.first, commit_sha: }
+      end
+
+      sig { params(content: T::Hash[String, T.untyped], filename: String).void }
+      def apply_security_baseline(content, filename)
+        baseline = security_baseline
+        return unless baseline && baseline[:file] == filename
+
+        path = T.must(manifest_baseline.location).last
+        key = path.last
+        return unless key
+
+        target = T.must(path[0...-1]).reduce(content) { |node, segment| node.is_a?(Hash) ? node[segment] : nil }
+        return unless target.is_a?(Hash)
+
+        target[key] = baseline[:commit_sha]
+      end
+
+      sig { returns(Dependabot::Vcpkg::ManifestBaseline) }
+      def manifest_baseline
+        @manifest_baseline ||= T.let(
+          Dependabot::Vcpkg::ManifestBaseline.new(dependency_files:),
+          T.nilable(Dependabot::Vcpkg::ManifestBaseline)
+        )
       end
 
       sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency, filename: String).void }

--- a/vcpkg/lib/dependabot/vcpkg/manifest_baseline.rb
+++ b/vcpkg/lib/dependabot/vcpkg/manifest_baseline.rb
@@ -1,0 +1,112 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "json"
+require "sorbet-runtime"
+
+require "dependabot/dependency_file"
+
+require "dependabot/vcpkg"
+
+module Dependabot
+  module Vcpkg
+    # Finds the commit a manifest pins the built-in registry to.
+    #
+    # This ignores any other registry, because the versions database shipped with the updater image
+    # only describes the built-in one.
+    class ManifestBaseline
+      extend T::Sig
+
+      sig { params(dependency_files: T::Array[Dependabot::DependencyFile]).void }
+      def initialize(dependency_files:)
+        @dependency_files = dependency_files
+        @ref = T.let(nil, T.nilable(String))
+        @resolved = T.let(false, T::Boolean)
+      end
+
+      sig { returns(T::Array[Dependabot::DependencyFile]) }
+      attr_reader :dependency_files
+
+      sig { returns(T.nilable(String)) }
+      def ref
+        return @ref if @resolved
+
+        @resolved = true
+        @ref = manifest_builtin_baseline || default_registry_builtin_baseline
+      end
+
+      # The file the baseline lives in, and the JSON path to it, so an updater knows what to
+      # rewrite.
+      sig { returns(T.nilable([String, T::Array[String]])) }
+      def location
+        return [T.must(vcpkg_manifest_file).name, [VCPKG_BUILTIN_BASELINE_KEY]] if manifest_builtin_baseline
+        return nil unless default_registry_builtin_baseline
+
+        [T.must(vcpkg_configuration_file).name, %w(default-registry baseline)]
+      end
+
+      private
+
+      sig { returns(T.nilable(String)) }
+      def manifest_builtin_baseline
+        manifest = vcpkg_manifest_file
+        return nil unless manifest
+
+        baseline = parsed_json(manifest)&.dig(VCPKG_BUILTIN_BASELINE_KEY)
+        baseline.is_a?(String) ? baseline : nil
+      end
+
+      sig { returns(T.nilable(String)) }
+      def default_registry_builtin_baseline
+        registry = default_registry
+        return nil unless registry
+        return nil unless builtin_registry?(registry)
+
+        baseline = registry["baseline"]
+        baseline.is_a?(String) ? baseline : nil
+      end
+
+      sig { returns(T.nilable(T::Hash[String, Object])) }
+      def default_registry
+        config = vcpkg_configuration_file
+        return nil unless config
+
+        registry = parsed_json(config)&.dig("default-registry")
+        registry.is_a?(Hash) ? registry : nil
+      end
+
+      sig { params(registry: T::Hash[String, Object]).returns(T::Boolean) }
+      def builtin_registry?(registry)
+        return true if registry["kind"] == "builtin"
+        return false unless registry["kind"] == "git"
+
+        repository = registry["repository"]
+        return false unless repository.is_a?(String)
+
+        official = [VCPKG_DEFAULT_REGISTRY_REPOSITORY, VCPKG_DEFAULT_BASELINE_URL]
+        official.include?(repository.delete_suffix("/"))
+      end
+
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
+      def vcpkg_manifest_file
+        dependency_files.find { |file| file.name == VCPKG_JSON_FILENAME }
+      end
+
+      sig { returns(T.nilable(Dependabot::DependencyFile)) }
+      def vcpkg_configuration_file
+        dependency_files.find { |file| file.name == VCPKG_CONFIGURATION_JSON_FILENAME }
+      end
+
+      sig { params(file: Dependabot::DependencyFile).returns(T.nilable(T::Hash[String, Object])) }
+      def parsed_json(file)
+        content = file.content
+        return nil unless content
+
+        parsed = JSON.parse(content)
+        parsed.is_a?(Hash) ? parsed : nil
+      rescue JSON::ParserError
+        nil
+      end
+    end
+  end
+end

--- a/vcpkg/lib/dependabot/vcpkg/package/package_details_fetcher.rb
+++ b/vcpkg/lib/dependabot/vcpkg/package/package_details_fetcher.rb
@@ -12,6 +12,7 @@ require "dependabot/shared_helpers"
 require "dependabot/update_checkers/base"
 
 require "dependabot/vcpkg"
+require "dependabot/vcpkg/package/versions_database"
 require "dependabot/vcpkg/version"
 
 module Dependabot
@@ -22,15 +23,20 @@ module Dependabot
 
         sig do
           params(
-            dependency: Dependabot::Dependency
+            dependency: Dependabot::Dependency,
+            versions_database: Dependabot::Vcpkg::Package::VersionsDatabase
           ).void
         end
-        def initialize(dependency:)
+        def initialize(dependency:, versions_database: Dependabot::Vcpkg::Package::VersionsDatabase.new)
           @dependency = dependency
+          @versions_database = versions_database
         end
 
         sig { returns(Dependabot::Dependency) }
         attr_reader :dependency
+
+        sig { returns(Dependabot::Vcpkg::Package::VersionsDatabase) }
+        attr_reader :versions_database
 
         sig { returns(T.nilable(Dependabot::Package::PackageDetails)) }
         def fetch
@@ -75,88 +81,14 @@ module Dependabot
 
         sig { returns(T.nilable(Dependabot::Package::PackageDetails)) }
         def fetch_port_releases
-          fetch_port_versions_from_git
-            .filter_map { |version_info| create_port_package_release(version_info) }
-            .reverse
-            .uniq(&:version)
-            .then do |releases|
-            Dependabot::Package::PackageDetails.new(
-              dependency: dependency,
-              releases: releases
-            )
-          end
-        end
+          release_dates = versions_database.release_dates_for(dependency.name)
 
-        sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
-        def fetch_port_versions_from_git
-          port_path = "ports/#{dependency.name}/vcpkg.json"
-          vcpkg_repo_path = "/opt/vcpkg"
+          releases = versions_database
+                     .versions_for(dependency.name)
+                     .map { |port_version| create_port_package_release(port_version, release_dates) }
+                     .uniq(&:version)
 
-          # Get each commit that modified the port's vcpkg.json
-          git_log_cmd = [
-            "git", "log", "--format=%H", "--follow", "--", port_path
-          ]
-
-          Dir.chdir(vcpkg_repo_path) do
-            log_output = Dependabot::SharedHelpers.run_shell_command(git_log_cmd.join(" "))
-
-            log_output.lines.map(&:strip).filter_map do |line|
-              next if line.empty?
-
-              commit_sha = line.strip
-              next unless commit_sha.match?(/\A[0-9a-f]{40}\z/) # Validate SHA format
-
-              # Get the vcpkg.json content for this commit
-              version_info = extract_version_from_commit(commit_sha, port_path)
-              version_info[:commit_sha] = commit_sha if version_info
-              version_info
-            end
-          end
-        rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
-          Dependabot.logger.warn("Failed to fetch port versions for #{dependency.name}: #{e.message}")
-          []
-        end
-
-        sig { params(commit_sha: String, file_path: String).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
-        def extract_version_from_commit(commit_sha, file_path)
-          show_cmd = ["git", "show", "#{commit_sha}:#{file_path}"]
-
-          file_content = Dependabot::SharedHelpers.run_shell_command(show_cmd.join(" "))
-          parsed_json = JSON.parse(file_content)
-
-          version = parsed_json["version"]
-          port_version = parsed_json["port-version"] || 0
-
-          return nil unless version
-
-          # Combine version and port-version
-          full_version = port_version.zero? ? version : "#{version}##{port_version}"
-
-          {
-            version: version,
-            port_version: port_version,
-            full_version: full_version,
-            commit_date: get_commit_date(commit_sha)
-          }
-        rescue JSON::ParserError => e
-          Dependabot.logger.warn("Failed to parse vcpkg.json for commit #{commit_sha}: #{e.message}")
-          nil
-        rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
-          Dependabot.logger.warn("Failed to show file #{file_path} for commit #{commit_sha}: #{e.message}")
-          nil
-        end
-
-        sig { params(commit_sha: String).returns(T.nilable(Time)) }
-        def get_commit_date(commit_sha)
-          date_cmd = ["git", "show", "--no-patch", "--format=%ci", commit_sha]
-          date_output = Dependabot::SharedHelpers.run_shell_command(date_cmd.join(" "))
-          Time.parse(date_output.strip)
-        rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
-          Dependabot.logger.warn("Failed to get commit date for #{commit_sha}: #{e.message}")
-          nil
-        rescue ArgumentError => e
-          Dependabot.logger.warn("Invalid date format for commit #{commit_sha}: #{e.message}")
-          nil
+          Dependabot::Package::PackageDetails.new(dependency: dependency, releases: releases)
         end
 
         sig { params(tag_info: T::Hash[Symbol, T.untyped]).returns(Dependabot::Package::PackageRelease) }
@@ -173,17 +105,27 @@ module Dependabot
           )
         end
 
-        sig { params(version_info: T::Hash[Symbol, T.untyped]).returns(Dependabot::Package::PackageRelease) }
-        def create_port_package_release(version_info)
+        sig do
+          params(
+            port_version: Dependabot::Vcpkg::Package::VersionsDatabase::PortVersion,
+            release_dates: T::Hash[String, Time]
+          ).returns(Dependabot::Package::PackageRelease)
+        end
+        def create_port_package_release(port_version, release_dates)
+          version = port_version.version
+          git_tree = port_version.git_tree
+
           Dependabot::Package::PackageRelease.new(
-            version: Dependabot::Vcpkg::Version.new(version_info.fetch(:full_version)),
-            tag: version_info.fetch(:full_version),
-            url: "#{Vcpkg::VCPKG_DEFAULT_BASELINE_URL}/tree/#{version_info[:commit_sha]}/ports/#{dependency.name}",
-            released_at: version_info[:commit_date],
+            version: version,
+            tag: version.to_s,
+            url: "#{Vcpkg::VCPKG_DEFAULT_REGISTRY_REPOSITORY}/tree/" \
+                 "#{Vcpkg::VCPKG_DEFAULT_BASELINE_DEFAULT_BRANCH}/ports/#{dependency.name}",
+            released_at: git_tree && release_dates[git_tree],
             details: {
-              "commit_sha" => version_info[:commit_sha],
-              "base_version" => version_info[:version],
-              "port_version" => version_info[:port_version]
+              "scheme" => port_version.scheme,
+              "base_version" => version.text,
+              "port_version" => version.port_version,
+              "git_tree" => git_tree
             }
           )
         end

--- a/vcpkg/lib/dependabot/vcpkg/package/versions_database.rb
+++ b/vcpkg/lib/dependabot/vcpkg/package/versions_database.rb
@@ -183,6 +183,9 @@ module Dependabot
 
         sig { returns(T::Array[String]) }
         def read_release_tags
+          # A release published since the image was built only appears once the registry is
+          # fetched, and a security fix may well be carried by it.
+          fetch_registry
           output = run_git("tag", "--list")
           return [] unless output
 
@@ -201,10 +204,13 @@ module Dependabot
         sig { params(port: String).returns(T::Hash[String, Time]) }
         def read_release_dates(port)
           # `run_shell_command` splits the command on whitespace, so the format cannot contain a
-          # literal space.
-          output = run_git(
-            "log", "--format=tformat:%H%x09%cI", "--patch", "--unified=0", "--", port_versions_path(port)
-          )
+          # literal space. The walk has to start from the same ref the versions themselves are read
+          # from, or an entry published since the image was built gets no date and skips cooldown.
+          log_arguments = [
+            "log", "--format=tformat:%H%x09%cI", "--patch", "--unified=0",
+            registry_ref, "--", port_versions_path(port)
+          ]
+          output = run_git(*log_arguments)
           return {} unless output
 
           current_date = T.let(nil, T.nilable(Time))

--- a/vcpkg/lib/dependabot/vcpkg/package/versions_database.rb
+++ b/vcpkg/lib/dependabot/vcpkg/package/versions_database.rb
@@ -1,0 +1,271 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "json"
+require "sorbet-runtime"
+require "time"
+
+require "dependabot/logger"
+require "dependabot/shared_helpers"
+
+require "dependabot/vcpkg"
+require "dependabot/vcpkg/version"
+
+module Dependabot
+  module Vcpkg
+    module Package
+      # Reads the vcpkg registry's versions database from the checkout the updater image ships.
+      #
+      # `versions/<letter>-/<port>.json` lists every published version of a port, newest first,
+      # along with the scheme it was published under. `versions/baseline.json` at a given commit
+      # gives the version floor that commit sets for every port.
+      #
+      # See https://learn.microsoft.com/vcpkg/users/versioning.concepts#acquiring-port-versions
+      class VersionsDatabase
+        extend T::Sig
+
+        class PortVersion < T::Struct
+          const :version, Dependabot::Vcpkg::Version
+          const :scheme, String
+          const :git_tree, T.nilable(String)
+        end
+
+        sig { params(repository_path: String).void }
+        def initialize(repository_path: Vcpkg.repository_path)
+          @repository_path = repository_path
+          @port_versions = T.let({}, T::Hash[String, T::Array[PortVersion]])
+          @baselines = T.let({}, T::Hash[String, T::Hash[String, Dependabot::Vcpkg::Version]])
+          @release_dates = T.let({}, T::Hash[String, T::Hash[String, Time]])
+          @release_tags = T.let(nil, T.nilable(T::Array[String]))
+          @registry_ref = T.let(nil, T.nilable(String))
+          @fetched = T.let(false, T::Boolean)
+        end
+
+        sig { returns(String) }
+        attr_reader :repository_path
+
+        sig { returns(T::Boolean) }
+        def available?
+          File.directory?(File.join(repository_path, ".git"))
+        end
+
+        # Every published version of a port, newest first.
+        sig { params(port: String).returns(T::Array[PortVersion]) }
+        def versions_for(port)
+          @port_versions[port] ||= read_port_versions(port)
+        end
+
+        # The version floor `ref` sets for `port`, or nil when the port did not exist there.
+        sig { params(port: String, ref: String).returns(T.nilable(Dependabot::Vcpkg::Version)) }
+        def baseline_version_for(port:, ref:)
+          baseline_versions(ref)[port]
+        end
+
+        sig { params(ref: String).returns(T::Hash[String, Dependabot::Vcpkg::Version]) }
+        def baseline_versions(ref)
+          @baselines[ref] ||= read_baseline_versions(ref)
+        end
+
+        # vcpkg's release tags, oldest first.
+        sig { returns(T::Array[String]) }
+        def release_tags
+          @release_tags ||= read_release_tags
+        end
+
+        # When each version of a port was published, keyed by the version's git-tree. The versions
+        # database records no dates, so they come from the commit that added each entry.
+        sig { params(port: String).returns(T::Hash[String, Time]) }
+        def release_dates_for(port)
+          @release_dates[port] ||= read_release_dates(port)
+        end
+
+        sig { params(ref: String).returns(T.nilable(String)) }
+        def commit_sha_for(ref)
+          run_git("rev-list", "-n", "1", ref)&.strip
+        end
+
+        # Whether `descendant` contains `ancestor`, used to make sure a baseline is only ever
+        # moved forwards.
+        sig { params(ancestor: String, descendant: String).returns(T::Boolean) }
+        def ancestor?(ancestor:, descendant:)
+          fetch_registry
+          return false unless available?
+
+          Dependabot::SharedHelpers.run_shell_command(
+            "git merge-base --is-ancestor #{ancestor} #{descendant}",
+            cwd: repository_path
+          )
+          true
+        rescue Dependabot::SharedHelpers::HelperSubprocessFailed
+          false
+        end
+
+        # The ref the versions database is read from. Prefers the fetched remote branch so a fix
+        # published after the image was built is still visible.
+        sig { returns(String) }
+        def registry_ref
+          @registry_ref ||= begin
+            remote_ref = "origin/#{VCPKG_DEFAULT_BASELINE_DEFAULT_BRANCH}"
+            ref_exists?(remote_ref) ? remote_ref : "HEAD"
+          end
+        end
+
+        COMMIT_HEADER_PATTERN = /\A[0-9a-f]{40}\t(?<date>\S+)\z/
+        ADDED_GIT_TREE_PATTERN = /\A\+\s*"git-tree":\s*"(?<git_tree>[0-9a-f]{40})"/
+
+        private
+
+        sig { params(port: String).returns(T::Array[PortVersion]) }
+        def read_port_versions(port)
+          content = show(registry_ref, port_versions_path(port))
+          return [] unless content
+
+          parsed = JSON.parse(content)
+          entries = parsed.is_a?(Hash) ? parsed["versions"] : nil
+          return [] unless entries.is_a?(Array)
+
+          entries.filter_map { |entry| build_port_version(entry) }
+        rescue JSON::ParserError => e
+          Dependabot.logger.warn("Failed to parse the vcpkg versions database for #{port}: #{e.message}")
+          []
+        end
+
+        sig { params(entry: Object).returns(T.nilable(PortVersion)) }
+        def build_port_version(entry)
+          return nil unless entry.is_a?(Hash)
+
+          scheme = VCPKG_VERSION_SCHEME_KEYS.find { |key| entry[key].is_a?(String) }
+          return nil unless scheme
+
+          text = entry.fetch(scheme)
+          port_version = entry["port-version"].to_i
+          version_string = port_version.zero? ? text : "#{text}##{port_version}"
+          return nil unless Dependabot::Vcpkg::Version.correct?(version_string)
+
+          PortVersion.new(
+            version: Dependabot::Vcpkg::Version.new(version_string),
+            scheme: scheme,
+            git_tree: entry["git-tree"]
+          )
+        end
+
+        sig { params(ref: String).returns(T::Hash[String, Dependabot::Vcpkg::Version]) }
+        def read_baseline_versions(ref)
+          content = show(ref, VCPKG_BASELINE_DATABASE_PATH)
+          return {} unless content
+
+          parsed = JSON.parse(content)
+          entries = parsed.is_a?(Hash) ? parsed["default"] : nil
+          return {} unless entries.is_a?(Hash)
+
+          entries.each_with_object({}) do |(port, entry), baselines|
+            version = baseline_version(entry)
+            baselines[port] = version if version
+          end
+        rescue JSON::ParserError => e
+          Dependabot.logger.warn("Failed to parse the vcpkg baseline at #{ref}: #{e.message}")
+          {}
+        end
+
+        sig { params(entry: Object).returns(T.nilable(Dependabot::Vcpkg::Version)) }
+        def baseline_version(entry)
+          return nil unless entry.is_a?(Hash)
+
+          text = entry["baseline"]
+          return nil unless text.is_a?(String)
+
+          port_version = entry["port-version"].to_i
+          version_string = port_version.zero? ? text : "#{text}##{port_version}"
+          return nil unless Dependabot::Vcpkg::Version.correct?(version_string)
+
+          Dependabot::Vcpkg::Version.new(version_string)
+        end
+
+        sig { returns(T::Array[String]) }
+        def read_release_tags
+          output = run_git("tag", "--list")
+          return [] unless output
+
+          output
+            .lines
+            .map(&:strip)
+            .select { |tag| VCPKG_RELEASE_TAG_PATTERN.match?(tag) }
+            .sort_by { |tag| Dependabot::Vcpkg::Version.new(tag.delete_prefix("v")) }
+        end
+
+        sig { params(port: String).returns(String) }
+        def port_versions_path(port)
+          File.join(VCPKG_VERSIONS_DIRECTORY, "#{port[0].to_s.downcase}-", "#{port}.json")
+        end
+
+        sig { params(port: String).returns(T::Hash[String, Time]) }
+        def read_release_dates(port)
+          # `run_shell_command` splits the command on whitespace, so the format cannot contain a
+          # literal space.
+          output = run_git(
+            "log", "--format=tformat:%H%x09%cI", "--patch", "--unified=0", "--", port_versions_path(port)
+          )
+          return {} unless output
+
+          current_date = T.let(nil, T.nilable(Time))
+          # `git log` walks newest first, so later assignments are older commits and win.
+          output.lines.each_with_object({}) do |line, dates|
+            line = line.chomp
+            if (header = COMMIT_HEADER_PATTERN.match(line))
+              current_date = parse_time(header[:date])
+            elsif (added = ADDED_GIT_TREE_PATTERN.match(line)) && current_date
+              dates[added[:git_tree]] = current_date
+            end
+          end
+        end
+
+        sig { params(value: T.nilable(String)).returns(T.nilable(Time)) }
+        def parse_time(value)
+          return nil unless value
+
+          Time.parse(value)
+        rescue ArgumentError
+          nil
+        end
+
+        sig { params(ref: String, path: String).returns(T.nilable(String)) }
+        def show(ref, path)
+          fetch_registry
+          run_git("show", "#{ref}:#{path}")
+        end
+
+        sig { params(ref: String).returns(T::Boolean) }
+        def ref_exists?(ref)
+          fetch_registry
+          !run_git("rev-parse", "--verify", "--quiet", ref).nil?
+        end
+
+        # The image's checkout is frozen at build time, so refs published since then are only
+        # reachable after a fetch. A failure here is not fatal: whatever is already local still
+        # answers most questions.
+        sig { void }
+        def fetch_registry
+          return if @fetched
+
+          @fetched = true
+          return unless available?
+
+          run_git("fetch", "--quiet", "--tags", "--force", "origin")
+        end
+
+        sig { params(arguments: String).returns(T.nilable(String)) }
+        def run_git(*arguments)
+          return nil unless available?
+
+          Dependabot::SharedHelpers.run_shell_command(
+            ["git", *arguments].join(" "),
+            cwd: repository_path
+          )
+        rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
+          Dependabot.logger.debug("git #{arguments.join(' ')} failed in #{repository_path}: #{e.message}")
+          nil
+        end
+      end
+    end
+  end
+end

--- a/vcpkg/lib/dependabot/vcpkg/requirement.rb
+++ b/vcpkg/lib/dependabot/vcpkg/requirement.rb
@@ -1,21 +1,60 @@
-# typed: strong
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
 
 require "dependabot/requirement"
 require "dependabot/utils"
+require "dependabot/vcpkg/version"
 
 module Dependabot
   module Vcpkg
     class Requirement < Dependabot::Requirement
       extend T::Sig
 
-      # Vcpkg requirements are simple strings, so we can just return a single
-      # requirement object for the given string.
+      # `Gem::Requirement::OPS` lists `>` before `>=`, which would make the shorter operator win
+      # against vcpkg's permissive version syntax. Longest first keeps `>=1.2.3` intact.
+      OPERATOR_PATTERN = T.let(
+        OPS.keys.sort_by { |op| -op.length }.map { |op| Regexp.quote(op) }.join("|").freeze,
+        String
+      )
+
+      PATTERN_RAW = T.let(
+        "\\s*(#{OPERATOR_PATTERN})?\\s*(#{Version::REQUIREMENT_VERSION_PATTERN.source})\\s*".freeze,
+        String
+      )
+      PATTERN = /\A#{PATTERN_RAW}\z/
+
+      # Vcpkg requirements are a single constraint, but ignore conditions arrive as a
+      # comma-separated list.
       sig { override.params(requirement_string: T.nilable(String)).returns(T::Array[Dependabot::Requirement]) }
       def self.requirements_array(requirement_string)
         [new(requirement_string)]
+      end
+
+      # Use `Vcpkg::Version` rather than `Gem::Version` so port versions and the string scheme
+      # survive requirement parsing.
+      sig { params(obj: T.any(Gem::Version, String)).returns([String, Gem::Version]) }
+      def self.parse(obj)
+        return ["=", Vcpkg::Version.new(obj.to_s)] if obj.is_a?(Gem::Version)
+
+        matches = PATTERN.match(obj.to_s)
+        raise BadRequirementError, "Illformed requirement [#{obj.inspect}]" unless matches
+
+        return DefaultRequirement if matches[1] == ">=" && matches[2] == "0"
+
+        [matches[1] || "=", Vcpkg::Version.new(T.must(matches[2]))]
+      end
+
+      sig { params(requirements: T.nilable(T.any(String, Gem::Version, T::Array[T.nilable(String)]))).void }
+      def initialize(*requirements)
+        requirements = requirements.flatten.flat_map do |req_string|
+          next req_string unless req_string.is_a?(String)
+
+          req_string.split(",").map(&:strip).reject(&:empty?)
+        end
+
+        super(requirements)
       end
     end
   end

--- a/vcpkg/lib/dependabot/vcpkg/update_checker.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker.rb
@@ -7,15 +7,28 @@ require "dependabot/errors"
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
 
+require "dependabot/vcpkg/package/versions_database"
+
 module Dependabot
   module Vcpkg
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       extend T::Sig
 
       require_relative "update_checker/latest_version_finder"
+      require_relative "update_checker/security_fix_resolver"
 
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_version
+        # A security fix may pin a version the baseline would never select, so it decides where
+        # this dependency is heading.
+        fix = security_fix
+        return fix.version if fix
+
+        # A port with no `version>=` constraint takes its version from the registry baseline, so
+        # the way to move it forwards is to move the baseline. Reporting it as already current
+        # keeps routine runs from pinning a constraint the manifest never had.
+        return dependency.numeric_version if baseline_governed?
+
         @latest_version ||= T.let(
           latest_version_finder.latest_version,
           T.nilable(T.any(String, Dependabot::Version))
@@ -30,6 +43,13 @@ module Dependabot
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_resolvable_version_with_no_unlock = latest_version
 
+      sig { override.returns(T.nilable(Dependabot::Version)) }
+      def lowest_security_fix_version = security_fix&.version
+
+      # A port fix is applied by editing the manifest, so nothing further can make it unresolvable.
+      sig { override.returns(T.nilable(Dependabot::Version)) }
+      def lowest_resolvable_security_fix_version = lowest_security_fix_version
+
       # The release tag for the current baseline commit SHA (else the SHA), so the
       # PR title's "from" shows the tag, not the "master" ref.
       sig { params(_updated_version: String).returns(T.nilable(String)) }
@@ -42,28 +62,75 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
+        fix = security_fix
+        return wrap_requirements(security_updated_requirements(fix)) if fix
         return dependency.requirements unless latest_version
 
-        updated = dependency.requirements.filter_map do |requirement|
-          source = T.cast(requirement[:source], T.nilable(T::Hash[Symbol, T.untyped]))
-          requirement_constraint = requirement[:requirement]
-
-          if source && registry_dependency?
-            # For git dependencies (baselines), update the git ref with the commit SHA
-            latest_commit_sha = latest_version_finder.latest_release_info&.details&.dig("commit_sha")
-            requirement.merge(source: source.merge(ref: latest_commit_sha))
-          elsif source.nil? && requirement_constraint
-            # For port dependencies (no source but has requirement), update the version constraint
-            requirement.merge(requirement: ">=#{latest_version}")
-          else
-            # Keep the original requirement unchanged for other cases
-            requirement
-          end
-        end
-        wrap_requirements(updated)
+        wrap_requirements(dependency.requirements.map { |requirement| updated_requirement(requirement) })
       end
 
       private
+
+      sig do
+        params(requirement: T::Hash[Symbol, T.anything]).returns(T::Hash[Symbol, T.anything])
+      end
+      def updated_requirement(requirement)
+        source = T.cast(requirement[:source], T.nilable(T::Hash[Symbol, T.anything]))
+
+        if source && registry_dependency?
+          # For git dependencies (baselines), update the git ref with the commit SHA
+          latest_commit_sha = latest_version_finder.latest_release_info&.details&.dig("commit_sha")
+          requirement.merge(source: source.merge(ref: latest_commit_sha))
+        elsif source.nil? && requirement[:requirement]
+          # For port dependencies (no source but has requirement), update the version constraint
+          requirement.merge(requirement: ">=#{latest_version}")
+        else
+          # Keep the original requirement unchanged for other cases
+          requirement
+        end
+      end
+
+      # Describes the manifest edit that fixes the advisory, so the file updater can apply it
+      # without repeating the resolution.
+      sig do
+        params(fix: SecurityFixResolver::Fix).returns(T::Array[T::Hash[Symbol, T.anything]])
+      end
+      def security_updated_requirements(fix)
+        dependency.requirements.map do |requirement|
+          metadata = T.cast(requirement[:metadata], T.nilable(T::Hash[Symbol, T.untyped])) || {}
+          updated = requirement.merge(
+            metadata: metadata.merge(
+              security_remediation: fix.kind,
+              security_version: fix.version.to_s,
+              baseline_commit_sha: fix.baseline_commit_sha,
+              baseline_tag: fix.baseline_tag
+            )
+          )
+
+          fix.kind == :version_constraint ? updated.merge(requirement: ">=#{fix.version}") : updated
+        end
+      end
+
+      sig { returns(T.nilable(SecurityFixResolver::Fix)) }
+      def security_fix
+        return @security_fix if @searched_for_security_fix
+
+        @searched_for_security_fix = T.let(true, T.nilable(T::Boolean))
+        return nil if registry_dependency?
+        return nil unless vulnerable?
+
+        @security_fix = T.let(
+          SecurityFixResolver.new(
+            dependency: dependency,
+            dependency_files: dependency_files,
+            security_advisories: security_advisories,
+            ignored_versions: ignored_versions,
+            lowest_comparable_version: latest_version_finder.lowest_security_fix_version,
+            versions_database: versions_database
+          ).fix,
+          T.nilable(SecurityFixResolver::Fix)
+        )
+      end
 
       sig { returns(T::Boolean) }
       def registry_dependency?
@@ -74,6 +141,33 @@ module Dependabot
       def port_dependency?
         # A port dependency has no git source but has a requirement constraint
         !registry_dependency? && dependency.requirements.any? { |req| req[:requirement] }
+      end
+
+      # A port whose version comes solely from the registry baseline.
+      sig { returns(T::Boolean) }
+      def baseline_governed?
+        return false if registry_dependency?
+        return false unless dependency.numeric_version
+
+        dependency.requirements.none? { |requirement| requirement[:requirement] }
+      end
+
+      # `latest_version` may be a version vcpkg cannot order against the current one, which is
+      # exactly when the override remediation applies. The base class's numeric comparison would
+      # then wrongly report the dependency as current, so defer to the resolver: it has already
+      # established that the current version is vulnerable and the fix is not.
+      sig { returns(T::Boolean) }
+      def numeric_version_up_to_date?
+        return false if security_fix
+
+        super
+      end
+
+      sig { returns(T::Boolean) }
+      def preferred_version_resolvable_with_unlock?
+        return true if security_fix
+
+        super
       end
 
       # `latest_version` is a git tag but the baseline is a commit SHA, so the base check never
@@ -98,6 +192,14 @@ module Dependabot
       sig { override.returns(T::Array[Dependabot::Dependency]) }
       def updated_dependencies_after_full_unlock
         raise NotImplementedError, "Vcpkg doesn't support full unlock operations"
+      end
+
+      sig { returns(Dependabot::Vcpkg::Package::VersionsDatabase) }
+      def versions_database
+        @versions_database ||= T.let(
+          Dependabot::Vcpkg::Package::VersionsDatabase.new,
+          T.nilable(Dependabot::Vcpkg::Package::VersionsDatabase)
+        )
       end
 
       sig { returns(LatestVersionFinder) }

--- a/vcpkg/lib/dependabot/vcpkg/update_checker/latest_version_finder.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker/latest_version_finder.rb
@@ -50,6 +50,26 @@ module Dependabot
           )
         end
 
+        # vcpkg refuses to compare versions whose schemes differ, so a release it could never
+        # select is not a candidate. Filtering here rather than in a later hook keeps every
+        # inherited comparison operating on a mutually comparable set. Registry baselines are
+        # exempt: they are release tags rather than port versions.
+        sig { returns(T.nilable(T::Array[Dependabot::Package::PackageRelease])) }
+        def available_versions
+          releases = super
+          return releases if registry_dependency?
+
+          current = current_version
+          return releases unless releases && current
+
+          current_scheme = declared_scheme(releases, current)
+          releases.select do |release|
+            version = release.version
+            version.is_a?(Dependabot::Vcpkg::Version) &&
+              Dependabot::Vcpkg::Version.comparable?(version, scheme_of(release), current, current_scheme)
+          end
+        end
+
         # The release tag for the given commit SHA, if any.
         sig { params(commit_sha: String).returns(T.nilable(String)) }
         def tag_for_commit_sha(commit_sha)
@@ -60,6 +80,35 @@ module Dependabot
         end
 
         private
+
+        # The scheme the registry published the currently selected version under.
+        sig do
+          params(
+            releases: T::Array[Dependabot::Package::PackageRelease],
+            current: Dependabot::Vcpkg::Version
+          ).returns(T.nilable(String))
+        end
+        def declared_scheme(releases, current)
+          scheme_of(releases.find { |release| release.version.eql?(current) })
+        end
+
+        sig { params(release: T.nilable(Dependabot::Package::PackageRelease)).returns(T.nilable(String)) }
+        def scheme_of(release)
+          scheme = T.cast(release&.details&.dig("scheme"), T.nilable(Object))
+          scheme.is_a?(String) ? scheme : nil
+        end
+
+        sig { returns(T.nilable(Dependabot::Vcpkg::Version)) }
+        def current_version
+          return @current_version if @looked_up_current_version
+
+          @looked_up_current_version = T.let(true, T.nilable(T::Boolean))
+          version = dependency.version
+          @current_version = T.let(
+            version && Dependabot::Vcpkg::Version.correct?(version) ? Dependabot::Vcpkg::Version.new(version) : nil,
+            T.nilable(Dependabot::Vcpkg::Version)
+          )
+        end
 
         sig { returns(T::Boolean) }
         def registry_dependency?

--- a/vcpkg/lib/dependabot/vcpkg/update_checker/security_fix_resolver.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker/security_fix_resolver.rb
@@ -1,0 +1,273 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/logger"
+require "dependabot/security_advisory"
+
+require "dependabot/vcpkg"
+require "dependabot/vcpkg/manifest_baseline"
+require "dependabot/vcpkg/package/versions_database"
+require "dependabot/vcpkg/requirement"
+require "dependabot/vcpkg/update_checker"
+require "dependabot/vcpkg/version"
+
+module Dependabot
+  module Vcpkg
+    class UpdateChecker < Dependabot::UpdateCheckers::Base
+      # Works out how to move a vulnerable port onto a safe version.
+      #
+      # vcpkg offers three levers, tried in this order:
+      #
+      #   1. raise the registry baseline, which lifts the version floor for every port
+      #   2. raise (or add) the port's own `version>=` constraint
+      #   3. pin the port with an `overrides` entry, for when the safe version uses a scheme vcpkg
+      #      refuses to compare against the one currently selected
+      #
+      # A safe floor always fixes the port on its own, because it sits above the current version,
+      # which in turn already satisfies any declared constraint. Levers 2 and 3 therefore only come
+      # up when no release carries the fix, and in that case there is no baseline worth moving to.
+      class SecurityFixResolver
+        extend T::Sig
+
+        class Fix < T::Struct
+          const :version, Dependabot::Vcpkg::Version
+          # `:baseline`, `:version_constraint` or `:override`.
+          const :kind, Symbol
+          const :baseline_tag, T.nilable(String)
+          const :baseline_commit_sha, T.nilable(String)
+        end
+
+        sig do
+          params(
+            dependency: Dependabot::Dependency,
+            dependency_files: T::Array[Dependabot::DependencyFile],
+            security_advisories: T::Array[Dependabot::SecurityAdvisory],
+            ignored_versions: T::Array[String],
+            lowest_comparable_version: T.nilable(Dependabot::Version),
+            versions_database: Dependabot::Vcpkg::Package::VersionsDatabase
+          ).void
+        end
+        def initialize(
+          dependency:,
+          dependency_files:,
+          security_advisories:,
+          ignored_versions:,
+          lowest_comparable_version:,
+          versions_database: Dependabot::Vcpkg::Package::VersionsDatabase.new
+        )
+          @dependency = dependency
+          @dependency_files = dependency_files
+          @security_advisories = security_advisories
+          @ignored_versions = ignored_versions
+          @lowest_comparable_version = lowest_comparable_version
+          @versions_database = versions_database
+
+          @fix = T.let(nil, T.nilable(Fix))
+          @resolved = T.let(false, T::Boolean)
+          @safe_baseline = T.let(nil, T.nilable([String, Dependabot::Vcpkg::Version]))
+          @searched_baseline = T.let(false, T::Boolean)
+        end
+
+        sig { returns(T.nilable(Fix)) }
+        def fix
+          return @fix if @resolved
+
+          @resolved = true
+          @fix = resolve
+        end
+
+        private
+
+        sig { returns(Dependabot::Dependency) }
+        attr_reader :dependency
+
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        attr_reader :dependency_files
+
+        sig { returns(T::Array[Dependabot::SecurityAdvisory]) }
+        attr_reader :security_advisories
+
+        sig { returns(T::Array[String]) }
+        attr_reader :ignored_versions
+
+        sig { returns(T.nilable(Dependabot::Version)) }
+        attr_reader :lowest_comparable_version
+
+        sig { returns(Dependabot::Vcpkg::Package::VersionsDatabase) }
+        attr_reader :versions_database
+
+        sig { returns(T.nilable(Fix)) }
+        def resolve
+          return nil unless current_version
+          return nil if security_advisories.none?
+
+          baseline = safe_baseline
+          return build_fix(version: baseline.last, kind: :baseline, tag: baseline.first) if
+            baseline && baseline_alone_resolves?(baseline.last)
+
+          constraint_version = comparable_fix_version
+          if constraint_version
+            return build_fix(version: constraint_version, kind: :version_constraint, tag: baseline&.first)
+          end
+
+          override_version = next_safe_published_version
+          return nil unless override_version
+
+          build_fix(version: override_version, kind: :override, tag: baseline&.first)
+        end
+
+        sig do
+          params(version: Dependabot::Vcpkg::Version, kind: Symbol, tag: T.nilable(String)).returns(Fix)
+        end
+        def build_fix(version:, kind:, tag:)
+          Fix.new(
+            version: version,
+            kind: kind,
+            baseline_tag: tag,
+            baseline_commit_sha: tag && versions_database.commit_sha_for(tag)
+          )
+        end
+
+        # The oldest release tag at or after the manifest's baseline whose version floor for this
+        # port is safe.
+        sig { returns(T.nilable([String, Dependabot::Vcpkg::Version])) }
+        def safe_baseline
+          return @safe_baseline if @searched_baseline
+
+          @searched_baseline = true
+          @safe_baseline = search_safe_baseline
+        end
+
+        sig { returns(T.nilable([String, Dependabot::Vcpkg::Version])) }
+        def search_safe_baseline
+          return nil unless baseline_ref
+
+          # A port's floor generally only moves forwards, but advisories enumerate affected versions
+          # rather than describing ranges, so a safe floor can be followed by a vulnerable one. That
+          # rules out bisection. The candidate list is bounded by the number of vcpkg releases since
+          # the baseline, so scanning it in order is cheap enough.
+          upgrade_tags.each do |tag|
+            version = safe_baseline_version_for(tag)
+            return [tag, version] if version
+          end
+
+          nil
+        end
+
+        sig { params(tag: String).returns(T.nilable(Dependabot::Vcpkg::Version)) }
+        def safe_baseline_version_for(tag)
+          version = versions_database.baseline_version_for(port: dependency.name, ref: tag)
+          return nil unless version
+          return nil unless version > T.must(current_version)
+          return nil unless safe?(version)
+
+          version
+        end
+
+        # Release tags that contain the manifest's current baseline, so a fix never moves it back.
+        sig { returns(T::Array[String]) }
+        def upgrade_tags
+          ref = baseline_ref
+          return [] unless ref
+
+          tags = versions_database.release_tags
+          index = tags.bsearch_index { |tag| versions_database.ancestor?(ancestor: ref, descendant: tag) }
+          return [] unless index
+
+          T.must(tags[index..])
+        end
+
+        # True when raising the baseline is enough on its own, i.e. no declared constraint holds
+        # the port back at a vulnerable version.
+        sig { params(baseline_version: Dependabot::Vcpkg::Version).returns(T::Boolean) }
+        def baseline_alone_resolves?(baseline_version)
+          declared = declared_constraint_version
+          return true unless declared
+          return false unless declared.comparable_with?(baseline_version)
+
+          declared <= baseline_version
+        end
+
+        sig { returns(T.nilable(Dependabot::Vcpkg::Version)) }
+        def comparable_fix_version
+          version = lowest_comparable_version
+          return nil unless version.is_a?(Dependabot::Vcpkg::Version)
+
+          version
+        end
+
+        # When no safe version shares a scheme with the current one, vcpkg can only be pointed at a
+        # version with an `overrides` entry. Publication order is the only ordering left, so this
+        # takes the earliest safe version published after the current one.
+        sig { returns(T.nilable(Dependabot::Vcpkg::Version)) }
+        def next_safe_published_version
+          published = versions_database.versions_for(dependency.name).map(&:version)
+          current_index = published.index { |version| version.eql?(current_version) }
+          # Without knowing where the current version sits, "published after it" is meaningless and
+          # picking anything risks pinning the port to an older version than it already uses.
+          return nil unless current_index
+
+          T.must(published[0...current_index]).reverse.find { |version| safe?(version) }
+        end
+
+        sig { params(version: Dependabot::Vcpkg::Version).returns(T::Boolean) }
+        def safe?(version)
+          return false if ignored?(version)
+
+          security_advisories.none? { |advisory| advisory.vulnerable?(version) }
+        end
+
+        sig { params(version: Dependabot::Vcpkg::Version).returns(T::Boolean) }
+        def ignored?(version)
+          ignore_requirements.any? { |requirement| requirement.satisfied_by?(version) }
+        end
+
+        sig { returns(T::Array[Dependabot::Requirement]) }
+        def ignore_requirements
+          @ignore_requirements ||= T.let(
+            ignored_versions.flat_map { |req| Dependabot::Vcpkg::Requirement.requirements_array(req) },
+            T.nilable(T::Array[Dependabot::Requirement])
+          )
+        end
+
+        sig { returns(T.nilable(Dependabot::Vcpkg::Version)) }
+        def declared_constraint_version
+          return @declared_constraint_version if @declared_constraint_version
+
+          constraint = dependency.requirements.filter_map { |req| req[:requirement] }.first
+          return nil unless constraint.is_a?(String)
+
+          text = constraint.delete_prefix(">=").strip
+          return nil unless Dependabot::Vcpkg::Version.correct?(text)
+
+          @declared_constraint_version = T.let(
+            Dependabot::Vcpkg::Version.new(text),
+            T.nilable(Dependabot::Vcpkg::Version)
+          )
+        end
+
+        sig { returns(T.nilable(Dependabot::Vcpkg::Version)) }
+        def current_version
+          return @current_version if @looked_up_current_version
+
+          @looked_up_current_version = T.let(true, T.nilable(T::Boolean))
+          version = dependency.version
+          @current_version = T.let(
+            version && Dependabot::Vcpkg::Version.correct?(version) ? Dependabot::Vcpkg::Version.new(version) : nil,
+            T.nilable(Dependabot::Vcpkg::Version)
+          )
+        end
+
+        sig { returns(T.nilable(String)) }
+        def baseline_ref
+          @baseline_ref ||= T.let(
+            Dependabot::Vcpkg::ManifestBaseline.new(dependency_files:).ref,
+            T.nilable(String)
+          )
+        end
+      end
+    end
+  end
+end

--- a/vcpkg/lib/dependabot/vcpkg/update_checker/security_fix_resolver.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker/security_fix_resolver.rb
@@ -104,30 +104,36 @@ module Dependabot
           return nil if security_advisories.none?
 
           baseline = safe_baseline
-          return build_fix(version: baseline.last, kind: :baseline, tag: baseline.first) if
-            baseline && baseline_alone_resolves?(baseline.last)
-
-          constraint_version = comparable_fix_version
-          if constraint_version
-            return build_fix(version: constraint_version, kind: :version_constraint, tag: baseline&.first)
+          if baseline && baseline_alone_resolves?(baseline.last)
+            return build_baseline_fix(version: baseline.last, tag: baseline.first)
           end
+
+          # The later levers deliberately leave the baseline alone. A safe floor that does not
+          # resolve the port on its own is one vcpkg cannot compare against the declared
+          # constraint, so moving it as well would only produce a manifest vcpkg rejects.
+          constraint_version = comparable_fix_version
+          return build_fix(version: constraint_version, kind: :version_constraint) if constraint_version
 
           override_version = next_safe_published_version
           return nil unless override_version
 
-          build_fix(version: override_version, kind: :override, tag: baseline&.first)
+          build_fix(version: override_version, kind: :override)
         end
 
-        sig do
-          params(version: Dependabot::Vcpkg::Version, kind: Symbol, tag: T.nilable(String)).returns(Fix)
+        sig { params(version: Dependabot::Vcpkg::Version, kind: Symbol).returns(Fix) }
+        def build_fix(version:, kind:)
+          Fix.new(version: version, kind: kind, baseline_tag: nil, baseline_commit_sha: nil)
         end
-        def build_fix(version:, kind:, tag:)
-          Fix.new(
-            version: version,
-            kind: kind,
-            baseline_tag: tag,
-            baseline_commit_sha: tag && versions_database.commit_sha_for(tag)
-          )
+
+        # A baseline remediation is only worth reporting if the commit it names can be resolved,
+        # otherwise the file updater has nothing to write and the run produces an empty pull
+        # request.
+        sig { params(version: Dependabot::Vcpkg::Version, tag: String).returns(T.nilable(Fix)) }
+        def build_baseline_fix(version:, tag:)
+          commit_sha = versions_database.commit_sha_for(tag)
+          return nil unless commit_sha
+
+          Fix.new(version: version, kind: :baseline, baseline_tag: tag, baseline_commit_sha: commit_sha)
         end
 
         # The oldest release tag at or after the manifest's baseline whose version floor for this
@@ -158,9 +164,13 @@ module Dependabot
 
         sig { params(tag: String).returns(T.nilable(Dependabot::Vcpkg::Version)) }
         def safe_baseline_version_for(tag)
+          current = T.must(current_version)
           version = versions_database.baseline_version_for(port: dependency.name, ref: tag)
           return nil unless version
-          return nil unless version > T.must(current_version)
+          # `#<=>` invents an order for incomparable schemes, so ask vcpkg's question first rather
+          # than deciding "is this an upgrade" from lexical text ordering.
+          return nil unless version.comparable_with?(current)
+          return nil unless version > current
           return nil unless safe?(version)
 
           version
@@ -203,13 +213,20 @@ module Dependabot
         # takes the earliest safe version published after the current one.
         sig { returns(T.nilable(Dependabot::Vcpkg::Version)) }
         def next_safe_published_version
+          current = T.must(current_version)
           published = versions_database.versions_for(dependency.name).map(&:version)
-          current_index = published.index { |version| version.eql?(current_version) }
+          current_index = published.index { |version| version.eql?(current) }
           # Without knowing where the current version sits, "published after it" is meaningless and
           # picking anything risks pinning the port to an older version than it already uses.
           return nil unless current_index
 
-          T.must(published[0...current_index]).reverse.find { |version| safe?(version) }
+          T.must(published[0...current_index]).reverse.find do |version|
+            # Publishing order is not version order: a backport can appear after a newer release.
+            # Where vcpkg can compare the two, refuse to pin the port backwards.
+            next false if version.comparable_with?(current) && version <= current
+
+            safe?(version)
+          end
         end
 
         sig { params(version: Dependabot::Vcpkg::Version).returns(T::Boolean) }

--- a/vcpkg/lib/dependabot/vcpkg/version.rb
+++ b/vcpkg/lib/dependabot/vcpkg/version.rb
@@ -62,6 +62,7 @@ module Dependabot
       sig { override.params(version: VersionParameter).void }
       def initialize(version)
         @version_string = T.let(version.to_s.strip, String)
+        raise ArgumentError, "Malformed version number string #{version}" unless self.class.correct?(@version_string)
 
         text, port_version = self.class.split_port_version(@version_string)
         @text = T.let(text, String)
@@ -136,7 +137,8 @@ module Dependabot
       end
 
       # Mirrors `compare_version_texts` in vcpkg-tool: dot versions compare with dot versions,
-      # dates with dates, and arbitrary strings only with an identical string.
+      # dates with dates, and arbitrary strings only with an identical string. A string-scheme
+      # version is never comparable with a typed one, even when the text matches.
       sig do
         params(
           left: Vcpkg::Version,
@@ -149,7 +151,8 @@ module Dependabot
         left_class = comparison_class_for_scheme(left_scheme) || left.comparison_class
         right_class = comparison_class_for_scheme(right_scheme) || right.comparison_class
 
-        return left.text == right.text if left_class == :string || right_class == :string
+        return left.text == right.text if left_class == :string && right_class == :string
+        return false if left_class == :string || right_class == :string
 
         left_class == right_class
       end

--- a/vcpkg/lib/dependabot/vcpkg/version.rb
+++ b/vcpkg/lib/dependabot/vcpkg/version.rb
@@ -1,4 +1,4 @@
-# typed: strong
+# typed: strict
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -8,59 +8,319 @@ require "dependabot/version"
 
 module Dependabot
   module Vcpkg
+    # vcpkg has four version schemes and a `#<port-version>` suffix, and it refuses to compare
+    # versions whose schemes are incomparable. This class mirrors `compare_any` in vcpkg-tool's
+    # `src/vcpkg/versions.cpp`: a version's comparison class is inferred from its text, dates
+    # compare with dates, dot-versions with dot-versions, and arbitrary strings only with
+    # themselves.
+    #
+    # See https://learn.microsoft.com/vcpkg/users/versioning#version-schemes
     class Version < Dependabot::Version
       extend T::Sig
 
-      VERSION_PATTERN = /\A([0-9]+(?:\.[0-9]+)*(?:-[0-9A-Za-z\-\.]+)?(?:\+[0-9A-Za-z\-\.]+)?)(?:\#([0-9]+))?\z/
+      # `version-date`: an ISO-8601 date with optional dot-separated disambiguators.
+      DATE_PATTERN = /\d{4}-\d{2}-\d{2}(?:\.(?:0|[1-9]\d*))*/
+
+      # `version` and `version-semver`: dot-separated numbers with optional semver pre-release
+      # identifiers and build metadata.
+      DOT_PATTERN = /
+        (?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))*
+        (?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?
+        (?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?
+      /x
+
+      # `version-string` accepts arbitrary text. `#` is reserved for the port version.
+      STRING_PATTERN = /[^\s#]+/
+
+      PORT_VERSION_PATTERN = /(?:\#(?:0|[1-9]\d*))?/
+
+      VERSION_PATTERN = /#{STRING_PATTERN}#{PORT_VERSION_PATTERN}/
+
+      # Requirement strings prefix a version with an operator, so the string scheme must not be
+      # allowed to swallow one.
+      REQUIREMENT_VERSION_PATTERN = /(?![=<>~!])#{VERSION_PATTERN}/
+
+      ANCHORED_VERSION_PATTERN = /\A\s*#{VERSION_PATTERN}\s*\z/
+      ANCHORED_DATE_PATTERN = /\A#{DATE_PATTERN}\z/
+      ANCHORED_DOT_PATTERN = /\A#{DOT_PATTERN}\z/
+
+      # A handful of ancient ports use a bare commit SHA as a `version-string`, but so does every
+      # vcpkg registry baseline. Treating those as versions would stop `UpdateCheckers::Base` from
+      # recognizing a baseline as a git SHA, so this rejects them. Digit-only strings still count,
+      # because they are valid relaxed versions.
+      GIT_SHA_PATTERN = /\A(?=[0-9a-f]*[a-f])[0-9a-f]{7,40}\z/
+
+      DATE_LENGTH = 10
 
       sig { override.params(version: VersionParameter).void }
       def initialize(version)
-        @version_string = T.let(version.to_s, String)
-        base_version, port_version = parse_version(@version_string)
-        super(base_version)
-        @port_version = T.let(port_version, T.nilable(Integer))
+        @version_string = T.let(version.to_s.strip, String)
+
+        text, port_version = self.class.split_port_version(@version_string)
+        @text = T.let(text, String)
+        @port_version = T.let(port_version, Integer)
+        @comparison_class = T.let(self.class.comparison_class_for(text), Symbol)
+
+        @dot_parts = T.let(nil, T.nilable([T::Array[Integer], T::Array[String]]))
+        @date_identifiers = T.let(nil, T.nilable(T::Array[Integer]))
+        @natural_key = T.let(nil, T.nilable(T::Array[T::Array[T.any(Integer, String)]]))
+
+        super(self.class.numeric_surrogate(text))
       end
 
-      sig { returns(T.nilable(Integer)) }
+      sig { returns(String) }
+      attr_reader :text
+
+      sig { returns(Integer) }
       attr_reader :port_version
 
-      sig { override.returns(String) }
-      def to_s
-        port_version ? "#{super}##{port_version}" : super
+      # One of `:dot`, `:date` or `:string`.
+      sig { returns(Symbol) }
+      attr_reader :comparison_class
+
+      sig { override.params(version: VersionParameter).returns(Dependabot::Vcpkg::Version) }
+      def self.new(version)
+        T.cast(super, Dependabot::Vcpkg::Version)
       end
+
+      sig { override.params(version: VersionParameter).returns(T::Boolean) }
+      def self.correct?(version)
+        return true if version.is_a?(Gem::Version)
+        return false if version.nil?
+
+        string = version.to_s.strip
+        return false if string.empty?
+        return false if GIT_SHA_PATTERN.match?(string)
+
+        ANCHORED_VERSION_PATTERN.match?(string)
+      end
+
+      sig { params(version_string: String).returns([String, Integer]) }
+      def self.split_port_version(version_string)
+        text, port_version = version_string.split("#", 2)
+        [text.to_s, port_version.to_i]
+      end
+
+      sig { params(text: String).returns(Symbol) }
+      def self.comparison_class_for(text)
+        return :date if ANCHORED_DATE_PATTERN.match?(text)
+        return :dot if ANCHORED_DOT_PATTERN.match?(text)
+
+        :string
+      end
+
+      # A version's scheme is declared in the versions database, not implied by its text: vcpkg
+      # publishes plenty of dotted values under `version-string`. Inference is only a fallback for
+      # values that arrive without one, such as advisory version lists.
+      SCHEME_CLASSES = T.let(
+        {
+          "version" => :dot,
+          "version-semver" => :dot,
+          "version-date" => :date,
+          "version-string" => :string
+        }.freeze,
+        T::Hash[String, Symbol]
+      )
+
+      sig { params(scheme: T.nilable(String)).returns(T.nilable(Symbol)) }
+      def self.comparison_class_for_scheme(scheme)
+        scheme && SCHEME_CLASSES[scheme]
+      end
+
+      # Mirrors `compare_version_texts` in vcpkg-tool: dot versions compare with dot versions,
+      # dates with dates, and arbitrary strings only with an identical string.
+      sig do
+        params(
+          left: Vcpkg::Version,
+          left_scheme: T.nilable(String),
+          right: Vcpkg::Version,
+          right_scheme: T.nilable(String)
+        ).returns(T::Boolean)
+      end
+      def self.comparable?(left, left_scheme, right, right_scheme)
+        left_class = comparison_class_for_scheme(left_scheme) || left.comparison_class
+        right_class = comparison_class_for_scheme(right_scheme) || right.comparison_class
+
+        return left.text == right.text if left_class == :string || right_class == :string
+
+        left_class == right_class
+      end
+
+      # `Gem::Version` only accepts dot-separated alphanumerics, so string-scheme versions get a
+      # numeric stand-in instead. This class overrides every comparison, so the stand-in only backs
+      # the inherited `segments` and sort-key plumbing.
+      sig { params(text: String).returns(String) }
+      def self.numeric_surrogate(text)
+        text[/\A\d+(?:\.\d+)*/] || "0"
+      end
+
+      sig { params(other: Object).returns(T.nilable(Vcpkg::Version)) }
+      def self.coerce(other)
+        return other if other.is_a?(Vcpkg::Version)
+        return nil unless other.is_a?(String) || other.is_a?(Integer) || other.is_a?(Gem::Version)
+
+        string = other.to_s
+        correct?(string) ? new(string) : nil
+      end
+
+      # Semver pre-release ordering: numeric identifiers sort below non-numeric ones, numerics
+      # compare numerically, and everything else compares as ASCII.
+      sig { params(left: T::Array[String], right: T::Array[String]).returns(Integer) }
+      def self.compare_identifiers(left, right)
+        left.each_with_index do |identifier, index|
+          other_identifier = right[index]
+          return 1 if other_identifier.nil?
+
+          comparison = compare_identifier(identifier, other_identifier)
+          return comparison unless comparison.zero?
+        end
+
+        left.length <=> right.length
+      end
+
+      sig { params(left: String, right: String).returns(Integer) }
+      def self.compare_identifier(left, right)
+        left_numeric = left.match?(/\A\d+\z/)
+        right_numeric = right.match?(/\A\d+\z/)
+
+        return left.to_i <=> right.to_i if left_numeric && right_numeric
+        return -1 if left_numeric
+        return 1 if right_numeric
+
+        T.must(left <=> right)
+      end
+
+      sig { returns(T::Boolean) }
+      def dot? = comparison_class == :dot
+
+      sig { returns(T::Boolean) }
+      def date? = comparison_class == :date
+
+      sig { returns(T::Boolean) }
+      def string? = comparison_class == :string
+
+      # vcpkg reports an error rather than an ordering when two versions have incomparable schemes.
+      # `#<=>` still has to return a total order so release lists can be sorted, so callers that
+      # need vcpkg's own answer ask this instead.
+      sig { params(other: Vcpkg::Version).returns(T::Boolean) }
+      def comparable_with?(other)
+        return true if dot? && other.dot?
+        return true if date? && other.date?
+
+        string? && other.string? && text == other.text
+      end
+
+      sig { override.returns(String) }
+      def to_s = @version_string
+
+      sig { override.returns(String) }
+      def to_semver = @version_string
+
+      sig { returns(String) }
+      def inspect = "#<#{self.class} #{@version_string.inspect}>"
+
+      sig { returns(T::Boolean) }
+      def prerelease? = dot? && dot_identifiers.any?
+
+      sig { params(other: Object).returns(T::Boolean) }
+      def eql?(other)
+        other.is_a?(Vcpkg::Version) && text == other.text && port_version == other.port_version
+      end
+
+      sig { returns(Integer) }
+      def hash = [text, port_version].hash
 
       sig { params(other: Object).returns(T.nilable(Integer)) }
       def <=>(other)
-        case other
-        when Version
-          # Compare with another vcpkg version
-          base_comparison = super
-          return base_comparison if base_comparison.nil? || !base_comparison.zero?
+        other = self.class.coerce(other)
+        return nil unless other
 
-          # If base versions are equal, compare port versions
-          (port_version || 0) <=> (other.port_version || 0)
-        when String
-          # Compare with a string by creating a version object from it
-          begin
-            self <=> self.class.new(other)
-          rescue ArgumentError
-            # If the string isn't a valid version, try comparing as base version only
-            super(Gem::Version.new(other))
-          end
-        when Gem::Version, Dependabot::Version
-          # Compare with a regular Gem::Version by comparing just the base version
-          super
+        comparison = compare_text(other)
+        return comparison unless comparison.zero?
+
+        port_version <=> other.port_version
+      end
+
+      protected
+
+      # The numeric segments of a dot-version, e.g. `[1, 2, 3]` for `1.2.3-alpha+build`.
+      sig { returns(T::Array[Integer]) }
+      def dot_numbers = dot_parts.first
+
+      # The semver pre-release identifiers of a dot-version, e.g. `["alpha", "1"]`.
+      sig { returns(T::Array[String]) }
+      def dot_identifiers = dot_parts.last
+
+      sig { returns(String) }
+      def date_part = text[0, DATE_LENGTH].to_s
+
+      sig { returns(T::Array[Integer]) }
+      def date_identifiers
+        @date_identifiers ||= text[DATE_LENGTH..].to_s.split(".").reject(&:empty?).map(&:to_i)
+      end
+
+      sig { returns(T::Array[T::Array[T.any(Integer, String)]]) }
+      def natural_key
+        @natural_key ||= text.scan(/\d+|\D+/).map do |match|
+          part = T.cast(match, String)
+          part.match?(/\A\d+\z/) ? [0, part.to_i, ""] : [1, 0, part]
         end
       end
 
       private
 
-      sig { params(version_string: String).returns([String, T.nilable(Integer)]) }
-      def parse_version(version_string)
-        match = version_string.match(VERSION_PATTERN)
-        raise ArgumentError, "Malformed version number string #{version_string}" unless match
+      sig { returns([T::Array[Integer], T::Array[String]]) }
+      def dot_parts
+        @dot_parts ||= parse_dot_version
+      end
 
-        [T.must(match[1]), match[2]&.to_i]
+      sig { params(other: Vcpkg::Version).returns(Integer) }
+      def compare_text(other)
+        return compare_dot(other) if dot? && other.dot?
+        return compare_date(other) if date? && other.date?
+        return 0 if text == other.text
+
+        compare_naturally(other)
+      end
+
+      sig { params(other: Vcpkg::Version).returns(Integer) }
+      def compare_dot(other)
+        comparison = dot_numbers <=> other.dot_numbers
+        return comparison unless comparison.nil? || comparison.zero?
+
+        # An absent pre-release sorts above one that is present, e.g. `1.0.0` > `1.0.0-1`.
+        return 0 if dot_identifiers.empty? && other.dot_identifiers.empty?
+        return 1 if dot_identifiers.empty?
+        return -1 if other.dot_identifiers.empty?
+
+        self.class.compare_identifiers(dot_identifiers, other.dot_identifiers)
+      end
+
+      sig { params(other: Vcpkg::Version).returns(Integer) }
+      def compare_date(other)
+        comparison = date_part <=> other.date_part
+        return comparison unless comparison.nil? || comparison.zero?
+
+        (date_identifiers <=> other.date_identifiers) || 0
+      end
+
+      # vcpkg refuses to order these, but sorting a release list still has to terminate, so fall
+      # back to a natural ordering of the raw text. Callers that need vcpkg's answer use
+      # `#comparable_with?`.
+      sig { params(other: Vcpkg::Version).returns(Integer) }
+      def compare_naturally(other)
+        comparison = natural_key <=> other.natural_key
+        return comparison unless comparison.nil? || comparison.zero?
+
+        (text <=> other.text) || 0
+      end
+
+      sig { returns([T::Array[Integer], T::Array[String]]) }
+      def parse_dot_version
+        return [[], []] unless dot?
+
+        core, prerelease = T.must(text.split("+", 2).first).split("-", 2)
+        [T.must(core).split(".").map(&:to_i), prerelease.to_s.split(".").reject(&:empty?)]
       end
     end
   end

--- a/vcpkg/lib/dependabot/vcpkg/version.rb
+++ b/vcpkg/lib/dependabot/vcpkg/version.rb
@@ -44,6 +44,13 @@ module Dependabot
       ANCHORED_DATE_PATTERN = /\A#{DATE_PATTERN}\z/
       ANCHORED_DOT_PATTERN = /\A#{DOT_PATTERN}\z/
 
+      # A vcpkg version always contains a digit. Requiring one keeps git refs out: a registry
+      # baseline's previous version is a ref such as `master`, and `MetadataFinders`, `Labeler` and
+      # `UpdateCheckers::Base` all use `correct?` to tell a version from a ref. Treating `master` as
+      # a `version-string` made `ReleaseFinder` compare release tags against it and discard them,
+      # dropping the release notes from baseline pull requests.
+      DIGIT_PATTERN = /[0-9]/
+
       # A handful of ancient ports use a bare commit SHA as a `version-string`, but so does every
       # vcpkg registry baseline. Treating those as versions would stop `UpdateCheckers::Base` from
       # recognizing a baseline as a git SHA, so this rejects them. Digit-only strings still count,
@@ -90,6 +97,7 @@ module Dependabot
 
         string = version.to_s.strip
         return false if string.empty?
+        return false unless DIGIT_PATTERN.match?(string)
         return false if GIT_SHA_PATTERN.match?(string)
 
         ANCHORED_VERSION_PATTERN.match?(string)

--- a/vcpkg/spec/dependabot/vcpkg/file_parser_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/file_parser_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Dependabot::Vcpkg::FileParser do
 
           zlib_dep = dependencies.find { |d| d.name == "zlib" }
           expect(zlib_dep).not_to be_nil
-          expect(zlib_dep.version).to eq("1.2.11")
+          expect(zlib_dep.version).to eq("1.2.11#3")
           expect(zlib_dep.requirements.first[:requirement]).to eq(">=1.2.11#3")
         end
 
@@ -119,6 +119,105 @@ RSpec.describe Dependabot::Vcpkg::FileParser do
           expect(Dependabot.logger)
             .to receive(:warn).with("Skipping vcpkg dependency 'curl' without version>= constraint")
           dependencies
+        end
+      end
+
+      context "when the registry baseline resolves the declared ports" do
+        let(:versions_database) { instance_double(Dependabot::Vcpkg::Package::VersionsDatabase) }
+        let(:vcpkg_json_content) do
+          <<~JSON
+            {
+              "builtin-baseline": "fe1cde61e971d53c9687cf9a46308f8f55da19fa",
+              "dependencies": [
+                "curl",
+                { "name": "fmt" },
+                { "name": "openssl", "version>=": "3.1" },
+                { "name": "zlib", "version>=": "1.4.0" },
+                "unknown-port"
+              ]
+            }
+          JSON
+        end
+
+        before do
+          allow(Dependabot::Vcpkg::Package::VersionsDatabase).to receive(:new).and_return(versions_database)
+          allow(versions_database).to receive(:baseline_version_for) do |port:, ref:|
+            next nil unless ref == "fe1cde61e971d53c9687cf9a46308f8f55da19fa"
+
+            {
+              "curl" => Dependabot::Vcpkg::Version.new("8.14.1"),
+              "fmt" => Dependabot::Vcpkg::Version.new("11.0.2#1"),
+              "openssl" => Dependabot::Vcpkg::Version.new("3.5.0"),
+              "zlib" => Dependabot::Vcpkg::Version.new("1.3.1")
+            }[port]
+          end
+        end
+
+        it "reads the baseline the manifest pins" do
+          dependencies
+
+          expect(versions_database)
+            .to have_received(:baseline_version_for)
+            .with(port: "curl", ref: "fe1cde61e971d53c9687cf9a46308f8f55da19fa")
+        end
+
+        it "gives bare string dependencies the version the baseline selects" do
+          expect(dependencies.find { |dep| dep.name == "curl" }).to have_attributes(
+            version: "8.14.1",
+            requirements: [{ requirement: nil, groups: [], source: nil, file: "vcpkg.json" }]
+          )
+        end
+
+        it "gives unconstrained object dependencies the version the baseline selects" do
+          expect(dependencies.find { |dep| dep.name == "fmt" }.version).to eq("11.0.2#1")
+        end
+
+        it "prefers the baseline when it outranks the declared constraint" do
+          expect(dependencies.find { |dep| dep.name == "openssl" }).to have_attributes(
+            version: "3.5.0",
+            requirements: [{ requirement: ">=3.1", groups: [], source: nil, file: "vcpkg.json" }]
+          )
+        end
+
+        it "prefers the declared constraint when it outranks the baseline" do
+          expect(dependencies.find { |dep| dep.name == "zlib" }.version).to eq("1.4.0")
+        end
+
+        it "skips ports the baseline does not know about" do
+          expect(dependencies.map(&:name)).not_to include("unknown-port")
+        end
+
+        context "when the baseline version uses an incomparable scheme" do
+          before do
+            allow(versions_database).to receive(:baseline_version_for)
+              .and_return(Dependabot::Vcpkg::Version.new("1.2.11-legacy"))
+          end
+
+          it "keeps the declared constraint rather than guessing across schemes" do
+            expect(dependencies.find { |dep| dep.name == "zlib" }.version).to eq("1.4.0")
+          end
+        end
+      end
+
+      context "when the manifest has no builtin-baseline" do
+        let(:versions_database) { instance_double(Dependabot::Vcpkg::Package::VersionsDatabase) }
+        let(:vcpkg_json_content) do
+          <<~JSON
+            {
+              "dependencies": ["curl"]
+            }
+          JSON
+        end
+
+        before do
+          allow(Dependabot::Vcpkg::Package::VersionsDatabase).to receive(:new).and_return(versions_database)
+          allow(versions_database).to receive(:baseline_version_for)
+        end
+
+        it "does not consult the versions database" do
+          dependencies
+
+          expect(versions_database).not_to have_received(:baseline_version_for)
         end
       end
 

--- a/vcpkg/spec/dependabot/vcpkg/file_parser_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/file_parser_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Dependabot::Vcpkg::FileParser do
           JSON
         end
 
-        it "returns a single dependency for the vcpkg baseline" do
-          expect(dependencies.length).to eq(1)
+        it "returns only the baseline when no registry checkout can resolve the ports" do
+          expect(dependencies.map(&:name)).to eq(["github.com/microsoft/vcpkg"])
         end
 
         describe "the parsed dependency" do
@@ -99,23 +99,19 @@ RSpec.describe Dependabot::Vcpkg::FileParser do
         end
 
         it "returns the baseline dependency and dependencies with version constraints" do
-          expect(dependencies.length).to eq(3)
-
-          baseline_dep = dependencies.find { |d| d.name == "github.com/microsoft/vcpkg" }
-          expect(baseline_dep).not_to be_nil
+          expect(dependencies.map(&:name))
+            .to contain_exactly("github.com/microsoft/vcpkg", "openssl", "zlib")
 
           openssl_dep = dependencies.find { |d| d.name == "openssl" }
-          expect(openssl_dep).not_to be_nil
           expect(openssl_dep.version).to eq("3.1")
           expect(openssl_dep.requirements.first[:requirement]).to eq(">=3.1")
 
           zlib_dep = dependencies.find { |d| d.name == "zlib" }
-          expect(zlib_dep).not_to be_nil
           expect(zlib_dep.version).to eq("1.2.11#3")
           expect(zlib_dep.requirements.first[:requirement]).to eq(">=1.2.11#3")
         end
 
-        it "logs warnings for dependencies without version constraints" do
+        it "logs a warning for a bare port no registry checkout can resolve" do
           expect(Dependabot.logger)
             .to receive(:warn).with("Skipping vcpkg dependency 'curl' without version>= constraint")
           dependencies

--- a/vcpkg/spec/dependabot/vcpkg/file_updater_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/file_updater_spec.rb
@@ -952,9 +952,8 @@ RSpec.describe Dependabot::Vcpkg::FileUpdater do
           )]
         end
 
-        it "splits the port version into its own key" do
-          expect(updated_content["overrides"])
-            .to eq([{ "name" => "zlib", "version" => "1.3.1", "port-version" => 2 }])
+        it "keeps the port version in the version string, as vcpkg now prefers" do
+          expect(updated_content["overrides"]).to eq([{ "name" => "zlib", "version" => "1.3.1#2" }])
         end
       end
 

--- a/vcpkg/spec/dependabot/vcpkg/file_updater_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/file_updater_spec.rb
@@ -807,4 +807,209 @@ RSpec.describe Dependabot::Vcpkg::FileUpdater do
       expect(updated_content["dependencies"]).to eq(["fmt"])
     end
   end
+
+  describe "security remediations" do
+    subject(:updated_content) { JSON.parse(updated_dependency_files.first.content) }
+
+    let(:updated_dependency_files) do
+      described_class.new(
+        dependencies: dependencies, dependency_files: dependency_files, credentials: []
+      ).updated_dependency_files
+    end
+
+    let(:baseline_sha) { "fe1cde61e971d53c9687cf9a46308f8f55da19fa" }
+    let(:vcpkg_json_content) do
+      <<~JSON
+        {
+          "builtin-baseline": "old-commit-sha",
+          "dependencies": [
+            "zlib",
+            { "name": "curl", "version>=": "8.0.0" }
+          ]
+        }
+      JSON
+    end
+
+    def port_dependency(name:, version:, previous_version:, requirement:, previous_requirement:, remediation:)
+      Dependabot::Dependency.new(
+        name: name,
+        version: version,
+        previous_version: previous_version,
+        package_manager: "vcpkg",
+        requirements: [{
+          requirement: requirement,
+          groups: [],
+          source: nil,
+          file: "vcpkg.json",
+          metadata: {
+            security_remediation: remediation,
+            security_version: version,
+            baseline_commit_sha: baseline_sha,
+            baseline_tag: "2024.01.12"
+          }
+        }],
+        previous_requirements: [{
+          requirement: previous_requirement,
+          groups: [],
+          source: nil,
+          file: "vcpkg.json"
+        }]
+      )
+    end
+
+    context "with a baseline remediation" do
+      let(:dependencies) do
+        [port_dependency(
+          name: "zlib",
+          version: "1.3.1",
+          previous_version: "1.2.11",
+          requirement: nil,
+          previous_requirement: nil,
+          remediation: :baseline
+        )]
+      end
+
+      it "moves the baseline" do
+        expect(updated_content["builtin-baseline"]).to eq(baseline_sha)
+      end
+
+      it "leaves the port entry alone" do
+        expect(updated_content["dependencies"].first).to eq("zlib")
+      end
+
+      it "adds no overrides" do
+        expect(updated_content).not_to have_key("overrides")
+      end
+    end
+
+    context "with a version constraint remediation" do
+      let(:dependencies) do
+        [port_dependency(
+          name: "curl",
+          version: "8.21.0#1",
+          previous_version: "8.0.0",
+          requirement: ">=8.21.0#1",
+          previous_requirement: ">=8.0.0",
+          remediation: :version_constraint
+        )]
+      end
+
+      it "raises the declared constraint" do
+        expect(updated_content["dependencies"].last).to eq("name" => "curl", "version>=" => "8.21.0#1")
+      end
+
+      it "moves the baseline as well" do
+        expect(updated_content["builtin-baseline"]).to eq(baseline_sha)
+      end
+    end
+
+    context "when the port is declared as a bare string" do
+      let(:dependencies) do
+        [port_dependency(
+          name: "zlib",
+          version: "1.3.1",
+          previous_version: "1.2.11",
+          requirement: ">=1.3.1",
+          previous_requirement: nil,
+          remediation: :version_constraint
+        )]
+      end
+
+      it "promotes it to an object so it can carry the constraint" do
+        expect(updated_content["dependencies"].first).to eq("name" => "zlib", "version>=" => "1.3.1")
+      end
+    end
+
+    context "with an override remediation" do
+      let(:dependencies) do
+        [port_dependency(
+          name: "zlib",
+          version: "1.3.1",
+          previous_version: "1.2.11",
+          requirement: nil,
+          previous_requirement: nil,
+          remediation: :override
+        )]
+      end
+
+      it "pins the port" do
+        expect(updated_content["overrides"]).to eq([{ "name" => "zlib", "version" => "1.3.1" }])
+      end
+
+      it "leaves the declared dependency alone" do
+        expect(updated_content["dependencies"].first).to eq("zlib")
+      end
+
+      context "with a port version" do
+        let(:dependencies) do
+          [port_dependency(
+            name: "zlib",
+            version: "1.3.1#2",
+            previous_version: "1.2.11",
+            requirement: nil,
+            previous_requirement: nil,
+            remediation: :override
+          )]
+        end
+
+        it "splits the port version into its own key" do
+          expect(updated_content["overrides"])
+            .to eq([{ "name" => "zlib", "version" => "1.3.1", "port-version" => 2 }])
+        end
+      end
+
+      context "when the port is already pinned" do
+        let(:vcpkg_json_content) do
+          <<~JSON
+            {
+              "builtin-baseline": "old-commit-sha",
+              "dependencies": ["zlib"],
+              "overrides": [{ "name": "zlib", "version": "1.2.11" }]
+            }
+          JSON
+        end
+
+        it "replaces the existing pin rather than adding a second" do
+          expect(updated_content["overrides"]).to eq([{ "name" => "zlib", "version" => "1.3.1" }])
+        end
+      end
+    end
+
+    context "when the baseline lives in vcpkg-configuration.json" do
+      let(:dependency_files) { [vcpkg_json, vcpkg_configuration_json] }
+      let(:vcpkg_json_content) do
+        <<~JSON
+          {
+            "dependencies": ["zlib"]
+          }
+        JSON
+      end
+      let(:vcpkg_configuration_json) do
+        Dependabot::DependencyFile.new(
+          name: "vcpkg-configuration.json",
+          content: <<~JSON
+            {
+              "default-registry": { "kind": "builtin", "baseline": "old-commit-sha" }
+            }
+          JSON
+        )
+      end
+      let(:dependencies) do
+        [port_dependency(
+          name: "zlib",
+          version: "1.3.1",
+          previous_version: "1.2.11",
+          requirement: nil,
+          previous_requirement: nil,
+          remediation: :baseline
+        )]
+      end
+
+      it "rewrites the configuration even though no requirement points at it" do
+        configuration = updated_dependency_files.find { |file| file.name == "vcpkg-configuration.json" }
+
+        expect(JSON.parse(configuration.content).dig("default-registry", "baseline")).to eq(baseline_sha)
+      end
+    end
+  end
 end

--- a/vcpkg/spec/dependabot/vcpkg/manifest_baseline_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/manifest_baseline_spec.rb
@@ -1,0 +1,112 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "dependabot/dependency_file"
+require "dependabot/vcpkg/manifest_baseline"
+
+RSpec.describe Dependabot::Vcpkg::ManifestBaseline do
+  subject(:baseline) { described_class.new(dependency_files: dependency_files) }
+
+  let(:sha) { "fe1cde61e971d53c9687cf9a46308f8f55da19fa" }
+
+  def manifest(content)
+    Dependabot::DependencyFile.new(name: "vcpkg.json", content: content)
+  end
+
+  def configuration(content)
+    Dependabot::DependencyFile.new(name: "vcpkg-configuration.json", content: content)
+  end
+
+  context "with a builtin-baseline in the manifest" do
+    let(:dependency_files) { [manifest(%({ "builtin-baseline": "#{sha}" }))] }
+
+    it "returns the pinned commit" do
+      expect(baseline.ref).to eq(sha)
+    end
+
+    it "reports where to rewrite it" do
+      expect(baseline.location).to eq(["vcpkg.json", ["builtin-baseline"]])
+    end
+  end
+
+  context "with a builtin default registry in the configuration" do
+    let(:dependency_files) do
+      [
+        manifest(%({ "dependencies": ["zlib"] })),
+        configuration(%({ "default-registry": { "kind": "builtin", "baseline": "#{sha}" } }))
+      ]
+    end
+
+    it "returns the pinned commit" do
+      expect(baseline.ref).to eq(sha)
+    end
+
+    it "reports where to rewrite it" do
+      expect(baseline.location).to eq(["vcpkg-configuration.json", %w(default-registry baseline)])
+    end
+  end
+
+  context "with a git default registry pointing at the official repository" do
+    let(:dependency_files) do
+      [
+        manifest(%({ "dependencies": ["zlib"] })),
+        configuration(
+          %({ "default-registry": { "kind": "git", "repository": "https://github.com/microsoft/vcpkg",
+              "baseline": "#{sha}" } })
+        )
+      ]
+    end
+
+    it "returns the pinned commit" do
+      expect(baseline.ref).to eq(sha)
+    end
+  end
+
+  context "with a git default registry pointing somewhere else" do
+    let(:dependency_files) do
+      [
+        manifest(%({ "dependencies": ["zlib"] })),
+        configuration(
+          %({ "default-registry": { "kind": "git", "repository": "https://example.com/registry",
+              "baseline": "#{sha}" } })
+        )
+      ]
+    end
+
+    it "ignores the registry, because the shipped versions database does not describe it" do
+      expect(baseline.ref).to be_nil
+      expect(baseline.location).to be_nil
+    end
+  end
+
+  context "when the manifest baseline wins over the configuration" do
+    let(:dependency_files) do
+      [
+        manifest(%({ "builtin-baseline": "#{sha}" })),
+        configuration(%({ "default-registry": { "kind": "builtin", "baseline": "#{'a' * 40}" } }))
+      ]
+    end
+
+    it "prefers the manifest" do
+      expect(baseline.ref).to eq(sha)
+      expect(baseline.location).to eq(["vcpkg.json", ["builtin-baseline"]])
+    end
+  end
+
+  context "with no baseline anywhere" do
+    let(:dependency_files) { [manifest(%({ "dependencies": ["zlib"] }))] }
+
+    it { expect(baseline.ref).to be_nil }
+    it { expect(baseline.location).to be_nil }
+  end
+
+  context "with unparseable JSON" do
+    let(:dependency_files) { [manifest("{ not json")] }
+
+    it "does not raise" do
+      expect(baseline.ref).to be_nil
+    end
+  end
+end

--- a/vcpkg/spec/dependabot/vcpkg/package/package_details_fetcher_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/package/package_details_fetcher_spec.rb
@@ -6,9 +6,10 @@ require "dependabot/vcpkg/package/package_details_fetcher"
 
 RSpec.describe Dependabot::Vcpkg::Package::PackageDetailsFetcher do
   subject(:fetcher) do
-    described_class.new(dependency: dependency)
+    described_class.new(dependency: dependency, versions_database: versions_database)
   end
 
+  let(:versions_database) { instance_double(Dependabot::Vcpkg::Package::VersionsDatabase) }
   let(:dependency_name) { "github.com/microsoft/vcpkg" }
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -45,39 +46,28 @@ RSpec.describe Dependabot::Vcpkg::Package::PackageDetailsFetcher do
         )
       end
 
-      before do
-        # Mock the git commands that would be run in /opt/vcpkg
-        allow(Dir).to receive(:chdir).with("/opt/vcpkg").and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd|
-          case cmd
-          when %r{git log --format=%H --follow -- ports/curl/vcpkg\.json}
-            <<~GIT
-              abc123def456789012345678901234567890abcd
-              def4561237890123456789012345678901abcdef
-              abc7890123456789012345678901abcdef123456
-            GIT
-          when "git show abc123def456789012345678901234567890abcd:ports/curl/vcpkg.json"
-            '{"name": "curl", "version": "8.15.0", "port-version": 1}'
-          when "git show def4561237890123456789012345678901abcdef:ports/curl/vcpkg.json"
-            '{"name": "curl", "version": "8.14.0"}'
-          when "git show abc7890123456789012345678901abcdef123456:ports/curl/vcpkg.json"
-            '{"name": "curl", "version": "8.10.0"}'
-          when "git show -s --format=%ci abc123def456789012345678901234567890abcd"
-            "2025-01-15 10:30:00 +0000"
-          when "git show -s --format=%ci def4561237890123456789012345678901abcdef"
-            "2025-01-10 14:20:00 +0000"
-          when "git show -s --format=%ci abc7890123456789012345678901abcdef123456"
-            "2025-01-05 09:15:00 +0000"
-          else
-            raise Dependabot::SharedHelpers::HelperSubprocessFailed.new("Command failed: #{cmd}", "Mock error")
-          end
-        end
+      let(:port_versions) do
+        [
+          build_port_version("8.15.0#1", "version", "aaa"),
+          build_port_version("8.14.0", "version", "bbb"),
+          build_port_version("8.10.0", "version", "ccc")
+        ]
       end
 
-      it "returns package details with releases from port history" do
+      before do
+        allow(versions_database).to receive_messages(
+          versions_for: port_versions,
+          release_dates_for: {
+            "aaa" => Time.utc(2025, 1, 15),
+            "bbb" => Time.utc(2025, 1, 10),
+            "ccc" => Time.utc(2025, 1, 5)
+          }
+        )
+      end
+
+      it "returns package details built from the versions database" do
         expect(details).to be_a(Dependabot::Package::PackageDetails)
         expect(details.dependency).to eq(dependency)
-        expect(details.releases).not_to be_empty
         expect(details.releases.size).to eq(3)
 
         latest_release = details.releases.first
@@ -85,16 +75,31 @@ RSpec.describe Dependabot::Vcpkg::Package::PackageDetailsFetcher do
         expect(latest_release.tag).to eq("8.15.0#1")
         expect(latest_release.details["base_version"]).to eq("8.15.0")
         expect(latest_release.details["port_version"]).to eq(1)
+        expect(latest_release.details["scheme"]).to eq("version")
+        expect(latest_release.released_at).to eq(Time.utc(2025, 1, 15))
 
         second_release = details.releases[1]
         expect(second_release.version.to_s).to eq("8.14.0")
-        expect(second_release.tag).to eq("8.14.0")
-        expect(second_release.details["base_version"]).to eq("8.14.0")
         expect(second_release.details["port_version"]).to eq(0)
+      end
+
+      it "deduplicates repeated versions" do
+        allow(versions_database).to receive(:versions_for)
+          .and_return(port_versions + [build_port_version("8.14.0", "version", "ddd")])
+
+        expect(details.releases.map { |release| release.version.to_s })
+          .to eq(%w(8.15.0#1 8.14.0 8.10.0))
+      end
+
+      it "carries the port's version scheme so incomparable schemes can be detected" do
+        allow(versions_database).to receive(:versions_for)
+          .and_return([build_port_version("1.2.11", "version-string", "eee")])
+
+        expect(details.releases.first.details["scheme"]).to eq("version-string")
       end
     end
 
-    context "when dependency is not a git dependency and git commands fail" do
+    context "when the port is missing from the versions database" do
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "nonexistent",
@@ -110,12 +115,7 @@ RSpec.describe Dependabot::Vcpkg::Package::PackageDetailsFetcher do
       end
 
       before do
-        allow(Dir).to receive(:chdir).with("/opt/vcpkg").and_yield
-        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
-          .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-                       message: "Command failed: Port not found",
-                       error_context: { command: "git log" }
-                     ))
+        allow(versions_database).to receive_messages(versions_for: [], release_dates_for: {})
       end
 
       it "returns empty package details" do
@@ -190,5 +190,13 @@ RSpec.describe Dependabot::Vcpkg::Package::PackageDetailsFetcher do
       expect(fetcher.send(:extract_release_date_from_tag, "invalid")).to be_nil
       expect(fetcher.send(:extract_release_date_from_tag, "1.2.3")).to be_nil
     end
+  end
+
+  def build_port_version(version_string, scheme, git_tree)
+    Dependabot::Vcpkg::Package::VersionsDatabase::PortVersion.new(
+      version: Dependabot::Vcpkg::Version.new(version_string),
+      scheme: scheme,
+      git_tree: git_tree
+    )
   end
 end

--- a/vcpkg/spec/dependabot/vcpkg/package/versions_database_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/package/versions_database_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Dependabot::Vcpkg::Package::VersionsDatabase do
     before do
       allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
         .with(
-          "git log --format=tformat:%H%x09%cI --patch --unified=0 -- versions/z-/zlib.json",
+          "git log --format=tformat:%H%x09%cI --patch --unified=0 origin/master -- versions/z-/zlib.json",
           cwd: "/opt/vcpkg"
         )
         .and_return(git_log)

--- a/vcpkg/spec/dependabot/vcpkg/package/versions_database_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/package/versions_database_spec.rb
@@ -1,0 +1,203 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/vcpkg/package/versions_database"
+
+RSpec.describe Dependabot::Vcpkg::Package::VersionsDatabase do
+  subject(:database) { described_class.new(repository_path: repository_path) }
+
+  let(:repository_path) { "/opt/vcpkg" }
+  let(:zlib_versions) do
+    {
+      "versions" => [
+        { "git-tree" => "a" * 40, "version" => "1.3.1", "port-version" => 0 },
+        { "git-tree" => "b" * 40, "version" => "1.3", "port-version" => 1 },
+        { "git-tree" => "c" * 40, "version-string" => "1.2.11", "port-version" => 0 },
+        { "git-tree" => "d" * 40, "version-date" => "2020-01-01" },
+        { "git-tree" => "e" * 40 }
+      ]
+    }.to_json
+  end
+  let(:baseline) do
+    {
+      "default" => {
+        "zlib" => { "baseline" => "1.3.1", "port-version" => 0 },
+        "fmt" => { "baseline" => "7.1.3", "port-version" => 1 },
+        "broken" => { "port-version" => 1 }
+      }
+    }.to_json
+  end
+
+  before do
+    allow(File).to receive(:directory?).with("/opt/vcpkg/.git").and_return(true)
+    allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, **|
+      case command
+      when "git fetch --quiet --tags --force origin" then ""
+      when "git rev-parse --verify --quiet origin/master" then "#{'f' * 40}\n"
+      when "git show origin/master:versions/z-/zlib.json" then zlib_versions
+      when "git show origin/master:versions/b-/broken.json" then "{ not json"
+      when "git show origin/master:versions/baseline.json", "git show 2025.06.13:versions/baseline.json"
+        baseline
+      when "git tag --list" then "2025.06.13\n2021.04.30\nv2024.12.16\nnot-a-release\n"
+      when "git rev-list -n 1 2025.06.13" then "#{'1' * 40}\n"
+      else
+        raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+          message: "no such path", error_context: { command: command }
+        )
+      end
+    end
+  end
+
+  describe "#available?" do
+    it { expect(database.available?).to be(true) }
+
+    context "when the checkout is missing" do
+      before { allow(File).to receive(:directory?).with("/opt/vcpkg/.git").and_return(false) }
+
+      it { expect(database.available?).to be(false) }
+
+      it "runs no git commands" do
+        database.versions_for("zlib")
+
+        expect(Dependabot::SharedHelpers).not_to have_received(:run_shell_command)
+      end
+    end
+  end
+
+  describe "#registry_ref" do
+    it "prefers the fetched remote branch" do
+      expect(database.registry_ref).to eq("origin/master")
+    end
+
+    it "fetches the registry so newly published versions are visible" do
+      database.registry_ref
+
+      expect(Dependabot::SharedHelpers)
+        .to have_received(:run_shell_command)
+        .with("git fetch --quiet --tags --force origin", cwd: "/opt/vcpkg")
+    end
+
+    it "fetches at most once" do
+      3.times { database.versions_for("zlib") }
+
+      expect(Dependabot::SharedHelpers)
+        .to have_received(:run_shell_command)
+        .with("git fetch --quiet --tags --force origin", cwd: "/opt/vcpkg")
+        .once
+    end
+  end
+
+  describe "#versions_for" do
+    subject(:versions) { database.versions_for("zlib") }
+
+    it "returns every published version, newest first" do
+      expect(versions.map { |entry| entry.version.to_s }).to eq(["1.3.1", "1.3#1", "1.2.11", "2020-01-01"])
+    end
+
+    it "records the scheme each version was published under" do
+      expect(versions.map(&:scheme)).to eq(%w(version version version-string version-date))
+    end
+
+    it "records the git tree so release dates can be looked up" do
+      expect(versions.first.git_tree).to eq("a" * 40)
+    end
+
+    it "skips entries with no version" do
+      expect(versions.map(&:git_tree)).not_to include("e" * 40)
+    end
+
+    it "memoises the lookup" do
+      2.times { database.versions_for("zlib") }
+
+      expect(Dependabot::SharedHelpers)
+        .to have_received(:run_shell_command)
+        .with("git show origin/master:versions/z-/zlib.json", cwd: "/opt/vcpkg")
+        .once
+    end
+
+    context "with an unknown port" do
+      it "returns nothing" do
+        expect(database.versions_for("definitely-not-a-port")).to eq([])
+      end
+    end
+
+    context "with an unparseable versions file" do
+      it "returns nothing" do
+        expect(database.versions_for("broken")).to eq([])
+      end
+    end
+  end
+
+  describe "#baseline_version_for" do
+    it "returns the version floor the ref sets" do
+      expect(database.baseline_version_for(port: "zlib", ref: "2025.06.13").to_s).to eq("1.3.1")
+    end
+
+    it "includes the port version" do
+      expect(database.baseline_version_for(port: "fmt", ref: "2025.06.13").to_s).to eq("7.1.3#1")
+    end
+
+    it "returns nil for a port the ref does not know about" do
+      expect(database.baseline_version_for(port: "absent", ref: "2025.06.13")).to be_nil
+    end
+
+    it "returns nil for a malformed entry" do
+      expect(database.baseline_version_for(port: "broken", ref: "2025.06.13")).to be_nil
+    end
+
+    it "memoises per ref" do
+      2.times { database.baseline_versions("2025.06.13") }
+
+      expect(Dependabot::SharedHelpers)
+        .to have_received(:run_shell_command)
+        .with("git show 2025.06.13:versions/baseline.json", cwd: "/opt/vcpkg")
+        .once
+    end
+  end
+
+  describe "#release_tags" do
+    it "returns vcpkg release tags oldest first, ignoring other tags" do
+      expect(database.release_tags).to eq(%w(2021.04.30 v2024.12.16 2025.06.13))
+    end
+  end
+
+  describe "#commit_sha_for" do
+    it "resolves a ref to a commit" do
+      expect(database.commit_sha_for("2025.06.13")).to eq("1" * 40)
+    end
+  end
+
+  describe "#release_dates_for" do
+    let(:git_log) do
+      <<~LOG
+        #{'1' * 40}\t2024-01-30T12:58:10-08:00
+        diff --git a/versions/z-/zlib.json b/versions/z-/zlib.json
+        @@ -2,0 +3,4 @@
+        +    {
+        +      "git-tree": "#{'a' * 40}",
+        +      "version": "1.3.1"
+        +    },
+        #{'2' * 40}\t2023-08-15T09:00:00+00:00
+        @@ -2,0 +3,4 @@
+        +      "git-tree": "#{'b' * 40}",
+      LOG
+    end
+
+    before do
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+        .with(
+          "git log --format=tformat:%H%x09%cI --patch --unified=0 -- versions/z-/zlib.json",
+          cwd: "/opt/vcpkg"
+        )
+        .and_return(git_log)
+    end
+
+    it "maps each version's git tree to the commit that published it" do
+      expect(database.release_dates_for("zlib")).to eq(
+        "a" * 40 => Time.parse("2024-01-30T12:58:10-08:00"),
+        "b" * 40 => Time.parse("2023-08-15T09:00:00+00:00")
+      )
+    end
+  end
+end

--- a/vcpkg/spec/dependabot/vcpkg/requirement_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/requirement_spec.rb
@@ -1,0 +1,82 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/vcpkg/requirement"
+require "dependabot/vcpkg/version"
+
+RSpec.describe Dependabot::Vcpkg::Requirement do
+  subject(:requirement) { described_class.new(requirement_string) }
+
+  let(:requirement_string) { ">=1.2.3" }
+  let(:version_class) { Dependabot::Vcpkg::Version }
+
+  describe ".new" do
+    it "parses an operator that is not separated by whitespace" do
+      expect(described_class.new(">=1.2.3").to_s).to eq(">= 1.2.3")
+    end
+
+    it "does not let the shorter operator win against the version" do
+      expect(described_class.new(">=1.2.3").requirements).to eq([[">=", version_class.new("1.2.3")]])
+    end
+
+    it "parses a port version" do
+      expect(described_class.new(">=1.2.11#9").to_s).to eq(">= 1.2.11#9")
+    end
+
+    it "parses a version with a letter suffix" do
+      expect(described_class.new(">=1.1.1n").to_s).to eq(">= 1.1.1n")
+    end
+
+    it "parses a version-string scheme value" do
+      expect(described_class.new("cares-1_15_0").to_s).to eq("= cares-1_15_0")
+    end
+
+    it "defaults to an equality constraint" do
+      expect(described_class.new("1.2.3").requirements).to eq([["=", version_class.new("1.2.3")]])
+    end
+
+    it "splits a comma separated ignore condition" do
+      expect(described_class.new("> 1.2.3, < 2.0").requirements)
+        .to contain_exactly([">", version_class.new("1.2.3")], ["<", version_class.new("2.0")])
+    end
+
+    it "accepts nil" do
+      expect(described_class.new(nil).to_s).to eq(">= 0")
+    end
+  end
+
+  describe ".requirements_array" do
+    it "wraps a single constraint" do
+      expect(described_class.requirements_array(">=1.2.3").map(&:to_s)).to eq([">= 1.2.3"])
+    end
+
+    it "handles every version shape found in vcpkg advisories" do
+      %w(1.1.1n 1.0.2h-1 1.2.11#9 cares-1_15_0 2021-11-01 apache-arrow-0.4.0-1).each do |version_string|
+        expect { described_class.requirements_array(version_string) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#satisfied_by?" do
+    it "compares port versions" do
+      expect(described_class.new(">=1.2.11#9")).to be_satisfied_by(version_class.new("1.2.11#10"))
+      expect(described_class.new(">=1.2.11#9")).not_to be_satisfied_by(version_class.new("1.2.11#8"))
+    end
+
+    it "matches an exact string scheme version" do
+      expect(described_class.new("=1.1.1n")).to be_satisfied_by(version_class.new("1.1.1n"))
+      expect(described_class.new("=1.1.1n")).not_to be_satisfied_by(version_class.new("1.1.1w"))
+    end
+
+    it "compares dot versions numerically" do
+      expect(described_class.new(">=1.9.0")).to be_satisfied_by(version_class.new("1.10.0"))
+    end
+  end
+
+  describe "with an unparseable requirement" do
+    it "raises" do
+      expect { described_class.new(">= >=") }.to raise_error(Gem::Requirement::BadRequirementError)
+    end
+  end
+end

--- a/vcpkg/spec/dependabot/vcpkg/update_checker/security_fix_resolver_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker/security_fix_resolver_spec.rb
@@ -1,0 +1,320 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/security_advisory"
+
+require "dependabot/vcpkg/package/versions_database"
+require "dependabot/vcpkg/update_checker/security_fix_resolver"
+
+RSpec.describe Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver do
+  subject(:fix) { resolver.fix }
+
+  let(:resolver) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: dependency_files,
+      security_advisories: security_advisories,
+      ignored_versions: ignored_versions,
+      lowest_comparable_version: lowest_comparable_version,
+      versions_database: versions_database
+    )
+  end
+
+  let(:versions_database) { instance_double(Dependabot::Vcpkg::Package::VersionsDatabase) }
+  let(:baseline_sha) { "fe1cde61e971d53c9687cf9a46308f8f55da19fa" }
+  let(:port) { "zlib" }
+  let(:current_version) { "1.2.11" }
+  let(:constraint) { nil }
+  let(:ignored_versions) { [] }
+  let(:lowest_comparable_version) { nil }
+
+  let(:dependency_files) do
+    [
+      Dependabot::DependencyFile.new(
+        name: "vcpkg.json",
+        content: %({ "builtin-baseline": "#{baseline_sha}", "dependencies": ["#{port}"] })
+      )
+    ]
+  end
+
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: port,
+      version: current_version,
+      package_manager: "vcpkg",
+      requirements: [{ requirement: constraint, groups: [], source: nil, file: "vcpkg.json" }]
+    )
+  end
+
+  let(:security_advisories) do
+    [
+      Dependabot::SecurityAdvisory.new(
+        dependency_name: port,
+        package_manager: "vcpkg",
+        vulnerable_versions: ["<= 1.2.12"]
+      )
+    ]
+  end
+
+  # Release tags oldest first, with the version floor each one sets for the port.
+  let(:tag_baselines) do
+    {
+      "2021.04.30" => "1.2.11",
+      "2021.05.12" => "1.2.11#10",
+      "2022.01.01" => "1.2.12",
+      "2023.01.09" => "1.2.13",
+      "2024.01.12" => "1.3.1"
+    }
+  end
+
+  let(:published_versions) { %w(1.3.1 1.2.13 1.2.12 1.2.11#10 1.2.11) }
+
+  before do
+    allow(versions_database).to receive_messages(
+      release_tags: tag_baselines.keys,
+      commit_sha_for: "c" * 40
+    )
+    allow(versions_database).to receive(:ancestor?) do |ancestor:, descendant:|
+      ancestor == baseline_sha && tag_baselines.keys.index(descendant).to_i >= 1
+    end
+    allow(versions_database).to receive(:baseline_version_for) do |port:, ref:|
+      _ = port
+      text = tag_baselines[ref]
+      text && Dependabot::Vcpkg::Version.new(text)
+    end
+    allow(versions_database).to receive(:versions_for) do
+      published_versions.map do |text|
+        Dependabot::Vcpkg::Package::VersionsDatabase::PortVersion.new(
+          version: Dependabot::Vcpkg::Version.new(text),
+          scheme: "version",
+          git_tree: text
+        )
+      end
+    end
+  end
+
+  describe "raising the baseline" do
+    it "picks the oldest release tag whose floor is safe" do
+      expect(fix).to have_attributes(
+        kind: :baseline,
+        version: Dependabot::Vcpkg::Version.new("1.2.13"),
+        baseline_tag: "2023.01.09",
+        baseline_commit_sha: "c" * 40
+      )
+    end
+
+    it "never moves the baseline backwards" do
+      resolver.fix
+
+      expect(versions_database).not_to have_received(:baseline_version_for).with(port:, ref: "2021.04.30")
+    end
+
+    it "resolves the advisory even when a constraint is declared below the new floor" do
+      allow(dependency).to receive(:requirements)
+        .and_return([{ requirement: ">=1.2.11", groups: [], source: nil, file: "vcpkg.json" }])
+
+      expect(fix.kind).to eq(:baseline)
+    end
+
+    context "when the release floors are all still vulnerable" do
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: port,
+            package_manager: "vcpkg",
+            vulnerable_versions: ["<= 1.3.1"]
+          )
+        ]
+      end
+
+      it "offers no fix when nothing else is safe either" do
+        expect(fix).to be_nil
+      end
+    end
+
+    # Advisories enumerate affected versions rather than describing ranges, so a safe floor can sit
+    # between two vulnerable ones. Bisecting the tag list would step over it.
+    context "when safe floors are not contiguous" do
+      let(:tag_baselines) do
+        {
+          "2021.04.30" => "7.50.0",
+          "2021.05.12" => "7.79.0",
+          "2022.01.01" => "7.80.0",
+          "2023.01.09" => "7.81.0",
+          "2024.01.12" => "7.84.0"
+        }
+      end
+      let(:current_version) { "7.10.0" }
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: port,
+            package_manager: "vcpkg",
+            vulnerable_versions: ["< 7.79.0"]
+          ),
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: port,
+            package_manager: "vcpkg",
+            vulnerable_versions: [">= 7.80.0, < 7.84.0"]
+          )
+        ]
+      end
+
+      it "picks the earliest safe floor rather than skipping past it" do
+        expect(fix).to have_attributes(kind: :baseline, baseline_tag: "2021.05.12")
+      end
+    end
+
+    context "when only the earliest candidate floor is safe" do
+      let(:tag_baselines) do
+        {
+          "2021.04.30" => "1.9.0",
+          "2021.05.12" => "2.0.0",
+          "2022.01.01" => "2.1.0",
+          "2023.01.09" => "2.2.0"
+        }
+      end
+      let(:current_version) { "1.5.0" }
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: port,
+            package_manager: "vcpkg",
+            vulnerable_versions: ["< 2.0.0"]
+          ),
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: port,
+            package_manager: "vcpkg",
+            vulnerable_versions: [">= 2.1.0"]
+          )
+        ]
+      end
+
+      it "still finds it" do
+        expect(fix).to have_attributes(kind: :baseline, baseline_tag: "2021.05.12")
+      end
+    end
+
+    context "when the manifest pins no baseline" do
+      let(:dependency_files) do
+        [Dependabot::DependencyFile.new(name: "vcpkg.json", content: %({ "dependencies": ["zlib"] }))]
+      end
+
+      it "falls through to pinning, because there is no baseline to raise" do
+        expect(fix).to have_attributes(kind: :override, baseline_tag: nil)
+      end
+    end
+  end
+
+  describe "raising the version constraint" do
+    let(:security_advisories) do
+      [
+        Dependabot::SecurityAdvisory.new(
+          dependency_name: port,
+          package_manager: "vcpkg",
+          vulnerable_versions: ["<= 1.3.1"]
+        )
+      ]
+    end
+    let(:published_versions) { %w(1.3.2 1.3.1 1.2.13 1.2.12 1.2.11#10 1.2.11) }
+    let(:lowest_comparable_version) { Dependabot::Vcpkg::Version.new("1.3.2") }
+
+    it "falls back to the constraint when no release floor carries the fix" do
+      expect(fix).to have_attributes(
+        kind: :version_constraint,
+        version: Dependabot::Vcpkg::Version.new("1.3.2"),
+        baseline_tag: nil
+      )
+    end
+  end
+
+  describe "pinning with an override" do
+    let(:security_advisories) do
+      [
+        Dependabot::SecurityAdvisory.new(
+          dependency_name: port,
+          package_manager: "vcpkg",
+          vulnerable_versions: ["<= 1.3.1"]
+        )
+      ]
+    end
+    let(:published_versions) { %w(1.3.2 1.3.1 1.2.13 1.2.12 1.2.11#10 1.2.11) }
+
+    it "pins the earliest safe version published after the current one" do
+      expect(fix).to have_attributes(
+        kind: :override,
+        version: Dependabot::Vcpkg::Version.new("1.3.2")
+      )
+    end
+
+    context "when several safe versions were published after the current one" do
+      let(:published_versions) { %w(1.4.0 1.3.2 1.3.1 1.2.13 1.2.12 1.2.11#10 1.2.11) }
+
+      it "chooses the smallest upgrade" do
+        expect(fix.version).to eq(Dependabot::Vcpkg::Version.new("1.3.2"))
+      end
+    end
+
+    context "when the only safe versions were published before the current one" do
+      let(:current_version) { "1.3.1" }
+      let(:published_versions) { %w(1.3.1 1.2.13 1.2.12) }
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: port,
+            package_manager: "vcpkg",
+            vulnerable_versions: ["= 1.3.1", "= 1.2.13"]
+          )
+        ]
+      end
+
+      it "offers no fix" do
+        expect(fix).to be_nil
+      end
+    end
+
+    context "when the current version is absent from the versions database" do
+      let(:current_version) { "1.3.5" }
+      let(:published_versions) { %w(1.4.0 1.3.1 1.2.13 1.0.0) }
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: port,
+            package_manager: "vcpkg",
+            vulnerable_versions: ["= 1.3.5", ">= 1.4.0"]
+          )
+        ]
+      end
+
+      it "offers no pin, rather than downgrading the port" do
+        expect(fix).to be_nil
+      end
+    end
+  end
+
+  describe "ignore conditions" do
+    let(:ignored_versions) { ["> 1.2.11#10"] }
+
+    it "does not offer an ignored version" do
+      expect(fix).to be_nil
+    end
+  end
+
+  describe "when the dependency is not vulnerable data" do
+    context "with no advisories" do
+      let(:security_advisories) { [] }
+
+      it { expect(fix).to be_nil }
+    end
+
+    context "with an unparseable current version" do
+      let(:current_version) { nil }
+
+      it { expect(fix).to be_nil }
+    end
+  end
+end

--- a/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
@@ -6,6 +6,7 @@ require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/credential"
+require "dependabot/security_advisory"
 
 require "dependabot/vcpkg/file_parser"
 require "dependabot/vcpkg/update_checker"
@@ -219,7 +220,7 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
       let(:commit_sha) { dependency_version }
       let(:mock_latest_release_info) { nil }
 
-      it "falls back to the base behaviour and is not up to date" do
+      it "falls back to the base behavior and is not up to date" do
         expect(up_to_date).to be(false)
       end
     end
@@ -586,6 +587,204 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
           file: "vcpkg.json"
         }]
       )
+    end
+  end
+
+  describe "security updates" do
+    subject(:security_checker) do
+      described_class.new(
+        dependency: port_dependency,
+        dependency_files: port_dependency_files,
+        credentials: [],
+        ignored_versions: ignored_versions,
+        security_advisories: port_advisories,
+        options: {}
+      )
+    end
+
+    let(:baseline_sha) { "fe1cde61e971d53c9687cf9a46308f8f55da19fa" }
+    let(:fix) { nil }
+    let(:port_constraint) { nil }
+    let(:port_version) { "1.2.11" }
+    let(:resolver) { instance_double(Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver) }
+
+    let(:port_advisories) do
+      [
+        Dependabot::SecurityAdvisory.new(
+          dependency_name: "zlib",
+          package_manager: "vcpkg",
+          vulnerable_versions: ["<= 1.2.12"]
+        )
+      ]
+    end
+
+    let(:port_dependency) do
+      Dependabot::Dependency.new(
+        name: "zlib",
+        version: port_version,
+        package_manager: "vcpkg",
+        requirements: [{ requirement: port_constraint, groups: [], source: nil, file: "vcpkg.json" }]
+      )
+    end
+
+    let(:port_dependency_files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "vcpkg.json",
+          content: %({ "builtin-baseline": "#{baseline_sha}", "dependencies": ["zlib"] }),
+          directory: "/"
+        )
+      ]
+    end
+
+    before do
+      allow(Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver).to receive(:new).and_return(resolver)
+      allow(resolver).to receive(:fix).and_return(fix)
+      allow(Dependabot::Vcpkg::Package::PackageDetailsFetcher).to receive(:new).and_return(
+        instance_double(Dependabot::Vcpkg::Package::PackageDetailsFetcher, fetch: nil)
+      )
+    end
+
+    context "when the port is vulnerable and a fix exists" do
+      let(:fix) do
+        Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver::Fix.new(
+          version: Dependabot::Vcpkg::Version.new("1.2.13"),
+          kind: :baseline,
+          baseline_tag: "2023.01.09",
+          baseline_commit_sha: "c" * 40
+        )
+      end
+
+      it "reports the fix as the lowest security fix version" do
+        expect(security_checker.lowest_security_fix_version).to eq(Dependabot::Vcpkg::Version.new("1.2.13"))
+      end
+
+      it "reports the same version as resolvable" do
+        expect(security_checker.lowest_resolvable_security_fix_version)
+          .to eq(Dependabot::Vcpkg::Version.new("1.2.13"))
+      end
+
+      it "drives latest_version from the fix, so the security operation does not bail out" do
+        expect(security_checker.latest_version).to eq(Dependabot::Vcpkg::Version.new("1.2.13"))
+        expect(security_checker.up_to_date?).to be(false)
+      end
+
+      it "can update via an own-requirement unlock" do
+        expect(security_checker.can_update?(requirements_to_unlock: :own)).to be(true)
+      end
+
+      it "describes the remediation on the requirement so the file updater can apply it" do
+        expect(security_checker.updated_requirements.first[:metadata]).to eq(
+          security_remediation: :baseline,
+          security_version: "1.2.13",
+          baseline_commit_sha: "c" * 40,
+          baseline_tag: "2023.01.09"
+        )
+      end
+
+      it "leaves the constraint alone for a baseline remediation" do
+        expect(security_checker.updated_requirements.first[:requirement]).to be_nil
+      end
+
+      context "with a version constraint remediation" do
+        let(:port_constraint) { ">=1.2.11" }
+        let(:fix) do
+          Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver::Fix.new(
+            version: Dependabot::Vcpkg::Version.new("1.3.2"),
+            kind: :version_constraint,
+            baseline_tag: nil,
+            baseline_commit_sha: nil
+          )
+        end
+
+        it "raises the declared constraint" do
+          expect(security_checker.updated_requirements.first[:requirement]).to eq(">=1.3.2")
+        end
+      end
+
+      context "with an override remediation" do
+        let(:fix) do
+          Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver::Fix.new(
+            version: Dependabot::Vcpkg::Version.new("0.27.4"),
+            kind: :override,
+            baseline_tag: nil,
+            baseline_commit_sha: nil
+          )
+        end
+
+        it "adds no constraint, because the pin goes in overrides" do
+          expect(security_checker.updated_requirements.first[:requirement]).to be_nil
+        end
+      end
+
+      # vcpkg cannot order a `version-date` against a `version`, so the inherited numeric
+      # comparison would call the dependency current and the security operation would give up.
+      context "when the fix cannot be ordered against the current version" do
+        let(:port_version) { "2023-06-01" }
+        let(:port_advisories) do
+          [
+            Dependabot::SecurityAdvisory.new(
+              dependency_name: "zlib",
+              package_manager: "vcpkg",
+              vulnerable_versions: ["= 2023-06-01"]
+            )
+          ]
+        end
+        let(:fix) do
+          Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver::Fix.new(
+            version: Dependabot::Vcpkg::Version.new("1.0.0"),
+            kind: :override,
+            baseline_tag: nil,
+            baseline_commit_sha: nil
+          )
+        end
+
+        it "is not reported as up to date" do
+          expect(security_checker.up_to_date?).to be(false)
+        end
+
+        it "can still update via an own-requirement unlock" do
+          expect(security_checker.can_update?(requirements_to_unlock: :own)).to be(true)
+        end
+
+        it "produces an updated dependency at the fix version" do
+          updated = security_checker.updated_dependencies(requirements_to_unlock: :own)
+
+          expect(updated.map(&:version)).to eq(["1.0.0"])
+        end
+      end
+    end
+
+    context "when no fix is available" do
+      it "reports no security fix version" do
+        expect(security_checker.lowest_security_fix_version).to be_nil
+      end
+
+      it "reports a baseline governed port as up to date rather than inventing a constraint" do
+        expect(security_checker.up_to_date?).to be(true)
+      end
+    end
+
+    context "when the port is not vulnerable" do
+      let(:port_version) { "1.3.1" }
+
+      it "does not consult the resolver" do
+        security_checker.lowest_security_fix_version
+
+        expect(Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver).not_to have_received(:new)
+      end
+
+      it "reports a baseline governed port as up to date" do
+        expect(security_checker.up_to_date?).to be(true)
+      end
+
+      context "with a declared constraint" do
+        let(:port_constraint) { ">=1.3.1" }
+
+        it "still looks for a newer version" do
+          expect(security_checker.latest_version).to be_nil
+        end
+      end
     end
   end
 end

--- a/vcpkg/spec/dependabot/vcpkg/version_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/version_spec.rb
@@ -91,6 +91,14 @@ RSpec.describe Dependabot::Vcpkg::Version do
     end
   end
 
+  describe ".new" do
+    it "rejects input that .correct? rejects, so the two cannot disagree" do
+      ["master", "", "1.2.3#", "fe1cde61e971d53c9687cf9a46308f8f55da19fa"].each do |string|
+        expect { described_class.new(string) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe "#comparison_class" do
     subject { described_class.new(version_string).comparison_class }
 
@@ -202,7 +210,7 @@ RSpec.describe Dependabot::Vcpkg::Version do
       %w(1.2.0 1.2.0#1) => -1,
       %w(1.2.0#1 1.2.0#2) => -1,
       %w(1.2.0#2 1.2.0#10) => -1,
-      %w(watermelon#0 watermelon#1) => -1,
+      %w(1_2_alpha#0 1_2_alpha#1) => -1,
       %w(1.2.3 1.2.3) => 0
     }.each do |(left, right), expected|
       it "orders #{left} against #{right}" do
@@ -232,8 +240,8 @@ RSpec.describe Dependabot::Vcpkg::Version do
       %w(1.2.3 1.3.0) => true,
       %w(1.0.0-alpha 2.0.0) => true,
       %w(2021-01-01 2021-02-01) => true,
-      %w(apple apple) => true,
-      %w(apple orange) => false,
+      %w(cares-1_15_0 cares-1_15_0) => true,
+      %w(cares-1_15_0 cares-1_16_0) => false,
       %w(1.2.3 2021-01-01) => false,
       %w(1.1.1n 1.1.1w) => false,
       %w(1.2.3 1.0.2h) => false
@@ -241,6 +249,38 @@ RSpec.describe Dependabot::Vcpkg::Version do
       it "reports #{left} and #{right} as #{expected ? 'comparable' : 'incomparable'}" do
         expect(described_class.new(left).comparable_with?(described_class.new(right))).to be(expected)
       end
+    end
+  end
+
+  describe ".comparable?" do
+    it "rejects a version-string value even when the text matches a typed one" do
+      left = described_class.new("1.2.11")
+      right = described_class.new("1.2.11")
+
+      expect(described_class.comparable?(left, "version-string", right, "version")).to be(false)
+    end
+
+    it "treats version and version-semver as comparable, as vcpkg does" do
+      left = described_class.new("1.2.3")
+      right = described_class.new("1.3.0")
+
+      expect(described_class.comparable?(left, "version", right, "version-semver")).to be(true)
+    end
+
+    it "compares two version-string values only when the text is identical" do
+      left = described_class.new("cares-1_15_0")
+      same = described_class.new("cares-1_15_0")
+      other = described_class.new("cares-1_16_0")
+
+      expect(described_class.comparable?(left, "version-string", same, "version-string")).to be(true)
+      expect(described_class.comparable?(left, "version-string", other, "version-string")).to be(false)
+    end
+
+    it "falls back to the inferred class when a scheme is not known" do
+      left = described_class.new("1.2.3")
+      right = described_class.new("2021-01-01")
+
+      expect(described_class.comparable?(left, nil, right, nil)).to be(false)
     end
   end
 
@@ -256,9 +296,10 @@ RSpec.describe Dependabot::Vcpkg::Version do
     end
 
     it "keeps distinct string scheme versions distinct when deduplicating" do
-      versions = %w(apple orange banana apple).map { |string| described_class.new(string) }
+      versions = %w(cares-1_15_0 cares-1_16_0 1.0.2h cares-1_15_0)
+                 .map { |string| described_class.new(string) }
 
-      expect(versions.uniq.map(&:to_s)).to contain_exactly("apple", "orange", "banana")
+      expect(versions.uniq.map(&:to_s)).to contain_exactly("cares-1_15_0", "cares-1_16_0", "1.0.2h")
     end
   end
 

--- a/vcpkg/spec/dependabot/vcpkg/version_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/version_spec.rb
@@ -1,0 +1,256 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/vcpkg/version"
+
+RSpec.describe Dependabot::Vcpkg::Version do
+  subject(:version) { described_class.new(version_string) }
+
+  let(:version_string) { "1.0.0" }
+
+  describe ".correct?" do
+    subject { described_class.correct?(version_string) }
+
+    context "with a relaxed version" do
+      let(:version_string) { "7.48.0" }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with a version carrying a port version" do
+      let(:version_string) { "1.2.11#9" }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with a date version" do
+      let(:version_string) { "2021-11-01" }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with a version-string scheme value" do
+      let(:version_string) { "cares-1_15_0" }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with an OpenSSL style letter suffix" do
+      let(:version_string) { "1.1.1n" }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with a bare commit SHA" do
+      let(:version_string) { "fe1cde61e971d53c9687cf9a46308f8f55da19fa" }
+
+      it "is rejected so registry baselines stay recognizable as git SHAs" do
+        expect(described_class.correct?(version_string)).to be(false)
+      end
+    end
+
+    context "with a digits-only value that could be a SHA prefix" do
+      let(:version_string) { "1234567" }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with a port version marker that has no number" do
+      let(:version_string) { "1.2.3#" }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "with an empty string" do
+      let(:version_string) { "" }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "with nil" do
+      let(:version_string) { nil }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#comparison_class" do
+    subject { described_class.new(version_string).comparison_class }
+
+    context "with dot-separated numerics" do
+      let(:version_string) { "1.2.3" }
+
+      it { is_expected.to eq(:dot) }
+    end
+
+    context "with a semver pre-release" do
+      let(:version_string) { "1.0.0-alpha.1" }
+
+      it { is_expected.to eq(:dot) }
+    end
+
+    context "with a date" do
+      let(:version_string) { "2021-11-01" }
+
+      it "prefers the date scheme over the dot scheme" do
+        expect(described_class.new(version_string).comparison_class).to eq(:date)
+      end
+    end
+
+    context "with a date carrying a disambiguator" do
+      let(:version_string) { "2021-11-01.1" }
+
+      it { is_expected.to eq(:date) }
+    end
+
+    context "with an arbitrary string" do
+      let(:version_string) { "1.0.2h-1" }
+
+      it { is_expected.to eq(:string) }
+    end
+  end
+
+  describe "#port_version" do
+    context "with an explicit port version" do
+      let(:version_string) { "1.2.11#9" }
+
+      its(:port_version) { is_expected.to eq(9) }
+    end
+
+    context "without a port version" do
+      let(:version_string) { "1.2.11" }
+
+      its(:port_version) { is_expected.to eq(0) }
+    end
+  end
+
+  describe "#to_s" do
+    context "with a port version" do
+      let(:version_string) { "1.2.11#9" }
+
+      its(:to_s) { is_expected.to eq("1.2.11#9") }
+    end
+
+    context "with a pre-release" do
+      let(:version_string) { "1.0.0-alpha.1" }
+
+      it "does not mangle the pre-release separator" do
+        expect(version.to_s).to eq("1.0.0-alpha.1")
+      end
+    end
+
+    context "with a version-string scheme value" do
+      let(:version_string) { "cares-1_15_0" }
+
+      its(:to_s) { is_expected.to eq("cares-1_15_0") }
+    end
+  end
+
+  describe "#prerelease?" do
+    context "with a semver pre-release" do
+      let(:version_string) { "1.0.0-alpha" }
+
+      its(:prerelease?) { is_expected.to be(true) }
+    end
+
+    context "with a release version" do
+      let(:version_string) { "1.0.0" }
+
+      its(:prerelease?) { is_expected.to be(false) }
+    end
+
+    context "with a string scheme value that looks like a pre-release" do
+      let(:version_string) { "3.0.5rc2" }
+
+      its(:prerelease?) { is_expected.to be(false) }
+    end
+  end
+
+  describe "#<=>" do
+    # Orderings taken from https://learn.microsoft.com/vcpkg/users/versioning#version-schemes
+    {
+      %w(0 0.1) => -1,
+      %w(0.1 0.1.0) => -1,
+      %w(0.1.0 1) => -1,
+      %w(1 1.0.0) => -1,
+      %w(1.0.0 1.0.1) => -1,
+      %w(1.0.1 1.1) => -1,
+      %w(1.1 2.0.0) => -1,
+      %w(1.0.0-1 1.0.0-alpha) => -1,
+      %w(1.0.0-alpha 1.0.0-beta) => -1,
+      %w(1.0.0-beta 1.0.0) => -1,
+      %w(2021-01-01 2021-01-01.1) => -1,
+      %w(2021-01-01.1 2021-02-01.1.2) => -1,
+      %w(2021-02-01.1.2 2021-02-01.1.3) => -1,
+      %w(1.2.0 1.2.0#1) => -1,
+      %w(1.2.0#1 1.2.0#2) => -1,
+      %w(1.2.0#2 1.2.0#10) => -1,
+      %w(watermelon#0 watermelon#1) => -1,
+      %w(1.2.3 1.2.3) => 0
+    }.each do |(left, right), expected|
+      it "orders #{left} against #{right}" do
+        expect(described_class.new(left) <=> described_class.new(right)).to eq(expected)
+      end
+    end
+
+    it "ignores build metadata when comparing the numeric core" do
+      expect(described_class.new("1.2.3+build") <=> described_class.new("1.2.3")).to eq(0)
+    end
+
+    it "returns a total order for incomparable schemes so release lists can be sorted" do
+      expect(described_class.new("1.2.3") <=> described_class.new("2021-01-01")).not_to be_nil
+    end
+
+    it "returns nil when the other value is not a version" do
+      expect(version <=> Object.new).to be_nil
+    end
+
+    it "compares against a plain string" do
+      expect(described_class.new("1.2.3") <=> "1.2.4").to eq(-1)
+    end
+  end
+
+  describe "#comparable_with?" do
+    {
+      %w(1.2.3 1.3.0) => true,
+      %w(1.0.0-alpha 2.0.0) => true,
+      %w(2021-01-01 2021-02-01) => true,
+      %w(apple apple) => true,
+      %w(apple orange) => false,
+      %w(1.2.3 2021-01-01) => false,
+      %w(1.1.1n 1.1.1w) => false,
+      %w(1.2.3 1.0.2h) => false
+    }.each do |(left, right), expected|
+      it "reports #{left} and #{right} as #{expected ? 'comparable' : 'incomparable'}" do
+        expect(described_class.new(left).comparable_with?(described_class.new(right))).to be(expected)
+      end
+    end
+  end
+
+  describe "#eql? and #hash" do
+    it "treats identical versions as equal" do
+      other = described_class.new("1.2.11#9")
+
+      expect(described_class.new("1.2.11#9")).to eql(other)
+    end
+
+    it "distinguishes versions that differ only by port version" do
+      expect(described_class.new("1.2.11#9")).not_to eql(described_class.new("1.2.11"))
+    end
+
+    it "keeps distinct string scheme versions distinct when deduplicating" do
+      versions = %w(apple orange banana apple).map { |string| described_class.new(string) }
+
+      expect(versions.uniq.map(&:to_s)).to contain_exactly("apple", "orange", "banana")
+    end
+  end
+
+  describe "sorting a mixed release list" do
+    it "does not raise" do
+      versions = %w(1.2.3 2021-01-01 cares-1_15_0 1.0.2h 1.2.3#4).map { |string| described_class.new(string) }
+
+      expect { versions.sort }.not_to raise_error
+    end
+  end
+end

--- a/vcpkg/spec/dependabot/vcpkg/version_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/version_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe Dependabot::Vcpkg::Version do
       end
     end
 
+    # A registry baseline's previous version is a ref, and `MetadataFinders` uses `correct?` to
+    # tell a version from a ref. Accepting one made `ReleaseFinder` discard every release.
+    context "with a git ref name" do
+      %w(master main HEAD develop).each do |ref|
+        it "rejects #{ref}" do
+          expect(described_class.correct?(ref)).to be(false)
+        end
+      end
+    end
+
+    context "with a version-string value that contains no digits" do
+      let(:version_string) { "orange" }
+
+      it { is_expected.to be(false) }
+    end
+
     context "with a digits-only value that could be a SHA prefix" do
       let(:version_string) { "1234567" }
 

--- a/vcpkg/spec/spec_helper.rb
+++ b/vcpkg/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "tmpdir"
+
 def common_dir
   @common_dir ||= Gem::Specification.find_by_name("dependabot-common").gem_dir
 end
@@ -10,3 +12,10 @@ def require_common_spec(path)
 end
 
 require "#{common_dir}/spec/spec_helper.rb"
+
+# The updater image ships a vcpkg checkout at /opt/vcpkg, so any spec that builds a
+# Package::VersionsDatabase without stubbing it would shell out to git and hit the network there
+# while silently passing on a machine that has no checkout. Pointing VCPKG_ROOT somewhere that
+# cannot exist makes the database report itself unavailable, so specs behave the same either way.
+# Specs that exercise the versions database stub it explicitly.
+ENV["VCPKG_ROOT"] = File.join(Dir.tmpdir, "dependabot-vcpkg-absent-registry")


### PR DESCRIPTION
### What are you trying to accomplish?

Dependabot can bump a vcpkg `builtin-baseline` and an explicit `version>=` constraint, but it cannot act on a security advisory: `lowest_security_fix_version` and `lowest_resolvable_security_fix_version` were never implemented, so `UpdateCheckers::Base` raises and `CreateSecurityUpdatePullRequest` gives up. This implements them.

Fixes #13325.

This also includes four prerequisite bug fixes:

* `Vcpkg::Version` never overrode `self.correct?`, so it inherited Gem's looser pattern. `correct?("1.1.1n")` returned true but `Vcpkg::Version.new("1.1.1n")` raised `ArgumentError`.
* `Vcpkg::Requirement` had no `PATTERN` or `self.parse`, so `Requirement.new(">=1.2.11#9")` raised `BadRequirementError`. `file_parser.rb` already built exactly that string from a manifest.
* Port revisions (`#N`) failed `correct?`, so `Dependency#numeric_version` returned nil and `UpdateCheckers::Base#vulnerable?` silently returned false.
* `updated_requirements` used `latest_version` rather than `preferred_resolvable_version`, so a security update would have written the latest version instead of the lowest fix.

Three vcpkg behaviours shaped the design, all from the [versioning docs](https://learn.microsoft.com/vcpkg/users/versioning):

* The baseline is a version **floor, not a ceiling**, so a port's effective version is `max(declared version>=, baseline version)`.
* vcpkg **refuses to compare versions across schemes**, and the scheme is *declared* in the versions database rather than implied by the text. `tensorflow-cc` publishes `"2.3.1"` under `version-string`; 55 of the top 60 advisory ports changed scheme at some point in their history.
* Bare string dependencies (`"dependencies": ["zlib"]`, the common case) carry no version in the manifest. Their version comes from `versions/baseline.json` at the pinned commit, so the parser now resolves it and a bare port finally has something to test an advisory against.

A vulnerable port is then moved by the first of three levers that works: raise the baseline to the oldest release tag whose floor is safe, raise the `version>=` constraint, or add an `overrides` entry when no safe version shares a comparable scheme.

### Anything you want to highlight for special attention from reviewers?

#### `Version#<=>` is deliberately a total order even though vcpkg's is not

`Package::PackageLatestVersionFinder` sorts releases with `min_by`/`max_by`, so returning nil for an incomparable pair would raise. Within a comparison class the ordering mirrors `compare_any` in vcpkg-tool's `src/vcpkg/versions.cpp`; across classes it falls back to a natural ordering of the raw text. Callers that need vcpkg's real answer ask `#comparable_with?` or `.comparable?`, and `LatestVersionFinder#available_versions` filters to a mutually comparable set up front so every inherited comparison downstream is meaningful.

#### `Version.correct?` rejects bare git-SHA-shaped strings

A registry baseline is a commit SHA, and `UpdateCheckers::Base#existing_version_is_sha?` needs to keep recognising it as one. Accepting SHAs as versions would also change `Labeler#version` and the metadata finders for the baseline dependency, which is the primary vcpkg use case. The cost is 7 of 4,280 real versions, all pre-2018 `version-string` entries, and it is documented in the README. Digit-only strings still count, because they are valid relaxed versions.

#### Routine runs deliberately leave baseline-governed ports alone

Now that bare string ports are parsed, `latest_version` reports them as current unless a security fix applies. Otherwise every vcpkg manifest would start collecting `version>=` constraints it never had, when bumping the baseline is the idiomatic way to move those ports.

#### `PackageDetailsFetcher` no longer walks `git log`

It ran `git log --follow -- ports/<name>/vcpkg.json` and then a `git show` per commit, so `2N+1` subprocesses per port. It now reads the versions database, which is authoritative, carries the declared scheme, and costs two git calls.

#### Transitive ports are out of scope

Which is worth naming because that is where most vcpkg exposure lives (`curl` pulling `openssl`). Remediating one means adding a top-level constraint for package the user never declared. `vcpkg install --dry-run` produces a full install plan without building and is the natural source for a later pass.

### How will you know you've accomplished your goal?

Beyond the unit specs, I drove the whole chain against a real `microsoft/vcpkg` checkout with a manifest pinned to the `2021.05.12` commit:

| Scenario | Port | Result |
| --- | --- | --- |
| Bare string port, a release carries the fix | `zlib` `1.2.11#10` | baseline moved to the `2021.06.31` release commit, `dependencies` untouched |
| Constrained port, no release carries the fix | `curl` `8.0.0` | `version>=` raised to `8.21.0#1` |
| Port at a `version-string` version, every fix is `version` scheme | `exiv2` `0.27.3#4` | `{"name": "exiv2", "version": "0.27.4"}` added to `overrides` |
| Every candidate ignored | `zlib` | no fix offered |

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
