### PR TITLE
Fix uv library detection for projects not published on PyPI

### DIFF
--- a/uv/lib/dependabot/uv/update_checker.rb
+++ b/uv/lib/dependabot/uv/update_checker.rb
@@ -213,29 +213,6 @@ module Dependabot
         )
       end
 
-      sig { override.returns(T::Boolean) }
-      def library?
-        return false unless updating_pyproject?
-        return false unless library_details
-
-        return false if T.must(library_details)["name"].nil?
-
-        # Hit PyPi and check whether there are details for a library with a
-        # matching name and description
-        index_response = Dependabot::RegistryClient.get(
-          url: "https://pypi.org/pypi/#{normalised_name(T.must(library_details)['name'])}/json/"
-        )
-
-        return false unless index_response.status == 200
-
-        pypi_info = JSON.parse(index_response.body)["info"] || {}
-        pypi_info["summary"] == T.must(library_details)["description"]
-      rescue Excon::Error::Timeout, Excon::Error::Socket
-        false
-      rescue URI::InvalidURIError
-        false
-      end
-
       sig { returns(T::Boolean) }
       def updating_pyproject?
         requirement_files.any? { |file| file.end_with?("pyproject.toml") }

--- a/uv/spec/dependabot/uv/update_checker_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker_spec.rb
@@ -644,13 +644,72 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
           its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
 
-        context "when dealing with a non-library" do
+        context "when the project is not on PyPI but has library metadata" do
           before do
             stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
               .to_return(status: 404)
           end
 
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
+        end
+
+        context "when the project is on PyPI but description is dynamic" do
+          let(:pyproject_fixture_name) { "standard_python_dynamic_description.toml" }
+
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_return(
+                status: 200,
+                body: fixture("pypi", "pypi_response_pendulum.json")
+              )
+          end
+
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
+        end
+
+        context "when dealing with a non-library" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_return(
+                status: 200,
+                body: { info: { summary: "A completely different package" } }.to_json
+              )
+          end
+
           its([:requirement]) { is_expected.to eq("~=2.19.1") }
+        end
+
+        context "when the PyPI request raises Excon::Error::Timeout" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_raise(Excon::Error::Timeout.new("connection timeout"))
+          end
+
+          it "treats the project as a library based on metadata" do
+            expect(checker.send(:library?)).to be true
+          end
+        end
+
+        context "when the PyPI request raises Excon::Error::Socket" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_raise(Excon::Error::Socket.new(SocketError.new("getaddrinfo failed")))
+          end
+
+          it "treats the project as a library based on metadata" do
+            expect(checker.send(:library?)).to be true
+          end
+        end
+
+        context "when the PyPI request raises URI::InvalidURIError" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_raise(URI::InvalidURIError.new("bad URI"))
+          end
+
+          it "treats the project as a library based on metadata" do
+            expect(checker.send(:library?)).to be true
+          end
         end
       end
 
@@ -701,10 +760,36 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
           its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
 
-        context "when dealing with a non-library" do
+        context "when the project is not on PyPI but has library metadata" do
           before do
             stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
               .to_return(status: 404)
+          end
+
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
+        end
+
+        context "when the project is on PyPI but description is dynamic" do
+          let(:pyproject_fixture_name) { "build_system_dynamic_description.toml" }
+
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_return(
+                status: 200,
+                body: fixture("pypi", "pypi_response_pendulum.json")
+              )
+          end
+
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
+        end
+
+        context "when dealing with a non-library" do
+          before do
+            stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
+              .to_return(
+                status: 200,
+                body: { info: { summary: "A completely different package" } }.to_json
+              )
           end
 
           its([:requirement]) { is_expected.to eq("~=2.19.1") }
@@ -782,8 +867,14 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
       end
 
       before do
+        # Stub a published package with a different summary so the project is
+        # treated as an application. This case is about resolving the workspace
+        # member's file path, not about library detection.
         stub_request(:get, "https://pypi.org/pypi/pendulum/json/")
-          .to_return(status: 404)
+          .to_return(
+            status: 200,
+            body: { info: { summary: "A completely different package" } }.to_json
+          )
       end
 
       it "updates the workspace member pyproject requirement" do

--- a/uv/spec/dependabot/uv/update_checker_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker_spec.rb
@@ -685,9 +685,7 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
               .to_raise(Excon::Error::Timeout.new("connection timeout"))
           end
 
-          it "treats the project as a library based on metadata" do
-            expect(checker.send(:library?)).to be true
-          end
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
 
         context "when the PyPI request raises Excon::Error::Socket" do
@@ -696,9 +694,7 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
               .to_raise(Excon::Error::Socket.new(SocketError.new("getaddrinfo failed")))
           end
 
-          it "treats the project as a library based on metadata" do
-            expect(checker.send(:library?)).to be true
-          end
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
 
         context "when the PyPI request raises URI::InvalidURIError" do
@@ -707,9 +703,7 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
               .to_raise(URI::InvalidURIError.new("bad URI"))
           end
 
-          it "treats the project as a library based on metadata" do
-            expect(checker.send(:library?)).to be true
-          end
+          its([:requirement]) { is_expected.to eq(">=1.0,<2.20") }
         end
       end
 

--- a/uv/spec/fixtures/pyproject_files/build_system_dynamic_description.toml
+++ b/uv/spec/fixtures/pyproject_files/build_system_dynamic_description.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["requests~=1.0.0"]
+
+[project]
+name = "pendulum"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+dynamic = ["description"]

--- a/uv/spec/fixtures/pyproject_files/standard_python_dynamic_description.toml
+++ b/uv/spec/fixtures/pyproject_files/standard_python_dynamic_description.toml
@@ -1,0 +1,12 @@
+[project]
+name = "pendulum"
+version = "2.0.0"
+homepage = "https://github.com/roghu/py3_projects"
+license = "MIT"
+readme = "README.md"
+authors = ["Dependabot <support@dependabot.com>"]
+dynamic = ["description"]
+
+dependencies = [
+  "requests~=1.0.0"
+]


### PR DESCRIPTION
### What are you trying to accomplish?

`Dependabot::Uv::UpdateChecker` inherits from `Dependabot::Python::UpdateChecker`, but it overrides `library?` with a copy of the pre-#14709 logic. As a result, the library-detection fallback that landed for `pip` in #14709 (and was corrected in #14747) never applies to the `uv` ecosystem.

Today, `uv`'s `library?` returns `true` only when PyPI answers `200` **and** the published `summary` matches the local `description` exactly. A project that is not published on PyPI is therefore always classified as an application, so `requirements_update_strategy` resolves to `BumpVersions` instead of `WidenRanges`. Private/internal libraries hit this by definition: they are never on PyPI, so there is currently no way to get range-widening updates for them under `uv`, with `versioning-strategy: auto` or otherwise.

This PR removes the override so `uv` inherits the parent implementation, bringing it in line with `pip`.

Related: #15290

### Anything you want to highlight for special attention from reviewers?

I chose to delete the override rather than copy the fixed implementation into `uv`, since the class already documents that it "overrides only the resolver selection and UV-specific features". Keeping a second copy of the detection logic is what caused this divergence in the first place.

The resulting behaviour changes, all inherited from the parent implementation:

| PyPI response | `description` in `pyproject.toml` | before | after |
| --- | --- | --- | --- |
| non-200 (not published) | present | not a library | library |
| non-200 (not published) | absent | not a library | not a library |
| 200, `summary` matches | present | library | library |
| 200, `summary` differs | present | not a library | not a library |
| 200 | absent (e.g. `dynamic = ["description"]`) | not a library | library |
| `Excon::Error::Timeout` / `Excon::Error::Socket` / `URI::InvalidURIError` | present | not a library | library |

Two other things worth a look:

- The removed method was the only user of `Excon`, `JSON`, `Dependabot::RegistryClient` and `NameNormaliser` in this file. I left the corresponding `require` lines in place to keep the diff focused and avoid changing load behaviour for code that picks them up transitively. Happy to drop them if you would rather have them gone.
- `uv` keeps its own `library_details` (`standard_details || build_system_details`, without `poetry_details`) and its own `updating_pyproject?`. Both are still honoured, because the inherited `check_pypi_for_library_match` dispatches to them.

### How will you know you've accomplished your goal?

`uv/spec/dependabot/uv/update_checker_spec.rb` is updated to mirror the `pip` specs:

- The existing "non-library" cases stubbed a `404`. Under the new behaviour a `404` means "library", so those cases are re-pointed at a `200` response whose `summary` differs — the actual non-library case.
- New cases cover "not on PyPI but has library metadata", "on PyPI but description is dynamic", and the three rescued network errors.
- Two fixtures are copied from `python/spec/fixtures/pyproject_files/` for the `dynamic = ["description"]` cases.
- The workspace-member example stubbed a `404` with a fixture that has a `description`, so it would now be treated as a library. Since that example is about resolving the member's file path rather than library detection, I switched its stub to a published package with a different summary and left the expectation unchanged.

Verified locally against the `ghcr.io/dependabot/dependabot-updater-uv` image:

- `bundle exec rspec` in `uv/` — 1130 examples, 0 failures, 2 pending
- `bundle exec rubocop` on both changed files — no offenses
- `sorbet @sorbet/config` — no errors

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
