### PR TITLE
build(deps): bump terraform to 1.15.9

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -3,13 +3,13 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
 # See https://github.com/hashicorp/terraform/releases or https://releases.hashicorp.com/terraform/
-ARG TERRAFORM_VERSION=1.15.3
+ARG TERRAFORM_VERSION=1.15.8
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-ARG TERRAFORM_AMD64_CHECKSUM=c3d4b579064745a5f7e918125db23b12ba52a8a7287adb9f32c49d637e02e3bf
+ARG TERRAFORM_AMD64_CHECKSUM=d25ce7b6902013ad905db3d2eab0be4cd905887fe88b81a6171b8d5503c31f3d
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_arm64.zip"
-ARG TERRAFORM_ARM64_CHECKSUM=9824eb010b835b2c872440a337a69acfa1782d36c24d3c09fe5defe75defc511
+ARG TERRAFORM_ARM64_CHECKSUM=8891e9dcedc9e3b8950bc6af9d4d8af1f4cfade3062f53b9dc403a89f6ce8c9c
 
 RUN cd /tmp \
   && curl -o terraform-${TARGETARCH}.tar.gz https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -3,13 +3,13 @@ FROM ghcr.io/dependabot/dependabot-updater-core
 ARG TARGETARCH
 
 # See https://github.com/hashicorp/terraform/releases or https://releases.hashicorp.com/terraform/
-ARG TERRAFORM_VERSION=1.15.3
+ARG TERRAFORM_VERSION=1.15.9
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-ARG TERRAFORM_AMD64_CHECKSUM=c3d4b579064745a5f7e918125db23b12ba52a8a7287adb9f32c49d637e02e3bf
+ARG TERRAFORM_AMD64_CHECKSUM=76edd0b22d2f27d3d2e097cd793209646f719cf60f02ff3af626b07361137da1
 
 # curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" | grep "terraform_${TERRAFORM_VERSION}_linux_arm64.zip"
-ARG TERRAFORM_ARM64_CHECKSUM=9824eb010b835b2c872440a337a69acfa1782d36c24d3c09fe5defe75defc511
+ARG TERRAFORM_ARM64_CHECKSUM=0afa6c29f61ca5ea270e950e43e50ecf2418b598507bf580e8ae76e1e6699b19
 
 RUN cd /tmp \
   && curl -o terraform-${TARGETARCH}.tar.gz https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \


### PR DESCRIPTION
### What are you trying to accomplish?

Bump the bundled Terraform version from `1.15.3` to `1.15.9`.

The bundled version has been `1.15.3` since dependabot/dependabot-core#15055 was merged on 2026-05-29, while the latest Terraform release is `1.15.9` (released 2026-08-19).

Where this bites: in a directory whose `.terraform.lock.hcl` needs its module sources installed before `terraform providers lock` can run, the lockfile updater falls back to `terraform init` (`terraform/lib/dependabot/terraform/file_updater.rb:252` and `:319`). If the repository's `required_version` excludes the bundled version, that `init` fails and the provider update is abandoned before Dependabot ever evaluates it. A repository tracking the latest release would see, for example:

```text
Error: Unsupported Terraform Core version

  on main.tf line 2, in terraform:
   2:   required_version = "1.15.9"

This configuration does not support Terraform version 1.15.3. To proceed,
either choose another supported Terraform version or update this version
constraint. Version constraints are normally set for good reason, so updating
the constraint may lead to other errors or unexpected behavior.
```

This is the same failure mode as dependabot/dependabot-core#15038, fixed at the time by dependabot/dependabot-core#15055, and as dependabot/dependabot-core#14062 before it. It recurs on every Terraform release, since the updater runs a fixed Terraform version regardless of the repository's constraint (dependabot/dependabot-core#5797).

### Anything you want to highlight for special attention from reviewers?

Only `terraform/Dockerfile` changes: the version and the two checksums. Both checksums come from the official `SHA256SUMS` for 1.15.9, using the commands documented in the comment above each `ARG`:

```console
$ curl "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_SHA256SUMS" | grep "terraform_1.15.9_linux_amd64.zip"
76edd0b22d2f27d3d2e097cd793209646f719cf60f02ff3af626b07361137da1  terraform_1.15.9_linux_amd64.zip
$ curl "https://releases.hashicorp.com/terraform/1.15.9/terraform_1.15.9_SHA256SUMS" | grep "terraform_1.15.9_linux_arm64.zip"
0afa6c29f61ca5ea270e950e43e50ecf2418b598507bf580e8ae76e1e6699b19  terraform_1.15.9_linux_arm64.zip
```

The branch name still refers to 1.15.8, the latest release when this PR was opened.

### How will you know you've accomplished your goal?

`arm64-build` builds the image, exercising both the download URL and the `sha256sum -c` verification, so a successful build confirms that the version and the checksums are correct.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass. — run in CI on this PR: `ci (terraform, terraform, terraform)`, `Lint` and `Sorbet` are green
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality. — a pinned version has no test to add, so the change is covered by `arm64-build` and by `e2e (terraform, terraform, smoke-terraform.yaml, 2f32ca5)`, which runs an end-to-end Terraform update against an image built with 1.15.9. Both are green
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

