### PR TITLE
Reconcile updated file line endings to git's index form

### DIFF
--- a/common/lib/dependabot/git_attributes.rb
+++ b/common/lib/dependabot/git_attributes.rb
@@ -1,0 +1,187 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "shellwords"
+require "sorbet-runtime"
+
+require "dependabot/dependency_file"
+require "dependabot/shared_helpers"
+
+module Dependabot
+  # Reconciles the line endings of updated file content to the form git would
+  # store in the index. Dependabot commits via provider APIs, which bypass git's
+  # `.gitattributes` clean filter, so without this an update can reintroduce line
+  # endings the repo doesn't expect (e.g. a CRLF gradlew.bat under
+  # `*.bat text eol=crlf`), leaving the file permanently "modified".
+  module GitAttributes
+    extend T::Sig
+
+    CRLF = "\r\n"
+    LF = "\n"
+
+    sig do
+      params(
+        updated_files: T::Array[Dependabot::DependencyFile],
+        original_files: T::Array[Dependabot::DependencyFile],
+        repo_contents_path: T.nilable(String)
+      ).void
+    end
+    def self.reconcile_line_endings!(updated_files, original_files:, repo_contents_path:)
+      return unless repo_contents_path && Dir.exist?(File.join(repo_contents_path, ".git"))
+
+      candidates = updated_files.reject { |f| f.binary? || f.content.nil? }
+      return if candidates.empty?
+
+      attrs = attributes_for(candidates.map(&:realpath), repo_contents_path)
+      originals = original_files.to_h { |f| [f.name, f] }
+
+      candidates.each { |file| reconcile_file!(file, attrs[file.realpath] || {}, originals[file.name]) }
+    end
+
+    sig do
+      params(
+        file: Dependabot::DependencyFile,
+        attrs: T::Hash[String, String],
+        original: T.nilable(Dependabot::DependencyFile)
+      ).void
+    end
+    def self.reconcile_file!(file, attrs, original)
+      content = T.must(file.content)
+      target = target_eol(attrs, content, original)
+      file.content = convert(content, target) unless target.nil?
+    end
+
+    # Resolves the target index-form EOL: :lf, :crlf, or nil (leave untouched).
+    sig do
+      params(
+        attrs: T::Hash[String, String],
+        content: String,
+        original: T.nilable(Dependabot::DependencyFile)
+      ).returns(T.nilable(Symbol))
+    end
+    def self.target_eol(attrs, content, original)
+      text = attrs["text"]
+
+      # An explicit `text`, or a bare `eol=` rule (which implicitly sets
+      # `text` when it was left unspecified), forces normalization: anything
+      # git normalizes is stored LF in the index; eol=crlf only affects
+      # checkout, never the committed blob.
+      return :lf if text == "set"
+      return :lf if text == "unspecified" && %w(lf crlf).include?(attrs["eol"].to_s)
+
+      # Content git's heuristic classifies as binary is stored verbatim under
+      # text=auto, and is too risky to rewrite under any fallback.
+      return nil if binary_content?(content)
+
+      # Deliberately more eager than git, which skips conversion for blobs
+      # whose committed form still has CRLF (the "safer autocrlf" rule): the
+      # update visibly renormalizes the file to what the attributes declare.
+      return :lf if text == "auto"
+
+      # -text or no governing attribute: git stores the bytes verbatim, so
+      # match the original file's endings to avoid noisy diffs.
+      original_eol(original)
+    end
+
+    # Mixed-ending originals have no convention to match and are left untouched.
+    sig { params(original: T.nilable(Dependabot::DependencyFile)).returns(T.nilable(Symbol)) }
+    def self.original_eol(original)
+      content = original&.content
+      return nil if content.nil? || content.empty?
+      return :lf unless content.include?(CRLF)
+      return :crlf unless content.gsub(CRLF, "").include?(LF)
+
+      nil
+    end
+
+    # Mirrors git's convert_is_binary (convert.c): NUL bytes, lone CRs, or a
+    # high ratio of non-printable characters mean the content is not text.
+    # Streams byte-wise; materializing an array would cost ~8x the file size.
+    sig { params(content: String).returns(T::Boolean) }
+    def self.binary_content?(content)
+      printable = 0
+      nonprintable = 0
+      prev = T.let(nil, T.nilable(Integer))
+
+      content.each_byte do |byte|
+        return true if prev == 0x0d && byte != 0x0a # lone CR
+
+        case byte
+        when 0x00 then return true
+        when 0x0a, 0x0d then nil
+        when 0x08, 0x09, 0x0c, 0x1b then printable += 1
+        when 0x7f then nonprintable += 1
+        else byte < 0x20 ? nonprintable += 1 : printable += 1
+        end
+        prev = byte
+      end
+      return true if prev == 0x0d # trailing lone CR
+
+      # A trailing DOS EOF marker (^Z) doesn't count against the content.
+      nonprintable -= 1 if prev == 0x1a
+
+      (printable >> 7) < nonprintable
+    end
+
+    sig { params(content: String, target: Symbol).returns(String) }
+    def self.convert(content, target)
+      lf = content.gsub(CRLF, LF)
+      target == :crlf ? lf.gsub(LF, CRLF) : lf
+    end
+
+    # Half of Linux's 128KiB cap on a single argv entry, which is what limits
+    # the assembled shell command; vendored updates can carry thousands of paths.
+    COMMAND_BYTE_BUDGET = 65_536
+
+    # Resolves attributes in size-bounded `git check-attr` batches; returns
+    # { realpath => { attr => value } }. The paths must stay on the command
+    # line: `check-attr --stdin` silently reads nothing through the git shim
+    # that fronts git in the updater images.
+    sig do
+      params(paths: T::Array[String], repo_contents_path: String)
+        .returns(T::Hash[String, T::Hash[String, String]])
+    end
+    def self.attributes_for(paths, repo_contents_path)
+      batches(paths.map { |p| Shellwords.escape(p) }).reduce({}) do |result, batch|
+        output = SharedHelpers.run_shell_command(
+          "git check-attr -z text eol -- #{batch.join(' ')}",
+          cwd: repo_contents_path,
+          stderr_to_stdout: false,
+          allow_unsafe_shell_command: true
+        ).to_s
+
+        result.merge!(parse(output))
+      end
+    end
+
+    # Groups the escaped paths so each command stays within COMMAND_BYTE_BUDGET.
+    sig { params(escaped: T::Array[String]).returns(T::Array[T::Array[String]]) }
+    def self.batches(escaped)
+      result = T.let([[]], T::Array[T::Array[String]])
+      bytes = 0
+
+      escaped.each do |path|
+        if bytes + path.bytesize + 1 > COMMAND_BYTE_BUDGET && !T.must(result.last).empty?
+          result << []
+          bytes = 0
+        end
+        T.must(result.last) << path
+        bytes += path.bytesize + 1
+      end
+
+      result.reject(&:empty?)
+    end
+
+    # `-z` output is a flat stream of NUL-terminated <path> <attr> <value> triples.
+    sig { params(output: String).returns(T::Hash[String, T::Hash[String, String]]) }
+    def self.parse(output)
+      result = T.let(Hash.new { |h, k| h[k] = {} }, T::Hash[String, T::Hash[String, String]])
+      output.split("\x00").each_slice(3) do |path, attr, value|
+        next if path.nil? || attr.nil? || value.nil?
+
+        T.must(result[path])[attr] = value
+      end
+      result
+    end
+  end
+end

--- a/common/spec/dependabot/git_attributes_spec.rb
+++ b/common/spec/dependabot/git_attributes_spec.rb
@@ -1,0 +1,201 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "dependabot/dependency_file"
+require "dependabot/git_attributes"
+
+RSpec.describe Dependabot::GitAttributes do
+  describe ".reconcile_line_endings!" do
+    let(:repo) { write_tmp_repo(attribute_files) }
+
+    after { FileUtils.remove_entry(repo) }
+
+    def dep_file(name:, content:, directory: "/")
+      Dependabot::DependencyFile.new(name: name, content: content, directory: directory)
+    end
+
+    def reconcile(updated, original: [], path: repo)
+      described_class.reconcile_line_endings!(updated, original_files: original, repo_contents_path: path)
+    end
+
+    context "with an attributes file declaring text/binary rules" do
+      let(:attribute_files) do
+        [
+          dep_file(name: ".gitattributes", content: <<~ATTRS),
+            * text=auto
+            *.bat text eol=crlf
+            *.ps1 eol=crlf
+            *.jar binary
+            vendor/** -text
+          ATTRS
+          dep_file(name: "sub/.gitattributes", content: "*.md text eol=lf\n")
+        ]
+      end
+
+      it "stores an eol=crlf file (gradlew.bat) as LF, the git index form" do
+        file = dep_file(name: "gradlew.bat", content: "@echo\r\noff\r\n")
+        reconcile([file])
+        expect(file.content).to eq("@echo\noff\n")
+      end
+
+      it "leaves binary files untouched" do
+        file = dep_file(name: "lib.jar", content: "a\r\nb\r\n")
+        reconcile([file])
+        expect(file.content).to eq("a\r\nb\r\n")
+      end
+
+      it "leaves -text files untouched even when a broader text=auto matches" do
+        file = dep_file(name: "blob.dat", content: "a\r\nb\r\n", directory: "/vendor")
+        reconcile([file])
+        expect(file.content).to eq("a\r\nb\r\n")
+      end
+
+      it "honors a nested .gitattributes rule" do
+        file = dep_file(name: "readme.md", content: "x\r\ny\r\n", directory: "/sub")
+        reconcile([file])
+        expect(file.content).to eq("x\ny\n")
+      end
+
+      it "normalizes text=auto content that looks textual" do
+        file = dep_file(name: "notes.txt", content: "one\r\ntwo\r\n")
+        reconcile([file])
+        expect(file.content).to eq("one\ntwo\n")
+      end
+
+      # git itself would skip conversion here (blob history is CRLF); we
+      # renormalize deliberately so the file converges on the declared attribute.
+      it "renormalizes text=auto content to LF even when the original was committed CRLF" do
+        original = dep_file(name: "notes.txt", content: "one\r\ntwo\r\n")
+        updated = dep_file(name: "notes.txt", content: "one\r\ntwo\r\nthree\r\n")
+        reconcile([updated], original: [original])
+        expect(updated.content).to eq("one\ntwo\nthree\n")
+      end
+
+      it "leaves text=auto content that contains NUL bytes untouched" do
+        file = dep_file(name: "weird.dat", content: "a\x00b\r\n")
+        reconcile([file])
+        expect(file.content).to eq("a\x00b\r\n")
+      end
+
+      it "leaves text=auto content with NUL bytes untouched even when an original exists" do
+        original = dep_file(name: "weird.dat", content: "a\r\nb\r\n")
+        updated = dep_file(name: "weird.dat", content: "a\x00b\nc\n")
+        reconcile([updated], original: [original])
+        expect(updated.content).to eq("a\x00b\nc\n")
+      end
+
+      it "leaves NUL-byte content under text=auto eol=crlf untouched, matching git" do
+        file = dep_file(name: "run.ps1", content: "a\x00b\r\nc\r\n")
+        reconcile([file])
+        expect(file.content).to eq("a\x00b\r\nc\r\n")
+      end
+
+      it "stores textual content under text=auto eol=crlf as LF" do
+        file = dep_file(name: "run.ps1", content: "a\r\nb\r\n")
+        reconcile([file])
+        expect(file.content).to eq("a\nb\n")
+      end
+
+      it "leaves text=auto content with a lone CR untouched, matching git" do
+        file = dep_file(name: "notes.txt", content: "a\rb\r\nc\r\n")
+        reconcile([file])
+        expect(file.content).to eq("a\rb\r\nc\r\n")
+      end
+
+      it "leaves text=auto content that is mostly non-printable untouched" do
+        file = dep_file(name: "notes.txt", content: "#{1.chr * 200}\r\n")
+        reconcile([file])
+        expect(file.content).to eq("#{1.chr * 200}\r\n")
+      end
+
+      it "matches the original endings of textual -text files to avoid noisy diffs" do
+        original = dep_file(name: "blob.dat", content: "a\r\nb\r\n", directory: "/vendor")
+        updated = dep_file(name: "blob.dat", content: "a\nb\nc\n", directory: "/vendor")
+        reconcile([updated], original: [original])
+        expect(updated.content).to eq("a\r\nb\r\nc\r\n")
+      end
+
+      # The dependabot/dependabot-core#8693 scenario: the updater rewrites only
+      # the lines it touches with LF, leaving a CRLF -text file with mixed endings.
+      it "restores uniform endings when the updater mixed LF into a CRLF -text file" do
+        original = dep_file(name: "nightly.yaml", content: "uses: a@v1\r\nname: x\r\n", directory: "/vendor")
+        updated = dep_file(name: "nightly.yaml", content: "uses: a@v2\nname: x\r\n", directory: "/vendor")
+        reconcile([updated], original: [original])
+        expect(updated.content).to eq("uses: a@v2\r\nname: x\r\n")
+      end
+    end
+
+    context "with more path bytes than fit one command line" do
+      let(:attribute_files) { [dep_file(name: ".gitattributes", content: "*.bat text eol=crlf\n")] }
+
+      it "reconciles every file" do
+        long_dir = "vendored/#{'d' * 200}"
+        files = Array.new(1000) do |i|
+          dep_file(name: "#{long_dir}/f#{i}.bat", content: "a\r\nb\r\n")
+        end
+        reconcile(files)
+        expect(files.first.content).to eq("a\nb\n")
+        expect(files.last.content).to eq("a\nb\n")
+      end
+    end
+
+    context "with a bare eol rule and no text attribute" do
+      let(:attribute_files) { [dep_file(name: ".gitattributes", content: "*.ps1 eol=crlf\n")] }
+
+      it "normalizes NUL-byte content, since a bare eol implicitly sets text" do
+        file = dep_file(name: "run.ps1", content: "a\x00b\r\nc\r\n")
+        reconcile([file])
+        expect(file.content).to eq("a\x00b\nc\n")
+      end
+
+      it "stores textual content as LF" do
+        file = dep_file(name: "run.ps1", content: "a\r\nb\r\n")
+        reconcile([file])
+        expect(file.content).to eq("a\nb\n")
+      end
+    end
+
+    context "when no attribute governs the file" do
+      let(:attribute_files) { [dep_file(name: ".gitattributes", content: "*.bat text eol=crlf\n")] }
+
+      it "matches the original file's line endings to avoid noisy diffs" do
+        original = dep_file(name: "config.yml", content: "a\r\nb\r\n")
+        updated = dep_file(name: "config.yml", content: "a\nb\nc\n")
+        reconcile([updated], original: [original])
+        expect(updated.content).to eq("a\r\nb\r\nc\r\n")
+      end
+
+      it "leaves a newly-created file as produced" do
+        updated = dep_file(name: "new.yml", content: "a\nb\n")
+        reconcile([updated], original: [])
+        expect(updated.content).to eq("a\nb\n")
+      end
+
+      it "leaves the update untouched when the original has mixed endings" do
+        original = dep_file(name: "config.yml", content: "a\r\nb\n")
+        updated = dep_file(name: "config.yml", content: "a\nb\nc\n")
+        reconcile([updated], original: [original])
+        expect(updated.content).to eq("a\nb\nc\n")
+      end
+    end
+
+    context "when no clone is available" do
+      let(:repo) { Dir.mktmpdir }
+
+      it "is a no-op when repo_contents_path is nil" do
+        file = dep_file(name: "gradlew.bat", content: "@echo\r\noff\r\n")
+        reconcile([file], path: nil)
+        expect(file.content).to eq("@echo\r\noff\r\n")
+      end
+
+      it "is a no-op when the path is not a git repo" do
+        file = dep_file(name: "gradlew.bat", content: "@echo\r\noff\r\n")
+        reconcile([file], path: repo)
+        expect(file.content).to eq("@echo\r\noff\r\n")
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -9,6 +9,7 @@ require "dependabot/experiments"
 require "dependabot/file_parsers"
 require "dependabot/file_updaters"
 require "dependabot/dependency_group"
+require "dependabot/git_attributes"
 require "dependabot/updater/blocked_version_detector"
 
 # This class is responsible for generating a DependencyChange for a given
@@ -81,6 +82,8 @@ module Dependabot
       unless updated_files.any?
         raise DependabotError, "FileUpdater failed to update any files for: #{dependency_info_for_error}"
       end
+
+      reconcile_line_endings(updated_files)
 
       enforce_blocked_transitive_versions!
 
@@ -255,6 +258,21 @@ module Dependabot
         "Skipping transitive dependency blocking check: #{e.class}"
       )
       nil
+    end
+
+    sig { params(updated_files: T::Array[Dependabot::DependencyFile]).void }
+    def reconcile_line_endings(updated_files)
+      Dependabot::GitAttributes.reconcile_line_endings!(
+        updated_files,
+        original_files: dependency_files,
+        repo_contents_path: job.repo_contents_path
+      )
+    rescue StandardError => e
+      # Cosmetic normalization must never break a valid update; on failure we
+      # commit the files as the updater produced them.
+      Dependabot.logger.warn(
+        "Skipping line-ending reconciliation: #{e.class}"
+      )
     end
 
     sig do

--- a/updater/spec/dependabot/dependency_change_builder_spec.rb
+++ b/updater/spec/dependabot/dependency_change_builder_spec.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tmpdir"
+require "fileutils"
 require "dependabot/dependency_change_builder"
 require "dependabot/dependency_file"
 require "dependabot/job"
@@ -127,6 +129,55 @@ RSpec.describe Dependabot::DependencyChangeBuilder do
 
     def dependency_group_source
       Dependabot::DependencyGroup.new(name: "dummy-pkg-*", rules: { patterns: ["dummy-pkg-*"] })
+    end
+
+    context "when the repo declares line endings via .gitattributes" do
+      let(:change_source) { lead_dependency_change_source }
+      let(:repo) { Dir.mktmpdir }
+
+      before do
+        Dir.chdir(repo) do
+          system("git", "init", "--quiet", exception: true)
+          File.write(".gitattributes", "*.bat text eol=crlf\n")
+        end
+        allow(job).to receive(:repo_contents_path).and_return(repo)
+        stub_file_updater(
+          updated_dependency_files: [
+            Dependabot::DependencyFile.new(
+              name: "gradlew.bat", content: "@echo\r\noff\r\n", directory: "/", support_file: false
+            )
+          ]
+        )
+      end
+
+      after { FileUtils.remove_entry(repo) }
+
+      it "commits gradlew.bat in the LF index form its .gitattributes declares" do
+        file = create_change.updated_dependency_files.find { |f| f.name == "gradlew.bat" }
+        expect(file.content).to eq("@echo\noff\n")
+      end
+
+      context "without a cloned repo" do
+        before { allow(job).to receive(:repo_contents_path).and_return(nil) }
+
+        it "leaves the content untouched" do
+          file = create_change.updated_dependency_files.find { |f| f.name == "gradlew.bat" }
+          expect(file.content).to eq("@echo\r\noff\r\n")
+        end
+      end
+
+      context "when reconciliation fails" do
+        before do
+          allow(Dependabot::GitAttributes).to receive(:reconcile_line_endings!)
+            .and_raise(StandardError, "git check-attr failed")
+        end
+
+        it "logs a warning and creates the change with the content as produced" do
+          expect(Dependabot.logger).to receive(:warn).with("Skipping line-ending reconciliation: StandardError")
+          file = create_change.updated_dependency_files.find { |f| f.name == "gradlew.bat" }
+          expect(file.content).to eq("@echo\r\noff\r\n")
+        end
+      end
     end
 
     context "when the job is a security update" do


### PR DESCRIPTION
### What are you trying to accomplish?

Dependabot commits file content via provider APIs, which bypass git's `.gitattributes` clean filter. When an update touches a file the repo stores in a different index form — e.g. a CRLF-checked-out `gradlew.bat` under `*.bat text eol=crlf`, which git stores as LF — the update reintroduces line endings the repo doesn't expect, leaving the file permanently "modified" after checkout. Fixes #8693.

This adds `Dependabot::GitAttributes`, which resolves the `text`/`eol` attributes with one batched `git check-attr` against the cloned repo and rewrites updated file content to the form git would store in the index:

- an explicit `text`, or a bare `eol=` rule (which implicitly sets `text`), forces the LF index form
- under `text=auto`, content git's binary heuristic (`convert_is_binary`: NUL bytes, lone CRs, non-printable ratio) classifies as binary is left verbatim; textual content is normalized to LF even when the committed blob was CRLF, deliberately renormalizing the file toward its declared attribute where git's safer-autocrlf rule would skip conversion
- under `-text` or with no governing attribute git stores bytes verbatim, so uniformly-LF/CRLF originals have their endings matched to avoid noisy diffs; mixed-ending originals and binary-looking content are never rewritten

The updater invokes this after file generation for every ecosystem, removing the need for per-ecosystem CRLF handling going forward.

### Anything you want to highlight for special attention from reviewers?

- The two failing `gradle` e2e checks are expected: the smoke-test snapshots were recorded with the old CRLF output and need regenerating against this PR. dependabot/smoke-tests#555 also adds a dedicated `.gitattributes` test case, verified to fail against the current `main` updater image and pass with an image built from this PR.
- An earlier Gradle-only attempt (#14976) stalled on two problems this design avoids: it runs only against the real clone (never a temp dir without `.gitattributes`), and `DependencyFile#realpath` handles the leading-slash path issue. It's also ecosystem-agnostic, as requested in that PR's discussion.
- Reconciliation is best-effort: failures are logged and never fail an otherwise valid update, mirroring the adjacent blocked-version detection in `DependencyChangeBuilder`.
- Existing per-ecosystem EOL handling (e.g. Poetry's CRLF-aware regexes from #13495) still runs first and remains compatible; simplifying it is left for a follow-up.

### How will you know you've accomplished your goal?

- New specs cover attribute-driven normalization (`text`, bare `eol=`, `binary`, `-text`, nested `.gitattributes`), git's binary heuristic, the no-attribute fallback, the no-clone no-op, and that a reconciliation failure doesn't break the update.
- The new smoke test in dependabot/smoke-tests#555 fails against the current `main` updater image with the `gradlew.bat` line endings as the only diff, and passes with an image built from this PR.
- Full `common` and `updater` suites pass in the Docker dev environment, rubocop clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
