### PR TITLE
Compare full path, not file name, when excluding fetched files

### DIFF
--- a/opentofu/lib/dependabot/opentofu/file_fetcher.rb
+++ b/opentofu/lib/dependabot/opentofu/file_fetcher.rb
@@ -38,7 +38,10 @@ module Dependabot
         fetched_files += [lockfile] if lockfile
 
         filtered_files = fetched_files.compact.reject do |file|
-          Dependabot::FileFiltering.should_exclude_path?(file.name, "file from final collection", @exclude_paths)
+          # `file.name` is relative to the fetched directory, while exclude_paths are
+          # relative to the repository root -- so comparing the two only ever matched
+          # for files in the root directory. `file.path` joins the two.
+          Dependabot::FileFiltering.should_exclude_path?(file.path, "file from final collection", @exclude_paths)
         end
 
         filtered_files

--- a/opentofu/spec/dependabot/opentofu/file_fetcher_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/file_fetcher_spec.rb
@@ -53,6 +53,32 @@ RSpec.describe Dependabot::Opentofu::FileFetcher do
     end
   end
 
+  context "when exclude-paths covers the whole directory" do
+    let(:project_name) { "lockfile_in_subdirectory" }
+    let(:directory) { "/frozen_project" }
+    let(:file_fetcher_instance) do
+      described_class.new(source: source, credentials: [], repo_contents_path: repo_contents_path).tap do |ff|
+        ff.exclude_paths = ["frozen_project/**"]
+      end
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_exclude_paths_subdirectory_manifest_files, true)
+    end
+
+    after do
+      Dependabot::Experiments.reset!
+    end
+
+    # The .tf files are dropped by the repo-contents filter, but the lockfile is fetched
+    # by path rather than from the listing, so it has to be caught by the final filter.
+    # If it survives, the directory reaches the parser holding a lockfile and no manifest.
+    it "excludes the lockfile as well as the manifests" do
+      expect { file_fetcher_instance.files }
+        .to raise_error(Dependabot::DependencyFileNotFound)
+    end
+  end
+
   context "with a directory that doesn't exist" do
     let(:directory) { "/nonexistent" }
 

--- a/opentofu/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/.terraform.lock.hcl
+++ b/opentofu/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "3.37.0"
+  constraints = ">= 3.37.0, < 3.46.0"
+  hashes = [
+    "h1:RvLGIfRZfbzY58wUja9B6CvGdgVVINy7zLVBdLqIelA=",
+    "zh:064c9b21bcd69be7a8631ccb3eccb8690c6a9955051145920803ef6ce6fc06bf",
+    "zh:277dd05750187a41282cf6e066e882eac0dd0056e3211d125f94bf62c19c4b8b",
+    "zh:47050211f72dcbf3d99c82147abd2eefbb7238efb94d5188979f60de66c8a3df",
+    "zh:4a4e0d070399a050847545721dae925c192a2d6354802fdfbea73769077acca5",
+    "zh:4cbc46f79239c85d69389f9e91ca9a9ebf6a8a937cfada026c5a037fd09130fb",
+    "zh:6548dcb1ac4a388ed46034a5317fa74b3b0b0f68eec03393f2d4d09342683f95",
+    "zh:75b4a82596aa525d95b0b2847fe648368c6e2b054059c4dc4dcdee01d374b592",
+    "zh:75cf5cc674b61c82300667a82650f56722618b119ab0526b47b5ecbb4bbf49d0",
+    "zh:93c896682359039960c38eb5a4b29d1cc06422f228db0572b90330427e2a21ec",
+    "zh:c7256663aedbc9de121316b6d0623551386a476fc12b8eb77e88532ce15de354",
+    "zh:e995c32f49c23b5938200386e08b2a3fd69cf5102b5299366c0608bbeac68429",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.0.0"
+  constraints = "3.0.0"
+  hashes = [
+    "h1:yhHJpb4IfQQfuio7qjUXuUFTU/s+ensuEpm23A+VWz0=",
+    "zh:0fcb00ff8b87dcac1b0ee10831e47e0203a6c46aafd76cb140ba2bab81f02c6b",
+    "zh:123c984c0e04bad910c421028d18aa2ca4af25a153264aef747521f4e7c36a17",
+    "zh:287443bc6fd7fa9a4341dec235589293cbcc6e467a042ae225fd5d161e4e68dc",
+    "zh:2c1be5596dd3cca4859466885eaedf0345c8e7628503872610629e275d71b0d2",
+    "zh:684a2ef6f415287944a3d966c4c8cee82c20e393e096e2f7cdcb4b2528407f6b",
+    "zh:7625ccbc6ff17c2d5360ff2af7f9261c3f213765642dcd84e84ae02a3768fd51",
+    "zh:9a60811ab9e6a5bfa6352fbb943bb530acb6198282a49373283a8fa3aa2b43fc",
+    "zh:c73e0eaeea6c65b1cf5098b101d51a2789b054201ce7986a6d206a9e2dacaefd",
+    "zh:e8f9ed41ac83dbe407de9f0206ef1148204a0d51ba240318af801ffb3ee5f578",
+    "zh:fbdd0684e62563d3ac33425b0ac9439d543a3942465f4b26582bcfabcb149515",
+  ]
+}

--- a/opentofu/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/main.tf
+++ b/opentofu/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/main.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "random_pet" "petname" {
+  length    = 5
+  separator = "-"
+}
+
+resource "aws_s3_bucket" "sample" {
+  bucket = random_pet.petname.id
+  acl    = "public-read"
+
+  region = "us-west-2"
+}

--- a/opentofu/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/versions.tf
+++ b/opentofu/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.0.0"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.37.0, < 3.46.0"
+    }
+  }
+}

--- a/terraform/lib/dependabot/terraform/file_fetcher.rb
+++ b/terraform/lib/dependabot/terraform/file_fetcher.rb
@@ -38,7 +38,10 @@ module Dependabot
         fetched_files += [lockfile] if lockfile
 
         filtered_files = fetched_files.compact.reject do |file|
-          Dependabot::FileFiltering.should_exclude_path?(file.name, "file from final collection", @exclude_paths)
+          # `file.name` is relative to the fetched directory, while exclude_paths are
+          # relative to the repository root -- so comparing the two only ever matched
+          # for files in the root directory. `file.path` joins the two.
+          Dependabot::FileFiltering.should_exclude_path?(file.path, "file from final collection", @exclude_paths)
         end
 
         filtered_files

--- a/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_fetcher_spec.rb
@@ -53,6 +53,34 @@ RSpec.describe Dependabot::Terraform::FileFetcher do
     end
   end
 
+  context "when exclude-paths covers the whole directory" do
+    let(:project_name) { "lockfile_in_subdirectory" }
+    let(:directory) { "/frozen_project" }
+    let(:file_fetcher_instance) do
+      described_class.new(source: source, credentials: [], repo_contents_path: repo_contents_path).tap do |ff|
+        ff.exclude_paths = ["frozen_project/**"]
+      end
+    end
+
+    before do
+      Dependabot::Experiments.register(:enable_exclude_paths_subdirectory_manifest_files, true)
+    end
+
+    after do
+      Dependabot::Experiments.reset!
+    end
+
+    # The .tf files are dropped by the repo-contents filter, but the lockfile is fetched
+    # by path rather than from the listing, so it has to be caught by the final filter.
+    # If it survives, the directory reaches the parser holding a lockfile and no manifest,
+    # and Terraform::FileParser#check_required_files raises "No Terraform configuration
+    # file!" -- an unhandled error that aborts every other directory in the job too.
+    it "excludes the lockfile as well as the manifests" do
+      expect { file_fetcher_instance.files }
+        .to raise_error(Dependabot::DependencyFileNotFound)
+    end
+  end
+
   context "with a directory that doesn't exist" do
     let(:directory) { "/nonexistent" }
 

--- a/terraform/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/.terraform.lock.hcl
+++ b/terraform/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.37.0"
+  constraints = ">= 3.37.0, < 3.46.0"
+  hashes = [
+    "h1:RvLGIfRZfbzY58wUja9B6CvGdgVVINy7zLVBdLqIelA=",
+    "zh:064c9b21bcd69be7a8631ccb3eccb8690c6a9955051145920803ef6ce6fc06bf",
+    "zh:277dd05750187a41282cf6e066e882eac0dd0056e3211d125f94bf62c19c4b8b",
+    "zh:47050211f72dcbf3d99c82147abd2eefbb7238efb94d5188979f60de66c8a3df",
+    "zh:4a4e0d070399a050847545721dae925c192a2d6354802fdfbea73769077acca5",
+    "zh:4cbc46f79239c85d69389f9e91ca9a9ebf6a8a937cfada026c5a037fd09130fb",
+    "zh:6548dcb1ac4a388ed46034a5317fa74b3b0b0f68eec03393f2d4d09342683f95",
+    "zh:75b4a82596aa525d95b0b2847fe648368c6e2b054059c4dc4dcdee01d374b592",
+    "zh:75cf5cc674b61c82300667a82650f56722618b119ab0526b47b5ecbb4bbf49d0",
+    "zh:93c896682359039960c38eb5a4b29d1cc06422f228db0572b90330427e2a21ec",
+    "zh:c7256663aedbc9de121316b6d0623551386a476fc12b8eb77e88532ce15de354",
+    "zh:e995c32f49c23b5938200386e08b2a3fd69cf5102b5299366c0608bbeac68429",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.0.0"
+  constraints = "3.0.0"
+  hashes = [
+    "h1:yhHJpb4IfQQfuio7qjUXuUFTU/s+ensuEpm23A+VWz0=",
+    "zh:0fcb00ff8b87dcac1b0ee10831e47e0203a6c46aafd76cb140ba2bab81f02c6b",
+    "zh:123c984c0e04bad910c421028d18aa2ca4af25a153264aef747521f4e7c36a17",
+    "zh:287443bc6fd7fa9a4341dec235589293cbcc6e467a042ae225fd5d161e4e68dc",
+    "zh:2c1be5596dd3cca4859466885eaedf0345c8e7628503872610629e275d71b0d2",
+    "zh:684a2ef6f415287944a3d966c4c8cee82c20e393e096e2f7cdcb4b2528407f6b",
+    "zh:7625ccbc6ff17c2d5360ff2af7f9261c3f213765642dcd84e84ae02a3768fd51",
+    "zh:9a60811ab9e6a5bfa6352fbb943bb530acb6198282a49373283a8fa3aa2b43fc",
+    "zh:c73e0eaeea6c65b1cf5098b101d51a2789b054201ce7986a6d206a9e2dacaefd",
+    "zh:e8f9ed41ac83dbe407de9f0206ef1148204a0d51ba240318af801ffb3ee5f578",
+    "zh:fbdd0684e62563d3ac33425b0ac9439d543a3942465f4b26582bcfabcb149515",
+  ]
+}

--- a/terraform/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/main.tf
+++ b/terraform/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/main.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "random_pet" "petname" {
+  length    = 5
+  separator = "-"
+}
+
+resource "aws_s3_bucket" "sample" {
+  bucket = random_pet.petname.id
+  acl    = "public-read"
+
+  region = "us-west-2"
+}

--- a/terraform/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/versions.tf
+++ b/terraform/spec/fixtures/projects/lockfile_in_subdirectory/frozen_project/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.0.0"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.37.0, < 3.46.0"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #15702.

### The bug

The "file from final collection" filter in the Terraform and OpenTofu file fetchers compares `file.name` against the configured `exclude_paths`:

```ruby
filtered_files = fetched_files.compact.reject do |file|
  Dependabot::FileFiltering.should_exclude_path?(file.name, "file from final collection", @exclude_paths)
end
```

`file.name` is relative to the directory being fetched; `exclude_paths` patterns are relative to the repository root. The two only coincide for files in the root directory, so for every other directory this filter silently matches nothing. `file.path` (`File.join(directory, name)`) is the repo-root-relative form, and `FileFiltering.normalize_path` already strips the leading slash, so it compares correctly.

### Why it is fatal for Terraform rather than merely wrong

For most files a missed exclusion is just a missed exclusion. For Terraform it takes down the whole job, because the lockfile reaches the collection by a different route than everything else:

1. `terraform_files` / `terragrunt_files` come from `repo_contents`, so the **listing-level** `filter_excluded` removes them. All `.tf` files disappear.
2. `lockfile` is fetched with `fetch_file_if_present(".terraform.lock.hcl")` — a direct path fetch that never goes through the listing. **This final filter is the only thing that could exclude it**, and it was comparing the wrong string.
3. `FileFetchers::Base#files` does not rescue the situation: it raises `DependencyFileNotFound` only when the collection is *empty*, and `Terraform::FileFetcher.required_files_in?` accepts any name ending in `.hcl` — which `.terraform.lock.hcl` does. So a lockfile-only collection looks valid.
4. `DependencySnapshot.create_from_job_definition` derives `job.source.directories` from the fetched files, so the directory stays in the job with exactly one file.
5. `Terraform::FileParser#check_required_files` requires a real configuration file (`[*terraform_files, *terragrunt_files].any?`) and the lockfile is neither, so it raises `RuntimeError: No Terraform configuration file!`.
6. That raise happens inside the un-rescued `directories.each` loop in `DependencySnapshot#initialize`, so it escapes and **aborts every other directory in the job**.

Had the lockfile been excluded correctly at step 2, `files` would have raised `DependencyFileNotFound`, `FileFetcherCommand#list_files_in_directory` would have `next`ed past the directory, and the run would have carried on.

Observed in production on a private monorepo whose terraform entry globs ~50 directories: adding an `exclude-paths` entry for a single frozen project took the whole entry to zero PRs. The updater's own logging shows the listing being emptied —

```
DEBUG filter_excluded: entries=10, exclude_paths=["<redacted>/frozen-project/**"]
DEBUG filter_excluded: Filtered from 10 to 0 entries
```

— and the job then dies in `check_required_files` a few seconds later.

### The change

`file.name` → `file.path` in the final filter for `terraform` and `opentofu`, plus a regression test in each.

The tests use a new `lockfile_in_subdirectory` fixture — the existing `lockfile` fixture sits at the repo root, where the bug is invisible precisely because `name == path` there. Both tests fail before the change (the lockfile survives and `files` returns it) and pass after (`DependencyFileNotFound`, so the caller skips the directory).

### Scope — please advise

The same `should_exclude_path?(file.name, "file from final collection", ...)` line appears in **eleven other ecosystems**: bun, bundler, cargo, composer, gradle, hex, maven, pre_commit, python, sbt. The path-vs-name mismatch is identical in all of them, but the consequence depends on whether that ecosystem also fetches files by path outside the listing, and on how permissive its `required_files_in?` is — I have only reproduced and tested the two here.

Happy to extend this PR to all thirteen if you would like it done in one go, or to leave the rest for a follow-up. Let me know which you prefer.

### Verification

- `bundle exec rspec spec/dependabot/terraform/file_fetcher_spec.rb` — 10 examples, 0 failures
- `bundle exec rspec spec/dependabot/opentofu/file_fetcher_spec.rb` — 10 examples, 0 failures
- Full `terraform/spec` suite: 72 failures before the change, 71 after, on the same machine — the remainder are pre-existing failures in my local (non-container) environment, and the difference is the new test.
- `bundle exec rubocop` clean on all four changed files.
