### PR TITLE
Gate full yarn dedupe behind yarn_full_dedupe experiment flag

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -340,7 +340,7 @@ module Dependabot
 
           commands = [
             ["add #{update} #{yarn_berry_args}".strip, "add <update> #{yarn_berry_args}".strip],
-            ["dedupe #{dep.name} #{yarn_berry_args}".strip, "dedupe <dep_name> #{yarn_berry_args}".strip],
+            ["dedupe #{yarn_berry_args}".strip, "dedupe #{yarn_berry_args}".strip],
             ["remove #{dep.name} #{yarn_berry_args}".strip, "remove <dep_name> #{yarn_berry_args}".strip]
           ]
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -338,15 +338,11 @@ module Dependabot
           dep = T.must(sub_dependencies.first)
           update = "#{dep.name}@#{dep.version}"
 
-          dedupe_args = if Dependabot::Experiments.enabled?(:yarn_full_dedupe)
-                          yarn_berry_args
-                        else
-                          "#{dep.name} #{yarn_berry_args}"
-                        end
+          dedupe = yarn_dedupe_args(dep.name)
 
           commands = [
             ["add #{update} #{yarn_berry_args}".strip, "add <update> #{yarn_berry_args}".strip],
-            ["dedupe #{dedupe_args}".strip, "dedupe #{dedupe_args}".strip],
+            ["dedupe #{dedupe}".strip, "dedupe #{dedupe}".strip],
             ["remove #{dep.name} #{yarn_berry_args}".strip, "remove <dep_name> #{yarn_berry_args}".strip]
           ]
 
@@ -393,6 +389,15 @@ module Dependabot
             Helpers.yarn_berry_args,
             T.nilable(String)
           )
+        end
+
+        sig { params(dep_name: String).returns(String) }
+        def yarn_dedupe_args(dep_name)
+          if Dependabot::Experiments.enabled?(:yarn_full_dedupe)
+            yarn_berry_args
+          else
+            "#{dep_name} #{yarn_berry_args}"
+          end
         end
 
         sig do

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -338,9 +338,15 @@ module Dependabot
           dep = T.must(sub_dependencies.first)
           update = "#{dep.name}@#{dep.version}"
 
+          dedupe_args = if Dependabot::Experiments.enabled?(:yarn_full_dedupe)
+                          yarn_berry_args
+                        else
+                          "#{dep.name} #{yarn_berry_args}"
+                        end
+
           commands = [
             ["add #{update} #{yarn_berry_args}".strip, "add <update> #{yarn_berry_args}".strip],
-            ["dedupe #{yarn_berry_args}".strip, "dedupe #{yarn_berry_args}".strip],
+            ["dedupe #{dedupe_args}".strip, "dedupe #{dedupe_args}".strip],
             ["remove #{dep.name} #{yarn_berry_args}".strip, "remove <dep_name> #{yarn_berry_args}".strip]
           ]
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
 
   # Variable to control the enabling feature flag for the corepack fix
   let(:enable_corepack_for_npm_and_yarn) { true }
+  let(:yarn_full_dedupe) { false }
 
   before do
     FileUtils.mkdir_p(tmp_path)
@@ -71,6 +72,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
       .with(:enable_private_registry_for_corepack).and_return(true)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_audit_fix_fallback).and_return(true)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:yarn_full_dedupe).and_return(yarn_full_dedupe)
   end
 
   after do
@@ -525,6 +528,78 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater do
           top_level_dependency_updates: [dep],
           yarn_lock: yarn_lock_file
         )
+      end
+    end
+  end
+
+  describe "#yarn_dedupe_args" do
+    let(:files) { project_dependency_files("yarn_berry/simple") }
+
+    before do
+      allow(Dependabot::NpmAndYarn::Helpers).to receive(:yarn_berry_args).and_return("--mode=update-lockfile")
+    end
+
+    context "when yarn_full_dedupe experiment is disabled (default)" do
+      let(:yarn_full_dedupe) { false }
+
+      it "returns scoped dedupe args with the dependency name" do
+        result = updater.send(:yarn_dedupe_args, "my-package")
+        expect(result).to eq("my-package --mode=update-lockfile")
+      end
+    end
+
+    context "when yarn_full_dedupe experiment is enabled" do
+      let(:yarn_full_dedupe) { true }
+
+      it "returns only yarn_berry_args without the dependency name" do
+        result = updater.send(:yarn_dedupe_args, "my-package")
+        expect(result).to eq("--mode=update-lockfile")
+      end
+    end
+  end
+
+  describe "#run_yarn_berry_subdependency_updater" do
+    let(:files) { project_dependency_files("yarn_berry/simple") }
+    let(:dependency_name) { "lodash" }
+    let(:version) { "4.17.21" }
+    let(:previous_version) { "4.17.20" }
+    let(:requirements) { [] }
+    let(:previous_requirements) { [] }
+
+    before do
+      allow(Dependabot::NpmAndYarn::Helpers).to receive(:yarn_berry_args).and_return("--mode=update-lockfile")
+      allow(File).to receive(:read).and_call_original
+    end
+
+    context "when yarn_full_dedupe experiment is disabled (default)" do
+      let(:yarn_full_dedupe) { false }
+
+      it "runs yarn dedupe scoped to the dependency name" do
+        yarn_lock_file = files.find { |f| f.name == "yarn.lock" }
+        allow(File).to receive(:read).with(yarn_lock_file.name).and_return("original")
+
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_yarn_commands) do |*commands|
+          dedupe_cmd = commands[1][0]
+          expect(dedupe_cmd).to eq("dedupe lodash --mode=update-lockfile")
+        end
+
+        updater.send(:run_yarn_berry_subdependency_updater, yarn_lock: yarn_lock_file)
+      end
+    end
+
+    context "when yarn_full_dedupe experiment is enabled" do
+      let(:yarn_full_dedupe) { true }
+
+      it "runs yarn dedupe on the entire lockfile" do
+        yarn_lock_file = files.find { |f| f.name == "yarn.lock" }
+        allow(File).to receive(:read).with(yarn_lock_file.name).and_return("original")
+
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_yarn_commands) do |*commands|
+          dedupe_cmd = commands[1][0]
+          expect(dedupe_cmd).to eq("dedupe --mode=update-lockfile")
+        end
+
+        updater.send(:run_yarn_berry_subdependency_updater, yarn_lock: yarn_lock_file)
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       .with(:enable_private_registry_for_corepack).and_return(false)
     allow(Dependabot::Experiments).to receive(:enabled?)
       .with(:enable_audit_fix_fallback).and_return(false)
+    allow(Dependabot::Experiments).to receive(:enabled?)
+      .with(:yarn_full_dedupe).and_return(false)
   end
 
   after do


### PR DESCRIPTION
## Summary

Disclaimer: Used Claude to improve the prior work of @smorimoto in #9388 to make this an opt-in feature.

- Reverts the default `yarn dedupe` behavior back to scoped dedupe (`yarn dedupe <pkg>`) instead of full lockfile dedupe
- Makes full lockfile dedupe opt-in via the `:yarn_full_dedupe` experiment flag
- Full dedupe can cause unexpected changes across the entire lockfile, so it should be an explicit opt-in through `dependabot.yml`

## Context

Thanks to @smorimoto for the initial work in #9388 to run `yarn dedupe` entirely instead of scoping it to specific packages. This PR makes that behavior opt-in via an experiment flag so users can choose when to enable it.

Fixes #5830

## Test plan

- [ ] Verify default behavior runs `yarn dedupe <dep_name>` (scoped)
- [ ] Verify `yarn_full_dedupe: true` experiment runs `yarn dedupe` (full lockfile)