### PR TITLE
Add typed requirement source API

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1040
+# Offense count: 1024
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"

--- a/bun/lib/dependabot/bun/file_updater/package_json_updater.rb
+++ b/bun/lib/dependabot/bun/file_updater/package_json_updater.rb
@@ -96,12 +96,12 @@ module Dependabot
            .find { |r| r[:groups] == new_requirement[:groups] }
         end
 
-        sig { params(dependency: Dependabot::Dependency).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { params(dependency: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
         def new_requirements(dependency)
           dependency.requirements.select { |r| r[:file] == package_json.name }
         end
 
-        sig { params(dependency: Dependabot::Dependency).returns(T.nilable(T::Array[T::Hash[Symbol, T.untyped]])) }
+        sig { params(dependency: Dependabot::Dependency).returns(T.nilable(T::Array[Dependabot::DependencyRequirement])) }
         def updated_requirements(dependency)
           return unless dependency.previous_requirements
 

--- a/bun/lib/dependabot/bun/update_checker/version_resolver.rb
+++ b/bun/lib/dependabot/bun/update_checker/version_resolver.rb
@@ -661,9 +661,9 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             path: String
-          ).returns(T::Array[T::Hash[Symbol, T.untyped]])
+          ).returns(T::Array[Dependabot::DependencyRequirement])
         end
         def requirements_for_path(requirements, path)
           return requirements if path.to_s == "."
@@ -671,7 +671,7 @@ module Dependabot
           requirements.filter_map do |r|
             next unless r[:file].start_with?("#{path}/")
 
-            r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, ""))
+            Dependabot::DependencyRequirement.create(r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, "")))
           end
         end
 

--- a/common/lib/dependabot/dependency_requirement.rb
+++ b/common/lib/dependabot/dependency_requirement.rb
@@ -115,6 +115,44 @@ module Dependabot
       optional_object_hash(:metadata)
     end
 
+    # The source as a hash, or nil when the requirement has no source or
+    # names a registry as a bare string (e.g. Python's "internal" index).
+    sig { returns(T.nilable(ObjectHash)) }
+    def source_hash
+      value = source
+      return if value.nil? || value.is_a?(String)
+
+      value
+    end
+
+    # Reads a known source field such as "type", "ref", "url", or "digest".
+    # Accepts either key style because file parsers emit symbols while
+    # deserialised job definitions emit strings. Returns nil when the source
+    # is absent or a bare registry name.
+    sig { params(key: String).returns(T.nilable(String)) }
+    def source_string(key)
+      details = source_hash
+      return if details.nil?
+
+      value = details[key.to_sym] || details[key]
+      return if value.nil?
+      return value if value.is_a?(String)
+
+      raise TypeError, "source #{key} must be a string or nil"
+    end
+
+    # The requirement as a plain string. Nil when the requirement is absent,
+    # and a TypeError for the `:unfixable` sentinel, which callers that build
+    # manifest content cannot render.
+    sig { returns(T.nilable(String)) }
+    def requirement_string
+      value = requirement
+      return if value.nil?
+      return value if value.is_a?(String)
+
+      raise TypeError, "requirement must be a string or nil"
+    end
+
     private
 
     sig { params(key: Symbol).returns(T.nilable(String)) }

--- a/common/spec/dependabot/dependency_requirement_spec.rb
+++ b/common/spec/dependabot/dependency_requirement_spec.rb
@@ -123,9 +123,82 @@ RSpec.describe Dependabot::DependencyRequirement do
     it "returns the mutable source and metadata hashes" do
       requirement.source[:mirror] = "https://example.com"
       requirement.metadata[:property_name] = "rack.version"
-
       expect(requirement.dig(:source, :mirror)).to eq("https://example.com")
       expect(requirement.dig(:metadata, :property_name)).to eq("rack.version")
+    end
+  end
+
+  describe "source helpers" do
+    it "reads symbol-keyed source fields" do
+      req = described_class.create(requirement_hash)
+
+      expect(req.source_hash).to eq(type: "rubygems", url: "https://rubygems.org")
+      expect(req.source_string("type")).to eq("rubygems")
+      expect(req.source_string("url")).to eq("https://rubygems.org")
+    end
+
+    it "reads string-keyed source fields" do
+      req = described_class.create(
+        requirement_hash.merge(source: { "type" => "git", "ref" => "main" })
+      )
+
+      expect(req.source_string("type")).to eq("git")
+      expect(req.source_string("ref")).to eq("main")
+    end
+
+    it "returns nil for absent source fields" do
+      req = described_class.create(requirement_hash)
+
+      expect(req.source_string("ref")).to be_nil
+    end
+
+    it "returns nil when the requirement has no source" do
+      req = described_class.create(requirement_hash.merge(source: nil))
+
+      expect(req.source_hash).to be_nil
+      expect(req.source_string("type")).to be_nil
+    end
+
+    it "returns nil when the source is a registry name string" do
+      req = described_class.create(requirement_hash.merge(source: "internal"))
+
+      expect(req.source_hash).to be_nil
+      expect(req.source_string("type")).to be_nil
+    end
+
+    it "rejects a non-string value under a known source key" do
+      req = described_class.create(requirement_hash.merge(source: { type: 1 }))
+
+      expect { req.source_string("type") }
+        .to raise_error(TypeError, "source type must be a string or nil")
+    end
+
+    it "rejects a malformed source container" do
+      req = described_class.create(requirement_hash.merge(source: []))
+
+      expect { req.source_hash }
+        .to raise_error(TypeError, "source must be a string or hash with string or symbol keys, or nil")
+    end
+  end
+
+  describe "#requirement_string" do
+    it "returns a string requirement" do
+      req = described_class.create(requirement_hash)
+
+      expect(req.requirement_string).to eq(">= 1.0, < 2.0")
+    end
+
+    it "returns nil when the requirement is absent" do
+      req = described_class.create(requirement_hash.merge(requirement: nil))
+
+      expect(req.requirement_string).to be_nil
+    end
+
+    it "rejects the unfixable sentinel" do
+      req = described_class.create(requirement_hash.merge(requirement: :unfixable))
+
+      expect { req.requirement_string }
+        .to raise_error(TypeError, "requirement must be a string or nil")
     end
   end
 

--- a/composer/lib/dependabot/composer/file_updater/manifest_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/manifest_updater.rb
@@ -52,7 +52,7 @@ module Dependabot
         sig { returns(Dependabot::DependencyFile) }
         attr_reader :manifest
 
-        sig { params(dependency: Dependabot::Dependency).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { params(dependency: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
         def new_requirements(dependency)
           dependency.requirements.select { |r| r[:file] == manifest.name }
         end
@@ -70,7 +70,7 @@ module Dependabot
            .find { |r| r[:groups] == new_requirement[:groups] }
         end
 
-        sig { params(dependency: Dependabot::Dependency).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { params(dependency: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements(dependency)
           new_requirements(dependency)
             .reject { |r| T.must(dependency.previous_requirements).include?(r) }

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -91,7 +91,7 @@ module Dependabot
         latest_channel&.fetch(:commit_sha) || channel_version_finder.current_channel_revision
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements_for_channel
         result = latest_channel
         return dependency.requirements unless result
@@ -100,7 +100,9 @@ module Dependabot
           source = req[:source]
           next req unless source
 
-          req.merge(source: source.merge(ref: result[:channel], url: result[:url]))
+          Dependabot::DependencyRequirement.create(
+            req.merge(source: source.merge(ref: result[:channel], url: result[:url]))
+          )
         end
       end
 
@@ -143,7 +145,7 @@ module Dependabot
 
       # --- Tag-pinned ref support ---
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements_for_tag
         new_tag = latest_version_tag
         return dependency.requirements unless new_tag
@@ -152,7 +154,7 @@ module Dependabot
           source = req[:source]
           next req unless source
 
-          req.merge(source: source.merge(ref: new_tag[:tag], branch: nil))
+          Dependabot::DependencyRequirement.create(req.merge(source: source.merge(ref: new_tag[:tag], branch: nil)))
         end
       end
 
@@ -172,7 +174,7 @@ module Dependabot
 
       # --- Versioned branch support ---
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements_for_versioned_branch
         result = latest_versioned_branch
         return dependency.requirements unless result
@@ -181,7 +183,7 @@ module Dependabot
           source = req[:source]
           next req unless source
 
-          req.merge(source: source.merge(ref: result[:branch], branch: nil))
+          Dependabot::DependencyRequirement.create(req.merge(source: source.merge(ref: result[:branch], branch: nil)))
         end
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb
@@ -103,12 +103,12 @@ module Dependabot
            .find { |r| r[:groups] == new_requirement[:groups] }
         end
 
-        sig { params(dependency: Dependabot::Dependency).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { params(dependency: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
         def new_requirements(dependency)
           dependency.requirements.select { |r| r[:file] == package_json.name }
         end
 
-        sig { params(dependency: Dependabot::Dependency).returns(T.nilable(T::Array[T::Hash[Symbol, T.untyped]])) }
+        sig { params(dependency: Dependabot::Dependency).returns(T.nilable(T::Array[Dependabot::DependencyRequirement])) }
         def updated_requirements(dependency)
           return unless dependency.previous_requirements
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -431,10 +431,10 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             path: String
           )
-            .returns(T::Array[T::Hash[Symbol, T.untyped]])
+            .returns(T::Array[Dependabot::DependencyRequirement])
         end
         def requirements_for_path(requirements, path)
           return requirements if path.to_s == "."
@@ -442,7 +442,7 @@ module Dependabot
           requirements.filter_map do |r|
             next unless r[:file].start_with?("#{path}/")
 
-            r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, ""))
+            Dependabot::DependencyRequirement.create(r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, "")))
           end
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -957,9 +957,9 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.untyped]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             path: String
-          ).returns(T::Array[T::Hash[Symbol, T.untyped]])
+          ).returns(T::Array[Dependabot::DependencyRequirement])
         end
         def requirements_for_path(requirements, path)
           return requirements if path.to_s == "."
@@ -967,7 +967,7 @@ module Dependabot
           requirements.filter_map do |r|
             next unless r[:file].start_with?("#{path}/")
 
-            r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, ""))
+            Dependabot::DependencyRequirement.create(r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, "")))
           end
         end
 

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -453,7 +453,7 @@ module Dependabot
         requirements.map { |r| r.fetch(:file) }
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def requirements
         dependency.requirements
       end


### PR DESCRIPTION
### What are you trying to accomplish?

`DependencyRequirement` still subclasses `Hash` so ecosystems can read entries with `[]`, `dig`, and `fetch`. Those reads are the only thing keeping its last two untyped generics alive. This PR adds the readers the rest of the migration needs.

- `source_hash` returns the source only when it is a hash, and nil when the source is absent or a bare registry name string.
- `source_string(key)` reads a known field through `source_hash`, accepts symbol or string keys, and raises `TypeError` for a non-string value.
- `requirement_string` returns the requirement as a string, nil when absent, and raises `TypeError` for the `:unfixable` sentinel.

It also converts 16 requirement-array signatures from `T::Array[T::Hash[Symbol, T.untyped]]` to `T::Array[Dependabot::DependencyRequirement]` in bun, composer, nix, npm_and_yarn, and python.

### Anything you want to highlight for special attention from reviewers?

`requirement.source` is `T.any(String, ObjectHash)`. A bare string is a registry name, which is why `source_hash` returns nil for it rather than raising. Typing this naively caused a real Python and UV regression in #15647, so the string case has a regression test.

`Hash#merge` is typed as returning `T::Hash` rather than `self`, so the six affected merge call sites are now wrapped in `DependencyRequirement.create`. Ruby preserves the subclass at runtime, so this is a typing concession rather than a behaviour change.

### How will you know you've accomplished your goal?

Sorbet is clean, RuboCop passes on every changed file, and the new readers are covered by ten examples in `dependency_requirement_spec.rb`. Focused suites pass for common, nix, composer, python, npm_and_yarn, and bun.

`Sorbet/ForbidTUntyped` drops from 1040 to 1024.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
