### PR TITLE
Type npm_and_yarn requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 1024
+# Offense count: 1008
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -352,7 +352,6 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/library_detector.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/version_selector.rb"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_files_filterer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_files_filterer.rb
@@ -68,7 +68,7 @@ module Dependabot
       def dependency_manifest_requirements
         @dependency_manifest_requirements ||= T.let(
           updated_dependencies.flat_map do |dep|
-            dep.requirements.map { |requirement| requirement[:file] }
+            dep.requirements.filter_map(&:file)
           end,
           T.nilable(T::Array[String])
         )

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -68,16 +68,16 @@ module Dependabot
           reqs = dep.requirements
 
           # Ignore dependencies defined in support files, since we don't want PRs for those
-          support_reqs = reqs.select { |r| support_package_files.any? { |f| f.name == r[:file] } }
+          support_reqs = reqs.select { |r| support_package_files.any? { |f| f.name == r.file } }
           next true if support_reqs.any?
 
           # TODO: Currently, Dependabot can't handle dependencies that have both
           # a git source *and* a non-git source. Fix that!
-          git_reqs = reqs.select { |r| r.dig(:source, :type) == "git" }
+          git_reqs = reqs.select { |r| r.source_string("type") == "git" }
           next false if git_reqs.none?
-          next true if git_reqs.map { |r| r.fetch(:source) }.uniq.count > 1
+          next true if git_reqs.map(&:source).uniq.count > 1
 
-          dep.requirements.any? { |r| r.dig(:source, :type) != "git" }
+          dep.requirements.any? { |r| r.source_string("type") != "git" }
         end
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb
@@ -428,7 +428,7 @@ module Dependabot
 
         sig { params(dependency: Dependabot::Dependency).returns(String) }
         def npm_install_args(dependency)
-          git_requirement = dependency.requirements.find { |req| req[:source] && req[:source][:type] == "git" }
+          git_requirement = dependency.requirements.find { |req| req.source_string("type") == "git" }
 
           if git_requirement
             # NOTE: For git dependencies we loose some information about the
@@ -437,7 +437,7 @@ module Dependabot
             # `dependabot/depeendabot-core#semver:^0.1` - this is required to
             # pass the correct install argument to `npm install`
             updated_version_requirement = updated_version_requirement_for_dependency(dependency)
-            updated_version_requirement ||= git_requirement[:source][:url]
+            updated_version_requirement ||= T.must(git_requirement.source_string("url"))
 
             # NOTE: Git is configured to auth over https while updating
             updated_version_requirement = updated_version_requirement.gsub(
@@ -446,7 +446,7 @@ module Dependabot
 
             # NOTE: Keep any semver range that has already been updated by the
             # PackageJsonUpdater when installing the new version
-            if updated_version_requirement.include?(dependency.version)
+            if updated_version_requirement.include?(T.must(dependency.version))
               "#{dependency.name}@#{updated_version_requirement}"
             else
               "#{dependency.name}@#{updated_version_requirement.sub(/#.*/, '')}##{dependency.version}"
@@ -459,7 +459,7 @@ module Dependabot
         sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
         def dependency_in_package_json?(dependency)
           dependency.requirements.any? do |req|
-            req[:file] == T.must(package_json).name
+            req.file == T.must(package_json).name
           end
         end
 
@@ -473,7 +473,7 @@ module Dependabot
         sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
         def optional_dependency?(dependency)
           dependency.requirements.any? do |req|
-            req[:groups]&.include?("optionalDependencies")
+            req.groups&.include?("optionalDependencies") || false
           end
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/package_json_updater.rb
@@ -93,19 +93,19 @@ module Dependabot
         sig do
           params(
             dependency: Dependabot::Dependency,
-            new_requirement: T::Hash[Symbol, T.untyped]
+            new_requirement: Dependabot::DependencyRequirement
           )
-            .returns(T.nilable(T::Hash[Symbol, T.untyped]))
+            .returns(T.nilable(Dependabot::DependencyRequirement))
         end
         def old_requirement(dependency, new_requirement)
           T.must(dependency.previous_requirements)
-           .select { |r| r[:file] == package_json.name }
-           .find { |r| r[:groups] == new_requirement[:groups] }
+           .select { |r| r.file == package_json.name }
+           .find { |r| r.groups == new_requirement.groups }
         end
 
         sig { params(dependency: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
         def new_requirements(dependency)
-          dependency.requirements.select { |r| r[:file] == package_json.name }
+          dependency.requirements.select { |r| r.file == package_json.name }
         end
 
         sig { params(dependency: Dependabot::Dependency).returns(T.nilable(T::Array[Dependabot::DependencyRequirement])) }
@@ -118,22 +118,22 @@ module Dependabot
             dependency.requirements.zip(T.must(dependency.previous_requirements))
                       .reject do |new_req, old_req|
               next true if new_req == old_req
-              next false unless old_req&.fetch(:source).nil?
+              next false unless old_req&.source.nil?
 
-              new_req[:requirement] == old_req&.fetch(:requirement)
+              new_req.requirement == old_req&.requirement
             end
 
           updated_requirement_pairs
             .map(&:first)
-            .select { |r| r[:file] == package_json.name }
+            .select { |r| r.file == package_json.name }
         end
 
         sig do
           params(
             package_json_content: String,
-            new_req: T::Hash[Symbol, T.untyped],
+            new_req: Dependabot::DependencyRequirement,
             dependency_name: String,
-            old_req: T.nilable(T::Hash[Symbol, T.untyped])
+            old_req: T.nilable(Dependabot::DependencyRequirement)
           )
             .returns(String)
         end
@@ -150,7 +150,7 @@ module Dependabot
             new_req: new_req
           )
 
-          groups = new_req.fetch(:groups)
+          groups = T.must(new_req.groups).map(&:to_s)
 
           update_package_json_sections(
             groups,
@@ -166,9 +166,9 @@ module Dependabot
         sig do
           params(
             package_json_content: String,
-            new_req: T::Hash[Symbol, T.untyped],
+            new_req: Dependabot::DependencyRequirement,
             dependency: Dependabot::Dependency,
-            old_req: T.nilable(T::Hash[Symbol, T.untyped])
+            old_req: T.nilable(Dependabot::DependencyRequirement)
           )
             .returns(String)
         end
@@ -182,16 +182,16 @@ module Dependabot
           resolutions.each do |_, resolution|
             original_line = declaration_line(
               dependency_name: dep.name,
-              dependency_req: { requirement: resolution },
+              dependency_req: Dependabot::DependencyRequirement.create(requirement: resolution),
               content: content
             )
 
-            new_resolution = resolution == old_req&.dig(:requirement) ? new_req.fetch(:requirement) : dep.version
+            new_resolution = resolution == old_req&.requirement ? new_req.requirement : dep.version
 
             replacement_line = replacement_declaration_line(
               original_line: original_line,
-              old_req: { requirement: resolution },
-              new_req: { requirement: new_resolution }
+              old_req: Dependabot::DependencyRequirement.create(requirement: resolution),
+              new_req: Dependabot::DependencyRequirement.create(requirement: new_resolution)
             )
 
             content = update_package_json_sections(
@@ -222,7 +222,7 @@ module Dependabot
           matching.each do |_, resolution|
             original_line = declaration_line(
               dependency_name: dependency.name,
-              dependency_req: { requirement: resolution },
+              dependency_req: Dependabot::DependencyRequirement.create(requirement: resolution),
               content: content
             )
 
@@ -230,8 +230,8 @@ module Dependabot
 
             replacement_line = replacement_declaration_line(
               original_line: original_line,
-              old_req: { requirement: resolution },
-              new_req: { requirement: new_resolution }
+              old_req: Dependabot::DependencyRequirement.create(requirement: resolution),
+              new_req: Dependabot::DependencyRequirement.create(requirement: new_resolution)
             )
 
             content = update_package_json_sections(
@@ -245,13 +245,13 @@ module Dependabot
           params(
             package_json_content: String,
             dep: Dependabot::Dependency,
-            old_req: T.nilable(T::Hash[Symbol, T.untyped])
+            old_req: T.nilable(Dependabot::DependencyRequirement)
           )
             .returns(T::Hash[String, String])
         end
         def matching_resolutions(package_json_content, dep, old_req)
           parsed = JSON.parse(package_json_content)
-          old_requirement = old_req&.dig(:requirement)
+          old_requirement = old_req&.requirement
 
           resolution_entries(parsed)
             .select { |_, v| v.is_a?(String) }
@@ -270,16 +270,16 @@ module Dependabot
         sig do
           params(
             dependency_name: String,
-            dependency_req: T.nilable(T::Hash[Symbol, T.untyped]),
+            dependency_req: T.nilable(Dependabot::DependencyRequirement),
             content: String
           )
             .returns(String)
         end
         def declaration_line(dependency_name:, dependency_req:, content:)
-          git_dependency = dependency_req&.dig(:source, :type) == "git"
+          git_dependency = dependency_req&.source_string("type") == "git"
 
           unless git_dependency
-            requirement = dependency_req&.fetch(:requirement)
+            requirement = T.must(dependency_req&.requirement)
             return content.match(
               /"#{Regexp.escape(dependency_name)}"\s*:\s*
                                                 "#{Regexp.escape(requirement)}"/x
@@ -287,37 +287,37 @@ module Dependabot
           end
 
           username, repo =
-            dependency_req&.dig(:source, :url)&.split("/")&.last(2)
+            T.must(dependency_req&.source_string("url")).split("/").last(2)
 
           content.match(
             %r{"#{Regexp.escape(dependency_name)}"\s*:\s*
-               ".*?#{Regexp.escape(username)}/#{Regexp.escape(repo)}.*"}x
+               ".*?#{Regexp.escape(T.must(username))}/#{Regexp.escape(T.must(repo))}.*"}x
           ).to_s
         end
 
         sig do
           params(
             original_line: String,
-            old_req: T.nilable(T::Hash[Symbol, T.untyped]),
-            new_req: T::Hash[Symbol, T.untyped]
+            old_req: T.nilable(Dependabot::DependencyRequirement),
+            new_req: Dependabot::DependencyRequirement
           )
             .returns(String)
         end
         def replacement_declaration_line(original_line:, old_req:, new_req:)
-          was_git_dependency = old_req&.dig(:source, :type) == "git"
-          now_git_dependency = new_req.dig(:source, :type) == "git"
+          was_git_dependency = old_req&.source_string("type") == "git"
+          now_git_dependency = new_req.source_string("type") == "git"
 
           unless was_git_dependency
             return original_line.gsub(
-              %("#{old_req&.fetch(:requirement)}"),
-              %("#{new_req.fetch(:requirement)}")
+              %("#{old_req&.requirement}"),
+              %("#{new_req.requirement}")
             )
           end
 
           unless now_git_dependency
             return original_line.gsub(
               /(?<=\s").*[^\\](?=")/,
-              new_req.fetch(:requirement)
+              T.must(new_req.requirement_string)
             )
           end
 
@@ -330,32 +330,32 @@ module Dependabot
           end
 
           original_line.gsub(
-            %(##{old_req&.dig(:source, :ref)}"),
-            %(##{new_req.dig(:source, :ref)}")
+            %(##{old_req&.source_string('ref')}"),
+            %(##{new_req.source_string('ref')}")
           )
         end
 
         sig do
           params(
             original_line: String,
-            old_req: T.nilable(T::Hash[Symbol, String]),
-            new_req: T::Hash[Symbol, String]
+            old_req: T.nilable(Dependabot::DependencyRequirement),
+            new_req: Dependabot::DependencyRequirement
           )
             .returns(String)
         end
         def update_git_semver_requirement(original_line:, old_req:, new_req:)
           if original_line.include?("semver:")
             return original_line.gsub(
-              %(semver:#{old_req&.fetch(:requirement)}"),
-              %(semver:#{new_req.fetch(:requirement)}")
+              %(semver:#{old_req&.requirement}"),
+              %(semver:#{new_req.requirement}")
             )
           end
 
           raise "Not a semver req!" unless original_line.match?(/#[\^~=<>]/)
 
           original_line.gsub(
-            %(##{old_req&.fetch(:requirement)}"),
-            %(##{new_req.fetch(:requirement)}")
+            %(##{old_req&.requirement}"),
+            %(##{new_req.requirement}")
           )
         end
 
@@ -408,13 +408,14 @@ module Dependabot
         sig { params(dependency: Dependabot::Dependency).void }
         def preliminary_check_for_update(dependency)
           T.must(dependency.previous_requirements).each do |req, _dep|
-            next if req.fetch(:requirement).nil?
+            requirement = req.requirement
+            next if requirement.nil?
 
             # some deps are patched with local patches, we don't need to update them
-            if req.fetch(:requirement).match?(Regexp.union(PATCH_PACKAGE))
+            if requirement.match?(Regexp.union(PATCH_PACKAGE))
               Dependabot.logger.info(
                 "Func: updated_requirements. dependency patched #{dependency.name}," \
-                " Requirement: '#{req.fetch(:requirement)}'"
+                " Requirement: '#{requirement}'"
               )
 
               raise DependencyFileNotResolvable,
@@ -422,11 +423,11 @@ module Dependabot
             end
 
             # some deps are added as local packages, we don't need to update them as they are referred to a local path
-            next unless req.fetch(:requirement).match?(Regexp.union(LOCAL_PACKAGE))
+            next unless requirement.match?(Regexp.union(LOCAL_PACKAGE))
 
             Dependabot.logger.info(
               "Func: updated_requirements. local package #{dependency.name}," \
-              " Requirement: '#{req.fetch(:requirement)}'"
+              " Requirement: '#{requirement}'"
             )
 
             raise DependencyFileNotResolvable,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -291,9 +291,9 @@ module Dependabot
           return unless version
 
           dep_name = T.cast(dep[:name], String)
-          reqs = dep[:requirements]
+          reqs = T.cast(dep[:requirements], T.nilable(T::Array[Dependabot::DependencyRequirement]))
           return if reqs.nil? || reqs.empty?
-          return if reqs.any? { |req| req[:source] && req[:source][:type] == "git" }
+          return if reqs.any? { |req| req.source_string("type") == "git" }
           return if BerryLockfileHandler.version_matches?(parsed_lockfile, dep_name, T.cast(version, String))
 
           saved_package_jsons = save_package_jsons
@@ -305,7 +305,7 @@ module Dependabot
           )
 
           reqs.each do |req|
-            requirement = req[:requirement]
+            requirement = req.requirement_string
             next unless requirement
 
             BerryLockfileHandler.replace_declaration(yarn_lock.name, dep_name, T.cast(version, String), requirement)
@@ -440,9 +440,10 @@ module Dependabot
           return requirements if path.to_s == "."
 
           requirements.filter_map do |r|
-            next unless r[:file].start_with?("#{path}/")
+            file = r.file
+            next unless file&.start_with?("#{path}/")
 
-            Dependabot::DependencyRequirement.create(r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, "")))
+            Dependabot::DependencyRequirement.create(r.merge(file: file.gsub(/^#{Regexp.quote("#{path}/")}/, "")))
           end
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb
@@ -208,11 +208,11 @@ module Dependabot
         nil
       end
 
-      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
+      sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
       def new_source
         sources = dependency.requirements
-                            .map { |r| r.fetch(:source) }.uniq.compact
-                            .sort_by { |source| Package::RegistryFinder.central_registry?(source[:url]) ? 1 : 0 }
+                            .map(&:source_hash).uniq.compact
+                            .sort_by { |source| Package::RegistryFinder.central_registry?(T.cast(source[:url], String)) ? 1 : 0 }
 
         sources.first
       end
@@ -272,7 +272,7 @@ module Dependabot
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_git_url
         url = new_source&.[](:url) || new_source&.fetch("url")
-        Source.from_url(url)
+        Source.from_url(T.cast(url, T.nilable(String)))
       end
 
       sig { returns(T::Hash[String, T.untyped]) }
@@ -358,10 +358,10 @@ module Dependabot
           return configured_registry.sub(%r{^https?://}, "")
         end
 
-        if new_source.nil? then "registry.npmjs.org"
-        else
-          new_source&.fetch(:url)&.gsub("https://", "")&.gsub("http://", "")
-        end
+        source = new_source
+        return "registry.npmjs.org" if source.nil?
+
+        T.cast(source.fetch(:url), String).gsub("https://", "").gsub("http://", "")
       end
 
       sig { returns(T.nilable(String)) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_finder.rb
@@ -414,8 +414,8 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def registry_source_url # rubocop:disable Metrics/PerceivedComplexity
           sources = dependency&.requirements
-                              &.map { |r| r.fetch(:source) }&.uniq&.compact
-                              &.sort_by { |source| self.class.central_registry?(source[:url]) ? 1 : 0 }
+                              &.map(&:source_hash)&.uniq&.compact
+                              &.sort_by { |source| self.class.central_registry?(T.cast(source[:url], String)) ? 1 : 0 }
 
           sources&.find { |s| s[:type] == "registry" }
                  &.fetch(:url)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -395,9 +395,10 @@ module Dependabot
       sig { returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_resolvable_version_with_no_unlock_for_git_dependency
         reqs = dependency.requirements.filter_map do |r|
-          next if r.fetch(:requirement).nil?
+          requirement = r.requirement_string
+          next if requirement.nil?
 
-          requirement_class.requirements_array(r.fetch(:requirement))
+          requirement_class.requirements_array(requirement)
         end
 
         current_version =
@@ -497,8 +498,8 @@ module Dependabot
       def latest_git_version_details
         semver_req =
           dependency.requirements
-                    .find { |req| req.dig(:source, :type) == "git" }
-                    &.fetch(:requirement)
+                    .find { |req| req.source_string("type") == "git" }
+                    &.requirement_string
 
         # If there was a semver requirement provided or the dependency was
         # pinned to a version, look for the latest tag
@@ -519,7 +520,7 @@ module Dependabot
         { sha: dependency.version }
       end
 
-      sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
       def updated_source
         # Never need to update source, unless a git_dependency
         return dependency_source_details unless git_dependency?
@@ -553,22 +554,22 @@ module Dependabot
         security_advisories.any?
       end
 
-      sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
       def dependency_source_details
         original_source(dependency)
       end
 
       sig do
         params(updated_dependency: Dependabot::Dependency)
-          .returns(T.nilable(T::Hash[Symbol, T.untyped]))
+          .returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash))
       end
       def original_source(updated_dependency)
         sources =
           updated_dependency
-          .requirements.map { |r| r.fetch(:source) }
-                       .uniq.compact
+          .requirements.map(&:source_hash)
+          .uniq.compact
           .sort_by do |source|
-            Package::RegistryFinder.central_registry?(source[:url]) ? 1 : 0
+            Package::RegistryFinder.central_registry?(T.cast(source[:url], String)) ? 1 : 0
           end
 
         sources.first

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -287,8 +287,8 @@ module Dependabot
           return nil unless dist_tags
 
           dist_tag_req = dependency.requirements
-                                   .find { |r| dist_tags.include?(r[:requirement]) }
-                                   &.fetch(:requirement)
+                                   .filter_map(&:requirement_string)
+                                   .find { |req| dist_tags.include?(req) }
 
           # For cooldown filtering, use filtered releases
           releases = available_versions
@@ -337,9 +337,10 @@ module Dependabot
         sig { returns(T::Boolean) }
         def specified_dist_tag_requirement?
           dependency.requirements.any? do |req|
-            next false if req[:requirement].nil?
+            requirement = req.requirement_string
+            next false if requirement.nil?
 
-            req_string = req[:requirement].sub(NpmAndYarn::Requirement::JSR_PREFIX, "")
+            req_string = requirement.sub(NpmAndYarn::Requirement::JSR_PREFIX, "")
             next false unless req_string.match?(/^[A-Za-z]/)
 
             !req_string.match?(/^v\d/i)
@@ -363,9 +364,10 @@ module Dependabot
         sig { params(version: Dependabot::Version).returns(T::Boolean) }
         def current_requirement_greater_than?(version)
           dependency.requirements.any? do |req|
-            next false unless req[:requirement]
+            requirement = req.requirement_string
+            next false unless requirement
 
-            req_version = req[:requirement]
+            req_version = requirement
                           .sub(NpmAndYarn::Requirement::JSR_PREFIX, "")
                           .sub(/^\^|~|>=?/, "")
             next false unless version_class.correct?(req_version)
@@ -383,10 +385,11 @@ module Dependabot
           end
 
           dependency.requirements.any? do |req|
-            next unless req[:requirement]&.match?(/\d-[A-Za-z]/)
+            requirement = req.requirement_string
+            next unless requirement&.match?(/\d-[A-Za-z]/)
 
             NpmAndYarn::Requirement
-              .requirements_array(req.fetch(:requirement))
+              .requirements_array(requirement)
               .any? do |r|
                 r.requirements.any? { |a| a.last.release == version.release }
               end
@@ -413,7 +416,7 @@ module Dependabot
         end
         def filter_out_of_range_versions(releases)
           reqs = dependency.requirements.filter_map do |r|
-            NpmAndYarn::Requirement.requirements_array(r.fetch(:requirement))
+            NpmAndYarn::Requirement.requirements_array(r.requirement_string)
           end
 
           releases.select do |release|

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/requirements_updater.rb
@@ -35,7 +35,7 @@ module Dependabot
         sig do
           params(
             requirements: T::Array[Dependabot::DependencyRequirement],
-            updated_source: T.nilable(T::Hash[Symbol, T.untyped]),
+            updated_source: T.nilable(Dependabot::DependencyRequirement::ObjectHash),
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             latest_resolvable_version: T.nilable(T.any(String, Gem::Version))
           )
@@ -66,9 +66,9 @@ module Dependabot
           requirements.map do |req|
             req = Dependabot::DependencyRequirement.create(req.merge(source: updated_source))
             next req unless latest_resolvable_version
-            next initial_req_after_source_change(req) unless req[:requirement]
-            next req if req[:requirement].sub(NpmAndYarn::Requirement::JSR_PREFIX, "")
-                                         .match?(/^([A-Za-uw-z]|v[^\d])/)
+            next initial_req_after_source_change(req) unless req.requirement_string
+            next req if T.must(req.requirement_string).sub(NpmAndYarn::Requirement::JSR_PREFIX, "")
+                         .match?(/^([A-Za-uw-z]|v[^\d])/)
 
             case update_strategy
             when RequirementsUpdateStrategy::WidenRanges then widen_requirement(req)
@@ -85,7 +85,7 @@ module Dependabot
         sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
-        sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+        sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
         attr_reader :updated_source
 
         sig { returns(Dependabot::RequirementsUpdateStrategy) }
@@ -105,21 +105,21 @@ module Dependabot
         def updating_from_git_to_npm?
           return false unless updated_source.nil?
 
-          original_source = requirements.filter_map { |r| r[:source] }.first
-          original_source&.fetch(:type) == "git"
+          original_source = requirements.find(&:source)
+          original_source&.source_string("type") == "git"
         end
 
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def initial_req_after_source_change(req)
           return req unless updating_from_git_to_npm?
-          return req unless req[:requirement].nil?
+          return req unless req.requirement_string.nil?
 
           Dependabot::DependencyRequirement.create(req.merge(requirement: "^#{latest_resolvable_version}"))
         end
 
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement(req)
-          current_requirement = req[:requirement]
+          current_requirement = T.must(req.requirement_string)
 
           if current_requirement.match?(/(<|-\s)/i)
             ruby_req = ruby_requirements(current_requirement).first
@@ -130,12 +130,12 @@ module Dependabot
           end
 
           reqs = current_requirement.strip.split(SEPARATOR).map(&:strip)
-          Dependabot::DependencyRequirement.create(req.merge(requirement: update_version_string(reqs.first)))
+          Dependabot::DependencyRequirement.create(req.merge(requirement: update_version_string(T.must(reqs.first))))
         end
 
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement_if_needed(req)
-          current_requirement = req[:requirement]
+          current_requirement = T.must(req.requirement_string)
           version = latest_resolvable_version
           return req if current_requirement.strip == ""
 
@@ -147,7 +147,7 @@ module Dependabot
 
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def widen_requirement(req)
-          current_requirement = req[:requirement]
+          current_requirement = T.must(req.requirement_string)
           version = latest_resolvable_version
           return req if current_requirement.strip == ""
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -348,8 +348,8 @@ module Dependabot
             relevant_versions = latest_version_finder(dependency)
                                 .possible_previous_versions_with_details
                                 .map(&:first)
-            reqs = dep.requirements.filter_map { |r| r[:requirement] }
-                                   .map { |r| requirement_class.requirements_array(r) }
+            reqs = dep.requirements.filter_map(&:requirement_string)
+                      .map { |r| requirement_class.requirements_array(r) }
 
             # Pick the lowest version from the max possible version from all
             # requirements. This matches the logic when combining the same
@@ -981,10 +981,10 @@ module Dependabot
           ).returns(String)
         end
         def version_install_arg(version:)
-          git_source = dependency.requirements.find { |req| req[:source] && req[:source][:type] == "git" }
+          git_source = dependency.requirements.find { |req| req.source_string("type") == "git" }
 
           if git_source
-            "#{dependency.name}@#{git_source[:source][:url]}##{version}"
+            "#{dependency.name}@#{git_source.source_string('url')}##{version}"
           else
             "#{dependency.name}@#{version}"
           end
@@ -1000,9 +1000,10 @@ module Dependabot
           return requirements if path.to_s == "."
 
           requirements.filter_map do |r|
-            next unless r[:file].start_with?("#{path}/")
+            file = r.file
+            next unless file&.start_with?("#{path}/")
 
-            Dependabot::DependencyRequirement.create(r.merge(file: r[:file].gsub(/^#{Regexp.quote("#{path}/")}/, "")))
+            Dependabot::DependencyRequirement.create(r.merge(file: file.gsub(/^#{Regexp.quote("#{path}/")}/, "")))
           end
         end
 
@@ -1050,13 +1051,13 @@ module Dependabot
         def version_for_dependency(dep)
           return version_class.new(dep.version) if dep.version && version_class.correct?(dep.version)
 
-          dep.requirements.filter_map { |r| r[:requirement] }
-                          .reject { |req_string| req_string.start_with?("<") }
-                          .select { |req_string| req_string.match?(version_regex) }
-                          .map { |req_string| req_string.match(version_regex) }
-                          .select { |version| version_class.correct?(version.to_s) }
-                          .map { |version| version_class.new(version.to_s) }
-                          .max
+          dep.requirements.filter_map(&:requirement_string)
+             .reject { |req_string| req_string.start_with?("<") }
+             .select { |req_string| req_string.match?(version_regex) }
+             .map { |req_string| req_string.match(version_regex) }
+             .select { |version| version_class.correct?(version.to_s) }
+             .map { |version| version_class.new(version.to_s) }
+             .max
         end
 
         sig { returns(T.class_of(Dependabot::Version)) }


### PR DESCRIPTION
### What are you trying to accomplish?

Migrates npm_and_yarn off hash-style requirement access, using the readers added in the base PR. `r[:file]` becomes `r.file`, `r.dig(:source, :ref)` becomes `r.source_string("ref")`, and so on across 11 files.

This is the largest of the three ecosystem migrations in this stack, with 41 read sites.

### Anything you want to highlight for special attention from reviewers?

Typing these reads surfaced nil and Symbol cases the untyped `fetch` calls had been hiding. Where the old code would have raised on nil anyway, I used `T.must` to keep that behaviour rather than silently tolerating it. Where a guard already existed but Sorbet could not see through the method call, I bound a local first.

A few `T.cast(source[:url], String)` calls appear at the registry sorting boundary. `central_registry?` takes a `String` and would previously have raised `TypeError` inside `String#include?` on a missing url, so the cast preserves the same failure.

Producer-side hash construction is untouched, and requirement entries keep their current wire shape.

### How will you know you've accomplished your goal?

Sorbet is clean and RuboCop passes on every changed file. The npm_and_yarn file updater, file parser, update checker, metadata finder, and registry finder suites pass, 1206 examples in total. Two failures are unrelated to this change and reproduce on the base commit: a `conflicting_dependencies` fixture mismatch and a pnpm spec that times out fetching a private git dependency.

`Sorbet/ForbidTUntyped` drops from 1024 to 1008, and `update_checker/requirements_updater.rb` leaves the exclusion list.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
