### PR TITLE
Type bundler requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 994
+# Offense count: 991
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -273,7 +273,6 @@ Sorbet/ForbidTUntyped:
     - "bundler/lib/dependabot/bundler/update_checker/force_updater.rb"
     - "bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb"
     - "bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb"
-    - "bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb"
     - "bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb"
     - "bundler/lib/dependabot/bundler/update_checker/version_resolver.rb"
     - "common/lib/dependabot/clients/azure.rb"

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -104,7 +104,7 @@ module Dependabot
       sig { params(dependencies: T::Array[Dependabot::Dependency]).returns(T::Boolean) }
       def git_source?(dependencies)
         dependencies.any? do |dep|
-          dep.requirements.any? { |req| req.fetch(:source)&.fetch(:type) == "git" }
+          dep.requirements.any? { |req| req.source_string("type") == "git" }
         end
       end
 
@@ -380,7 +380,7 @@ module Dependabot
       sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
       def production?(dependency)
         groups = dependency.requirements
-                           .flat_map { |r| r.fetch(:groups) }
+                           .flat_map { |r| r.groups || [] }
                            .map(&:to_s)
 
         return true if groups.empty?

--- a/bundler/lib/dependabot/bundler/file_updater/gemfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemfile_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/bundler/file_updater"
@@ -56,18 +56,18 @@ module Dependabot
 
           updated_requirement =
             dependency.requirements
-                      .find { |r| r[:file] == file.name }
-                      &.fetch(:requirement)
+                      .find { |r| r.file == file.name }
+                      &.requirement_string
 
           previous_requirement =
             dependency.previous_requirements
-                      &.find { |r| r[:file] == file.name }
-                      &.fetch(:requirement)
+                      &.find { |r| r.file == file.name }
+                      &.requirement_string
 
           RequirementReplacer.new(
             dependency: dependency,
             file_type: :gemfile,
-            updated_requirement: updated_requirement,
+            updated_requirement: T.must(updated_requirement),
             previous_requirement: previous_requirement
           ).rewrite(content)
         end
@@ -77,34 +77,34 @@ module Dependabot
           changed_requirements =
             dependency.requirements - T.must(dependency.previous_requirements)
 
-          changed_requirements.any? { |f| f[:file] == file.name }
+          changed_requirements.any? { |f| f.file == file.name }
         end
 
         sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
         def remove_git_source?(dependency)
           old_gemfile_req =
             dependency.previous_requirements
-                      &.find { |f| GEMFILE_FILENAMES.include?(f[:file]) }
+                      &.find { |f| GEMFILE_FILENAMES.include?(f.file) }
 
-          return false unless old_gemfile_req&.dig(:source, :type) == "git"
+          return false unless old_gemfile_req&.source_string("type") == "git"
 
           new_gemfile_req =
             dependency.requirements
-                      .find { |f| GEMFILE_FILENAMES.include?(f[:file]) }
+                      .find { |f| GEMFILE_FILENAMES.include?(f.file) }
 
-          T.must(new_gemfile_req)[:source].nil?
+          T.must(new_gemfile_req).source.nil?
         end
 
         sig { params(dependency: Dependabot::Dependency, file: Dependabot::DependencyFile).returns(T::Boolean) }
         def update_git_pin?(dependency, file)
           new_gemfile_req =
             dependency.requirements
-                      .find { |f| f[:file] == file.name }
-          return false unless new_gemfile_req&.dig(:source, :type) == "git"
+                      .find { |f| f.file == file.name }
+          return false unless new_gemfile_req&.source_string("type") == "git"
 
           # If the new requirement is a git dependency with a ref then there's
           # no harm in doing an update
-          !T.must(new_gemfile_req).dig(:source, :ref).nil?
+          !T.must(new_gemfile_req).source_string("ref").nil?
         end
 
         sig { params(dependency: Dependabot::Dependency, content: String).returns(String) }
@@ -118,12 +118,11 @@ module Dependabot
         def update_gemfile_git_pin(dependency, file, content)
           new_pin =
             dependency.requirements
-                      .find { |f| f[:file] == file.name }
-                      &.fetch(:source)
-                      &.fetch(:ref)
+                      .find { |f| f.file == file.name }
+                      &.source_string("ref")
 
           GitPinReplacer
-            .new(dependency: dependency, new_pin: new_pin)
+            .new(dependency: dependency, new_pin: T.must(new_pin))
             .rewrite(content)
         end
       end

--- a/bundler/lib/dependabot/bundler/file_updater/gemspec_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/gemspec_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/bundler/file_updater"
@@ -51,21 +51,21 @@ module Dependabot
           updated_requirement =
             T.must(
               dependency.requirements
-                                    .find { |r| r[:file] == gemspec.name }
+                                    .find { |r| r.file == gemspec.name }
             )
-             .fetch(:requirement)
+             .requirement_string
 
           previous_requirement =
             T.must(
               T.must(dependency.previous_requirements)
-                                    .find { |r| r[:file] == gemspec.name }
+                                    .find { |r| r.file == gemspec.name }
             )
-             .fetch(:requirement)
+             .requirement_string
 
           RequirementReplacer.new(
             dependency: dependency,
             file_type: :gemspec,
-            updated_requirement: updated_requirement,
+            updated_requirement: T.must(updated_requirement),
             previous_requirement: previous_requirement
           ).rewrite(content)
         end
@@ -75,7 +75,7 @@ module Dependabot
           changed_requirements =
             dependency.requirements - T.must(dependency.previous_requirements)
 
-          changed_requirements.any? { |f| f[:file] == file.name }
+          changed_requirements.any? { |f| f.file == file.name }
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/metadata_finder.rb
+++ b/bundler/lib/dependabot/bundler/metadata_finder.rb
@@ -95,9 +95,9 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_git_url
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
+        info = T.must(dependency.requirements.filter_map(&:source_hash).first)
 
-        url = info[:url] || info.fetch("url")
+        url = T.cast(info[:url] || info.fetch("url"), T.nilable(String))
         Source.from_url(url)
       end
 
@@ -222,8 +222,8 @@ module Dependabot
       def registry_url
         return base_url if new_source_type == "default"
 
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-        info[:url] || info.fetch("url")
+        info = T.must(dependency.requirements.filter_map(&:source_hash).first)
+        T.cast(info[:url] || info.fetch("url"), String)
       end
 
       sig { returns(String) }

--- a/bundler/lib/dependabot/bundler/package/package_details_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/package/package_details_fetcher.rb
@@ -214,9 +214,9 @@ module Dependabot
           return nil unless dependency&.requirements&.any?
 
           first_requirement = dependency.requirements.first
-          return nil unless first_requirement && first_requirement[:source]
+          return nil unless first_requirement
 
-          url = T.let(first_requirement[:source][:url], T.nilable(String))
+          url = first_requirement.source_string("url")
           return nil unless url
 
           url.end_with?("/") ? url.chop : url
@@ -242,9 +242,9 @@ module Dependabot
           return nil unless dependency.requirements.any?
 
           first_requirement = dependency.requirements.first
-          return nil unless first_requirement && first_requirement[:source]
+          return nil unless first_requirement
 
-          first_requirement[:source][:type]
+          first_requirement.source_string("type")
         end
 
         sig { override.returns(String) }

--- a/bundler/lib/dependabot/bundler/requirement.rb
+++ b/bundler/lib/dependabot/bundler/requirement.rb
@@ -13,9 +13,9 @@ module Dependabot
 
       GEM_DEP_SPLIT = T.let(/\A(?<name>[a-zA-Z0-9_\-]+):(?<version>.+)\z/, Regexp)
 
-      sig { params(req: T::Hash[Symbol, String], version: Gem::Version).returns(T::Boolean) }
+      sig { params(req: Dependabot::DependencyRequirement, version: Gem::Version).returns(T::Boolean) }
       def self.satisfied_by?(req, version)
-        new(req[:requirement]).satisfied_by?(version)
+        new(req.requirement_string).satisfied_by?(version)
       end
 
       # For consistency with other languages, we define a requirements array.

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -102,7 +102,7 @@ module Dependabot
 
         dependency.specific_requirements
                   .all? do |req|
-          file = T.must(dependency_files.find { |f| f.name == req.fetch(:file) })
+          file = T.must(dependency_files.find { |f| f.name == req.file })
           updated = FileUpdater::RequirementReplacer.new(
             dependency: dependency,
             file_type: file.name.end_with?("gemspec") ? :gemspec : :gemfile,

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -273,20 +273,20 @@ module Dependabot
         sig { params(filename: String).returns(String) }
         def updated_version_req_lower_bound(filename) # rubocop:disable Metrics/CyclomaticComplexity
           original_req = dependency.requirements
-                                   .find { |r| r.fetch(:file) == filename }
-                                   &.fetch(:requirement)
+                                   .find { |r| r.file == filename }
+                                   &.requirement_string
 
           if original_req && !unlock_requirement? then original_req
           elsif dependency.version&.match?(/^[0-9a-f]{40}$/) then ">= 0"
           elsif dependency.version then ">= #{dependency.version}"
           else
             version_for_requirement =
-              dependency.requirements.map { |r| r[:requirement] }
-                                     .reject { |req_string| req_string.start_with?("<") }
-                                     .select { |req_string| req_string.match?(VERSION_REGEX) }
-                                     .map { |req_string| req_string.match(VERSION_REGEX)&.to_s }
-                                     .select { |version| Bundler::Version.correct?(version) }
-                                     .max_by { |version| Bundler::Version.new(version) }
+              dependency.requirements.filter_map(&:requirement_string)
+                        .reject { |req_string| req_string.start_with?("<") }
+                        .select { |req_string| req_string.match?(VERSION_REGEX) }
+                        .map { |req_string| req_string.match(VERSION_REGEX)&.to_s }
+                        .select { |version| Bundler::Version.correct?(version) }
+                        .max_by { |version| Bundler::Version.new(version) }
 
             ">= #{version_for_requirement || 0}"
           end

--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -94,7 +94,7 @@ module Dependabot
         # rubocop:disable Metrics/AbcSize
         sig { returns(T::Array[Dependabot::Dependency]) }
         def force_update
-          requirement = dependency.requirements.find { |req| req[:file] == T.must(gemfile).name }
+          requirement = dependency.requirements.find { |req| req.file == T.must(gemfile).name }
 
           valid_gem_version?(target_version)
 
@@ -192,11 +192,11 @@ module Dependabot
           )
         end
 
-        sig { params(dependency: Dependabot::Dependency).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+        sig { params(dependency: Dependabot::Dependency).returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
         def source_for(dependency)
           dependency.requirements
-                    .find { |r| r.fetch(:source) }
-                    &.fetch(:source)
+                    .find(&:source)
+                    &.source_hash
         end
 
         sig { returns(T.nilable(Dependabot::DependencyFile)) }

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"
@@ -128,7 +128,7 @@ module Dependabot
             begin
               current_version = dependency.numeric_version
               current_version&.prerelease? || dependency.requirements.any? do |req|
-                req[:requirement].match?(/[a-z]/i)
+                T.must(req.requirement_string).match?(/[a-z]/i)
               end
             end,
             T.nilable(T::Boolean)

--- a/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb
@@ -85,8 +85,10 @@ module Dependabot
             return unless git?
 
             source_details =
-              dependency.requirements.map { |r| r.fetch(:source) }
-                                     .uniq.compact.first
+              T.must(
+                dependency.requirements.map(&:source_hash)
+                                                     .uniq.compact.first
+              )
 
             SharedHelpers.with_git_configured(credentials: credentials) do
               in_a_native_bundler_context do |tmp_dir|

--- a/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/requirements_updater.rb
@@ -28,7 +28,7 @@ module Dependabot
           params(
             requirements: T::Array[Dependabot::DependencyRequirement],
             update_strategy: Dependabot::RequirementsUpdateStrategy,
-            updated_source: T.nilable(T::Hash[Symbol, T.untyped]),
+            updated_source: T.nilable(Dependabot::DependencyRequirement::ObjectHash),
             latest_version: T.nilable(String),
             latest_resolvable_version: T.nilable(String)
           ).void
@@ -66,7 +66,7 @@ module Dependabot
           return requirements if update_strategy.lockfile_only?
 
           requirements.map do |req|
-            if req[:file].include?(".gemspec")
+            if T.must(req.file).include?(".gemspec")
               update_gemspec_requirement(req)
             else
               # If a requirement doesn't come from a gemspec, it must be from
@@ -81,7 +81,7 @@ module Dependabot
         sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
-        sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+        sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
         attr_reader :updated_source
 
         sig { returns(T.nilable(Dependabot::Bundler::Version)) }
@@ -124,13 +124,13 @@ module Dependabot
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement(req)
           requirements =
-            req[:requirement].split(",").map { |r| Gem::Requirement.new(r) }
+            T.must(req.requirement_string).split(",").map { |r| Gem::Requirement.new(r) }
 
           new_requirement =
             if requirements.any?(&:exact?) then latest_resolvable_version.to_s
             elsif requirements.any? { |r| r.to_s.start_with?("~>") }
               tw_req = requirements.find { |r| r.to_s.start_with?("~>") }
-              update_twiddle_version(tw_req, T.must(latest_resolvable_version)).to_s
+              update_twiddle_version(T.must(tw_req), T.must(latest_resolvable_version)).to_s
             else
               update_gemfile_range(requirements).join(", ")
             end
@@ -185,21 +185,22 @@ module Dependabot
         # rubocop:disable Metrics/PerceivedComplexity
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_gemspec_requirement(req)
-          req = Dependabot::DependencyRequirement.create(req.merge(source: updated_source)) if req.fetch(:source)
+          req = Dependabot::DependencyRequirement.create(req.merge(source: updated_source)) if req.source
           return req unless latest_version && latest_resolvable_version
 
           requirements =
-            req[:requirement].split(",").map { |r| Gem::Requirement.new(r) }
+            T.must(req.requirement_string).split(",").map { |r| Gem::Requirement.new(r) }
+          groups = T.must(req.groups).map(&:to_s)
 
           return req if requirements.all? do |r|
-            requirement_satisfied?(r, req[:groups])
+            requirement_satisfied?(r, groups)
           end
 
           updated_requirements =
             requirements.flat_map do |r|
-              next r if requirement_satisfied?(r, req[:groups])
+              next r if requirement_satisfied?(r, groups)
 
-              if req[:groups] == ["development"] then bumped_requirements(r)
+              if groups == ["development"] then bumped_requirements(r)
               else
                 widened_requirements(r)
               end


### PR DESCRIPTION
### What are you trying to accomplish?

The same migration for bundler, across the Gemfile and gemspec updaters, requirements updater, file preparer, force updater, latest version finder, metadata finder, and package details fetcher.

Removing the untyped reads left three files with no implicit untyped calls, so `file_updater/gemfile_updater.rb`, `file_updater/gemspec_updater.rb`, and `update_checker/latest_version_finder.rb` move to `typed: strong`.

### Anything you want to highlight for special attention from reviewers?

`shared_bundler_helpers.rb` has five `error.message.match(regex)[:source]` reads that look like requirement access but are `MatchData` named captures, so they are left alone.

`Bundler::Requirement.satisfied_by?` now takes a `DependencyRequirement` rather than a `T::Hash[Symbol, String]`. Every caller already passes a real requirement entry.

### How will you know you've accomplished your goal?

Sorbet is clean and RuboCop passes on every changed file. The bundler update checker, file updater, file parser, metadata finder, requirement, and package suites pass, 721 examples with no failures.

I also verified the three sigil bumps by flipping every file this stack touches to `strong` and checking which ones Sorbet accepts, since `spoom srb bump --dry` runs in CI and fails when an eligible file is left behind.

`Sorbet/ForbidTUntyped` drops from 994 to 991, and `update_checker/requirements_updater.rb` leaves the exclusion list.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
