### PR TITLE
only call package restore targets on transitive projects

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -955,5 +955,104 @@ public partial class DiscoveryWorkerTests
                 }
             );
         }
+
+        [Fact]
+        public async Task RestoreDoesNotCallBuildOnTransitiveProjectReference()
+        {
+            // Ensure the `Build` target isn't invoked in transitive project references.
+
+            // To test this a custom target is added with `BeforeTargets="Build"` which writes a sentinel file to disk
+            // so we have to ensure that file doesn't get created.
+            using var tempDir = new TemporaryDirectory();
+            var sentinelFile1 = Path.Combine(tempDir.DirectoryPath, "sentinel1.txt");
+            var sentinelFile2 = Path.Combine(tempDir.DirectoryPath, "sentinel2.txt");
+
+            await TestDiscoveryAsync(
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net10.0"),
+                ],
+                workspacePath: "src/client",
+                files: [
+                    ("Directory.Build.props", "<Project />"),
+                    ("Directory.Build.targets", "<Project />"),
+                    ("Directory.Packages.props", """
+                        <Project>
+                          <PropertyGroup>
+                            <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+                          </PropertyGroup>
+                        </Project>
+                        """),
+                    ("src/client/client.csproj", $$"""
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFramework>net10.0</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <ProjectReference Include="..\common\common.csproj" />
+                          </ItemGroup>
+                          <Target Name="BuildSentinel" BeforeTargets="Build">
+                            <WriteLinesToFile File="{{sentinelFile1}}" Lines="Build target was called" Overwrite="true" />
+                          </Target>
+                        </Project>
+                        """),
+                    ("src/common/common.csproj", $$"""
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFramework>net10.0</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageReference Include="Some.Package" Version="1.0.0" />
+                          </ItemGroup>
+                          <Target Name="BuildSentinel" BeforeTargets="Build">
+                            <WriteLinesToFile File="{{sentinelFile2}}" Lines="Build target was called" Overwrite="true" />
+                          </Target>
+                        </Project>
+                        """),
+                ],
+                expectedResult: new()
+                {
+                    Path = "src/client",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "client.csproj",
+                            TargetFrameworks = ["net10.0"],
+                            Dependencies = [
+                                new("Some.Package", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net10.0"], IsTopLevel: false),
+                            ],
+                            ReferencedProjectPaths = [
+                                "../common/common.csproj"
+                            ],
+                            ImportedFiles = [
+                                "../../Directory.Build.props",
+                                "../../Directory.Build.targets",
+                                "../../Directory.Packages.props"
+                            ],
+                            AdditionalFiles = [],
+                        },
+                        new()
+                        {
+                            FilePath = "../common/common.csproj",
+                            TargetFrameworks = ["net10.0"],
+                            Dependencies = [
+                                new("Some.Package", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net10.0"], IsTopLevel: true),
+                            ],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [
+                                "../../Directory.Build.props",
+                                "../../Directory.Build.targets",
+                                "../../Directory.Packages.props"
+                            ],
+                            AdditionalFiles = [],
+                        }
+                    ],
+                }
+            );
+
+            // Verify that the Build target was not called (and BeforeTargets="Build") by checking that the sentinel file was not created
+            Assert.False(File.Exists(sentinelFile1), "Build target should not have been called on primary project");
+            Assert.False(File.Exists(sentinelFile2), "Build target should not have been called on referenced project");
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -178,6 +178,9 @@ internal static class SdkProjectDiscovery
                     args.Add($"/p:InnerTargets=\"{string.Join(";", requiredTargets)}\"");
                 }
 
+                // only execute the desired targets on transitive project references
+                args.Add($"/p:ProjectReferenceBuildTargets=\"{string.Join(";", requiredTargets)}\"");
+
                 // inject various props and targets to help with discovery
                 var dependencyDiscoveryTargetingPacksPropsPath = MSBuildHelper.GetFileFromRuntimeDirectory("DependencyDiscoveryTargetingPacks.props");
                 var dependencyDiscoveryTargetsPath = MSBuildHelper.GetFileFromRuntimeDirectory("DependencyDiscovery.targets");


### PR DESCRIPTION
When discovering project dependencies, we directly invoke the targets `Restore`, `ResolveProjectReferences`, and `GenerateBuildDependencyFile`.  When MSBuild traverses through `<ProjectReference>` elements, it will call `Build` which indirectly calls the targets we care about.  This extra call to `Build` can be slow and fill the log with unnecessary errors, although it doesn't prevent dependency discovery.

The fix is to explicitly set what targets can be called on project references to the ones we want.