### PR TITLE
Feature flag clean up

### DIFF
--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -341,9 +341,9 @@ module Dependabot
     # rubocop:disable Metrics/MethodLength
     sig { params(job: T.nilable(Dependabot::Job)).void }
     def record_cooldown_meta(job)
-      return if job&.cooldown.nil?
+      return unless job
 
-      cooldown = T.must(job).cooldown
+      cooldown = job.cooldown
 
       begin
         ::Dependabot::OpenTelemetry.tracer.in_span("record_cooldown_meta", kind: :internal) do |_span|
@@ -353,13 +353,13 @@ module Dependabot
             data: [
               {
                 cooldown: {
-                  ecosystem_name: T.must(job).package_manager,
+                  ecosystem_name: job.package_manager,
                   config:
                   {
-                    default_days: T.must(cooldown).default_days,
-                    semver_major_days: T.must(cooldown).semver_major_days,
-                    semver_minor_days: T.must(cooldown).semver_minor_days,
-                    semver_patch_days: T.must(cooldown).semver_patch_days
+                    default_days: cooldown.default_days,
+                    semver_major_days: cooldown.semver_major_days,
+                    semver_minor_days: cooldown.semver_minor_days,
+                    semver_patch_days: cooldown.semver_patch_days
                   }
                 }
               }

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -39,8 +39,7 @@ module Dependabot
     extend T::Sig
 
     TOP_LEVEL_DEPENDENCY_TYPES = T.let(%w(direct production development).freeze, T::Array[String])
-    # Default cooldown period (in days) applied when a cooldown is configured
-    # without an explicit `default-days` value.
+    # Default cooldown period (in days) applied when `default-days` is not configured.
     DEFAULT_COOLDOWN_DAYS = 3
     PERMITTED_KEYS = T.let(
       %i(
@@ -128,7 +127,7 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_reader :dependency_group_to_refresh
 
-    sig { returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
+    sig { returns(Dependabot::Package::ReleaseCooldownOptions) }
     attr_reader :cooldown
 
     sig { returns(T::Array[Dependabot::Job::BlockedVersion]) }
@@ -246,7 +245,7 @@ module Dependabot
       @vendor_dependencies = T.let(definition.vendor_dependencies, T::Boolean)
       @cooldown = T.let(
         build_cooldown(definition.cooldown),
-        T.nilable(Dependabot::Package::ReleaseCooldownOptions)
+        Dependabot::Package::ReleaseCooldownOptions
       )
       @multi_ecosystem_update = T.let(definition.multi_ecosystem_update, T::Boolean)
       @dependency_groups = T.let(definition.dependency_groups, T::Array[DependencyGroupDefinition])
@@ -692,16 +691,19 @@ module Dependabot
 
     sig do
       params(cooldown: T.nilable(CooldownDefinition))
-        .returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions))
+        .returns(Dependabot::Package::ReleaseCooldownOptions)
     end
     def build_cooldown(cooldown)
-      return nil unless cooldown
+      unless cooldown
+        return Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: default_cooldown_days
+        )
+      end
 
       cooldown.to_options(default_days: default_cooldown_days)
     end
 
-    # The fallback applied when a cooldown block is present but `default-days`
-    # is not explicitly set. Defaults to DEFAULT_COOLDOWN_DAYS.
+    # The fallback applied when `default-days` is not explicitly set.
     sig { returns(Integer) }
     def default_cooldown_days
       DEFAULT_COOLDOWN_DAYS

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -793,7 +793,7 @@ RSpec.describe Dependabot::ApiClient do
       )
     end
 
-    context "when cooldown is nil" do
+    context "when job is nil" do
       it "does not send a request" do
         client.record_cooldown_meta(nil)
         expect(WebMock).not_to have_requested(:post, record_cooldown_meta_url)

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -774,11 +774,16 @@ RSpec.describe Dependabot::Job do
       end
     end
 
-    context "when cooldown is nil" do
+    context "when cooldown is not configured" do
       let(:cooldown) { nil }
 
-      it "returns nil" do
-        expect(job.cooldown).to be_nil
+      it "defaults all cooldown periods to DEFAULT_COOLDOWN_DAYS" do
+        expect(job.cooldown).to have_attributes(
+          default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS,
+          semver_major_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS,
+          semver_minor_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS,
+          semver_patch_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS
+        )
       end
     end
   end

--- a/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
@@ -385,6 +385,18 @@ RSpec.describe Dependabot::Updater::Operations::UpdateAllVersions do
       end
     end
 
+    context "when job is a version update without cooldown configured" do
+      it "passes the default cooldown to the UpdateChecker" do
+        update_all_versions.send(:update_checker_for, dependency, raise_on_ignored: false)
+
+        expect(stub_update_checker_class).to have_received(:new).with(
+          hash_including(
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS)
+          )
+        )
+      end
+    end
+
     context "when job is a version update with cooldown configured" do
       let(:job_definition) do
         job_definition_fixture("bundler/version_updates/pull_request_simple").tap do |definition|

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe Dependabot::Updater do
           security_advisories: anything,
           raise_on_ignored: anything,
           requirements_update_strategy: anything,
-          update_cooldown: nil,
+          update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
           options: anything
         ).once
       end
@@ -486,7 +486,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: false,
             requirements_update_strategy: anything,
-            update_cooldown: nil,
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
             options: anything
           )
         end
@@ -518,7 +518,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: true,
             requirements_update_strategy: anything,
-            update_cooldown: nil,
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
             options: anything
           )
         end
@@ -550,7 +550,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: true,
             requirements_update_strategy: anything,
-            update_cooldown: nil,
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
             options: anything
           )
         end
@@ -814,7 +814,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: true,
             requirements_update_strategy: anything,
-            update_cooldown: nil
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS)
           ).twice.ordered
           # this is the "peer checker" instantiation
           expect(Dependabot::Bundler::UpdateChecker).to have_received(:new).with(
@@ -827,7 +827,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: false,
             requirements_update_strategy: anything,
-            update_cooldown: nil
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS)
           ).ordered
         end
       end
@@ -2193,7 +2193,7 @@ RSpec.describe Dependabot::Updater do
           security_advisories: anything,
           raise_on_ignored: anything,
           requirements_update_strategy: anything,
-          update_cooldown: nil,
+          update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
           options: { large_hadron_collider: true }
         ).twice
       end


### PR DESCRIPTION
## Summary
- apply the three-day default when the job payload has no `cooldown` block
- preserve explicit `default-days: 0` opt-out and the security-update bypass
- remove obsolete nil handling from cooldown telemetry

## Reproduction
The DSP fixture [dependabot-default-cooldown-no-config](https://github.com/dsp-testing/dependabot-default-cooldown-no-config) omitted `cooldown` but opened [PR #1](https://github.com/dsp-testing/dependabot-default-cooldown-no-config/pull/1) for `3.1098.0`, released less than one day earlier. The newest release outside the three-day window was `3.1095.0`.

## Validation
- 261 updater examples
- RuboCop on changed files
- Sorbet typecheck