### PR TITLE
Feature flag clean up

### DIFF
--- a/silent/tests/testdata/err-fetching.txt
+++ b/silent/tests/testdata/err-fetching.txt
@@ -6,6 +6,8 @@ stdout 'mark_as_processed'
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/err-glob-not-found.txt
+++ b/silent/tests/testdata/err-glob-not-found.txt
@@ -6,6 +6,8 @@ stderr dependency_file_not_found
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "**/*"

--- a/silent/tests/testdata/err-parsing.txt
+++ b/silent/tests/testdata/err-parsing.txt
@@ -17,6 +17,8 @@ This isn't JSON
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/su-basic.txt
+++ b/silent/tests/testdata/su-basic.txt
@@ -42,6 +42,8 @@ pr-updated expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:
@@ -67,6 +69,8 @@ job:
 -- input-rebase-old.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:
@@ -98,6 +102,8 @@ job:
 -- input-rebase-new.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-err-all-versions-ignored-rebase.txt
+++ b/silent/tests/testdata/su-err-all-versions-ignored-rebase.txt
@@ -21,6 +21,8 @@ stdout '{"data":{"error-type":"all_versions_ignored","error-details":null},"type
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-err-all-versions-ignored.txt
+++ b/silent/tests/testdata/su-err-all-versions-ignored.txt
@@ -26,6 +26,8 @@ stdout -count=1 create_pull_request
 -- input-1.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:
@@ -47,6 +49,8 @@ job:
 -- input-2.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-err-dependency-not-found.txt
+++ b/silent/tests/testdata/su-err-dependency-not-found.txt
@@ -20,6 +20,8 @@ stdout '{"data":{"error-type":"security_update_dependency_not_found","error-deta
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - not-found
   source:

--- a/silent/tests/testdata/su-err-not-found.txt
+++ b/silent/tests/testdata/su-err-not-found.txt
@@ -30,6 +30,8 @@ stdout {"data":{"error-type":"security_update_not_found","error-details":{"depen
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-err-not-needed.txt
+++ b/silent/tests/testdata/su-err-not-needed.txt
@@ -20,6 +20,8 @@ stdout '{"data":{"error-type":"security_update_not_needed","error-details":{"dep
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-err-not-possible.txt
+++ b/silent/tests/testdata/su-err-not-possible.txt
@@ -31,6 +31,8 @@ stdout '{"data":{"error-type":"security_update_not_possible","error-details":{"c
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-err-not-supported.txt
+++ b/silent/tests/testdata/su-err-not-supported.txt
@@ -14,6 +14,8 @@ stdout '{"data":{"error-type":"dependency_file_not_supported","error-details":{"
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-err-not-vulnerable.txt
+++ b/silent/tests/testdata/su-err-not-vulnerable.txt
@@ -28,6 +28,8 @@ stdout {"data":{"error-type":"security_update_not_needed","error-details":{"depe
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-err-pr-exists-latest.txt
+++ b/silent/tests/testdata/su-err-pr-exists-latest.txt
@@ -21,6 +21,8 @@ stdout '{"data":{"error-type":"pull_request_exists_for_latest_version","error-de
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-err-pr-exists-security.txt
+++ b/silent/tests/testdata/su-err-pr-exists-security.txt
@@ -21,6 +21,8 @@ stdout '{"data":{"error-type":"pull_request_exists_for_security_update","error-d
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-exists-latest-dir.txt
+++ b/silent/tests/testdata/su-exists-latest-dir.txt
@@ -26,6 +26,8 @@ pr-created expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-exists-security-dir.txt
+++ b/silent/tests/testdata/su-exists-security-dir.txt
@@ -27,6 +27,8 @@ pr-created expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/su-group-pattern-multidir.txt
+++ b/silent/tests/testdata/su-group-pattern-multidir.txt
@@ -85,6 +85,8 @@ pr-created expected-individual-2.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - related-a
     - related-b

--- a/silent/tests/testdata/su-group-pattern.txt
+++ b/silent/tests/testdata/su-group-pattern.txt
@@ -54,6 +54,8 @@ pr-created expected-individual.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - related-a
     - related-b

--- a/silent/tests/testdata/su-group-semver.txt
+++ b/silent/tests/testdata/su-group-semver.txt
@@ -53,6 +53,8 @@ pr-created expected-individual.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/"

--- a/silent/tests/testdata/su-group-type.txt
+++ b/silent/tests/testdata/su-group-type.txt
@@ -54,6 +54,8 @@ pr-created expected-prod-group.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/"

--- a/silent/tests/testdata/su-multidir-rebase.txt
+++ b/silent/tests/testdata/su-multidir-rebase.txt
@@ -74,3 +74,5 @@ job:
     repo: test/dependabot-testing
     branch: main
   package-manager: silent
+  cooldown:
+    default-days: 0

--- a/silent/tests/testdata/su-multidir.txt
+++ b/silent/tests/testdata/su-multidir.txt
@@ -47,6 +47,8 @@ pr-created backend/expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
       - dependency-a
       - dependency-a

--- a/silent/tests/testdata/su-versions.txt
+++ b/silent/tests/testdata/su-versions.txt
@@ -36,6 +36,8 @@ pr-created expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   dependencies:
     - dependency-a
   source:

--- a/silent/tests/testdata/vs-close-up-to-date.txt
+++ b/silent/tests/testdata/vs-close-up-to-date.txt
@@ -23,6 +23,8 @@ stdout '{"data":{"dependency-names":\["dependency-a"\],"reason":"up_to_date"},"t
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-basic-directories.txt
+++ b/silent/tests/testdata/vu-basic-directories.txt
@@ -28,6 +28,8 @@ pr-updated expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/"
@@ -39,6 +41,8 @@ job:
 -- input-2.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/"

--- a/silent/tests/testdata/vu-basic.txt
+++ b/silent/tests/testdata/vu-basic.txt
@@ -37,6 +37,8 @@ pr-updated expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example
@@ -47,6 +49,8 @@ job:
 -- input-pr-exists.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example
@@ -63,6 +67,8 @@ job:
 -- input-rebase-old.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example
@@ -81,6 +87,8 @@ job:
 -- input-rebase-new.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-glob-overlap.txt
+++ b/silent/tests/testdata/vu-glob-overlap.txt
@@ -66,6 +66,8 @@ pr-created backend/expected-3.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "**/*"

--- a/silent/tests/testdata/vu-glob.txt
+++ b/silent/tests/testdata/vu-glob.txt
@@ -66,6 +66,8 @@ pr-created backend/expected-3.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "**/*"

--- a/silent/tests/testdata/vu-group-all.txt
+++ b/silent/tests/testdata/vu-group-all.txt
@@ -39,6 +39,8 @@ pr-updated expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example
@@ -54,6 +56,8 @@ job:
 -- input-updating-pr.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-err-creation.txt
+++ b/silent/tests/testdata/vu-group-err-creation.txt
@@ -43,6 +43,8 @@ pr-created expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-err-update.txt
+++ b/silent/tests/testdata/vu-group-err-update.txt
@@ -46,6 +46,8 @@ pr-created expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-exclude-patterns.txt
+++ b/silent/tests/testdata/vu-group-exclude-patterns.txt
@@ -54,6 +54,8 @@ pr-created expected-2.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-incidental.txt
+++ b/silent/tests/testdata/vu-group-incidental.txt
@@ -39,6 +39,8 @@ pr-created expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-individual.txt
+++ b/silent/tests/testdata/vu-group-individual.txt
@@ -55,6 +55,8 @@ pr-created expected-2.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-multidir-all.txt
+++ b/silent/tests/testdata/vu-group-multidir-all.txt
@@ -75,6 +75,8 @@ dependabot update -f input-preexisting.yml --local . --updater-image ghcr.io/dep
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/foo"
@@ -92,6 +94,8 @@ job:
 -- input-preexisting.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/foo"

--- a/silent/tests/testdata/vu-group-multidir-pattern.txt
+++ b/silent/tests/testdata/vu-group-multidir-pattern.txt
@@ -84,6 +84,8 @@ pr-created bar/expected-individual.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/foo"

--- a/silent/tests/testdata/vu-group-multidir-rebase.txt
+++ b/silent/tests/testdata/vu-group-multidir-rebase.txt
@@ -58,6 +58,8 @@ pr-updated foo/expected.json bar/expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/foo"

--- a/silent/tests/testdata/vu-group-multidir-semver.txt
+++ b/silent/tests/testdata/vu-group-multidir-semver.txt
@@ -65,6 +65,8 @@ pr-created foo/expected-2.json bar/expected-2.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/foo"

--- a/silent/tests/testdata/vu-group-multigroup-rebase-first.txt
+++ b/silent/tests/testdata/vu-group-multigroup-rebase-first.txt
@@ -46,6 +46,8 @@ pr-updated expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-multigroup-rebase-second.txt
+++ b/silent/tests/testdata/vu-group-multigroup-rebase-second.txt
@@ -47,6 +47,8 @@ pr-updated expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-overlap.txt
+++ b/silent/tests/testdata/vu-group-overlap.txt
@@ -36,6 +36,8 @@ pr-created expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-semver-error.txt
+++ b/silent/tests/testdata/vu-group-semver-error.txt
@@ -52,6 +52,8 @@ This is unparseable
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-semver-git.txt
+++ b/silent/tests/testdata/vu-group-semver-git.txt
@@ -41,6 +41,8 @@ pr-created expected-individual.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-semver-ignore-major.txt
+++ b/silent/tests/testdata/vu-group-semver-ignore-major.txt
@@ -46,6 +46,8 @@ pr-created expected-group.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-semver.txt
+++ b/silent/tests/testdata/vu-group-semver.txt
@@ -55,6 +55,8 @@ pr-created expected-individual.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-type.txt
+++ b/silent/tests/testdata/vu-group-type.txt
@@ -79,6 +79,8 @@ pr-created expected-prod-group.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-unmatched.txt
+++ b/silent/tests/testdata/vu-group-unmatched.txt
@@ -20,6 +20,8 @@ stdout create_pull_request
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-group-update-not-possible.txt
+++ b/silent/tests/testdata/vu-group-update-not-possible.txt
@@ -35,6 +35,8 @@ stdout -count=1 mark_as_processed
 -- input-up-to-date.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/up-to-date"
     provider: example
@@ -76,6 +78,8 @@ THIS IS NOT JSON
 -- input-errored.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/errors"
     provider: example

--- a/silent/tests/testdata/vu-incidental.txt
+++ b/silent/tests/testdata/vu-incidental.txt
@@ -47,6 +47,8 @@ pr-created expected-2.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-multi-ecosystem-combined-filters.txt
+++ b/silent/tests/testdata/vu-multi-ecosystem-combined-filters.txt
@@ -68,6 +68,8 @@ pr-created expected-prod-all.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-multi-ecosystem-dependency-type.txt
+++ b/silent/tests/testdata/vu-multi-ecosystem-dependency-type.txt
@@ -63,6 +63,8 @@ pr-created expected-prod-group.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-multi-ecosystem-exclude-patterns.txt
+++ b/silent/tests/testdata/vu-multi-ecosystem-exclude-patterns.txt
@@ -53,6 +53,8 @@ pr-created expected-grouped.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-multi-ecosystem-multidir-update-types.txt
+++ b/silent/tests/testdata/vu-multi-ecosystem-multidir-update-types.txt
@@ -56,6 +56,8 @@ dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/depe
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/frontend"

--- a/silent/tests/testdata/vu-multi-ecosystem-patterns-with-filters.txt
+++ b/silent/tests/testdata/vu-multi-ecosystem-patterns-with-filters.txt
@@ -38,6 +38,8 @@ dependabot update -f input.yml --local . --updater-image ghcr.io/dependabot/depe
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-multi-ecosystem-update-types.txt
+++ b/silent/tests/testdata/vu-multi-ecosystem-update-types.txt
@@ -47,6 +47,8 @@ pr-created expected-minor-patch-group.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-multidir-rebase.txt
+++ b/silent/tests/testdata/vu-multidir-rebase.txt
@@ -34,6 +34,8 @@ pr-created backend/expected.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
 #     - "/frontend" It's important that the API doesn't send unrelated directories.

--- a/silent/tests/testdata/vu-multidir.txt
+++ b/silent/tests/testdata/vu-multidir.txt
@@ -56,6 +56,8 @@ pr-created backend/expected-3.json
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directories:
       - "/frontend"

--- a/silent/tests/testdata/vu-unsupported.txt
+++ b/silent/tests/testdata/vu-unsupported.txt
@@ -14,6 +14,8 @@ stdout {"data":{"error-type":"tool_version_not_supported","error-details":{"dete
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/silent/tests/testdata/vu-update-not-possible.txt
+++ b/silent/tests/testdata/vu-update-not-possible.txt
@@ -14,6 +14,8 @@ This isn't JSON
 -- input.yml --
 job:
   package-manager: "silent"
+  cooldown:
+    default-days: 0
   source:
     directory: "/"
     provider: example

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -341,7 +341,8 @@ module Dependabot
     # rubocop:disable Metrics/MethodLength
     sig { params(job: T.nilable(Dependabot::Job)).void }
     def record_cooldown_meta(job)
-      return unless job
+      # The CLI's local API does not implement this hosted-service telemetry endpoint.
+      return if job.nil? || job_id == "cli"
 
       cooldown = job.cooldown
 

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -341,8 +341,7 @@ module Dependabot
     # rubocop:disable Metrics/MethodLength
     sig { params(job: T.nilable(Dependabot::Job)).void }
     def record_cooldown_meta(job)
-      # The CLI's local API does not implement this hosted-service telemetry endpoint.
-      return if job.nil? || job_id == "cli"
+      return if job.nil?
 
       cooldown = job.cooldown
 

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -341,7 +341,8 @@ module Dependabot
     # rubocop:disable Metrics/MethodLength
     sig { params(job: T.nilable(Dependabot::Job)).void }
     def record_cooldown_meta(job)
-      return if job.nil?
+      # The CLI's local API does not implement this hosted-service telemetry endpoint.
+      return if job.nil? || job_id == "cli"
 
       cooldown = job.cooldown
 

--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -341,9 +341,9 @@ module Dependabot
     # rubocop:disable Metrics/MethodLength
     sig { params(job: T.nilable(Dependabot::Job)).void }
     def record_cooldown_meta(job)
-      return if job&.cooldown.nil?
+      return unless job
 
-      cooldown = T.must(job).cooldown
+      cooldown = job.cooldown
 
       begin
         ::Dependabot::OpenTelemetry.tracer.in_span("record_cooldown_meta", kind: :internal) do |_span|
@@ -353,13 +353,13 @@ module Dependabot
             data: [
               {
                 cooldown: {
-                  ecosystem_name: T.must(job).package_manager,
+                  ecosystem_name: job.package_manager,
                   config:
                   {
-                    default_days: T.must(cooldown).default_days,
-                    semver_major_days: T.must(cooldown).semver_major_days,
-                    semver_minor_days: T.must(cooldown).semver_minor_days,
-                    semver_patch_days: T.must(cooldown).semver_patch_days
+                    default_days: cooldown.default_days,
+                    semver_major_days: cooldown.semver_major_days,
+                    semver_minor_days: cooldown.semver_minor_days,
+                    semver_patch_days: cooldown.semver_patch_days
                   }
                 }
               }

--- a/updater/lib/dependabot/job.rb
+++ b/updater/lib/dependabot/job.rb
@@ -39,8 +39,7 @@ module Dependabot
     extend T::Sig
 
     TOP_LEVEL_DEPENDENCY_TYPES = T.let(%w(direct production development).freeze, T::Array[String])
-    # Default cooldown period (in days) applied when a cooldown is configured
-    # without an explicit `default-days` value.
+    # Default cooldown period (in days) applied when `default-days` is not configured.
     DEFAULT_COOLDOWN_DAYS = 3
     PERMITTED_KEYS = T.let(
       %i(
@@ -128,7 +127,7 @@ module Dependabot
     sig { returns(T.nilable(String)) }
     attr_reader :dependency_group_to_refresh
 
-    sig { returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
+    sig { returns(Dependabot::Package::ReleaseCooldownOptions) }
     attr_reader :cooldown
 
     sig { returns(T::Array[Dependabot::Job::BlockedVersion]) }
@@ -246,7 +245,7 @@ module Dependabot
       @vendor_dependencies = T.let(definition.vendor_dependencies, T::Boolean)
       @cooldown = T.let(
         build_cooldown(definition.cooldown),
-        T.nilable(Dependabot::Package::ReleaseCooldownOptions)
+        Dependabot::Package::ReleaseCooldownOptions
       )
       @multi_ecosystem_update = T.let(definition.multi_ecosystem_update, T::Boolean)
       @dependency_groups = T.let(definition.dependency_groups, T::Array[DependencyGroupDefinition])
@@ -692,16 +691,19 @@ module Dependabot
 
     sig do
       params(cooldown: T.nilable(CooldownDefinition))
-        .returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions))
+        .returns(Dependabot::Package::ReleaseCooldownOptions)
     end
     def build_cooldown(cooldown)
-      return nil unless cooldown
+      unless cooldown
+        return Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: default_cooldown_days
+        )
+      end
 
       cooldown.to_options(default_days: default_cooldown_days)
     end
 
-    # The fallback applied when a cooldown block is present but `default-days`
-    # is not explicitly set. Defaults to DEFAULT_COOLDOWN_DAYS.
+    # The fallback applied when `default-days` is not explicitly set.
     sig { returns(Integer) }
     def default_cooldown_days
       DEFAULT_COOLDOWN_DAYS

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -799,6 +799,17 @@ RSpec.describe Dependabot::ApiClient do
         expect(WebMock).not_to have_requested(:post, record_cooldown_meta_url)
       end
     end
+
+    context "when running through the Dependabot CLI" do
+      subject(:client) { described_class.new("http://example.com", "cli", "token") }
+
+      let(:record_cooldown_meta_url) { "http://example.com/update_jobs/cli/record_cooldown_meta" }
+
+      it "does not send hosted-service telemetry" do
+        client.record_cooldown_meta(job)
+        expect(WebMock).not_to have_requested(:post, record_cooldown_meta_url)
+      end
+    end
   end
 
   describe "fetch_blocked_versions" do

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -793,7 +793,7 @@ RSpec.describe Dependabot::ApiClient do
       )
     end
 
-    context "when cooldown is nil" do
+    context "when job is nil" do
       it "does not send a request" do
         client.record_cooldown_meta(nil)
         expect(WebMock).not_to have_requested(:post, record_cooldown_meta_url)

--- a/updater/spec/dependabot/job_spec.rb
+++ b/updater/spec/dependabot/job_spec.rb
@@ -774,11 +774,16 @@ RSpec.describe Dependabot::Job do
       end
     end
 
-    context "when cooldown is nil" do
+    context "when cooldown is not configured" do
       let(:cooldown) { nil }
 
-      it "returns nil" do
-        expect(job.cooldown).to be_nil
+      it "defaults all cooldown periods to DEFAULT_COOLDOWN_DAYS" do
+        expect(job.cooldown).to have_attributes(
+          default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS,
+          semver_major_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS,
+          semver_minor_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS,
+          semver_patch_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS
+        )
       end
     end
   end

--- a/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/update_all_versions_spec.rb
@@ -385,6 +385,18 @@ RSpec.describe Dependabot::Updater::Operations::UpdateAllVersions do
       end
     end
 
+    context "when job is a version update without cooldown configured" do
+      it "passes the default cooldown to the UpdateChecker" do
+        update_all_versions.send(:update_checker_for, dependency, raise_on_ignored: false)
+
+        expect(stub_update_checker_class).to have_received(:new).with(
+          hash_including(
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS)
+          )
+        )
+      end
+    end
+
     context "when job is a version update with cooldown configured" do
       let(:job_definition) do
         job_definition_fixture("bundler/version_updates/pull_request_simple").tap do |definition|

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe Dependabot::Updater do
           security_advisories: anything,
           raise_on_ignored: anything,
           requirements_update_strategy: anything,
-          update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
+          update_cooldown: having_attributes(default_days: 0),
           options: anything
         ).once
       end
@@ -486,7 +486,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: false,
             requirements_update_strategy: anything,
-            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
+            update_cooldown: having_attributes(default_days: 0),
             options: anything
           )
         end
@@ -518,7 +518,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: true,
             requirements_update_strategy: anything,
-            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
+            update_cooldown: having_attributes(default_days: 0),
             options: anything
           )
         end
@@ -550,7 +550,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: true,
             requirements_update_strategy: anything,
-            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
+            update_cooldown: having_attributes(default_days: 0),
             options: anything
           )
         end
@@ -814,7 +814,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: true,
             requirements_update_strategy: anything,
-            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS)
+            update_cooldown: having_attributes(default_days: 0)
           ).twice.ordered
           # this is the "peer checker" instantiation
           expect(Dependabot::Bundler::UpdateChecker).to have_received(:new).with(
@@ -827,7 +827,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: false,
             requirements_update_strategy: anything,
-            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS)
+            update_cooldown: having_attributes(default_days: 0)
           ).ordered
         end
       end
@@ -2193,7 +2193,7 @@ RSpec.describe Dependabot::Updater do
           security_advisories: anything,
           raise_on_ignored: anything,
           requirements_update_strategy: anything,
-          update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
+          update_cooldown: having_attributes(default_days: 0),
           options: { large_hadron_collider: true }
         ).twice
       end
@@ -2540,7 +2540,7 @@ RSpec.describe Dependabot::Updater do
     dependency_groups: [],
     lockfile_only: false,
     repo_contents_path: nil,
-    update_cooldown: nil
+    update_cooldown: { "default-days" => 0 }
   )
     Dependabot::Job.new(
       id: "1",
@@ -2586,7 +2586,7 @@ RSpec.describe Dependabot::Updater do
       security_updates_only: security_updates_only,
       repo_contents_path: repo_contents_path,
       dependency_groups: dependency_groups,
-      update_cooldown: update_cooldown
+      cooldown: update_cooldown
     )
   end
   # rubocop:enable Metrics/MethodLength

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe Dependabot::Updater do
           security_advisories: anything,
           raise_on_ignored: anything,
           requirements_update_strategy: anything,
-          update_cooldown: nil,
+          update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
           options: anything
         ).once
       end
@@ -486,7 +486,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: false,
             requirements_update_strategy: anything,
-            update_cooldown: nil,
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
             options: anything
           )
         end
@@ -518,7 +518,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: true,
             requirements_update_strategy: anything,
-            update_cooldown: nil,
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
             options: anything
           )
         end
@@ -550,7 +550,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: true,
             requirements_update_strategy: anything,
-            update_cooldown: nil,
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
             options: anything
           )
         end
@@ -814,7 +814,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: true,
             requirements_update_strategy: anything,
-            update_cooldown: nil
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS)
           ).twice.ordered
           # this is the "peer checker" instantiation
           expect(Dependabot::Bundler::UpdateChecker).to have_received(:new).with(
@@ -827,7 +827,7 @@ RSpec.describe Dependabot::Updater do
             security_advisories: anything,
             raise_on_ignored: false,
             requirements_update_strategy: anything,
-            update_cooldown: nil
+            update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS)
           ).ordered
         end
       end
@@ -2193,7 +2193,7 @@ RSpec.describe Dependabot::Updater do
           security_advisories: anything,
           raise_on_ignored: anything,
           requirements_update_strategy: anything,
-          update_cooldown: nil,
+          update_cooldown: having_attributes(default_days: Dependabot::Job::DEFAULT_COOLDOWN_DAYS),
           options: { large_hadron_collider: true }
         ).twice
       end


### PR DESCRIPTION
### What are you trying to accomplish?

Make the documented three-day cooldown apply when a version-update job has no `cooldown` block. Currently, `Job#build_cooldown` returns `nil` for an absent block, so update checkers receive no cooldown and can select releases published less than three days ago.

This change constructs the default three-day cooldown when configuration is absent, while preserving an explicit `default-days: 0` opt-out and the existing security-update bypass. It also removes obsolete nil handling from cooldown telemetry now that version-update jobs always have effective cooldown options.

### Anything you want to highlight for special attention from reviewers?

The default is applied in Core rather than synthesizing a `cooldown` block in the API job payload. This keeps explicit configuration parsing unchanged and ensures CLI/local jobs receive the same default behavior. Security update paths continue passing `nil` to update checkers, so security fixes are not delayed.

### How will you know you've accomplished your goal?

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
