### PR TITLE
Support array, glob, and gh variable in target-branch

### DIFF
--- a/common/lib/dependabot/config/file.rb
+++ b/common/lib/dependabot/config/file.rb
@@ -3,6 +3,7 @@
 
 require "dependabot/config/update_config"
 require "sorbet-runtime"
+require "wildcard_matcher"
 
 module Dependabot
   module Config
@@ -10,7 +11,7 @@ module Dependabot
     class File
       extend T::Sig
 
-      sig { returns(T::Array[T::Hash[Symbol, String]]) }
+      sig { returns(T::Array[T::Hash[Symbol, T.anything]]) }
       attr_reader :updates
 
       sig { returns(T::Hash[Symbol, T::Hash[Symbol, String]]) }
@@ -18,13 +19,13 @@ module Dependabot
 
       sig do
         params(
-          updates: T.nilable(T::Array[T::Hash[Symbol, String]]),
+          updates: T.nilable(T::Array[T::Hash[Symbol, T.anything]]),
           registries: T.nilable(T::Hash[Symbol, T::Hash[Symbol, String]])
         )
           .void
       end
       def initialize(updates:, registries: nil)
-        @updates = T.let(updates || [], T::Array[T::Hash[Symbol, String]])
+        @updates = T.let(updates || [], T::Array[T::Hash[Symbol, T.anything]])
         @registries = T.let(registries || {}, T::Hash[Symbol, T::Hash[Symbol, String]])
       end
 
@@ -36,8 +37,9 @@ module Dependabot
         dir = directory || "/"
         package_ecosystem = REVERSE_PACKAGE_MANAGER_LOOKUP.fetch(package_manager, "dummy")
         cfg = updates.find do |u|
-          u[:"package-ecosystem"] == package_ecosystem && u[:directory] == dir &&
-            (target_branch.nil? || u[:"target-branch"] == target_branch)
+          string_value(u[:"package-ecosystem"]) == package_ecosystem &&
+            string_value(u[:directory]) == dir &&
+            match_target_branch?(u[:"target-branch"], target_branch)
         end
         UpdateConfig.new(
           ignore_conditions: ignore_conditions(cfg),
@@ -57,6 +59,39 @@ module Dependabot
       end
 
       private
+
+      sig { params(config_branch: T.anything, target_branch: T.nilable(String)).returns(T::Boolean) }
+      def match_target_branch?(config_branch, target_branch)
+        return true if target_branch.nil?
+
+        case config_branch
+        when Array
+          config_branch.any? do |branch|
+            case branch
+            when String then match_branch_pattern?(branch, target_branch)
+            else false
+            end
+          end
+        when String
+          match_branch_pattern?(config_branch, target_branch)
+        else
+          false
+        end
+      end
+
+      sig { params(pattern: T.nilable(String), target_branch: String).returns(T::Boolean) }
+      def match_branch_pattern?(pattern, target_branch)
+        return true if pattern == target_branch
+        return false if pattern.nil?
+
+        # match gh variable
+        return true if pattern.start_with?("${{") && pattern.end_with?("}}")
+
+        # match glob pattern
+        return true if pattern.include?("*") && WildcardMatcher.match?(pattern, target_branch)
+
+        false
+      end
 
       PACKAGE_MANAGER_LOOKUP = T.let(
         {

--- a/common/spec/dependabot/config/file_spec.rb
+++ b/common/spec/dependabot/config/file_spec.rb
@@ -46,6 +46,54 @@ RSpec.describe Dependabot::Config::File do
         expect(update_config).to be_a(Dependabot::Config::UpdateConfig)
         expect(update_config.commit_message_options.prefix).to be_nil
       end
+
+      context "with advanced target-branch patterns" do
+        let(:yaml) do
+          <<~YAML
+            version: 2
+            updates:
+              - package-ecosystem: "npm"
+                directory: "/target"
+                target-branch: ["branch-a", "branch-b"]
+                commit-message:
+                  prefix: "array match"
+              - package-ecosystem: "npm"
+                directory: "/target"
+                target-branch: "features/*"
+                commit-message:
+                  prefix: "glob match"
+              - package-ecosystem: "npm"
+                directory: "/target"
+                target-branch: "${{ github.event.repository.default_branch }}"
+                commit-message:
+                  prefix: "variable match"
+          YAML
+        end
+        let(:advanced_config) { described_class.parse(yaml) }
+
+        it "matches an array of branches" do
+          update_config = advanced_config.update_config("npm_and_yarn", directory: "/target", target_branch: "branch-b")
+          expect(update_config.commit_message_options.prefix).to eq("array match")
+        end
+
+        it "matches a glob pattern" do
+          update_config = advanced_config.update_config(
+            "npm_and_yarn",
+            directory: "/target",
+            target_branch: "features/new-thing"
+          )
+          expect(update_config.commit_message_options.prefix).to eq("glob match")
+        end
+
+        it "matches a gh variable automatically" do
+          update_config = advanced_config.update_config(
+            "npm_and_yarn",
+            directory: "/target",
+            target_branch: "any-branch-at-all"
+          )
+          expect(update_config.commit_message_options.prefix).to eq("variable match")
+        end
+      end
     end
 
     describe "#parse" do


### PR DESCRIPTION
This PR adds support for arrays, glob patterns, and GitHub variables in the `target-branch` configuration.

Motivation: One of my use cases involves keeping multiple branches upto date using dependabot, which currently needs me to have the same exact configuration repeated with just the target-branch variable changed. This change would be a much cleaner solution for my use case.
