### PR TITLE
Regenerate packages.lock.json after NuGet dependency updates

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
@@ -1382,6 +1382,269 @@ public class EndToEndTests
     }
 
     [Fact]
+    public async Task LockFileIsRegeneratedWithCentralPackageManagementAndLockedMode()
+    {
+        // this test needs to do some dynamic checks so we have to set it up manually
+        // the package version is managed centrally in `Directory.Packages.props` and the update is written through the
+        // project that has no lock file, but a sibling project that imports the same file owns a `packages.lock.json`
+        // and sets `RestoreLockedMode`; the restores performed during discovery report NU1004 and refuse to rewrite
+        // that now out-of-date lock file, so it has to be regenerated explicitly or the pull request will contain a
+        // `Directory.Packages.props` that no longer agrees with the lock file
+
+        // arrange
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("Directory.Packages.props", """
+                <Project>
+                  <PropertyGroup>
+                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageVersion Include="Some.Package" Version="1.0.0" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/dirs.proj", """
+                <Project>
+                  <ItemGroup>
+                    <ProjectFile Include="app\app.csproj" />
+                    <ProjectFile Include="library\library.csproj" />
+                  </ItemGroup>
+                </Project>
+                """),
+            // this project has no lock file, so the update can be written through it
+            ("src/library/library.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Some.Package" />
+                  </ItemGroup>
+                </Project>
+                """),
+            // ...but this project's lock file has to be brought along with it
+            ("src/app/app.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Some.Package" />
+                  </ItemGroup>
+                </Project>
+                """)
+        );
+        var repoContentsPath = tempDirectory.DirectoryPath;
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory([
+            MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0", [(null, [("Transitive.Package", "1.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Some.Package", "2.0.0", "net9.0", [(null, [("Transitive.Package", "2.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Transitive.Package", "1.0.0", "net9.0"),
+            MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.0.0", "net9.0"),
+        ], repoContentsPath);
+
+        // the lock file can't be hand-authored because the mock packages get a different `contentHash` on every run, so
+        // a real restore has to produce it; `RestoreLockedMode` is only turned on afterwards, which is also the order
+        // these repos are built in practice - the committed lock file comes from an ordinary restore and only later
+        // builds are locked
+        var appProjectPath = Path.Join(repoContentsPath, "src", "app", "app.csproj");
+        var appLockFilePath = Path.Join(repoContentsPath, "src", "app", "packages.lock.json");
+        var (exitCode, stdout, stderr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(["restore", appProjectPath], repoContentsPath);
+        Assert.True(exitCode == 0, $"Initial restore failed.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+
+        var initialLockFileJson = JsonDocument.Parse(await File.ReadAllTextAsync(appLockFilePath, TestContext.Current.CancellationToken));
+        var initialResolved = initialLockFileJson.RootElement
+            .GetProperty("dependencies")
+            .GetProperty("net9.0")
+            .GetProperty("Some.Package")
+            .GetProperty("resolved")
+            .GetString();
+        Assert.Equal("1.0.0", initialResolved);
+
+        await File.WriteAllTextAsync(appProjectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net9.0</TargetFramework>
+                <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+                <RestoreLockedMode>true</RestoreLockedMode>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Some.Package" />
+              </ItemGroup>
+            </Project>
+            """, TestContext.Current.CancellationToken);
+
+        var jobId = "TEST-JOB-ID";
+        var experimentsManager = new ExperimentsManager();
+        var logger = new TestLogger();
+        var apiHandler = new TestApiHandler();
+        var discoveryWorker = new DiscoveryWorker(jobId, experimentsManager, logger);
+        var analyzeWorker = new AnalyzeWorker(jobId, experimentsManager, logger);
+        var updaterWorker = new UpdaterWorker(jobId, experimentsManager, logger);
+        var worker = new RunWorker(jobId, apiHandler, discoveryWorker, analyzeWorker, updaterWorker, logger);
+        var job = new Job()
+        {
+            Source = new()
+            {
+                Provider = "github",
+                Repo = "test/repo",
+                Directory = "/src",
+            }
+        };
+
+        // act
+        await worker.RunAsync(job, new DirectoryInfo(repoContentsPath), null, "TEST-COMMIT-SHA", experimentsManager);
+
+        // assert
+        var createPr = (CreatePullRequest)apiHandler.ReceivedMessages.Single(m => m.Type == typeof(CreatePullRequest)).Object;
+        var updatedFiles = createPr.UpdatedDependencyFiles.ToDictionary(df => Path.Join(df.Directory, df.Name).NormalizePathToUnix(), df => df.Content.Replace("\r", ""));
+
+        // neither project is changed; the version only lives in the central package management file
+        Assert.False(updatedFiles.ContainsKey("/src/app/app.csproj"));
+        Assert.False(updatedFiles.ContainsKey("/src/library/library.csproj"));
+        Assert.Equal("""
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="Some.Package" Version="2.0.0" />
+              </ItemGroup>
+            </Project>
+            """.Replace("\r", ""), updatedFiles["/Directory.Packages.props"]);
+
+        // the lock file was regenerated despite the owning project being in locked mode
+        var lockFileDependencies = JsonDocument.Parse(updatedFiles["/src/app/packages.lock.json"]).RootElement
+            .GetProperty("dependencies")
+            .GetProperty("net9.0");
+        Assert.Equal("2.0.0", lockFileDependencies.GetProperty("Some.Package").GetProperty("resolved").GetString());
+        Assert.Equal("2.0.0", lockFileDependencies.GetProperty("Transitive.Package").GetProperty("resolved").GetString());
+    }
+
+    [Fact]
+    public async Task LockFileIsRegeneratedForSingleProjectWithCentralPackageManagementAndLockedMode()
+    {
+        // this test needs to do some dynamic checks so we have to set it up manually
+        // this is the single project shape of the scenario above: the one project both owns the `packages.lock.json`
+        // and carries the `PackageReference` whose version comes from `Directory.Packages.props`; once the new version
+        // is written the lock file is out of date, so the verification discovery that follows the write reports NU1004,
+        // returns nothing, and the update is rolled back - the result being no pull request at all unless discovery's
+        // restore ignores locked mode
+
+        // arrange
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("Directory.Packages.props", """
+                <Project>
+                  <PropertyGroup>
+                    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageVersion Include="Some.Package" Version="1.0.0" />
+                  </ItemGroup>
+                </Project>
+                """),
+            ("src/app/app.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Some.Package" />
+                  </ItemGroup>
+                </Project>
+                """)
+        );
+        var repoContentsPath = tempDirectory.DirectoryPath;
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory([
+            MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net9.0", [(null, [("Transitive.Package", "1.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Some.Package", "2.0.0", "net9.0", [(null, [("Transitive.Package", "2.0.0")])]),
+            MockNuGetPackage.CreateSimplePackage("Transitive.Package", "1.0.0", "net9.0"),
+            MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.0.0", "net9.0"),
+        ], repoContentsPath);
+
+        // the lock file can't be hand-authored because the mock packages get a different `contentHash` on every run, so
+        // a real restore has to produce it; `RestoreLockedMode` is only turned on afterwards, which is also the order
+        // these repos are built in practice - the committed lock file comes from an ordinary restore and only later
+        // builds are locked
+        var appProjectPath = Path.Join(repoContentsPath, "src", "app", "app.csproj");
+        var appLockFilePath = Path.Join(repoContentsPath, "src", "app", "packages.lock.json");
+        var (exitCode, stdout, stderr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(["restore", appProjectPath], repoContentsPath);
+        Assert.True(exitCode == 0, $"Initial restore failed.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+
+        var initialLockFileJson = JsonDocument.Parse(await File.ReadAllTextAsync(appLockFilePath, TestContext.Current.CancellationToken));
+        var initialResolved = initialLockFileJson.RootElement
+            .GetProperty("dependencies")
+            .GetProperty("net9.0")
+            .GetProperty("Some.Package")
+            .GetProperty("resolved")
+            .GetString();
+        Assert.Equal("1.0.0", initialResolved);
+
+        await File.WriteAllTextAsync(appProjectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net9.0</TargetFramework>
+                <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+                <RestoreLockedMode>true</RestoreLockedMode>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Some.Package" />
+              </ItemGroup>
+            </Project>
+            """, TestContext.Current.CancellationToken);
+
+        var jobId = "TEST-JOB-ID";
+        var experimentsManager = new ExperimentsManager();
+        var logger = new TestLogger();
+        var apiHandler = new TestApiHandler();
+        var discoveryWorker = new DiscoveryWorker(jobId, experimentsManager, logger);
+        var analyzeWorker = new AnalyzeWorker(jobId, experimentsManager, logger);
+        var updaterWorker = new UpdaterWorker(jobId, experimentsManager, logger);
+        var worker = new RunWorker(jobId, apiHandler, discoveryWorker, analyzeWorker, updaterWorker, logger);
+        var job = new Job()
+        {
+            Source = new()
+            {
+                Provider = "github",
+                Repo = "test/repo",
+                Directory = "/src/app",
+            }
+        };
+
+        // act
+        await worker.RunAsync(job, new DirectoryInfo(repoContentsPath), null, "TEST-COMMIT-SHA", experimentsManager);
+
+        // assert
+        var createPr = (CreatePullRequest)apiHandler.ReceivedMessages.Single(m => m.Type == typeof(CreatePullRequest)).Object;
+        var updatedFiles = createPr.UpdatedDependencyFiles.ToDictionary(df => Path.Join(df.Directory, df.Name).NormalizePathToUnix(), df => df.Content.Replace("\r", ""));
+
+        // the project isn't changed; the version only lives in the central package management file
+        Assert.False(updatedFiles.ContainsKey("/src/app/app.csproj"));
+        Assert.Equal("""
+            <Project>
+              <PropertyGroup>
+                <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+                <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageVersion Include="Some.Package" Version="2.0.0" />
+              </ItemGroup>
+            </Project>
+            """.Replace("\r", ""), updatedFiles["/Directory.Packages.props"]);
+
+        // the lock file was regenerated despite the project being in locked mode
+        var lockFileDependencies = JsonDocument.Parse(updatedFiles["/src/app/packages.lock.json"]).RootElement
+            .GetProperty("dependencies")
+            .GetProperty("net9.0");
+        Assert.Equal("2.0.0", lockFileDependencies.GetProperty("Some.Package").GetProperty("resolved").GetString());
+        Assert.Equal("2.0.0", lockFileDependencies.GetProperty("Transitive.Package").GetProperty("resolved").GetString());
+    }
+
+    [Fact]
     public async Task FindRootDirectory_ExpandsDirectoryThroughProjChain()
     {
         // Job starts at /src/client, but a .proj chain leads up to the repo root.

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -202,6 +202,11 @@ internal static class SdkProjectDiscovery
                 // if using CPM and a project also sets TreatWarningsAsErrors to true, this can cause discovery to fail; explicitly don't allow that
                 args.Add("/p:TreatWarningsAsErrors=false");
                 args.Add("/p:MSBuildTreatWarningsAsErrors=false");
+
+                // discovery's restore is a read-only evaluation of the dependency graph; a project that sets `RestoreLockedMode`
+                // would otherwise fail it with NU1004 whenever the lock file is out of date, which is exactly the situation we're
+                // in after a version has been written
+                args.Add("/p:RestoreLockedMode=false");
                 args.Add($"/bl:{binLogPath}");
 
                 var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, startingProjectDirectory);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -146,6 +146,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
                 }
             }
 
+            await LockFileUpdater.UpdateLockFilesAsync(repoContentsPath, discoveryResult, logger);
             var updatedDependencyFiles = await tracker.StopTrackingAsync();
             var rawDependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)).ToArray();
             if (rawDependencies.Length > 0)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -149,6 +149,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     }
                 }
 
+                await LockFileUpdater.UpdateLockFilesAsync(repoContentsPath, discoveryResult, logger);
                 var updatedDependencyFiles = await tracker.StopTrackingAsync(restoreOriginalContents: true);
                 allUpdatedDependencyFiles = ModifiedFilesTracker.MergeUpdatedFileSet(allUpdatedDependencyFiles, updatedDependencyFiles);
             }
@@ -268,6 +269,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     }
                 }
 
+                await LockFileUpdater.UpdateLockFilesAsync(repoContentsPath, discoveryResult, logger);
                 var updatedDependencyFiles = await tracker.StopTrackingAsync(restoreOriginalContents: true);
                 if (updateOperationsPerformed.Count > 0)
                 {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -146,6 +146,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                 }
             }
 
+            await LockFileUpdater.UpdateLockFilesAsync(repoContentsPath, discoveryResult, logger);
             var updatedDependencyFiles = await tracker.StopTrackingAsync();
             allUpdatedDependencyFiles = ModifiedFilesTracker.MergeUpdatedFileSet(allUpdatedDependencyFiles, updatedDependencyFiles);
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -156,6 +156,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
             }
 
             // update or create
+            await LockFileUpdater.UpdateLockFilesAsync(repoContentsPath, discoveryResult, logger);
             var updatedDependencyFiles = await tracker.StopTrackingAsync();
             var rawDependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)).ToArray();
             if (rawDependencies.Length > 0)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -146,6 +146,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
             }
 
             // update or create
+            await LockFileUpdater.UpdateLockFilesAsync(repoContentsPath, discoveryResult, logger);
             var updatedDependencyFiles = await tracker.StopTrackingAsync();
             var rawDependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)).ToArray();
             if (rawDependencies.Length > 0)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/LockFileUpdater.cs
@@ -1,17 +1,63 @@
+using NuGetUpdater.Core.Discover;
+using NuGetUpdater.Core.Utilities;
+
 namespace NuGetUpdater.Core;
 
 internal static class LockFileUpdater
 {
-    public static async Task UpdateLockFileAsync(
-        string repoRootPath,
+    /// <summary>
+    /// Regenerates the `packages.lock.json` file of every discovered project that has one.  This can't be left to the
+    /// plain restore that discovery performs: a project with `RestoreLockedMode` set will refuse to rewrite an
+    /// out-of-date lock file and report NU1004 instead, and with Central Package Management the version change lands
+    /// in a `Directory.Packages.props` that the lock-file-owning project merely imports, so the pinned transitive
+    /// versions are never re-resolved.  `dotnet restore --force-evaluate` is the only command that rewrites the lock
+    /// file in either case.
+    /// </summary>
+    public static async Task UpdateLockFilesAsync(
+        DirectoryInfo repoContentsPath,
+        WorkspaceDiscoveryResult discoveryResult,
+        ILogger logger)
+    {
+        foreach (var project in discoveryResult.Projects)
+        {
+            // `AdditionalFiles` entries are relative to the project's own directory
+            var hasLockFile = project.AdditionalFiles.Any(f => Path.GetFileName(f).Equals(ProjectHelper.PackagesLockJsonFileName, StringComparison.OrdinalIgnoreCase));
+            if (!hasLockFile)
+            {
+                continue;
+            }
+
+            var projectPath = Path.Join(repoContentsPath.FullName, discoveryResult.Path, project.FilePath).FullyNormalizedRootedPath();
+            if (!File.Exists(projectPath))
+            {
+                continue;
+            }
+
+            logger.Info($"Regenerating lock file for project [{project.FilePath}]");
+            await UpdateLockFileAsync(projectPath, logger);
+        }
+    }
+
+    private static async Task UpdateLockFileAsync(
         string projectPath,
         ILogger logger)
     {
         var projectDirectory = Path.GetDirectoryName(projectPath)!;
-        var (exitCode, stdout, stderr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(["restore", "--force-evaluate", "-p:EnableWindowsTargeting=true", projectPath], projectDirectory);
+        var args = new List<string>()
+        {
+            "restore",
+            "--force-evaluate",
+            "-p:EnableWindowsTargeting=true",
+            // if using CPM and a project also sets TreatWarningsAsErrors to true, this can cause the restore to fail; explicitly don't allow that
+            "-p:TreatWarningsAsErrors=false",
+            "-p:MSBuildTreatWarningsAsErrors=false",
+            projectPath,
+        };
+        var (exitCode, stdout, stderr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(args, projectDirectory);
         if (exitCode != 0)
         {
-            logger.Error($"      Lock file update failed.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+            // a failed lock file regeneration shouldn't fail the whole update; report it and keep going
+            logger.Error($"  Lock file update failed for [{projectPath}].\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
         }
     }
 }


### PR DESCRIPTION
Dependabot updates a NuGet dependency but leaves `packages.lock.json` untouched, so the resulting PR fails the consumer's build:

```
error NU1004: The package reference AspNetCore.HealthChecks.MySql version has changed from [8.0.1, ) to [9.0.0, ).
error NU1004: Mistmatch between the requestedVersion of a lock file dependency marked as CentralTransitive and
              the version specified in the central package management file.
              Lock file version [14.1.2, ), central package management version [14.2.0, ).
The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode.
Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to
update the lock file.
```

The repo shape that triggers it: Central Package Management at the root (`Directory.Packages.props` with `CentralPackageTransitivePinningEnabled`), and a single project in the solution opting into `RestorePackagesWithLockFile` + `RestoreLockedMode`. The PR updates `Directory.Packages.props` only; the lock file is never regenerated.

## Root cause

Lock files are currently regenerated only as a *side effect* of the plain restore that discovery performs — see the comment at `FileWriterWorker.cs:279`, "this final call to discover has the benefit of also updating the lock file if it exists". That is not sufficient, for two independent reasons.

**1. A plain restore refuses to rewrite the lock file under locked mode.** In `RestoreCommand.cs` the NU1004 bail-out is guarded solely by `RestoreLockedMode`, and `RestoreForceEvaluate` short-circuits lock-file validation entirely:

```csharp
// read packages.lock.json file if exists and RestoreForceEvaluate flag is not set to true
if (!_request.RestoreForceEvaluate && File.Exists(packagesLockFilePath))
...
    else if (_request.IsRestoreOriginalAction && _request.Project.RestoreMetadata.RestoreLockProperties.RestoreLockedMode)
    {
        success = false;   // NU1004
```

`MSBuildHelper.ThrowOnError` does not match NU1004, so `SdkProjectDiscovery.cs:223` logs it as a warning and carries on. The stale lock file ships in the PR.

**2. Under CPM the write may not even touch the lock-file-owning project.** The version lands in a shared `Directory.Packages.props`. `RunWorker.GetUpdateOperations` emits one operation per project per dependency, and once the first project's write satisfies the others, `FileWriterWorker.cs:163` early-returns for the rest. Discovery is also scoped to the initial project's directory plus its `ProjectReference` closure, so a sibling project that owns a lock file is out of scope entirely.

There is already a helper that does the right thing — `LockFileUpdater`, which runs `dotnet restore --force-evaluate`. It has had **zero callers** since b180e6a03 removed the `PackageReferenceUpdater` path; the replacement `FileWriterWorker` path never picked it back up.

## The fix

**Re-wire `LockFileUpdater` at handler level.** New `UpdateLockFilesAsync` iterates every project in the discovery result whose `AdditionalFiles` contains a `packages.lock.json` and runs `dotnet restore --force-evaluate` for it. Called from six sites across the five update handlers, immediately before `tracker.StopTrackingAsync(...)`, so the regenerated file is picked up by the existing diffing machinery — `ModifiedFilesTracker` already lists `packages.lock.json` in `AllowedEditableFilePatterns` and already snapshots `AdditionalFiles`, so nothing changed there.

Iterating the whole discovery result rather than just the written project is what covers the CPM case. When no project has a lock file the method launches no processes, so the common case is unaffected.

It passes `-p:SolutionDir=` when discovery captured a solution directory, using the same rooting and trailing-separator normalisation as `SdkProjectDiscovery`, and sets `-p:EnableWindowsTargeting=true` only for projects with a `-windows` TFM, matching the condition in `DependencyDiscovery.props:16`.

**Stop discovery's restore from tripping over locked mode.** `SdkProjectDiscovery` now passes `/p:RestoreLockedMode=false`. Discovery's restore is a read-only evaluation of the dependency graph; it has no business being blocked by the consumer's locked-mode policy.

This second part is not cosmetic. Without it, a *single-project* repo in this shape gets no PR at all: the version is written to `Directory.Packages.props`, the verification discovery at `FileWriterWorker.cs:279` then fails NU1004, `finalProjectDiscovery` comes back null, and `RestoreOriginalFileContentsAsync` rolls the write back. The handler-level refresh runs too late to help. Both parts are needed.

**Only regenerate for directories that performed an update.** The first draft called `UpdateLockFilesAsync` unconditionally. Four of the six sites ran it even when nothing had been updated, and the worst — in `RunUngroupedDependencyUpdates`, the default path for ordinary version updates — sat *inside* the per-dependency-set loop while the "did we update anything" check was two lines below it. That meant a full `dotnet restore --force-evaluate` per lock-file-owning project per outdated dependency, including for dependencies later filtered out as not permitted, ignored, or not updatable. Each call is now gated; `StopTrackingAsync` deliberately stays unconditional, since in the grouped handlers it is what restores the working tree between directories. `RefreshSecurityUpdatePullRequestHandler` and `RefreshVersionUpdatePullRequestHandler` already return early unless every requested dependency updated, so they were left alone.

## Tests

Four end-to-end tests, all CPM + `RestoreLockedMode=true`.

Two cover the discovery half: one multi-project (PR contains a stale lock file today) and one single-project (no PR at all today). Each was confirmed to fail with the corresponding fix reverted.

Two cover the handler wiring, which the first two do *not*: because `FileWriterWorker` re-runs discovery scoped to the project it wrote, and that restore now ignores locked mode, deleting every `UpdateLockFilesAsync` call left the first two tests green. In the new pair the lock-file-owning project reaches the updated package only through a `<ProjectReference>`, so it is never top-level, `Job.IsUpdatePermitted` filters it out before the writer runs, and no discovery is ever scoped to its directory — only `UpdateLockFilesAsync` can bring its lock file up to date. One exercises the ungrouped path, one the grouped. Both were confirmed to fail with all six calls removed.

Existing lock-file tests all seed an empty stub (`"{}"`), which NuGet unconditionally rewrites — that is why this went unnoticed. These tests instead generate a genuine lock file by running a real restore during arrange, then enable locked mode. The lock file can't be hand-authored: `MockNuGetPackage` nupkgs embed `DateTime.Now` in their zip entries, so `contentHash` differs on every run.

## Notes for reviewers

- **Coverage gap.** The two new tests cover the ungrouped and grouped sites in `GroupUpdateAllVersionsHandler`. The sites in `CreateSecurityUpdatePullRequestHandler` and `RefreshGroupUpdatePullRequestHandler` are gated but have no red/green test — the former filters on vulnerability and the latter never consults `IsUpdatePermitted`, so neither is reachable from this fixture. The grouped test also only exercises its per-directory snapshot gate in the single-directory case, where it degenerates to a plain count check.
- **Multi-directory CPM is still open**, and is pre-existing rather than introduced here. In `RefreshGroupUpdatePullRequestHandler`, which does not restore original contents between directories, a shared root `Directory.Packages.props` written during directory 1 persists; directory 2's discovery then rewrites its lock file *before* `StartTrackingAsync` baselines it, so the lock is silently brought up to date and never reported. Before this change neither directory's lock file was regenerated at all. Closing it means reworking the per-directory rollback across all the handlers — happy to open a separate issue.
- **`git init` is now required in tests that use `ModifiedFilesTracker`.** `StopTrackingAsync` reads line endings from the Git index via `GitEOLMetadataProvider`, which throws outside a repository. This does not reproduce on a developer machine, because fixtures are created under `artifacts/` inside this repo's own checkout and `git` walks up to find it; it fails only in the container. It cost a full debugging cycle here and will catch the next contributor — worth a helper or a clearer error.
- Restore failures during regeneration are logged and non-fatal, matching how the gradle lockfile updater soft-fails. A failure therefore reproduces the stale-lock-file symptom silently; surfacing it to the handler would be a reasonable follow-up.
- Rebased onto current `main`.
