### PR TITLE
github_actions: recognize action-name-prefixed version tags monorepos

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -430,8 +430,58 @@ module Dependabot
 
     sig { params(commit_sha: T.nilable(String)).returns(T::Array[Dependabot::GitRef]) }
     def local_tags_matching_sha(commit_sha)
-      local_tags.select { |t| t.commit_sha == commit_sha && version_class.correct?(t.name) }
-                .sort_by { |t| version_class.new(t.name) }
+      tags = local_tags.select { |t| t.commit_sha == commit_sha && version_class.correct?(t.name) }
+      tags_for_this_action(tags).sort_by { |t| version_class.new(t.name) }
+    end
+
+    # Keep only this action's tags so a monorepo SHA pin never resolves to an unrelated action's tag.
+    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T::Array[Dependabot::GitRef]) }
+    def tags_for_this_action(tags)
+      action = action_path_segment
+      return tags unless action
+
+      # Prefer this action's own family, e.g. "<action>-v1.2.3"/"<action>/1.2.3" (not "<action>-utils-v1").
+      mine = tags.select { |t| t.name.match?(%r{\A#{Regexp.escape(action)}[-/]v?\d}) }
+      return mine if mine.any?
+
+      # No per-action family here (e.g. repo publishes only repo-wide tags like "v3.1.0"),
+      # so keep repo-wide tags while still dropping other actions' families.
+      tags.reject { |t| action_family_tag?(t.name) }
+    end
+
+    # True for a name-prefixed tag like "<action>-v1.2.3" or "<action>/1.2.3", but not a
+    # repo-wide tag ("v1.2.3") or a date-style tag ("2021-01-01").
+    sig { params(name: String).returns(T::Boolean) }
+    def action_family_tag?(name)
+      dash = name.index(/-v\d/) # dash form requires the "v" so dates aren't treated as families
+      return true if dash&.positive?
+
+      slash = name.index(%r{/v?\d})
+      slash&.positive? || false
+    end
+
+    # The action's directory name in a monorepo, e.g. "resolve-gh-token" for the
+    # dependency "owner/repo/resolve-gh-token" (nil when it isn't a sub-path).
+    sig { returns(T.nilable(String)) }
+    def action_path_segment
+      url = dependency_source_details&.url
+      repo = url && Source.from_url(url)&.repo
+      return unless repo
+
+      name = dependency.name
+      prefix = "#{repo}/"
+      # GitHub owner/repo names are case-insensitive, so compare case-insensitively.
+      return unless name.downcase.start_with?(prefix.downcase)
+
+      action = name[prefix.length..]
+      return if action.nil? || action.empty?
+
+      segment = action.split("/").last
+      # Reusable-workflow refs (e.g. ".github/workflows/test.yml") use repo-wide
+      # tags rather than action-prefixed ones, so they aren't scoped to a sub-path.
+      return if segment.nil? || segment.end_with?(".yml", ".yaml")
+
+      segment
     end
 
     sig { params(version: T.any(String, Gem::Version)).returns(T::Boolean) }

--- a/github_actions/lib/dependabot/github_actions/version.rb
+++ b/github_actions/lib/dependabot/github_actions/version.rb
@@ -24,14 +24,32 @@ module Dependabot
 
       sig { params(version: VersionParameter).returns(VersionParameter) }
       def self.remove_leading_v(version)
-        return version unless version.to_s.match?(%r{\A(?:.*/)?v?([0-9])})
+        str = version.to_s.split("/").last || "" # drop a leading path segment
+        return str if str.match?(/\A\d/) # already a bare version
+        return T.must(str[1..]) if str.match?(/\Av\d/) # leading "v1.2.3"
 
-        version.to_s.sub(%r{\A(?:.*/)?v?}, "")
+        # An action-name prefix precedes the version (e.g. "resolve-gh-token-v2.1.0", or
+        # "cache-v2-helper-v1.0.0" whose name itself contains "-v2"). The version begins at the
+        # first "-v" with a dotted core; fall back to the last "-v" for moving-major tags ("...-v2").
+        last = T.let(nil, T.nilable(Integer))
+        offset = 0
+        while (i = str.index(/-v\d/, offset))
+          core = T.must(str[(i + 2)..])
+          return core if core.match?(/\A\d+\.\d/)
+
+          last = i
+          offset = i + 2
+        end
+        last ? T.must(str[(last + 2)..]) : str
       end
 
       sig { params(version: VersionParameter).returns(T::Boolean) }
       def self.path_based?(version)
-        version.to_s.match?(%r{\A.+/v?([0-9])})
+        str = version.to_s
+        idx = str.rindex("/")
+        return false if idx.nil? || idx.zero? # needs a non-empty path prefix before "/"
+
+        T.must(str[(idx + 1)..]).match?(/\Av?[0-9]/)
       end
 
       sig { override.params(version: VersionParameter).returns(T::Boolean) }

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "json"
 require "dependabot/dependency"
 require "dependabot/github_actions/update_checker"
 require "dependabot/github_actions/metadata_finder"
@@ -1750,5 +1751,128 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
 
       it { is_expected.to eq(expected_requirements) }
     end
+  end
+
+  describe "#local_tag_for_pinned_sha in a monorepo with multiple tag families" do
+    subject(:local_tag) { git_commit_checker.local_tag_for_pinned_sha }
+
+    # Keep the outer `before` happy; this describe re-stubs the request below with
+    # a git ref advertisement built at runtime from the JSON fixture.
+    let(:upload_pack_fixture) { "checkout" }
+    let(:service_pack_url) do
+      "https://github.com/some-org/monorepo-actions.git/info/refs" \
+        "?service=git-upload-pack"
+    end
+    # Pinned commit that is tagged for two different actions at once:
+    # "resolve-gh-token-v2.1.0" and the higher "usage-metrics-v9.9.9".
+    let(:pinned_sha) { "ae04af897f79a65c232823bd96070ed1d7897213" }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: dependency_name,
+        version: nil,
+        requirements: [{
+          requirement: nil,
+          groups: [],
+          file: ".github/workflows/workflow.yml",
+          source: {
+            type: "git",
+            url: "https://github.com/some-org/monorepo-actions",
+            ref: pinned_sha,
+            branch: nil
+          },
+          metadata: { declaration_string: "#{dependency_name}@#{pinned_sha}" }
+        }],
+        package_manager: "github_actions"
+      )
+    end
+
+    before do
+      stub_request(:get, service_pack_url).to_return(
+        status: 200,
+        body: git_upload_pack_from_json("monorepo-multi-family"),
+        headers: { "content-type" => "application/x-git-upload-pack-advertisement" }
+      )
+    end
+
+    context "when the dependency is the resolve-gh-token action" do
+      let(:dependency_name) { "some-org/monorepo-actions/resolve-gh-token" }
+
+      it "resolves to the resolve-gh-token tag, not the higher usage-metrics tag" do
+        expect(local_tag).to eq("resolve-gh-token-v2.1.0")
+      end
+    end
+
+    context "when the dependency is the usage-metrics action" do
+      let(:dependency_name) { "some-org/monorepo-actions/usage-metrics" }
+
+      it "resolves to the usage-metrics tag sharing the commit" do
+        expect(local_tag).to eq("usage-metrics-v9.9.9")
+      end
+    end
+
+    context "when the dependency name casing differs from the repo url" do
+      # GitHub owner/repo names are case-insensitive, so the action scoping must
+      # still match when the manifest uses different casing than the source url.
+      let(:dependency_name) { "Some-Org/Monorepo-Actions/resolve-gh-token" }
+
+      it "still scopes to the resolve-gh-token tag" do
+        expect(local_tag).to eq("resolve-gh-token-v2.1.0")
+      end
+    end
+
+    context "when the dependency is a reusable workflow sub-path" do
+      # Reusable workflows are pinned to repo-wide tags, not action-prefixed ones,
+      # so scoping must not filter them out.
+      let(:dependency_name) { "some-org/monorepo-actions/.github/workflows/test.yml" }
+
+      it "does not scope away the repo-wide tags" do
+        expect(local_tag).to eq("usage-metrics-v9.9.9")
+      end
+    end
+
+    context "when the action has no tag family and only repo-wide tags exist" do
+      # A monorepo sub-path that publishes only repo-wide tags (e.g. "v1.0.0")
+      # must still resolve to those tags rather than nothing.
+      let(:dependency_name) { "some-org/monorepo-actions/some-action" }
+      let(:pinned_sha) { "2222222222222222222222222222222222222222" }
+
+      it "keeps the repo-wide tag" do
+        expect(local_tag).to eq("v1.0.0")
+      end
+    end
+
+    context "when a repo-wide tag and another action's tag share the commit" do
+      # Repo-wide tags are preserved, but a different action's family is excluded.
+      let(:dependency_name) { "some-org/monorepo-actions/some-action" }
+      let(:pinned_sha) { "55e9c392bee14d03cc0ca8bf875fd0bf37602bd1" }
+
+      it "keeps the repo-wide tag and drops the other action's tag" do
+        expect(local_tag).to eq("v1.0.4")
+      end
+    end
+  end
+
+  # Builds a git-upload-pack ref advertisement (pkt-line format) from a decoded
+  # JSON fixture, so the repository of record for the refs is human-readable JSON.
+  def git_upload_pack_from_json(name)
+    data = JSON.parse(fixture("git", "upload_packs", "#{name}.json"))
+    caps = "multi_ack thin-pack side-band side-band-64k ofs-delta shallow deepen-since deepen-not " \
+           "deepen-relative no-progress include-tag multi_ack_detailed allow-tip-sha1-in-want " \
+           "allow-reachable-sha1-in-want no-done symref=HEAD:refs/heads/main filter " \
+           "object-format=sha1 agent=git/github-test"
+
+    body = +""
+    body << pkt_line("# service=#{data['service']}\n")
+    body << "0000"
+    data["refs"].each do |ref|
+      line = ref["ref"] == "HEAD" ? "#{ref['sha']} HEAD\x00#{caps}\n" : "#{ref['sha']} #{ref['ref']}\n"
+      body << pkt_line(line)
+    end
+    body << "0000"
+    body
+  end
+
+  def pkt_line(line)
+    format("%04x", line.bytesize + 4) + line
   end
 end

--- a/github_actions/spec/dependabot/github_actions/version_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/version_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Dependabot::GithubActions::Version do
   let(:semver_without_v) { "1.2.3" }
   let(:path_based_sem_version) { "dummy/v1.2.3" }
   let(:path_based_sem_without_v) { "dummy/1.2.3" }
+  let(:name_prefixed_version) { "resolve-gh-token-v2.1.0" }
+  let(:name_prefixed_prerelease) { "resolve-gh-token-v2.1.0-beta.1" }
 
   describe "#correct?" do
     it "rejects nil" do
@@ -29,6 +31,25 @@ RSpec.describe Dependabot::GithubActions::Version do
 
     it "accepts path based sem version without v" do
       expect(described_class.correct?(path_based_sem_without_v)).to be(true)
+    end
+
+    it "accepts monorepo action-name prefixed tags" do
+      expect(described_class.correct?(name_prefixed_version)).to be(true)
+    end
+
+    it "rejects non-version refs" do
+      expect(described_class.correct?("main")).to be(false)
+    end
+
+    it "does not mangle hyphenated date-style version tags" do
+      # Regression guard: greedy prefix-stripping must not turn "2021-01-01" into "01".
+      expect(described_class.new("2021-01-01").segments.first).to eq(2021)
+    end
+
+    it "does not strip a '-v' that is part of the version itself" do
+      # Regression guard: name-prefix stripping must not turn "1.0.0-v2" into "2".
+      expect(described_class.new("1.0.0-v2")).not_to eq(described_class.new("2"))
+      expect(described_class.new("1.0.0-v2").segments.first).to eq(1)
     end
   end
 
@@ -63,6 +84,30 @@ RSpec.describe Dependabot::GithubActions::Version do
       version = described_class.new(path_based_sem_version)
       version_without_v = described_class.new(path_based_sem_without_v)
       expect(version).to eq(version_without_v)
+    end
+
+    it "strips action-name prefix from monorepo tags" do
+      version = described_class.new(name_prefixed_version)
+      expect(version.to_s).to eq("2.1.0")
+    end
+
+    it "preserves prerelease suffixes on name prefixed tags" do
+      version = described_class.new(name_prefixed_prerelease)
+      expect(version).to eq(described_class.new("2.1.0-beta.1"))
+      expect(version.prerelease?).to be(true)
+    end
+
+    it "strips only the action-name prefix, not a '-v' inside the version" do
+      # Regression guard: "action-v1.0.0-v2" must become "1.0.0-v2", not "2".
+      version = described_class.new("action-v1.0.0-v2")
+      expect(version).to eq(described_class.new("1.0.0-v2"))
+      expect(version.segments.first).to eq(1)
+    end
+
+    it "handles action names that themselves contain '-v<digit>'" do
+      # "cache-v2-helper-v1.0.0" must normalize to 1.0.0, not "2-helper-v1.0.0".
+      expect(described_class.new("cache-v2-helper-v1.0.0")).to eq(described_class.new("1.0.0"))
+      expect(described_class.new("cache-v2-helper-v2")).to eq(described_class.new("2"))
     end
   end
 

--- a/github_actions/spec/fixtures/git/upload_packs/monorepo-multi-family.json
+++ b/github_actions/spec/fixtures/git/upload_packs/monorepo-multi-family.json
@@ -1,0 +1,59 @@
+{
+  "service": "git-upload-pack",
+  "description": "Decoded ref advertisement for a GitHub Actions monorepo where one commit is tagged for two different action families (resolve-gh-token and usage-metrics).",
+  "refs": [
+    {
+      "sha": "1111111111111111111111111111111111111111",
+      "ref": "HEAD",
+      "type": "head"
+    },
+    {
+      "sha": "1111111111111111111111111111111111111111",
+      "ref": "refs/heads/main",
+      "type": "branch",
+      "name": "main"
+    },
+    {
+      "sha": "ae04af897f79a65c232823bd96070ed1d7897213",
+      "ref": "refs/tags/resolve-gh-token-v2.1.0",
+      "type": "tag",
+      "name": "resolve-gh-token-v2.1.0"
+    },
+    {
+      "sha": "ae04af897f79a65c232823bd96070ed1d7897213",
+      "ref": "refs/tags/usage-metrics-v9.9.9",
+      "type": "tag",
+      "name": "usage-metrics-v9.9.9"
+    },
+    {
+      "sha": "371c4bd81e6db3f0d9f03fdd3b510580b3f0e0c2",
+      "ref": "refs/tags/resolve-gh-token-v2",
+      "type": "tag",
+      "name": "resolve-gh-token-v2"
+    },
+    {
+      "sha": "371c4bd81e6db3f0d9f03fdd3b510580b3f0e0c2",
+      "ref": "refs/tags/resolve-gh-token-v2.1.1",
+      "type": "tag",
+      "name": "resolve-gh-token-v2.1.1"
+    },
+    {
+      "sha": "55e9c392bee14d03cc0ca8bf875fd0bf37602bd1",
+      "ref": "refs/tags/usage-metrics-v1.0.4",
+      "type": "tag",
+      "name": "usage-metrics-v1.0.4"
+    },
+    {
+      "sha": "55e9c392bee14d03cc0ca8bf875fd0bf37602bd1",
+      "ref": "refs/tags/v1.0.4",
+      "type": "tag",
+      "name": "v1.0.4"
+    },
+    {
+      "sha": "2222222222222222222222222222222222222222",
+      "ref": "refs/tags/v1.0.0",
+      "type": "tag",
+      "name": "v1.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
Strip an action-name prefix from monorepo tags such as "resolve-gh-token-v2.1.0" so SHA-pinned actions resolve to a real version and receive updates. The "-v" marker is required, so hyphenated date-style tags like "2021-01-01" are left intact.


### What are you trying to accomplish?

For a SHA-pinned monorepo action whose releases are tagged with the action name
prefixing the version (e.g. `resolve-gh-token-v2.1.0`), Dependabot reported "no
update needed" even when a newer release existed.
`Dependabot::GithubActions::Version.correct?` rejected these tags because
`remove_leading_v` only stripped a leading `v` or a `path/` segment, so the
pinned tag was filtered out and no update was proposed.

### Anything you want to highlight for special attention from reviewers?

`remove_leading_v` now also strips an action-name prefix, but only when the
version is marked by `-v` (e.g. `resolve-gh-token-v2.1.0`). The explicit `-v`
requirement is intentional so hyphenated date-style tags such as `2021-01-01`
are left intact. All previously-parseable tags are unchanged.

### How will you know you've accomplished your goal?

- Added spec cases for action-name-prefixed tags, prerelease preservation, and
  a `2021-01-01` regression guard in `version_spec.rb`.
- Verified end-to-end on `dsp-testing`: before the fix `can_update?` is
  `false`; after the fix the pinned `resolve-gh-token-v2.1.0` SHA resolves and
  Dependabot proposes the `v2.1.1` bump.
- Ran the `github_actions` version spec (all passing) and RuboCop (clean).

### Checklist

- [x] I have run the complete test suite in GitHub_actions to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
