### PR TITLE
Harden SHA-pinned monorepo action tag resolution across prefix, family, and casing edge cases

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -430,8 +430,55 @@ module Dependabot
 
     sig { params(commit_sha: T.nilable(String)).returns(T::Array[Dependabot::GitRef]) }
     def local_tags_matching_sha(commit_sha)
-      local_tags.select { |t| t.commit_sha == commit_sha && version_class.correct?(t.name) }
-                .sort_by { |t| version_class.new(t.name) }
+      tags = local_tags.select { |t| t.commit_sha == commit_sha && version_class.correct?(t.name) }
+      tags_for_this_action(tags).sort_by { |t| version_class.new(t.name) }
+    end
+
+    sig { params(tags: T::Array[Dependabot::GitRef]).returns(T::Array[Dependabot::GitRef]) }
+    def tags_for_this_action(tags)
+      # Action-family scoping only applies to SHA-pinned refs. For non-SHA refs
+      # (e.g. path-based tags such as "run/v1.0.0") the dependency name isn't a
+      # plain action path, so scoping would drop the real tag; leave it unscoped.
+      return tags unless pinned_ref_looks_like_commit_sha?
+
+      action = action_path_segment
+      return tags unless action
+
+      action_family_pattern = %r{\A#{Regexp.escape(action)}(?:-v|/v?)\d}
+      matching_action_family = tags.select { |tag| tag.name.match?(action_family_pattern) }
+      return matching_action_family if matching_action_family.any?
+
+      tags.reject { |tag| action_family_tag?(tag.name) }
+    end
+
+    sig { params(name: String).returns(T::Boolean) }
+    def action_family_tag?(name)
+      return false if name.match?(/\Av?\d/)
+
+      dash = name.index(/-v\d/)
+      return true if dash&.positive?
+
+      slash = name.index(%r{/v?\d})
+      slash&.positive? || false
+    end
+
+    sig { returns(T.nilable(String)) }
+    def action_path_segment
+      source_url = dependency_source_details&.url
+      return unless source_url
+
+      repo = Source.from_url(source_url)&.repo
+      return unless repo
+
+      name = dependency.name
+      prefix = "#{repo}/"
+      return unless name.downcase.start_with?(prefix.downcase)
+
+      action_path = name[prefix.length..]
+      return if action_path.nil? || action_path.empty?
+      return if action_path.downcase.start_with?(".github/workflows/")
+
+      action_path.split("/").last
     end
 
     sig { params(version: T.any(String, Gem::Version)).returns(T::Boolean) }

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -1819,7 +1819,7 @@ RSpec.describe Dependabot::GitCommitChecker do
   end
 
   describe "#local_tag_for_pinned_sha" do
-    subject { checker.local_tag_for_pinned_sha }
+    subject(:local_tag_for_pinned_sha) { checker.local_tag_for_pinned_sha }
 
     context "with a git commit pin" do
       let(:source) do
@@ -1874,6 +1874,131 @@ RSpec.describe Dependabot::GitCommitChecker do
         let(:source_commit) { "5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f" }
 
         it { is_expected.to eq("v2.3.4") }
+      end
+    end
+
+    context "with github actions monorepo tags" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: source_commit,
+          requirements: requirements,
+          package_manager: "dummy"
+        )
+      end
+      let(:source_commit) { "a" * 40 }
+      let(:dependency_name) { "some-org/monorepo-actions/resolve-gh-token" }
+      let(:source) do
+        {
+          type: "git",
+          url: "https://github.com/some-org/monorepo-actions",
+          branch: "main",
+          ref: source_commit
+        }
+      end
+      let(:matching_tag) do
+        Dependabot::GitRef.new(name: "resolve-gh-token-v2.1.0", commit_sha: source_commit)
+      end
+      let(:local_tags) do
+        [
+          Dependabot::GitRef.new(name: "resolve-gh-token-v2.0.0", commit_sha: source_commit),
+          matching_tag,
+          Dependabot::GitRef.new(name: "usage-metrics-v3.0.0", commit_sha: source_commit),
+          Dependabot::GitRef.new(name: "v9.9.9", commit_sha: source_commit)
+        ]
+      end
+
+      let(:stub_version_class) do
+        Class.new do
+          def self.correct?(_name)
+            true
+          end
+
+          def self.new(name)
+            normalized = name.to_s
+                             .sub(%r{\A.*(?:-v|/v?)}, "")
+                             .delete_prefix("v")
+            Gem::Version.new(normalized)
+          end
+        end
+      end
+
+      before do
+        allow(checker).to receive_messages(
+          pinned_ref_looks_like_commit_sha?: true,
+          local_tags: local_tags,
+          version_class: stub_version_class
+        )
+      end
+
+      it "selects only tags from the current action family when present" do
+        expect(local_tag_for_pinned_sha).to eq("resolve-gh-token-v2.1.0")
+      end
+
+      context "when no tag exists for the current action family" do
+        let(:local_tags) do
+          [
+            Dependabot::GitRef.new(name: "v1.0.0", commit_sha: source_commit),
+            Dependabot::GitRef.new(name: "1.0.0-v2", commit_sha: source_commit),
+            Dependabot::GitRef.new(name: "v1.0.0-v2", commit_sha: source_commit),
+            Dependabot::GitRef.new(name: "usage-metrics-v3.0.0", commit_sha: source_commit)
+          ]
+        end
+
+        it "falls back to repo-wide tags and excludes other action families" do
+          selected_tags = checker.most_specific_version_tags_for_sha(source_commit)
+          expect(selected_tags).to include("v1.0.0", "1.0.0-v2", "v1.0.0-v2")
+          expect(selected_tags).not_to include("usage-metrics-v3.0.0")
+          expect(local_tag_for_pinned_sha).to eq(selected_tags.last)
+        end
+      end
+
+      context "when dependency casing differs from repository casing" do
+        let(:dependency_name) { "Some-Org/Monorepo-Actions/resolve-gh-token" }
+        let(:local_tags) do
+          [
+            Dependabot::GitRef.new(name: "resolve-gh-token-v1.0.0", commit_sha: source_commit),
+            Dependabot::GitRef.new(name: "usage-metrics-v9.0.0", commit_sha: source_commit)
+          ]
+        end
+
+        it "matches repository prefix case-insensitively" do
+          expect(local_tag_for_pinned_sha).to eq("resolve-gh-token-v1.0.0")
+        end
+      end
+
+      context "when the ref is a path-based tag rather than a SHA" do
+        let(:dependency_name) { "some-org/monorepo-actions/first/run@run/v1.0.0" }
+        let(:local_tags) do
+          [
+            Dependabot::GitRef.new(name: "run/v1.0.0", commit_sha: source_commit),
+            Dependabot::GitRef.new(name: "usage-metrics-v3.0.0", commit_sha: source_commit)
+          ]
+        end
+
+        before do
+          allow(checker).to receive(:pinned_ref_looks_like_commit_sha?).and_return(false)
+        end
+
+        it "retains the real family tag instead of scoping by action" do
+          selected_tags = checker.most_specific_version_tags_for_sha(source_commit)
+          expect(selected_tags).to include("run/v1.0.0")
+        end
+      end
+
+      context "when dependency is a reusable workflow" do
+        let(:dependency_name) { "some-org/monorepo-actions/.github/workflows/release.yml" }
+        let(:local_tags) do
+          [
+            Dependabot::GitRef.new(name: "resolve-gh-token-v1.0.0", commit_sha: source_commit),
+            Dependabot::GitRef.new(name: "usage-metrics-v3.0.0", commit_sha: source_commit),
+            Dependabot::GitRef.new(name: "v2.0.0", commit_sha: source_commit)
+          ]
+        end
+
+        it "skips action-family scoping" do
+          expect(local_tag_for_pinned_sha).to eq("usage-metrics-v3.0.0")
+        end
       end
     end
   end

--- a/github_actions/lib/dependabot/github_actions/version.rb
+++ b/github_actions/lib/dependabot/github_actions/version.rb
@@ -24,9 +24,23 @@ module Dependabot
 
       sig { params(version: VersionParameter).returns(VersionParameter) }
       def self.remove_leading_v(version)
-        return version unless version.to_s.match?(%r{\A(?:.*/)?v?([0-9])})
+        str = version.to_s.split("/").last.to_s
+        return str if str.match?(/\A\d/)
+        return T.must(str[1..]) if str.match?(/\Av\d/)
 
-        version.to_s.sub(%r{\A(?:.*/)?v?}, "")
+        last_moving_major = T.let(nil, T.nilable(Integer))
+        offset = 0
+        while (idx = str.index(/-v\d/, offset))
+          core = T.must(str[(idx + 2)..])
+          return core if core.match?(/\A\d+\.\d/)
+
+          last_moving_major = idx
+          offset = idx + 2
+        end
+
+        return T.must(str[(last_moving_major + 2)..]) if last_moving_major
+
+        str
       end
 
       sig { params(version: VersionParameter).returns(T::Boolean) }

--- a/github_actions/spec/dependabot/github_actions/version_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/version_spec.rb
@@ -87,4 +87,27 @@ RSpec.describe Dependabot::GithubActions::Version do
       expect(described_class.path_based?(semver_without_v)).to be(false)
     end
   end
+
+  describe ".remove_leading_v" do
+    it "strips prefixed semver tags" do
+      expect(described_class.remove_leading_v("action-v1.2.3")).to eq("1.2.3")
+    end
+
+    it "uses the semver boundary when action names include -v digits" do
+      expect(described_class.remove_leading_v("cache-v2-helper-v1.0.0")).to eq("1.0.0")
+    end
+
+    it "preserves prerelease suffixes" do
+      expect(described_class.remove_leading_v("action-v1.0.0-v2")).to eq("1.0.0-v2")
+      expect(described_class.remove_leading_v("1.0.0-v2")).to eq("1.0.0-v2")
+    end
+
+    it "preserves date-like tags" do
+      expect(described_class.remove_leading_v("2021-01-01")).to eq("2021-01-01")
+    end
+
+    it "falls back to moving-major tags" do
+      expect(described_class.remove_leading_v("action-v2")).to eq("2")
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

For SHA-pinned GitHub Actions in a monorepo, the referenced commit can carry multiple action-name-prefixed version tags (e.g. `resolve-gh-token-v2.1.0` and `usage-metrics-v3.0.0` on the same SHA). Previously the resolver picked the highest normalized version tag at that SHA without considering which action was referenced, so a pin for one action could be attributed to — and updated to a release of — a sibling action in the same repository. Conversely, subpath actions that only publish repo-wide tags (e.g. `v3.1.0`) could lose their current version entirely.

This PR scopes SHA tag resolution to the referenced action path so the correct tag family is chosen, while preserving repo-wide tags as a fallback when no per-action tag family is present.

### Anything you want to highlight for special attention from reviewers?

- `GitCommitChecker#tags_for_this_action` now prefers the matching action family (`<action>-vN` / `<action>/vN`) and only falls back to repo-wide tags when no per-action family exists, rejecting other actions' families.
- `action_family_tag?` classifies which tags belong to a *foreign* action family. It exempts numeric and leading-`v` repo-wide versions (`1.0.0-v2`, `v1.0.0-v2`) so valid repo-wide tags are retained.
- The action-path prefix match is case-insensitive, and reusable-workflow refs (`.github/workflows/*.yml`) intentionally skip action-family scoping.
- `GithubActions::Version#remove_leading_v` disambiguates the version delimiter from `-v<digit>` sequences that appear inside action names (e.g. `cache-v2-helper-v1.0.0` → `1.0.0`) while preserving suffixes such as `action-v1.0.0-v2`.

### How will you know you've accomplished your goal?

- New/updated specs in `common/spec/dependabot/git_commit_checker_spec.rb` cover: selecting the current action family when multiple families share a SHA, falling back to repo-wide tags (including `v1.0.0-v2`) while excluding foreign families, case-insensitive prefix matching, and the reusable-workflow exception.
- `github_actions/spec/dependabot/github_actions/version_spec.rb` covers normalization of action names containing `-v<digit>`.
- `srb tc` is clean and RuboCop passes on the changed source files.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, and added tests to prevent regressions.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request.
- [x] I have documented my code, particularly in hard-to-understand areas.
