### PR TITLE
Stop retrying client errors when recording cooldown telemetry

### DIFF
--- a/updater/lib/dependabot/api_client.rb
+++ b/updater/lib/dependabot/api_client.rb
@@ -355,8 +355,7 @@ module Dependabot
               {
                 cooldown: {
                   ecosystem_name: job.package_manager,
-                  config:
-                  {
+                  config: {
                     default_days: cooldown.default_days,
                     semver_major_days: cooldown.semver_major_days,
                     semver_minor_days: cooldown.semver_minor_days,
@@ -371,7 +370,13 @@ module Dependabot
 
           begin
             response = post(path: api_url, body: body.to_json)
-            raise ApiError, response.body if response.status >= 400
+
+            # Not every host implements this telemetry endpoint, so a client error won't clear on retry.
+            if response.status >= 500
+              raise ApiError, response.body
+            elsif response.status >= 400
+              Dependabot.logger.debug("Unable to record cooldown meta: #{response.status} #{response.body}")
+            end
           rescue Excon::Error::Socket, Excon::Error::Timeout, OpenSSL::SSL::SSLError, ApiError => e
             retry_count += 1
             if retry_count <= MAX_REQUEST_RETRIES

--- a/updater/spec/dependabot/api_client_spec.rb
+++ b/updater/spec/dependabot/api_client_spec.rb
@@ -800,6 +800,18 @@ RSpec.describe Dependabot::ApiClient do
       end
     end
 
+    context "when the host does not implement the endpoint" do
+      before do
+        stub_request(:post, record_cooldown_meta_url).to_return(status: 404, body: "The resource cannot be found.")
+      end
+
+      it "does not retry" do
+        client.record_cooldown_meta(job)
+
+        expect(WebMock).to have_requested(:post, record_cooldown_meta_url).once
+      end
+    end
+
     context "when running through the Dependabot CLI" do
       subject(:client) { described_class.new("http://example.com", "cli", "token") }
 


### PR DESCRIPTION
### What are you trying to accomplish?

#15724 gave every version update job a default three day cooldown, so `record_cooldown_meta` now fires for every job rather than only the ones with an explicit `cooldown` block. Azure DevOps does not implement that endpoint, so every call 404s, and the client retried three times with a 3 to 10 second sleep between attempts. The call sits in a per dependency `ensure` block, so that is roughly 20 seconds of dead time per dependency.

This treats 4xx as terminal and logs at debug instead. Other failures still retry.

### Anything you want to highlight for special attention from reviewers?

The `config: {` reindent only exists to keep the block under the RuboCop length limit.

### How will you know you've accomplished your goal?

New spec asserts a 404 response sends exactly one request.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
