### PR TITLE
Add typed requirement metadata readers

### DIFF
--- a/common/lib/dependabot/dependency_requirement.rb
+++ b/common/lib/dependabot/dependency_requirement.rb
@@ -153,7 +153,50 @@ module Dependabot
       raise TypeError, "requirement must be a string or nil"
     end
 
+    # Reads a known metadata field such as "property_name". Accepts either key
+    # style for the same reason as `source_string`. Returns nil when the
+    # requirement carries no metadata or the key is absent.
+    sig { params(key: String).returns(T.nilable(String)) }
+    def metadata_string(key)
+      value = metadata_value(key)
+      return if value.nil?
+      return value if value.is_a?(String)
+
+      raise TypeError, "metadata #{key} must be a string or nil"
+    end
+
+    # Reads a nested metadata hash whose values are all strings, such as
+    # "dependency_set" (`{ group: "my.group", version: "1.4.0" }`). Keys are
+    # symbolised so callers can read them with symbols regardless of how the
+    # requirement was built.
+    sig { params(key: String).returns(T.nilable(T::Hash[Symbol, String])) }
+    def metadata_string_hash(key)
+      value = metadata_value(key)
+      return if value.nil?
+      raise TypeError, "metadata #{key} must be a hash of strings or nil" unless value.is_a?(Hash)
+
+      value.to_h do |raw_entry_key, raw_entry_value|
+        entry_key = T.cast(raw_entry_key, Object)
+        entry_value = T.cast(raw_entry_value, Object)
+        unless (entry_key.is_a?(Symbol) || entry_key.is_a?(String)) && entry_value.is_a?(String)
+          raise TypeError, "metadata #{key} must be a hash of strings or nil"
+        end
+
+        [entry_key.to_sym, entry_value]
+      end
+    end
+
     private
+
+    # Reads a raw metadata field, accepting either key style. Nil when the
+    # requirement carries no metadata or the key is absent.
+    sig { params(key: String).returns(T.nilable(Object)) }
+    def metadata_value(key)
+      details = metadata
+      return if details.nil?
+
+      details[key.to_sym] || details[key]
+    end
 
     sig { params(key: Symbol).returns(T.nilable(String)) }
     def optional_string(key)

--- a/common/spec/dependabot/dependency_requirement_spec.rb
+++ b/common/spec/dependabot/dependency_requirement_spec.rb
@@ -202,6 +202,73 @@ RSpec.describe Dependabot::DependencyRequirement do
     end
   end
 
+  describe "metadata helpers" do
+    it "reads a symbol-keyed metadata string" do
+      req = described_class.create(requirement_hash)
+
+      expect(req.metadata_string("property_name")).to eq("rails.version")
+    end
+
+    it "reads a string-keyed metadata string" do
+      req = described_class.create(
+        requirement_hash.merge(metadata: { "property_name" => "rails.version" })
+      )
+
+      expect(req.metadata_string("property_name")).to eq("rails.version")
+    end
+
+    it "returns nil when the metadata key is absent" do
+      req = described_class.create(requirement_hash)
+
+      expect(req.metadata_string("dependency_set")).to be_nil
+    end
+
+    it "returns nil when the requirement has no metadata" do
+      req = described_class.create(requirement_hash.merge(metadata: nil))
+
+      expect(req.metadata_string("property_name")).to be_nil
+      expect(req.metadata_string_hash("dependency_set")).to be_nil
+    end
+
+    it "rejects a non-string metadata value" do
+      req = described_class.create(requirement_hash.merge(metadata: { property_name: 1 }))
+
+      expect { req.metadata_string("property_name") }
+        .to raise_error(TypeError, "metadata property_name must be a string or nil")
+    end
+
+    it "reads a metadata hash of strings" do
+      req = described_class.create(
+        requirement_hash.merge(metadata: { dependency_set: { group: "my.group", version: "1.4.0" } })
+      )
+
+      expect(req.metadata_string_hash("dependency_set"))
+        .to eq(group: "my.group", version: "1.4.0")
+    end
+
+    it "symbolises string keys in a metadata hash" do
+      req = described_class.create(
+        requirement_hash.merge(metadata: { dependency_set: { "group" => "my.group" } })
+      )
+
+      expect(req.metadata_string_hash("dependency_set")).to eq(group: "my.group")
+    end
+
+    it "rejects a metadata hash that is not a hash" do
+      req = described_class.create(requirement_hash.merge(metadata: { dependency_set: "nope" }))
+
+      expect { req.metadata_string_hash("dependency_set") }
+        .to raise_error(TypeError, "metadata dependency_set must be a hash of strings or nil")
+    end
+
+    it "rejects a non-string value inside a metadata hash" do
+      req = described_class.create(requirement_hash.merge(metadata: { dependency_set: { group: 1 } }))
+
+      expect { req.metadata_string_hash("dependency_set") }
+        .to raise_error(TypeError, "metadata dependency_set must be a hash of strings or nil")
+    end
+  end
+
   describe "hash compatibility" do
     subject(:requirement) { described_class.create(requirement_hash) }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Requirement metadata is read today with untyped `dig` calls, for example `r.dig(:metadata, :property_name)`. This adds readers so those call sites can be typed, following the `source_string` helpers already on `DependencyRequirement`.

- `metadata_string(key)` reads a known field such as `property_name`.
- `metadata_string_hash(key)` reads a nested hash of strings such as `dependency_set` (`{ group: "my.group", version: "1.4.0" }`), symbolising its keys.

Both accept symbol or string keys, return nil when the metadata or the key is absent, and raise `TypeError` on a malformed value. That matches `source_string` and `Dependency#metadata_string`.

This is groundwork for the follow-up PR that migrates `common`, and eventually for giving `DependencyRequirement` real Hash generics instead of `T.untyped`.

### Anything you want to highlight for special attention from reviewers?

`metadata_string_hash` symbolises keys on the way out so callers can use symbols regardless of how the requirement was built. The two consumers both declare `T::Hash[Symbol, String]`, so this makes the reader match the contract that already exists.

### How will you know you've accomplished your goal?

Sorbet is clean, RuboCop passes, and the new readers have nine examples in `dependency_requirement_spec.rb` covering both key styles, absent metadata, absent keys, and each malformed shape. The full `common` suite passes with 2100 examples.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
