### PR TITLE
Type common requirement access

### DIFF
--- a/common/lib/dependabot/config/update_config.rb
+++ b/common/lib/dependabot/config/update_config.rb
@@ -52,7 +52,7 @@ module Dependabot
       sig { params(dependency: Dependency).returns(Dependency) }
       def extract_base_version_from_requirement(dependency)
         requirements = dependency.requirements
-        requirement = T.must(requirements.first)[:requirement]
+        requirement = T.must(requirements.first).requirement_string
         version = requirement&.match(/\d+\.\d+\.\d+/)&.to_s
         Dependabot::Dependency.new(
           name: dependency.name,

--- a/common/lib/dependabot/file_updaters/base.rb
+++ b/common/lib/dependabot/file_updaters/base.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -79,7 +79,7 @@ module Dependabot
       def requirement_changed?(file, dependency)
         changed_requirements = dependency.requirements - T.must(dependency.previous_requirements)
 
-        changed_requirements.any? { |f| f[:file] == file.name }
+        changed_requirements.any? { |f| f.file == file.name }
       end
 
       sig { params(file: Dependabot::DependencyFile, content: String).returns(Dependabot::DependencyFile) }

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -452,7 +452,7 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def previous_ref
           previous_refs = dependency.previous_requirements&.filter_map do |r|
-            r.dig(:source, "ref") || r.dig(:source, :ref)
+            r.source_string("ref")
           end&.uniq
           previous_refs.first if previous_refs&.one?
         end
@@ -460,7 +460,7 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def new_ref
           new_refs = dependency.requirements.filter_map do |r|
-            r.dig(:source, "ref") || r.dig(:source, :ref)
+            r.source_string("ref")
           end.uniq
           new_refs.first if new_refs.one?
         end
@@ -479,7 +479,7 @@ module Dependabot
           return false if dependency.package_manager == "composer"
 
           requirements = dependency.requirements
-          sources = requirements.map { |r| r.fetch(:source) }.uniq.compact
+          sources = requirements.map(&:source_hash).uniq.compact
           return false if sources.empty?
 
           sources.all? { |s| s[:type] == "git" || s["type"] == "git" }

--- a/common/lib/dependabot/metadata_finders/base/changelog_pruner.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_pruner.rb
@@ -169,7 +169,7 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def previous_ref
           previous_refs = T.must(dependency.previous_requirements).filter_map do |r|
-            r.dig(:source, "ref") || r.dig(:source, :ref)
+            r.source_string("ref")
           end.uniq
           previous_refs.first if previous_refs.one?
         end
@@ -177,7 +177,7 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def new_ref
           new_refs = dependency.requirements.filter_map do |r|
-            r.dig(:source, "ref") || r.dig(:source, :ref)
+            r.source_string("ref")
           end.uniq
           new_refs.first if new_refs.one?
         end
@@ -190,7 +190,7 @@ module Dependabot
           return false if dependency.package_manager == "composer"
 
           requirements = dependency.requirements
-          sources = requirements.map { |r| r.fetch(:source) }.uniq.compact
+          sources = requirements.map(&:source_hash).uniq.compact
           return false if sources.empty?
 
           sources.all? { |s| s[:type] == "git" || s["type"] == "git" }

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -136,10 +136,11 @@ module Dependabot
         sig { params(version: T.nilable(Dependabot::Version)).returns(T::Boolean) }
         def satisfies_previous_reqs?(version)
           T.must(dependency.previous_requirements).all? do |req|
-            next true unless req.fetch(:requirement)
+            requirement = req.requirement_string
+            next true unless requirement
 
             requirement_class
-              .requirements_array(req.fetch(:requirement))
+              .requirements_array(requirement)
               .all? { |r| r.satisfied_by?(version) }
           end
         end
@@ -151,7 +152,7 @@ module Dependabot
           # internally
           return false if dependency.package_manager == "composer"
 
-          sources = requirements&.map { |r| r.fetch(:source) }&.uniq&.compact
+          sources = requirements&.map(&:source_hash)&.uniq&.compact
           return false if sources.nil? || sources.empty?
 
           sources.all? { |s| s[:type] == "git" || s["type"] == "git" }
@@ -168,7 +169,7 @@ module Dependabot
           return unless git_source?(dependency.previous_requirements)
 
           previous_refs = T.must(dependency.previous_requirements).filter_map do |r|
-            r.dig(:source, "ref") || r.dig(:source, :ref)
+            r.source_string("ref")
           end.uniq
           previous_refs.first if previous_refs.one?
         end
@@ -178,7 +179,7 @@ module Dependabot
           return unless git_source?(dependency.previous_requirements)
 
           new_refs = dependency.requirements.filter_map do |r|
-            r.dig(:source, "ref") || r.dig(:source, :ref)
+            r.source_string("ref")
           end.uniq
           new_refs.first if new_refs.one?
         end

--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -290,9 +290,10 @@ module Dependabot
       end
       def filter_out_of_range_versions(releases)
         reqs = dependency.requirements.filter_map do |r|
-          next if r.fetch(:requirement).nil?
+          requirement = r.requirement_string
+          next if requirement.nil?
 
-          requirement_class.requirements_array(r.fetch(:requirement))
+          requirement_class.requirements_array(requirement)
         end
 
         releases
@@ -325,7 +326,7 @@ module Dependabot
         return true if dependency.numeric_version&.prerelease?
 
         dependency.requirements.any? do |req|
-          req_string = req.fetch(:requirement) || ""
+          req_string = req.requirement_string || ""
           req_string.split(",").map(&:strip).any? do |r|
             version_str = r.gsub(/^\s*[!<>=~^]+\s*/, "").strip
             next false unless version_class.correct?(version_str)

--- a/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_namer/solo_strategy.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "digest"
@@ -88,14 +88,14 @@ module Dependabot
         def updating_a_property?
           T.must(dependencies.first)
            .requirements
-           .any? { |r| r.dig(:metadata, :property_name) }
+           .any? { |r| r.metadata_string("property_name") }
         end
 
         sig { returns(T::Boolean) }
         def updating_a_dependency_set?
           T.must(dependencies.first)
            .requirements
-           .any? { |r| r.dig(:metadata, :dependency_set) }
+           .any? { |r| r.metadata_string_hash("dependency_set") }
         end
 
         sig { returns(String) }
@@ -103,8 +103,8 @@ module Dependabot
           @property_name ||=
             T.let(
               T.must(dependencies.first).requirements
-                                              .find { |r| r.dig(:metadata, :property_name) }
-                                              &.dig(:metadata, :property_name),
+                                              .find { |r| r.metadata_string("property_name") }
+                                              &.metadata_string("property_name"),
               T.nilable(String)
             )
 
@@ -118,9 +118,9 @@ module Dependabot
           @dependency_set ||=
             T.let(
               T.must(dependencies.first).requirements
-                                 .find { |r| r.dig(:metadata, :dependency_set) }
-                                 &.dig(:metadata, :dependency_set),
-              T.nilable(T::Hash[String, String])
+                                 .find { |r| r.metadata_string_hash("dependency_set") }
+                                 &.metadata_string_hash("dependency_set"),
+              T.nilable(T::Hash[Symbol, String])
             )
 
           raise "No dependency set!" unless @dependency_set
@@ -172,9 +172,11 @@ module Dependabot
             T.must(dependency.version)[0..6]
           elsif dependency.version == dependency.previous_version &&
                 package_manager == "docker"
-            dependency.requirements
-                      .filter_map { |r| r.dig(:source, "digest") || r.dig(:source, :digest) }
-                      .first.split(":").last[0..6]
+            T.must(
+              dependency.requirements
+                                    .filter_map { |r| r.source_string("digest") }
+                                    .first
+            ).split(":").last&.[](0..6)
           else
             dependency.version
           end
@@ -183,7 +185,7 @@ module Dependabot
         sig { params(dependency: Dependabot::Dependency).returns(T.nilable(String)) }
         def previous_ref(dependency)
           previous_refs = T.must(dependency.previous_requirements).filter_map do |r|
-            r.dig(:source, "ref") || r.dig(:source, :ref)
+            r.source_string("ref")
           end.uniq
           previous_refs.first if previous_refs.one?
         end
@@ -191,7 +193,7 @@ module Dependabot
         sig { params(dependency: Dependabot::Dependency).returns(T.nilable(String)) }
         def new_ref(dependency)
           new_refs = dependency.requirements.filter_map do |r|
-            r.dig(:source, "ref") || r.dig(:source, :ref)
+            r.source_string("ref")
           end.uniq
           new_refs.first if new_refs.one?
         end
@@ -208,10 +210,10 @@ module Dependabot
             dependency.requirements - T.must(dependency.previous_requirements)
 
           gemspec =
-            updated_reqs.find { |r| r[:file].match?(%r{^[^/]*\.gemspec$}) }
-          return gemspec[:requirement] if gemspec
+            updated_reqs.find { |r| T.must(r.file).match?(%r{^[^/]*\.gemspec$}) }
+          return gemspec.requirement_string if gemspec
 
-          updated_reqs.first&.fetch(:requirement)
+          updated_reqs.first&.requirement_string
         end
 
         # TODO: Bring this in line with existing library checks that we do in the

--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -165,43 +165,36 @@ module Dependabot
         )
       end
 
-      # rubocop:disable Metrics/PerceivedComplexity
       sig { params(dep: Dependabot::Dependency).returns(T.nilable(String)) }
       def version(dep)
         return dep.version if version_class.correct?(dep.version)
 
-        source = dep.requirements.find { |r| r.fetch(:source) }&.fetch(:source)
-        type = source&.fetch("type", nil) || source&.fetch(:type)
-        return dep.version unless type == "git"
+        source = dep.requirements.find(&:source)
+        return dep.version if source.nil?
+        return dep.version unless source.source_string("type") == "git"
 
-        ref = source.fetch("ref", nil) || source.fetch(:ref)
-        version_from_ref = ref&.gsub(/^v/, "")
+        version_from_ref = source.source_string("ref")&.gsub(/^v/, "")
         return dep.version unless version_from_ref
         return dep.version unless version_class.correct?(version_from_ref)
 
         version_from_ref
       end
-      # rubocop:enable Metrics/PerceivedComplexity
 
-      # rubocop:disable Metrics/PerceivedComplexity
       sig { params(dep: Dependabot::Dependency).returns(T.nilable(String)) }
       def previous_version(dep)
         version_str = dep.previous_version
         return version_str if version_class.correct?(version_str)
 
-        source = T.must(dep.previous_requirements)
-                  .find { |r| r.fetch(:source) }&.fetch(:source)
-        type = source&.fetch("type", nil) || source&.fetch(:type)
-        return version_str unless type == "git"
+        source = T.must(dep.previous_requirements).find(&:source)
+        return version_str if source.nil?
+        return version_str unless source.source_string("type") == "git"
 
-        ref = source.fetch("ref", nil) || source.fetch(:ref)
-        version_from_ref = ref&.gsub(/^v/, "")
+        version_from_ref = source.source_string("ref")&.gsub(/^v/, "")
         return version_str unless version_from_ref
         return version_str unless version_class.correct?(version_from_ref)
 
         version_from_ref
       end
-      # rubocop:enable Metrics/PerceivedComplexity
 
       sig { returns(T.nilable(T::Array[String])) }
       def create_default_dependencies_label_if_required

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -636,14 +636,14 @@ module Dependabot
       def updating_a_property?
         T.must(dependencies.first)
          .requirements
-         .any? { |r| r.dig(:metadata, :property_name) }
+         .any? { |r| r.metadata_string("property_name") }
       end
 
       sig { returns(T::Boolean) }
       def updating_a_dependency_set?
         T.must(dependencies.first)
          .requirements
-         .any? { |r| r.dig(:metadata, :dependency_set) }
+         .any? { |r| r.metadata_string_hash("dependency_set") }
       end
 
       sig { returns(T::Boolean) }
@@ -663,8 +663,8 @@ module Dependabot
           T.let(
             dependencies.first
               &.requirements
-              &.find { |r| r.dig(:metadata, :property_name) }
-              &.dig(:metadata, :property_name),
+              &.find { |r| r.metadata_string("property_name") }
+              &.metadata_string("property_name"),
             T.nilable(String)
           )
 
@@ -679,9 +679,9 @@ module Dependabot
           T.let(
             dependencies.first
               &.requirements
-              &.find { |r| r.dig(:metadata, :dependency_set) }
-              &.dig(:metadata, :dependency_set),
-            T.nilable(T.nilable(T::Hash[Symbol, String]))
+              &.find { |r| r.metadata_string_hash("dependency_set") }
+              &.metadata_string_hash("dependency_set"),
+            T.nilable(T::Hash[Symbol, String])
           )
 
         raise "No dependency set!" unless @dependency_set
@@ -910,10 +910,10 @@ module Dependabot
           T.must(dependency.previous_requirements) - dependency.requirements
 
         gemspec =
-          old_reqs.find { |r| r[:file].match?(%r{^[^/]*\.gemspec$}) }
-        return gemspec.fetch(:requirement) if gemspec
+          old_reqs.find { |r| T.must(r.file).match?(%r{^[^/]*\.gemspec$}) }
+        return gemspec.requirement_string if gemspec
 
-        req = T.must(old_reqs.first).fetch(:requirement)
+        req = T.must(old_reqs.first).requirement_string
         return req if req
 
         dependency.previous_ref if dependency.ref_changed?
@@ -925,10 +925,10 @@ module Dependabot
           dependency.requirements - T.must(dependency.previous_requirements)
 
         gemspec =
-          updated_reqs.find { |r| r[:file].match?(%r{^[^/]*\.gemspec$}) }
-        return gemspec.fetch(:requirement) if gemspec
+          updated_reqs.find { |r| T.must(r.file).match?(%r{^[^/]*\.gemspec$}) }
+        return T.must(gemspec.requirement_string) if gemspec
 
-        req = T.must(updated_reqs.first).fetch(:requirement)
+        req = T.must(updated_reqs.first).requirement_string
         return req if req
         return T.must(dependency.new_ref) if dependency.ref_changed? && dependency.new_ref
 

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -379,7 +379,7 @@ module Dependabot
           return false
         end
 
-        updated_requirements.none? { |r| r[:requirement] == :unfixable }
+        updated_requirements.none? { |r| r.requirement == :unfixable }
       end
 
       sig { returns(T::Boolean) }
@@ -415,7 +415,7 @@ module Dependabot
       def version_from_requirements
         @version_from_requirements ||=
           T.let(
-            dependency.requirements.filter_map { |r| r.fetch(:requirement) }
+            dependency.requirements.filter_map(&:requirement_string)
                       .flat_map { |req_str| requirement_class.requirements_array(req_str) }
                       .flat_map(&:requirements)
                       .reject { |req_array| req_array.first.start_with?("<") }
@@ -429,7 +429,7 @@ module Dependabot
       def requirements_can_update?
         return false if changed_requirements.none?
 
-        changed_requirements.none? { |r| r[:requirement] == :unfixable }
+        changed_requirements.none? { |r| r.requirement == :unfixable }
       end
     end
   end

--- a/common/spec/dependabot/update_checkers/base_spec.rb
+++ b/common/spec/dependabot/update_checkers/base_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Dependabot::UpdateCheckers::Base do
         latest_resolvable_version: latest_resolvable_version,
         latest_resolvable_version_with_no_unlock: latest_resolvable_version_with_no_unlock,
         latest_resolvable_previous_version: latest_resolvable_previous_version,
-        updated_requirements: updated_requirements
+        updated_requirements: updated_requirements.map { |r| Dependabot::DependencyRequirement.create(r) }
       )
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

`DependencyRequirement` subclasses `Hash` with its value generics pinned to `T.untyped`, and it stays that way until callers stop reading entries with `dig`, `fetch`, and `[]`. Three ecosystems were migrated recently; this does the same for `common`.

Giving those generics a real type today produces 440 Sorbet errors. 64 of them are in `common`, and this PR removes 58. The remaining six are five `T.cast` calls inside `DependencyRequirement` itself, which only become redundant once the generics actually change, plus `wrap_requirements`, which is a write-side signature better handled with that change.

### Anything you want to highlight for special attention from reviewers?

**This does not move the `ForbidTUntyped` count.** Nine of the ten files already had zero `T.untyped` tokens. The value is unblocking the generics work, not burndown, and the ratchet reports no change.

Two behavioural details worth a look:

- `labeler.rb` read the source type with `source&.fetch(:type)` and no default, so a git source with no `type` key raised `KeyError`. `source_string("type")` returns nil, and the method falls through to its existing "not a git source" branch. Simplifying these two methods also made their `Metrics/PerceivedComplexity` disables redundant.
- `update_checkers/base_spec.rb` stubbed `updated_requirements` with plain hashes. The method declares `T::Array[DependencyRequirement]` and every real override honours it, but an RSpec stub bypasses the runtime check, so the double was asserting a shape production never produces. It now builds `DependencyRequirement` instances.

The repeated `r.dig(:source, "ref") || r.dig(:source, :ref)` idiom collapses to `r.source_string("ref")`, which already accepts either key style. I deliberately left the four near-duplicate `previous_ref`/`new_ref`/`ref_changed?` implementations in place rather than folding them into the equivalents on `Dependency`, since that is a refactor of user-visible changelog and PR-message output, not a typing change.

### How will you know you've accomplished your goal?

Sorbet is clean and RuboCop passes on all 11 changed files. The full `common` suite passes with 2100 examples, plus docker (222) and bundler (140) metadata finder and update checker specs as a cross-ecosystem smoke test, since `common` is shared.

`file_updaters/base.rb` and the solo branch namer no longer make any untyped call, so both move to `typed: strong`. I verified that by flipping every changed file to `strong` and keeping only the ones Sorbet accepts, because `spoom srb bump --dry` runs in CI and fails when an eligible file is left behind.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
