### PR TITLE
Stop pinning the resolved js-yaml version in sub-dependency specs

### DIFF
--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -3663,13 +3663,14 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         let(:requirements) { [] }
         let(:previous_requirements) { nil }
 
+        # The yarn sub-dependency updater deletes the entries and reinstalls, so
+        # yarn resolves the ranges against the registry rather than the version
+        # requested above. Match the resolved version loosely, otherwise every
+        # js-yaml 3.x release breaks this spec.
         it "de-duplicates all entries to the same version" do
           expect(updated_files.map(&:name)).to contain_exactly("yarn.lock")
           expect(updated_yarn_lock.content)
-            .to include(
-              "js-yaml@^3.10.0, js-yaml@^3.4.6, js-yaml@^3.9.0:\n" \
-              '  version "3.15.0"'
-            )
+            .to match(/js-yaml@\^3\.10\.0, js-yaml@\^3\.4\.6, js-yaml@\^3\.9\.0:\n  version "3\.\d+\.\d+"/)
         end
       end
 
@@ -3990,10 +3991,13 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         let(:requirements) { [] }
         let(:previous_requirements) { nil }
 
+        # As with the yarn spec above, pnpm resolves the ranges against the
+        # registry, so assert a single resolved 3.x entry rather than a literal
+        # version that every js-yaml release invalidates.
         it "de-duplicates all entries to the same version" do
           expect(updated_files.map(&:name)).to contain_exactly("pnpm-lock.yaml")
 
-          expect(updated_pnpm_lock.content).to include("js-yaml@3.15.0:\n    resolution").once
+          expect(updated_pnpm_lock.content.scan(/js-yaml@3\.\d+\.\d+:\n    resolution/).size).to eq(1)
         end
       end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Two npm_and_yarn sub-dependency specs are failing on `main` and blocking unrelated PRs.

Both asserted an exact resolved version of `js-yaml`:

```ruby
'  version "3.15.0"'
include("js-yaml@3.15.0:\n    resolution").once
```

But the yarn and pnpm sub-dependency updaters delete the lockfile entries and reinstall, so the requirement ranges (`^3.10.0`, `^3.4.6`, `^3.9.0`) get resolved against the live registry. `subdependency-updater.ts` only ever reads `dependency.name`, never the version, and says so:

```
// SubDependencyVersionResolver relies on the install finding the latest
// version of a sub-dependency that's been removed from the lockfile
```

So the assertion was really "npm's newest js-yaml 3.x is exactly 3.15.0". js-yaml 3.15.1 was published on 2026-07-31 at 17:48 UTC and broke both. Reruns do not help, since the registry keeps serving the new version.

This is the third time:

| Release | Published | Fixed by |
| --- | --- | --- |
| 3.14.2 | 2025-11-14 | #13568, titled "Fix npm_and_yarn file_updater specs for js-yaml 3.14.2" |
| 3.15.0 | 2026-06-26 | #15444, as a drive-by |
| 3.15.1 | 2026-07-31 | this PR |

Both specs are named "de-duplicates all entries to the same version", so they now assert that: the ranges collapse into a single resolved 3.x entry. The pnpm one keeps its "exactly one entry" check via `scan(...).size`, which is the part that actually proves de-duplication.

### Anything you want to highlight for special attention from reviewers?

This does not weaken the specs in a meaningful way. Neither updater is given the resolved version, so the exact patch number was never something the code under test controls. Pinning it only asserted a fact about the registry.

The real fix would be to stop hitting the network here at all, which the repo's own testing guidelines ask for. That needs a fixture-backed registry for these two specs and felt too large to bundle with an unblock.

I left `let(:version) { "3.15.0" }` alone in both, since it is the version Dependabot passes in and is ignored on these paths.

### How will you know you've accomplished your goal?

Both specs pass, the full `file_updater_spec.rb` passes with 167 examples, and RuboCop is clean. I confirmed both failed on an unmodified `main` first, so this is not masking a regression.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
