### PR TITLE
Preserve .NET SDK prerelease version strings

### DIFF
--- a/dotnet_sdk/lib/dependabot/dotnet_sdk/version.rb
+++ b/dotnet_sdk/lib/dependabot/dotnet_sdk/version.rb
@@ -10,6 +10,13 @@ module Dependabot
     # However, for simpliticy, we will treat it as semver.
     # See: https://learn.microsoft.com/en-us/dotnet/core/versions/#versioning-details
     class Version < Dependabot::Version
+      extend T::Sig
+
+      # Gem::Version rewrites prerelease hyphens as ".pre.", which is not a valid .NET SDK version.
+      sig { override.returns(String) }
+      def to_s
+        @original_version
+      end
     end
   end
 end

--- a/dotnet_sdk/spec/dependabot/dotnet_sdk/file_updater_spec.rb
+++ b/dotnet_sdk/spec/dependabot/dotnet_sdk/file_updater_spec.rb
@@ -6,6 +6,7 @@ require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/dotnet_sdk/file_updater"
 require "dependabot/dotnet_sdk/requirement"
+require "dependabot/dotnet_sdk/version"
 require_common_spec "file_updaters/shared_examples_for_file_updaters"
 
 RSpec.describe Dependabot::DotnetSdk::FileUpdater do
@@ -91,6 +92,53 @@ RSpec.describe Dependabot::DotnetSdk::FileUpdater do
 
       it "does not update the version in global.json when the requirement has not changed" do
         expect(updated_dependency_files.size).to eq(0)
+      end
+    end
+
+    context "when updating to a preview version" do
+      let(:files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "global.json",
+            content: <<~JSON
+              {
+                "sdk": {
+                  "version": "11.0.100-preview.5.26302.115"
+                }
+              }
+            JSON
+          )
+        ]
+      end
+      let(:dependencies) do
+        [
+          Dependabot::Dependency.new(
+            name: "dotnet-sdk",
+            version: Dependabot::DotnetSdk::Version.new("11.0.100-preview.6.26359.118"),
+            previous_version: "11.0.100-preview.5.26302.115",
+            requirements: [{
+              requirement: "11.0.100-preview.6.26359.118",
+              file: "global.json",
+              groups: nil,
+              source: nil
+            }],
+            previous_requirements: [{
+              requirement: "11.0.100-preview.5.26302.115",
+              file: "global.json",
+              groups: nil,
+              source: nil
+            }],
+            package_manager: "dotnet_sdk"
+          )
+        ]
+      end
+
+      it "preserves the preview version in global.json" do
+        expect(updated_dependency_files.size).to eq(1)
+
+        config = updated_dependency_files.first
+        expect(config.name).to eq("global.json")
+        expect(JSON.parse(config.content).dig("sdk", "version")).to eq("11.0.100-preview.6.26359.118")
       end
     end
   end

--- a/dotnet_sdk/spec/dependabot/dotnet_sdk/package/package_details_fetcher_spec.rb
+++ b/dotnet_sdk/spec/dependabot/dotnet_sdk/package/package_details_fetcher_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe Dependabot::DotnetSdk::Package::PackageDetailsFetcher do
           expect(release.version).to be_a(Dependabot::DotnetSdk::Version)
         end
       end
+
+      it "preserves prerelease version strings" do
+        versions = fetcher.fetch.releases.map { |release| release.version.to_s }
+
+        expect(versions).to include("9.0.100-preview.7.24407.12", "9.0.100-rc.1.24452.12")
+      end
     end
 
     context "when releases index request fails" do

--- a/dotnet_sdk/spec/dependabot/dotnet_sdk/update_checker_spec.rb
+++ b/dotnet_sdk/spec/dependabot/dotnet_sdk/update_checker_spec.rb
@@ -100,4 +100,41 @@ RSpec.describe Dependabot::DotnetSdk::UpdateChecker do
       it { is_expected.to eq(Dependabot::Version.new("8.0.300")) }
     end
   end
+
+  describe "#updated_dependencies" do
+    subject(:updated_dependency) do
+      checker.updated_dependencies(requirements_to_unlock: :own).first
+    end
+
+    include_context "when the config is in root"
+
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "dotnet-sdk",
+        version: "11.0.100-preview.5.26302.115",
+        requirements: [{
+          requirement: "11.0.100-preview.5.26302.115",
+          file: "global.json",
+          groups: nil,
+          source: nil
+        }],
+        package_manager: "dotnet_sdk",
+        metadata: { allow_prerelease: true }
+      )
+    end
+    let(:target_version) do
+      Dependabot::DotnetSdk::Version.new("11.0.100-preview.6.26359.118")
+    end
+
+    before do
+      allow(Dependabot::DotnetSdk::UpdateChecker::LatestVersionFinder)
+        .to receive(:new).and_return(latest_version_finder)
+      allow(latest_version_finder).to receive(:latest_version).and_return(target_version)
+    end
+
+    it "preserves the preview version" do
+      expect(updated_dependency.version).to eq("11.0.100-preview.6.26359.118")
+      expect(updated_dependency.requirements.first[:requirement]).to eq("11.0.100-preview.6.26359.118")
+    end
+  end
 end

--- a/dotnet_sdk/spec/dependabot/dotnet_sdk/version_spec.rb
+++ b/dotnet_sdk/spec/dependabot/dotnet_sdk/version_spec.rb
@@ -1,0 +1,40 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dotnet_sdk/version"
+
+RSpec.describe Dependabot::DotnetSdk::Version do
+  subject(:version) { described_class.new(version_string) }
+
+  describe "#to_s" do
+    subject { version.to_s }
+
+    context "with a stable version" do
+      let(:version_string) { "11.0.100" }
+
+      it { is_expected.to eq("11.0.100") }
+    end
+
+    context "with a preview version" do
+      let(:version_string) { "11.0.100-preview.6.26359.118" }
+
+      it { is_expected.to eq("11.0.100-preview.6.26359.118") }
+    end
+
+    context "with a release candidate version" do
+      let(:version_string) { "9.0.100-rc.1.24452.12" }
+
+      it { is_expected.to eq("9.0.100-rc.1.24452.12") }
+    end
+  end
+
+  describe "#<=>" do
+    it "orders preview versions by their preview number" do
+      older = described_class.new("11.0.100-preview.5.26302.115")
+      newer = described_class.new("11.0.100-preview.6.26359.118")
+
+      expect(older).to be < newer
+    end
+  end
+end


### PR DESCRIPTION
Fixes #15583.

Preserve .NET SDK prerelease version strings when updating `global.json`. RubyGems currently rewrites `-preview` and `-rc` into invalid `.pre.*` forms.

Adds coverage from release metadata through dependency generation and file updates.

Smoke fixture: dependabot/smoke-tests#557. The prerelease smoke check will pass once that fixture is merged.
