### PR TITLE
Validate PR approval against current commit

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -52,6 +52,19 @@ jobs:
           # For security, the `gh` call that retrieves the PR approval status *must* also retrieve the commit at the
           # tip of the PR to ensure that any subsequent unreviewed commits are not pulled into this action workflow.
           DECISION=$(gh pr view ${{ env.PR }} --json reviewDecision,state,commits --jq '"\(.reviewDecision):\(.state):\(.commits | last .oid)"')
+
+          # Verify the last approval was granted on the exact current PR tip commit.
+          # This guards against stale approvals when "Dismiss stale reviews" is not enforced:
+          # without this check, reviewDecision stays APPROVED even after new (unreviewed) commits
+          # are pushed, allowing an attacker's commit to be recorded as the "approved" SHA.
+          PR_TIP=$(gh pr view ${{ env.PR }} --json commits --jq '.commits | last .oid')
+          APPROVED_COMMIT=$(gh api "repos/${{ github.repository }}/pulls/${{ env.PR }}/reviews" \
+            --jq '[.[] | select(.state == "APPROVED")] | sort_by(.submitted_at) | last | .commit_id')
+          if [[ "$APPROVED_COMMIT" != "$PR_TIP" ]]; then
+            echo "Stale approval detected: last approval was on $APPROVED_COMMIT but PR tip is $PR_TIP. Blocking build."
+            exit 1
+          fi
+
           echo "decision=$DECISION" >> $GITHUB_OUTPUT
 
   push-updater-images:


### PR DESCRIPTION
### What are you trying to accomplish?

**Issue:**

- Commit `10001` receives approval.
- The contributor later pushes commits `10002` and `10003`.
- GitHub continues reporting the PR as `APPROVED` because stale approvals are not dismissed.
- The workflow records and checks out `10003` as the current PR tip.
- Since the recorded SHA matches the checked-out SHA, it builds and pushes `10003`, even though that commit was never reviewed.


**Fix:**

Add explicit **approval-to-commit** validation:
- Retrieve the current PR tip SHA.
- Retrieve the commit SHA associated with the latest approval.
- Compare the two SHAs.
- Fail the approval job when they differ, preventing unreviewed commits from being built or pushed.

### Anything you want to highlight for special attention from reviewers?

This fix does not rely on the repository’s **Dismiss stale pull request approvals when new commits are pushed** setting. It validates the approval directly against the current PR tip SHA, so the workflow fails closed when the latest commit has not been approved.

Reviewers should pay particular attention to the GitHub Reviews API query and confirm that `commit_id` reliably represents the commit on which the approval was submitted.

### How will you know you've accomplished your goal?

**Not yet verified end to end**. The expected validation is:
- An approved current PR tip allows the image job to proceed.
- Pushing a new commit without reapproval causes the approval job to fail.
- The build and push job remains skipped.
- Approving the new tip allows the workflow to proceed again.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
