### PR TITLE
Fix spurious security_update_not_possible for multi-range npm advisories

### DIFF
--- a/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
+++ b/npm_and_yarn/helpers/lib/npm/vulnerability-auditor.ts
@@ -313,7 +313,12 @@ function convertAdvisoriesToRegistryBulkFormat(
       >((memo, version) => {
         memo.push({
           id: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
-          vulnerable_versions: version,
+          // Dependabot advisories join comparators with ", " but npm semver
+          // uses spaces. Loose semver parsing silently drops the comparator
+          // before a comma (">= 3.0.0, < 3.1.2" parses as "<3.1.2"), turning
+          // a range for one major into one that also covers every lower
+          // version, so strip the commas before Arborist sees the range.
+          vulnerable_versions: version.replace(/,/g, " "),
         });
         return memo;
       }, []);

--- a/npm_and_yarn/helpers/test/npm/fixtures/vulnerability-auditor/range-order-lower-major-only/package-lock.json
+++ b/npm_and_yarn/helpers/test/npm/fixtures/vulnerability-auditor/range-order-lower-major-only/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "test-vulnerability-range-order-lower-major-only",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-vulnerability-range-order-lower-major-only",
+      "version": "1.0.0",
+      "dependencies": {
+        "@msgpack/msgpack": "^2.7.2"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.7.2.tgz",
+      "integrity": "sha512-rYEi46+gIzufyYUAoHDnRzkWGxajpD9vVXFQ3g1vbjrBm6P7MBmm+s/fqPa46sxa+8FOUdEuRQKaugo5a4JWpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  }
+}

--- a/npm_and_yarn/helpers/test/npm/fixtures/vulnerability-auditor/range-order-lower-major-only/package.json
+++ b/npm_and_yarn/helpers/test/npm/fixtures/vulnerability-auditor/range-order-lower-major-only/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-vulnerability-range-order-lower-major-only",
+  "version": "1.0.0",
+  "private": true,
+  "description": "",
+  "dependencies": {
+    "@msgpack/msgpack": "^2.7.2"
+  }
+}

--- a/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
+++ b/npm_and_yarn/helpers/test/npm/vulnerability-auditor.test.ts
@@ -348,4 +348,80 @@ describe("findVulnerableDependencies", () => {
       ])
     );
   });
+
+  // Regression tests for https://github.com/dependabot/dependabot-core/issues/13644:
+  // the audit outcome must not depend on the order of affected_versions ranges.
+  // GitHub's API emits multi-major advisories in descending-major order (the
+  // higher-major ranges first), which is the order that triggers the bug.
+
+  it("reports the same fix when affected_versions lists the higher major first", async () => {
+    helpers.copyDependencies(
+      "vulnerability-auditor/update-needed-across-two-versions",
+      tempDir
+    );
+
+    // Identical to "finds vulnerable dependencies when multiple versions of the
+    // same package are affected", except the two ranges are swapped.
+    const advisories = [
+      {
+        dependency_name: "@msgpack/msgpack",
+        affected_versions: [">= 3.0.0, < 3.1.2", ">= 2.0.0, < 2.8.0"],
+      },
+    ];
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.dependency_name).toBe("@msgpack/msgpack");
+    expect(actual.current_version).toBe("2.7.2");
+    expect(actual.fix_available).toBe(true);
+    expect(actual.target_version).toBe("2.8.0");
+
+    expect(actual.fix_updates).toEqual(
+      expect.arrayContaining([
+        {
+          dependency_name: "@msgpack/msgpack",
+          current_version: "2.7.2",
+          target_version: "2.8.0",
+          top_level_ancestors: [],
+        },
+        {
+          dependency_name: "@msgpack/msgpack",
+          current_version: "3.0.0",
+          target_version: "3.1.3",
+          top_level_ancestors: ["wireql-client"],
+        },
+      ])
+    );
+  });
+
+  it("fixes an installed lower major when a range for an uninstalled higher major is listed first", async () => {
+    helpers.copyDependencies(
+      "vulnerability-auditor/range-order-lower-major-only",
+      tempDir
+    );
+
+    // Only @msgpack/msgpack 2.7.2 is installed (manifest range ^2.7.2, so the
+    // patched 2.8.0 is an in-range lockfile-only update). The 3.x range applies
+    // to published versions that don't appear in this tree and must be inert.
+    const advisories = [
+      {
+        dependency_name: "@msgpack/msgpack",
+        affected_versions: [">= 3.0.0, < 3.1.2", ">= 2.0.0, < 2.8.0"],
+      },
+    ];
+    const actual = await findVulnerableDependencies(tempDir, advisories);
+
+    expect(actual.dependency_name).toBe("@msgpack/msgpack");
+    expect(actual.current_version).toBe("2.7.2");
+    expect(actual.fix_available).toBe(true);
+    expect(actual.target_version).toBe("2.8.0");
+
+    expect(actual.fix_updates).toEqual([
+      {
+        dependency_name: "@msgpack/msgpack",
+        current_version: "2.7.2",
+        target_version: "2.8.0",
+        top_level_ancestors: [],
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
### What are you trying to accomplish?

#### Problem
npm security updates for multi-range advisories spuriously fail with `security_update_not_possible` (or propose semver-major fix targets for in-range, lockfile-only updates) depending on the order of the affected-versions ranges.

This is also what is reported in #13644.

#### Example

The error recorded by GitHub's production service on one such alert (`brace-expansion`, [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), vulnerable range `< 1.1.17`, locked at `1.1.14`)

> The latest possible version that can be installed is `1.1.14` because of the following conflicting dependency:
>
>```
> brace-expansion can't be automatically updated to a non-vulnerable version. The following top-level dependencies still require a vulnerable brace-expansion and need to be updated:
>  - @babel/cli: requires brace-expansion@^1.1.7 (via minimatch@3.1.2)
>  - @storybook/html-webpack5: requires brace-expansion@^1.1.7 (via minimatch@3.1.2)
>  - eslint: requires brace-expansion@^1.1.7 (via minimatch@3.1.2)
>  - twig: requires brace-expansion@^1.1.7 (via minimatch@3.0.8)
>  - twig-drupal-filters: requires brace-expansion@^1.1.7 (via minimatch@3.0.8)
>  - twig-loader: requires brace-expansion@^1.1.7 (via minimatch@3.0.8)
>  
> To resolve this, update @babel/cli, ... to a release that depends on a non-vulnerable brace-expansion, or add an override/resolution pinning brace-expansion to a non-vulnerable version.
> ```
>
> The earliest fixed version is `1.1.17`.

To me this makes no sense. All top level dependencies allow updating to `brace-expansion` to `1.1.17`.


#### Root cause

Dependabot advisories join comparators with `, ` but [npm semver separates them with spaces](https://github.com/npm/node-semver#range-grammar), and loose semver parsing silently drops the comparator before a comma:

```
  new semver.Range('>= 3.0.0, < 3.1.2')                  // throws: Invalid comparator: >=3.0.0,
  new semver.Range('>= 3.0.0, < 3.1.2', { loose: true }) // .range === '<3.1.2'  (comparator silently filtered, classes/range.js "in loose mode, throw out any that are not valid comparators")
```  

The vulnerability auditor serves these ranges verbatim to Arborist's audit endpoint, so a higher major's range degrades into one that also covers every lower version. In `AuditReport#init`, whichever advisory reaches a node first claims it (the `vuln.nodes.has(node)` short-circuit) and computes `fixAvailable` from its range alone — so the range order decides between a correct in-range fix and a spurious dead end. 

Any advisory patched separately across majors is affected (e.g. `brace-expansion` [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) with four ranges, `js-yaml` [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)).

The fix normalizes the ranges to npm syntax (`,` → ` `) in `convertAdvisoriesToRegistryBulkFormat()`, the boundary where Dependabot's advisory format meets npm's parser.

### Anything you want to highlight for special attention from reviewers?

  - The range order itself is left untouched: once the ranges parse correctly, order no longer affects the outcome (the regression tests assert this invariant directly).
  - The normalization lives in the TS helper rather than the Ruby side because Ruby parses the comma format correctly everywhere else — the recorded errors for affected alerts even
  state the right "earliest fixed version" while the resolution works from the mangled range. Only the data handed to Arborist needs npm syntax.
  - Scope is the `npm` vulnerability auditor only; the `yarn` code path was not assessed here.

### How will you know you've accomplished your goal?

  - The first commit adds two regression tests that fail on `main` and pass with the fix: 
    - The existing two-major fixture with its advisory ranges swapped (target becomes `3.1.3` instead
  of `2.8.0`)
    - A new single-major fixture where the swapped order yields a target from a major that isn't in the tree and can't satisfy `^2.7.2`.
  - Reproduced end-to-end with the `dependabot` CLI (updater image of 2026-08-02) against two real-world lockfiles hit by GHSA-mh99-v99m-4gvg: GitHub's API range order records `security_update_not_possible` errors identical to production; the installed major's range first produces correct lockfile-only PRs — including one fixing `brace-expansion` at `1.x` and `2.x` in a single PR.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
