### PR TITLE
gracefully handle exceptions generated during package detail fetch

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGeneratorTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/DetailedPullRequestBodyGeneratorTests.cs
@@ -1088,6 +1088,56 @@ public class DetailedPullRequestBodyGeneratorTests
         );
     }
 
+    [Fact]
+    public async Task ExceptionDuringDetailFetchDoesNotAbortDetailsBuilding()
+    {
+        // arrange
+        var throwingHttpFetcher = new TestHttpFetcher(_ => throw new HttpRequestException("this endpoint cannot be queried"));
+        var prGenerator = new DetailedPullRequestBodyGenerator(throwingHttpFetcher);
+        var job = new Job()
+        {
+            Source = new()
+            {
+                Provider = "github",
+                Repo = "test/repo"
+            },
+        };
+        var updateOperationsPerformed = ImmutableArray.Create<UpdateOperationBase>(
+            new DirectUpdate()
+            {
+                DependencyName = "Some.Dependency",
+                OldVersion = NuGetVersion.Parse("1.0.0"),
+                NewVersion = NuGetVersion.Parse("2.0.0"),
+                UpdatedFiles = []
+            }
+        );
+        var updatedDependencies = ImmutableArray.Create(
+            new ReportedDependency()
+            {
+                Name = "Some.Dependency",
+                PreviousVersion = "1.0.0",
+                Version = "2.0.0",
+                Requirements = [
+                    new ReportedRequirement()
+                    {
+                        File = "",
+                        Requirement = "2.0.0",
+                        Source = new()
+                        {
+                            SourceUrl = "https://github.com/Some.Owner/Some.Dependency",
+                        },
+                    }
+                ]
+            }
+        );
+
+        // act
+        var prBody = await prGenerator.GeneratePullRequestBodyTextAsync(job, updateOperationsPerformed, updatedDependencies);
+
+        // assert
+        Assert.Contains("No release notes found for this version range.", prBody);
+    }
+
     private static async Task TestAsync(
         ImmutableArray<UpdateOperationBase> updateOperationsPerformed,
         ImmutableArray<ReportedDependency> updatedDependencies,
@@ -1108,7 +1158,7 @@ public class DetailedPullRequestBodyGeneratorTests
 
         // act
         var responses = httpResponses.ToDictionary(x => x.Url, x => x.Body);
-        var httpFetcher = new TestHttpFetcher(responses);
+        var httpFetcher = new TestStringResponseHttpFetcher(responses);
         var generator = new DetailedPullRequestBodyGenerator(httpFetcher);
         var actualBody = await generator.GeneratePullRequestBodyTextAsync(job, updateOperationsPerformed, updatedDependencies);
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/TestHttpFetcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/TestHttpFetcher.cs
@@ -4,11 +4,11 @@ namespace NuGetUpdater.Core.Test.Run.PullRequestBodyGenerator;
 
 internal class TestHttpFetcher : IHttpFetcher
 {
-    private readonly Dictionary<string, string> _responses;
+    private readonly Func<string, string?> _responseHandler;
 
-    public TestHttpFetcher(Dictionary<string, string> responses)
+    public TestHttpFetcher(Func<string, string?> responseHandler)
     {
-        _responses = responses;
+        _responseHandler = responseHandler;
     }
 
     public void Dispose()
@@ -17,7 +17,7 @@ internal class TestHttpFetcher : IHttpFetcher
 
     public Task<string?> GetStringAsync(string url)
     {
-        _responses.TryGetValue(url, out var response);
+        var response = _responseHandler(url);
         return Task.FromResult(response);
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/TestStringResponseHttpFetcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestBodyGenerator/TestStringResponseHttpFetcher.cs
@@ -1,0 +1,22 @@
+namespace NuGetUpdater.Core.Test.Run.PullRequestBodyGenerator;
+
+internal class TestStringResponseHttpFetcher : TestHttpFetcher
+{
+    public TestStringResponseHttpFetcher(Dictionary<string, string> responses)
+        : base(BuildResponseGenerator(responses))
+    {
+    }
+
+    private static Func<string, string?> BuildResponseGenerator(Dictionary<string, string> responses)
+    {
+        return new Func<string, string?>(url =>
+        {
+            if (responses.TryGetValue(url, out var response))
+            {
+                return response;
+            }
+
+            return null;
+        });
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IHttpFetcher.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestBodyGenerator/IHttpFetcher.cs
@@ -11,18 +11,18 @@ internal static class IHttpFetcherExtensions
 {
     public static async Task<JsonElement?> GetJsonElementAsync(this IHttpFetcher fetcher, string url)
     {
-        var jsonString = await fetcher.GetStringAsync(url);
-        if (jsonString is null)
-        {
-            return null;
-        }
-
         try
         {
+            var jsonString = await fetcher.GetStringAsync(url);
+            if (jsonString is null)
+            {
+                return null;
+            }
+
             var json = JsonSerializer.Deserialize<JsonElement>(jsonString);
             return json;
         }
-        catch (JsonException)
+        catch (Exception)
         {
             return null;
         }


### PR DESCRIPTION
When building a detailed PR body message for an update, requests are sent to `https://api.github.com`.  If an exception is thrown during that fetch, the whole process will be aborted.  This can happen for a number of reasons, but some quick ones are:

- `api.github.com` returns an error code like 401 or 500
- the dependabot updater is being run in a pseudo-air gapped environment where the calls to `api.github.com` are either intercepted or blocked

Either way, the initial request to `api.github.com` is correct and should still be attempted, but any failure there should allow the updater to continue as best as possible.

The fix is to expand the `try`/`catch` to also surround the request, not just the deserialization.  In either case, the correct behavior is to report nothing because we can still generate a PR body without the details.

This required a new implementation of `IHttpFetcher` that throws an exception instead of mocking a response.  To accomplish this, the class `TestHttpFetcher` was made more general and given a simple `Func<string, string?>` handler and the existing one was renamed to `TestStringResponseHttpFetcher` and passed through the more generic code.