### PR TITLE
Fix(uv): stop editing editable path deps outside the update directory

### DIFF
--- a/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
@@ -109,7 +109,53 @@ module Dependabot
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
         def workspace_member_pyproject_files
-          dependency_files.select { |file| file.support_file? && file.name.end_with?("pyproject.toml") }
+          return [] if workspace_member_patterns.empty?
+
+          dependency_files.select do |file|
+            next false unless file.support_file? && file.name.end_with?("pyproject.toml")
+
+            workspace_member_file?(file)
+          end
+        end
+
+        # Only pyprojects declared under `[tool.uv.workspace].members` in the root
+        # manifest are true workspace members whose requirements should be updated.
+        # Editable `[tool.uv.sources]` path dependencies are separate packages that
+        # are fetched as support files for resolution but must not be modified.
+        sig { returns(T::Array[String]) }
+        def workspace_member_patterns
+          workspace_globs("members")
+        end
+
+        # uv removes paths matching `[tool.uv.workspace].exclude` after expanding
+        # `members`, so an excluded directory is not a workspace member even when it
+        # matches a `members` glob.
+        sig { returns(T::Array[String]) }
+        def workspace_exclude_patterns
+          workspace_globs("exclude")
+        end
+
+        sig { params(key: String).returns(T::Array[String]) }
+        def workspace_globs(key)
+          return [] unless pyproject
+
+          globs = parsed_pyproject.dig("tool", "uv", "workspace", key)
+          globs.is_a?(Array) ? globs.grep(String) : []
+        end
+
+        sig { params(file: Dependabot::DependencyFile).returns(T::Boolean) }
+        def workspace_member_file?(file)
+          member_dir = File.dirname(file.name)
+
+          return false if workspace_exclude_patterns.any? { |pattern| glob_matches_dir?(pattern, member_dir) }
+
+          workspace_member_patterns.any? { |pattern| glob_matches_dir?(pattern, member_dir) }
+        end
+
+        sig { params(pattern: String, dir: String).returns(T::Boolean) }
+        def glob_matches_dir?(pattern, dir)
+          normalized_pattern = pattern.gsub(%r{^\./}, "").chomp("/")
+          File.fnmatch?(normalized_pattern, dir, File::FNM_PATHNAME)
         end
 
         sig { returns(Dependabot::FileParsers::Base::DependencySet) }

--- a/uv/spec/dependabot/uv/file_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser_spec.rb
@@ -1076,7 +1076,7 @@ RSpec.describe Dependabot::Uv::FileParser do
             name = "pkg-b"
             version = "0.1.0"
             dependencies = [
-              "click>=8.4.1",
+              "only-in-b>=1.0.0",
             ]
           TOML
         )
@@ -1089,19 +1089,34 @@ RSpec.describe Dependabot::Uv::FileParser do
           pyproject_path = args.first
           parsed_files << pyproject_path
 
-          raise "Unexpected pyproject path: #{pyproject_path}" unless pyproject_path == "pyproject.toml"
-
-          [
-            {
-              "name" => "click",
-              "version" => nil,
-              "markers" => nil,
-              "file" => "pyproject.toml",
-              "requirement" => ">=8.4.1",
-              "extras" => [],
-              "requirement_type" => nil
-            }
-          ]
+          case pyproject_path
+          when "pyproject.toml"
+            [
+              {
+                "name" => "click",
+                "version" => nil,
+                "markers" => nil,
+                "file" => "pyproject.toml",
+                "requirement" => ">=8.4.1",
+                "extras" => [],
+                "requirement_type" => nil
+              }
+            ]
+          when "../../packages/b/pyproject.toml"
+            [
+              {
+                "name" => "only-in-b",
+                "version" => nil,
+                "markers" => nil,
+                "file" => "../../packages/b/pyproject.toml",
+                "requirement" => ">=1.0.0",
+                "extras" => [],
+                "requirement_type" => nil
+              }
+            ]
+          else
+            raise "Unexpected pyproject path: #{pyproject_path}"
+          end
         end
       end
 
@@ -1109,6 +1124,10 @@ RSpec.describe Dependabot::Uv::FileParser do
         dependencies
 
         expect(parsed_files).to contain_exactly("pyproject.toml")
+      end
+
+      it "excludes dependencies declared only in the editable package" do
+        expect(dependencies.map(&:name)).not_to include("only-in-b")
       end
 
       it "only records click's requirement from the consumer manifest" do
@@ -1154,7 +1173,7 @@ RSpec.describe Dependabot::Uv::FileParser do
             name = "pkg-b"
             version = "0.1.0"
             dependencies = [
-              "click>=8.4.1",
+              "only-in-b>=1.0.0",
             ]
           TOML
         )
@@ -1167,19 +1186,34 @@ RSpec.describe Dependabot::Uv::FileParser do
           pyproject_path = args.first
           parsed_files << pyproject_path
 
-          raise "Unexpected pyproject path: #{pyproject_path}" unless pyproject_path == "pyproject.toml"
-
-          [
-            {
-              "name" => "click",
-              "version" => nil,
-              "markers" => nil,
-              "file" => "pyproject.toml",
-              "requirement" => ">=8.4.1",
-              "extras" => [],
-              "requirement_type" => nil
-            }
-          ]
+          case pyproject_path
+          when "pyproject.toml"
+            [
+              {
+                "name" => "click",
+                "version" => nil,
+                "markers" => nil,
+                "file" => "pyproject.toml",
+                "requirement" => ">=8.4.1",
+                "extras" => [],
+                "requirement_type" => nil
+              }
+            ]
+          when "packages/b/pyproject.toml"
+            [
+              {
+                "name" => "only-in-b",
+                "version" => nil,
+                "markers" => nil,
+                "file" => "packages/b/pyproject.toml",
+                "requirement" => ">=1.0.0",
+                "extras" => [],
+                "requirement_type" => nil
+              }
+            ]
+          else
+            raise "Unexpected pyproject path: #{pyproject_path}"
+          end
         end
       end
 
@@ -1187,6 +1221,10 @@ RSpec.describe Dependabot::Uv::FileParser do
         dependencies
 
         expect(parsed_files).to contain_exactly("pyproject.toml")
+      end
+
+      it "excludes dependencies declared only in the excluded member" do
+        expect(dependencies.map(&:name)).not_to include("only-in-b")
       end
     end
   end

--- a/uv/spec/dependabot/uv/file_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser_spec.rb
@@ -1046,6 +1046,149 @@ RSpec.describe Dependabot::Uv::FileParser do
         )
       end
     end
+
+    context "with an editable path dependency that is not a workspace member" do
+      let(:files) { [pyproject, editable_path_pyproject] }
+      let(:parsed_files) { [] }
+      let(:pyproject) do
+        Dependabot::DependencyFile.new(
+          name: "pyproject.toml",
+          content: <<~TOML
+            [project]
+            name = "service-c"
+            version = "0.1.0"
+            dependencies = [
+              "click>=8.4.1",
+              "pkg-b",
+            ]
+
+            [tool.uv.sources]
+            pkg-b = { path = "../../packages/b", editable = true }
+          TOML
+        )
+      end
+      let(:editable_path_pyproject) do
+        Dependabot::DependencyFile.new(
+          name: "../../packages/b/pyproject.toml",
+          support_file: true,
+          content: <<~TOML
+            [project]
+            name = "pkg-b"
+            version = "0.1.0"
+            dependencies = [
+              "click>=8.4.1",
+            ]
+          TOML
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess) do |function:, args:, **|
+          raise "Unexpected helper function: #{function}" unless function == "parse_pep621_pep735_dependencies"
+
+          pyproject_path = args.first
+          parsed_files << pyproject_path
+
+          raise "Unexpected pyproject path: #{pyproject_path}" unless pyproject_path == "pyproject.toml"
+
+          [
+            {
+              "name" => "click",
+              "version" => nil,
+              "markers" => nil,
+              "file" => "pyproject.toml",
+              "requirement" => ">=8.4.1",
+              "extras" => [],
+              "requirement_type" => nil
+            }
+          ]
+        end
+      end
+
+      it "does not parse the editable package's manifest" do
+        dependencies
+
+        expect(parsed_files).to contain_exactly("pyproject.toml")
+      end
+
+      it "only records click's requirement from the consumer manifest" do
+        dependency = dependencies.find { |dep| dep.name == "click" }
+
+        expect(dependency&.requirements).to eq(
+          [{
+            requirement: ">=8.4.1",
+            file: "pyproject.toml",
+            groups: [],
+            source: nil
+          }]
+        )
+      end
+    end
+
+    context "with a workspace member that is excluded from the workspace" do
+      let(:files) { [pyproject, excluded_member_pyproject] }
+      let(:parsed_files) { [] }
+      let(:pyproject) do
+        Dependabot::DependencyFile.new(
+          name: "pyproject.toml",
+          content: <<~TOML
+            [project]
+            name = "workspace-root"
+            version = "0.1.0"
+            dependencies = [
+              "click>=8.4.1",
+            ]
+
+            [tool.uv.workspace]
+            members = ["packages/*"]
+            exclude = ["packages/b"]
+          TOML
+        )
+      end
+      let(:excluded_member_pyproject) do
+        Dependabot::DependencyFile.new(
+          name: "packages/b/pyproject.toml",
+          support_file: true,
+          content: <<~TOML
+            [project]
+            name = "pkg-b"
+            version = "0.1.0"
+            dependencies = [
+              "click>=8.4.1",
+            ]
+          TOML
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess) do |function:, args:, **|
+          raise "Unexpected helper function: #{function}" unless function == "parse_pep621_pep735_dependencies"
+
+          pyproject_path = args.first
+          parsed_files << pyproject_path
+
+          raise "Unexpected pyproject path: #{pyproject_path}" unless pyproject_path == "pyproject.toml"
+
+          [
+            {
+              "name" => "click",
+              "version" => nil,
+              "markers" => nil,
+              "file" => "pyproject.toml",
+              "requirement" => ">=8.4.1",
+              "extras" => [],
+              "requirement_type" => nil
+            }
+          ]
+        end
+      end
+
+      it "does not parse the excluded member's manifest" do
+        dependencies
+
+        expect(parsed_files).to contain_exactly("pyproject.toml")
+      end
+    end
   end
 
   describe "#run_in_parsed_context" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #15253.

When updating a uv project, Dependabot also rewrites the dependency floor in **separate editable packages** referenced via `[tool.uv.sources]` path deps — files that live **outside** the configured update directory.

**Why it happens**

- Editable path deps are fetched as *support files* so `uv lock` can resolve them.
- The parser treated **every** support-file `pyproject.toml` as a uv workspace member.
- So their requirements were parsed and bumped, even though they aren't workspace members.

**The fix**

- Only manifests declared under `[tool.uv.workspace].members` count as workspace members.
- Editable path deps are still fetched for resolution, but never modified.

### Anything you want to highlight for special attention from reviewers?

- Membership is matched against the root manifest's `[tool.uv.workspace].members` globs, mirroring the fetcher's matching (`File.fnmatch?` with `FNM_PATHNAME`).
- Real workspace members are unaffected — the existing workspace test still passes.

### How will you know you've accomplished your goal?

Reproduced with **unmodified** Dependabot against a real repo (`dsp-testing/uv-editable-lock-repro-15253`, layout: consumer at `/services/c`, editable dep at `/packages/b`).

Bumping `click` 8.4.1 → 8.4.2:

| | Files changed | `packages/b` touched? |
|---|---|---|
| **Before** (hosted PR) | `services/c/pyproject.toml`, `services/c/uv.lock`, `packages/b/pyproject.toml` | ❌ Yes (the bug) |
| **After** (patched dry-run) | `services/c/pyproject.toml`, `services/c/uv.lock` | ✅ No |

- `uv lock --check` passes on the patched result → lockfile stays consistent, CI green.
- New regression test covers the editable-path-dep case; full uv parser spec passes (69 examples); RuboCop clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
