### PR TITLE
Type shared container requirement access

### DIFF
--- a/common/lib/dependabot/dependency_requirement.rb
+++ b/common/lib/dependabot/dependency_requirement.rb
@@ -165,6 +165,16 @@ module Dependabot
       raise TypeError, "metadata #{key} must be a string or nil"
     end
 
+    # Reads a known symbol-valued metadata field such as Helm's "type".
+    sig { params(key: String).returns(T.nilable(Symbol)) }
+    def metadata_symbol(key)
+      value = metadata_value(key)
+      return if value.nil?
+      return value if value.is_a?(Symbol)
+
+      raise TypeError, "metadata #{key} must be a symbol or nil"
+    end
+
     # Reads a nested metadata hash whose values are all strings, such as
     # "dependency_set" (`{ group: "my.group", version: "1.4.0" }`). Keys are
     # symbolised so callers can read them with symbols regardless of how the

--- a/common/spec/dependabot/dependency_requirement_spec.rb
+++ b/common/spec/dependabot/dependency_requirement_spec.rb
@@ -237,6 +237,31 @@ RSpec.describe Dependabot::DependencyRequirement do
         .to raise_error(TypeError, "metadata property_name must be a string or nil")
     end
 
+    it "reads a symbol metadata value" do
+      req = described_class.create(requirement_hash.merge(metadata: { type: :helm_chart }))
+
+      expect(req.metadata_symbol("type")).to eq(:helm_chart)
+    end
+
+    it "reads a symbol value from string-keyed metadata" do
+      req = described_class.create(requirement_hash.merge(metadata: { "type" => :docker_image }))
+
+      expect(req.metadata_symbol("type")).to eq(:docker_image)
+    end
+
+    it "returns nil for an absent symbol metadata value" do
+      req = described_class.create(requirement_hash)
+
+      expect(req.metadata_symbol("type")).to be_nil
+    end
+
+    it "rejects a non-symbol metadata value" do
+      req = described_class.create(requirement_hash.merge(metadata: { type: "helm_chart" }))
+
+      expect { req.metadata_symbol("type") }
+        .to raise_error(TypeError, "metadata type must be a symbol or nil")
+    end
+
     it "reads a metadata hash of strings" do
       req = described_class.create(
         requirement_hash.merge(metadata: { dependency_set: { group: "my.group", version: "1.4.0" } })

--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/file_updaters"
@@ -17,9 +17,13 @@ module Dependabot
 
       FROM_REGEX = /FROM(\s+--platform\=\S+)?/i
 
+      ImageSource = T.type_alias do
+        T::Hash[Symbol, T.nilable(String)]
+      end
+
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
       def updated_dependency_files
-        updated_files = []
+        updated_files = T.let([], T::Array[Dependabot::DependencyFile])
         dependency_files.each do |file|
           next unless requirement_changed?(file, T.must(dependency))
 
@@ -72,8 +76,8 @@ module Dependabot
       sig do
         params(
           previous_content: String,
-          old_source: T::Hash[Symbol, T.nilable(String)],
-          new_source: T::Hash[Symbol, T.nilable(String)]
+          old_source: ImageSource,
+          new_source: ImageSource
         ).returns(String)
       end
       def update_digest_and_tag(previous_content, old_source, new_source)
@@ -178,19 +182,21 @@ module Dependabot
 
       sig { params(file: Dependabot::DependencyFile).returns(String) }
       def new_yaml_image(file)
-        element = T.must(dependency).requirements.find { |r| r[:file] == file.name }
-        prefix = element&.dig(:source, :registry) ? "#{element.fetch(:source)[:registry]}/" : ""
-        digest = element&.dig(:source, :digest) ? "@sha256:#{element.fetch(:source)[:digest]}" : ""
-        tag = element&.dig(:source, :tag) ? ":#{element.fetch(:source)[:tag]}" : ""
+        element = T.must(dependency).requirements.find { |r| r.file == file.name }
+        source = image_source(element)
+        prefix = source[:registry] ? "#{source[:registry]}/" : ""
+        digest = source[:digest] ? "@sha256:#{source[:digest]}" : ""
+        tag = source[:tag] ? ":#{source[:tag]}" : ""
         "#{prefix}#{T.must(dependency).name}#{tag}#{digest}"
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(T::Array[String]) }
       def old_yaml_images(file)
         T.must(previous_requirements(file)).map do |r|
-          prefix = r.fetch(:source)[:registry] ? "#{r.fetch(:source)[:registry]}/" : ""
-          digest = r.fetch(:source)[:digest] ? "@sha256:#{r.fetch(:source)[:digest]}" : ""
-          tag = r.fetch(:source)[:tag] ? ":#{r.fetch(:source)[:tag]}" : ""
+          source = image_source(r)
+          prefix = source[:registry] ? "#{source[:registry]}/" : ""
+          digest = source[:digest] ? "@sha256:#{source[:digest]}" : ""
+          tag = source[:tag] ? ":#{source[:tag]}" : ""
           "#{prefix}#{T.must(dependency).name}#{tag}#{digest}"
         end
       end
@@ -198,17 +204,19 @@ module Dependabot
       sig { params(file: Dependabot::DependencyFile).returns(T::Array[String]) }
       def old_helm_tags(file)
         T.must(previous_requirements(file)).map do |r|
-          tag = r.fetch(:source)[:tag] || ""
-          digest = r.fetch(:source)[:digest] ? "@sha256:#{r.fetch(:source)[:digest]}" : ""
+          source = image_source(r)
+          tag = source[:tag] || ""
+          digest = source[:digest] ? "@sha256:#{source[:digest]}" : ""
           "#{tag}#{digest}"
         end
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(String) }
       def new_helm_tag(file)
-        element = T.must(dependency).requirements.find { |r| r[:file] == file.name }
-        tag = T.must(element).dig(:source, :tag) || ""
-        digest = T.must(element).dig(:source, :digest) ? "@sha256:#{T.must(element).dig(:source, :digest)}" : ""
+        element = T.must(dependency).requirements.find { |r| r.file == file.name }
+        source = image_source(element)
+        tag = source[:tag] || ""
+        digest = source[:digest] ? "@sha256:#{source[:digest]}" : ""
         "#{tag}#{digest}"
       end
 
@@ -219,15 +227,15 @@ module Dependabot
         changed_requirements =
           dependency.requirements - T.must(dependency.previous_requirements)
 
-        changed_requirements.any? { |f| f[:file] == file.name }
+        changed_requirements.any? { |f| f.file == file.name }
       end
 
-      sig { params(source: T::Hash[Symbol, T.nilable(String)]).returns(T::Boolean) }
+      sig { params(source: ImageSource).returns(T::Boolean) }
       def specified_with_tag?(source)
         !source[:tag].nil?
       end
 
-      sig { params(source: T::Hash[Symbol, T.nilable(String)]).returns(T::Boolean) }
+      sig { params(source: ImageSource).returns(T::Boolean) }
       def specified_with_digest?(source)
         !source[:digest].nil?
       end
@@ -235,28 +243,41 @@ module Dependabot
       sig { params(file: Dependabot::DependencyFile).returns(T::Array[Dependabot::DependencyRequirement]) }
       def requirements(file)
         T.must(dependency).requirements
-         .select { |r| r[:file] == file.name }
+         .select { |r| r.file == file.name }
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(T.nilable(T::Array[Dependabot::DependencyRequirement])) }
       def previous_requirements(file)
         T.must(dependency).previous_requirements
-         &.select { |r| r[:file] == file.name }
+         &.select { |r| r.file == file.name }
       end
 
-      sig { params(source: T::Hash[Symbol, T.nilable(String)]).returns(T.nilable(String)) }
+      sig { params(source: ImageSource).returns(T.nilable(String)) }
       def private_registry_url(source)
         source[:registry]
       end
 
-      sig { params(file: Dependabot::DependencyFile).returns(T::Array[T::Hash[Symbol, T.nilable(String)]]) }
+      sig { params(file: Dependabot::DependencyFile).returns(T::Array[ImageSource]) }
       def sources(file)
-        requirements(file).map { |r| r.fetch(:source) }
+        requirements(file).map { |r| image_source(r) }
       end
 
-      sig { params(file: Dependabot::DependencyFile).returns(T.nilable(T::Array[T::Hash[Symbol, T.nilable(String)]])) }
+      sig { params(file: Dependabot::DependencyFile).returns(T.nilable(T::Array[ImageSource])) }
       def previous_sources(file)
-        previous_requirements(file)&.map { |r| r.fetch(:source) }
+        previous_requirements(file)&.map { |r| image_source(r) }
+      end
+
+      sig { params(requirement: T.nilable(Dependabot::DependencyRequirement)).returns(ImageSource) }
+      def image_source(requirement)
+        return { registry: nil, tag: nil, digest: nil } if requirement.nil?
+
+        raise TypeError, "container source must be a hash" if requirement.source_hash.nil?
+
+        {
+          registry: requirement.source_string("registry"),
+          tag: requirement.source_string("tag"),
+          digest: requirement.source_string("digest")
+        }
       end
 
       sig { returns(T.nilable(Dependabot::Dependency)) }

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -158,6 +158,34 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       its(:content) { is_expected.to include "RUN apt-get update" }
     end
 
+    context "when nested source keys are strings" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "ubuntu",
+          version: "17.10",
+          previous_version: "17.04",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { "tag" => "17.10" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { "tag" => "17.04" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      it "updates the image tag" do
+        expect(updated_files.find { |f| f.name == "Dockerfile" }&.content)
+          .to include("FROM ubuntu:17.10\n")
+      end
+    end
+
     context "when the old tag is a prefix of the new tag" do
       let(:dependency) do
         Dependabot::Dependency.new(


### PR DESCRIPTION
### What are you trying to accomplish?

`DependencyRequirement` still has untyped Hash generics while container file updaters read requirement entries with `[]`, `dig`, and `fetch`.

This PR adds `metadata_symbol`, then migrates the shared file updater used by Docker, Docker Compose, and Helm. Container sources are projected into a typed `{ registry, tag, digest }` hash through the existing readers.

The shared updater also moves to `typed: strong`.

### Anything you want to highlight for special attention from reviewers?

Nested source keys may be symbols or strings. Missing or malformed container source hashes now fail at the typed boundary instead of flowing through as dynamic values.

The Dockerfile/YAML update algorithm is unchanged, including private registries, digest pinning, and Helm tag-plus-digest updates.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 382 to 362 errors, with none left in the shared updater.

Passing specs: `DependencyRequirement` (40), Docker file updater (97), Docker Compose file updater (35), and Helm file updaters (38). Sorbet and RuboCop are clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
