### PR TITLE
Type Docker requirement access

### DIFF
--- a/docker/lib/dependabot/docker/metadata_finder.rb
+++ b/docker/lib/dependabot/docker/metadata_finder.rb
@@ -27,8 +27,11 @@ module Dependabot
       def look_up_source
         return if dependency.requirements.empty?
 
-        new_source = dependency.requirements.first&.fetch(:source)
-        return unless new_source && new_source[:registry] && (new_source[:tag] || new_source[:digest])
+        requirement = dependency.requirements.first
+        return unless requirement
+
+        new_source = docker_source(requirement)
+        return unless new_source[:registry] && (new_source[:tag] || new_source[:digest])
 
         details = image_details(new_source)
         image_source = image_label(details, "org.opencontainers.image.source")
@@ -42,6 +45,17 @@ module Dependabot
       rescue StandardError => e
         Dependabot.logger.warn("Error looking up Docker source: #{e.message}")
         nil
+      end
+
+      sig { params(requirement: Dependabot::DependencyRequirement).returns(DockerSource) }
+      def docker_source(requirement)
+        raise TypeError, "Docker source must be a hash" if requirement.source_hash.nil?
+
+        {
+          registry: requirement.source_string("registry"),
+          tag: requirement.source_string("tag"),
+          digest: requirement.source_string("digest")
+        }
       end
 
       sig do

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -157,23 +157,25 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        updated = dependency.requirements.map do |req|
-          updated_source = req.fetch(:source).dup
-
-          tag = req[:source][:tag]
-          digest = req[:source][:digest]
+        dependency.requirements.map do |req|
+          updated_source = T.must(req.source_hash).dup
+          source = docker_source(req)
+          tag = source[:tag]
+          digest = source[:digest]
 
           if tag
             updated_tag = latest_version_from(tag)
-            updated_source[:tag] = updated_tag
-            updated_source[:digest] = resolved_digest_for(tag, updated_tag, digest) if digest || pin_digests?
+            set_source_string(updated_source, "tag", updated_tag)
+            if digest || pin_digests?
+              set_source_string(updated_source, "digest", resolved_digest_for(tag, updated_tag, digest))
+            end
           elsif digest
-            updated_source[:digest] = digest_within_cooldown?("latest") ? digest : digest_of("latest")
+            updated_digest = digest_within_cooldown?("latest") ? digest : digest_of("latest")
+            set_source_string(updated_source, "digest", updated_digest)
           end
 
-          req.merge(source: updated_source)
+          Dependabot::DependencyRequirement.create(req.merge(source: updated_source))
         end
-        wrap_requirements(updated)
       end
 
       private
@@ -236,8 +238,8 @@ module Dependabot
 
       sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
       def digest_requirement_up_to_date?(req)
-        source = req.fetch(:source)
-        source_digest = source.fetch(:digest)
+        source = docker_source(req)
+        source_digest = T.must(source[:digest])
         source_tag = source[:tag]
 
         if source_tag
@@ -858,11 +860,7 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def registry_hostname
-        if dependency.requirements.first&.dig(:source, :registry)
-          return T.must(dependency.requirements.first).dig(:source, :registry)
-        end
-
-        credentials_finder.base_registry
+        dependency.requirements.first&.source_string("registry") || credentials_finder.base_registry
       end
 
       sig { returns(T::Boolean) }
@@ -994,7 +992,35 @@ module Dependabot
       sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def digest_requirements
         dependency.requirements.select do |requirement|
-          requirement.dig(:source, :digest)
+          requirement.source_string("digest")
+        end
+      end
+
+      sig { params(requirement: Dependabot::DependencyRequirement).returns(DockerSource) }
+      def docker_source(requirement)
+        raise TypeError, "Docker source must be a hash" if requirement.source_hash.nil?
+
+        {
+          registry: requirement.source_string("registry"),
+          tag: requirement.source_string("tag"),
+          digest: requirement.source_string("digest"),
+          platform: requirement.source_string("platform")
+        }
+      end
+
+      sig do
+        params(
+          source: Dependabot::DependencyRequirement::ObjectHash,
+          key: String,
+          value: T.nilable(String)
+        ).void
+      end
+      def set_source_string(source, key, value)
+        symbol_key = key.to_sym
+        if source.key?(key) && !source.key?(symbol_key)
+          source[key] = value
+        else
+          source[symbol_key] = value
         end
       end
 

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -3296,6 +3296,15 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       end
     end
 
+    context "when the source has string keys and extra fields" do
+      let(:source) { { "tag" => version, "path" => "services.web.image" } }
+
+      it "updates the existing tag key and preserves the other fields" do
+        expect(checker.updated_requirements.first&.source)
+          .to eq("tag" => "17.10", "path" => "services.web.image")
+      end
+    end
+
     context "when specified with a digest" do
       let(:source) { { digest: "old_digest" } }
 
@@ -3354,12 +3363,12 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       let(:source) { { tag: "trusty-20170728" } }
 
       before do
-        dependency.requirements << {
+        dependency.requirements << Dependabot::DependencyRequirement.create(
           requirement: nil,
           groups: [],
           file: "Dockerfile.other",
           source: { tag: "xenial-20170802" }
-        }
+        )
       end
 
       it "updates the tags" do


### PR DESCRIPTION
### What are you trying to accomplish?

Migrate Docker's update checker and metadata finder off hash-style `DependencyRequirement` access.

Known source fields are read through typed projections. Updating a requirement preserves the complete source hash and its nested key style, changes only the tag or digest, then wraps the merged value with `DependencyRequirement.create`.

### Anything you want to highlight for special attention from reviewers?

The source may contain fields Docker does not update, such as `path` or platform data. Those fields are preserved. A regression test covers a string-keyed source with an extra field.

One existing spec appended a plain hash directly to the typed requirements array, bypassing `Dependency`'s normal wrapping. It now appends a `DependencyRequirement`, matching the production contract.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 362 to 346 errors, with none left in Docker's checker or metadata finder.

The focused Docker checker and metadata suites pass with 227 examples. The full Docker suite passes with 577 examples. Sorbet and RuboCop are clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
