### PR TITLE
Type Helm requirement access

### DIFF
--- a/helm/lib/dependabot/helm/file_parser.rb
+++ b/helm/lib/dependabot/helm/file_parser.rb
@@ -65,9 +65,8 @@ module Dependabot
       sig { params(dependency: Dependabot::Dependency, type: Symbol).void }
       def add_dependency_type_to_dependency(dependency, type)
         dependency.requirements.map! do |req|
-          req[:metadata] = {} unless req[:metadata]
-          req[:metadata][:type] = type
-          req
+          metadata = req.metadata || {}
+          Dependabot::DependencyRequirement.create(req.merge(metadata: metadata.merge(type: type)))
         end
       end
 

--- a/helm/lib/dependabot/helm/file_updater/chart_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/chart_updater.rb
@@ -122,16 +122,16 @@ module Dependabot
         sig { params(file: Dependabot::DependencyFile, old_version: String).returns(T.nilable(String)) }
         def updated_requirement_string(file, old_version)
           reqs = dependency.requirements.select do |r|
-            r[:file] == file.name && r.dig(:metadata, :type) == :helm_chart
+            r.file == file.name && r.metadata_symbol("type") == :helm_chart
           end
-          req = reqs.find { |r| r.dig(:source, :tag) == old_version } || reqs.first
-          req && req[:requirement]
+          req = reqs.find { |r| r.source_string("tag") == old_version } || reqs.first
+          req&.requirement_string
         end
 
         sig { params(file: Dependabot::DependencyFile).returns(T::Boolean) }
         def update_chart_dependency?(file)
-          reqs = dependency.requirements.select { |r| r[:file] == file.name }
-          reqs.any? { |r| r[:metadata]&.dig(:type) == :helm_chart }
+          reqs = dependency.requirements.select { |r| r.file == file.name }
+          reqs.any? { |r| r.metadata_symbol("type") == :helm_chart }
         end
       end
     end

--- a/helm/lib/dependabot/helm/file_updater/image_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/image_updater.rb
@@ -116,9 +116,11 @@ module Dependabot
         end
         def update_version_tags(value_node, content, dependency_version)
           dependency.requirements.each do |req|
-            next unless req[:metadata][:type] == :docker_image
+            next unless req.metadata_symbol("type") == :docker_image
 
-            tag_value = req[:source][:tag]
+            tag_value = req.source_string("tag")
+            next unless tag_value
+
             version_scalar = value_node.children.find do |node|
               node.is_a?(Psych::Nodes::Scalar) && node.value == tag_value
             end

--- a/helm/lib/dependabot/helm/update_checker.rb
+++ b/helm/lib/dependabot/helm/update_checker.rb
@@ -47,14 +47,16 @@ module Dependabot
       def updated_requirements
         return dependency.requirements unless latest_version
 
-        updated_reqs = dependency.requirements.map do |req|
-          case req.dig(:metadata, :type)
+        dependency.requirements.map do |req|
+          case req.metadata_symbol("type")
           when nil then req
           when :helm_chart then updated_chart_requirement(req)
-          else req.merge(requirement: latest_version.to_s) # image deps: exact overwrite
+          else
+            Dependabot::DependencyRequirement.create(
+              req.merge(requirement: latest_version.to_s)
+            ) # image deps: exact overwrite
           end
         end
-        wrap_requirements(updated_reqs)
       end
 
       private
@@ -68,7 +70,7 @@ module Dependabot
       sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def updated_chart_requirement(req)
         current_constraint = chart_constraint_for(req)
-        synthetic = T.cast(req.merge(requirement: current_constraint), Dependabot::DependencyRequirement)
+        synthetic = Dependabot::DependencyRequirement.create(req.merge(requirement: current_constraint))
 
         T.must(
           RequirementsUpdater.new(
@@ -85,7 +87,7 @@ module Dependabot
       # or ranges) into one dependency with a single combined version.
       sig { params(req: Dependabot::DependencyRequirement).returns(String) }
       def chart_constraint_for(req)
-        (req[:requirement] || req.dig(:source, :tag) || dependency.version).to_s
+        (req.requirement || req.source_string("tag") || dependency.version).to_s
       end
 
       sig { returns(Dependabot::RequirementsUpdateStrategy) }
@@ -111,7 +113,7 @@ module Dependabot
       sig { returns(Dependabot::Version) }
       def chart_anchor_version
         constraints = dependency.requirements
-                                .select { |r| r.dig(:metadata, :type) == :helm_chart }
+                                .select { |r| r.metadata_symbol("type") == :helm_chart }
                                 .map { |r| chart_constraint_for(r) }
         constraints = [dependency.version.to_s] if constraints.empty?
         T.must(constraints.map { |c| anchor_for_constraint(c) }.min)
@@ -283,12 +285,12 @@ module Dependabot
       # name across files/entries); an update is warranted if even one changes.
       sig { returns(T::Boolean) }
       def chart_requirement_changes?
-        chart_reqs = dependency.requirements.select { |r| r.dig(:metadata, :type) == :helm_chart }
+        chart_reqs = dependency.requirements.select { |r| r.metadata_symbol("type") == :helm_chart }
         chart_reqs = dependency.requirements if chart_reqs.empty?
         return true if chart_reqs.empty?
 
         chart_reqs.any? do |req|
-          updated_chart_requirement(req)[:requirement].to_s != chart_constraint_for(req)
+          updated_chart_requirement(req).requirement.to_s != chart_constraint_for(req)
         end
       end
 
@@ -307,7 +309,7 @@ module Dependabot
       sig { returns(Symbol) }
       def dependency_type
         req = dependency.requirements.first
-        type = T.must(req).dig(:metadata, :type)
+        type = T.must(req).metadata_symbol("type")
 
         type || :unknown
       end
@@ -350,8 +352,7 @@ module Dependabot
       sig { returns(T.nilable(Gem::Version)) }
       def fetch_latest_chart_version
         chart_name = dependency.name
-        source = dependency.requirements.first&.dig(:source)
-        repo_url = source&.dig(:registry)
+        repo_url = dependency.requirements.first&.source_string("registry")
         repo_name = extract_repo_name(repo_url)
         releases = fetch_releases_with_helm_cli(chart_name, repo_name, repo_url)
         return releases if releases
@@ -518,19 +519,20 @@ module Dependabot
 
       sig { returns(Dependabot::Dependency) }
       def build_docker_dependency
-        source = T.must(dependency.requirements.first)[:source]
+        requirement = T.must(dependency.requirements.first)
+        path = requirement.source_string("path")
         name = dependency.name
         version = dependency.version
 
-        if source[:path]
-          parts = source[:path].split(".")
+        if path
+          parts = path.split(".")
           if parts.length > 1 && (parts.last == "tag" || parts.last == "image")
             # The actual image name might be in image.repository
-            name = parts[0...-1].join(".")
+            name = T.must(parts[0...-1]).join(".")
           end
         end
 
-        registry = source[:registry] || nil
+        registry = requirement.source_string("registry")
 
         Dependency.new(
           name: name,
@@ -538,7 +540,7 @@ module Dependabot
           requirements: [{
             requirement: nil,
             groups: [],
-            file: T.must(dependency.requirements.first)[:file],
+            file: requirement.file,
             source: {
               registry: registry,
               tag: version

--- a/helm/lib/dependabot/helm/update_checker/requirements_updater.rb
+++ b/helm/lib/dependabot/helm/update_checker/requirements_updater.rb
@@ -71,9 +71,11 @@ module Dependabot
 
           requirements.map do |req|
             next req unless latest_resolvable_version
-            next req unless req[:requirement]
+
+            requirement = req.requirement_string
+            next req unless requirement
             # Leave dist-tags / non-numeric leading tokens untouched.
-            next req if req[:requirement].match?(/^([A-Za-uw-z]|v[^\d])/)
+            next req if requirement.match?(/^([A-Za-uw-z]|v[^\d])/)
 
             case update_strategy
             when RequirementsUpdateStrategy::WidenRanges then widen_requirement(req)
@@ -105,7 +107,7 @@ module Dependabot
 
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement(req)
-          current_requirement = req[:requirement]
+          current_requirement = T.must(req.requirement_string)
           return req if current_requirement.strip == ""
 
           if current_requirement.match?(/(<|-\s)/i)
@@ -114,7 +116,7 @@ module Dependabot
             return req if ruby_requirements(current_requirement).any? { |r| r.satisfied_by?(latest_resolvable_version) }
 
             updated_req = update_range_requirement(current_requirement)
-            return T.cast(req.merge(requirement: updated_req), Dependabot::DependencyRequirement)
+            return Dependabot::DependencyRequirement.create(req.merge(requirement: updated_req))
           end
 
           # Strict lower-bound (`>`) and not-equal (`!=`) constraints are already
@@ -128,13 +130,15 @@ module Dependabot
           end
 
           reqs = current_requirement.strip.split(SEPARATOR).map(&:strip)
-          T.cast(req.merge(requirement: update_version_string(reqs.first)), Dependabot::DependencyRequirement)
+          Dependabot::DependencyRequirement.create(
+            req.merge(requirement: update_version_string(T.must(reqs.first)))
+          )
         end
 
         # Blank, or already permitted by the resolved version, under any strategy.
         sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
         def already_satisfied?(req)
-          current_requirement = req[:requirement]
+          current_requirement = T.must(req.requirement_string)
           return true if current_requirement.strip == ""
 
           ruby_requirements(current_requirement).any? { |r| r.satisfied_by?(latest_resolvable_version) }
@@ -151,7 +155,7 @@ module Dependabot
         def widen_requirement(req)
           return req if already_satisfied?(req)
 
-          current_requirement = req[:requirement]
+          current_requirement = T.must(req.requirement_string)
           reqs = current_requirement.strip.split(SEPARATOR).map(&:strip)
 
           updated_requirement =
@@ -166,7 +170,7 @@ module Dependabot
               "#{current_requirement} || ^#{latest_resolvable_version}"
             end
 
-          T.cast(req.merge(requirement: updated_requirement), Dependabot::DependencyRequirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: updated_requirement))
         end
 
         sig { params(requirement_string: String).returns(T::Array[Helm::Requirement]) }


### PR DESCRIPTION
### What are you trying to accomplish?

Finish the container-family migration by replacing Helm's requirement hash reads with `metadata_symbol`, `source_string`, `file`, and the typed requirement readers.

The parser and update paths now create `DependencyRequirement` instances after merges instead of mutating or casting plain hashes.

### Anything you want to highlight for special attention from reviewers?

The existing behavior is retained for per-occurrence chart constraints, merged same-name dependencies, lower-bound anchoring, OCI registries, Docker image paths, and unknown dependency types.

All five files remain `typed: strict`; their remaining strong-mode errors are unrelated dynamic YAML and helper boundaries.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 346 to 317 errors, with none left in Helm. Across the stack the reduction is 382 to 317.

The full Helm suite passes with 283 examples. The final Docker suite passes with 577 examples and Docker Compose with 35. Sorbet, RuboCop, and the untyped ratchet are clean; the explicit offense count remains 991 as expected.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
