### PR TITLE
Ensure final newline state preserved for NuGet modified files

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ModifiedFilesTrackerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ModifiedFilesTrackerTests.cs
@@ -430,6 +430,95 @@ public class ModifiedFilesTrackerTests
         Assert.Empty(updatedFiles);
     }
 
+    [Theory]
+    [InlineData("project.csproj",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net9.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n")]
+    [InlineData("project.csproj",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net9.0</TargetFramework>\n  </PropertyGroup>\n</Project>",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>")]
+    [InlineData("project.csproj",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\r\n  <PropertyGroup>\r\n    <TargetFramework>net9.0</TargetFramework>\r\n  </PropertyGroup>\r\n</Project>",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\r\n  <PropertyGroup>\r\n    <TargetFramework>net10.0</TargetFramework>\r\n  </PropertyGroup>\r\n</Project>\r\n",
+        "<Project Sdk=\"Microsoft.NET.Sdk\">\r\n  <PropertyGroup>\r\n    <TargetFramework>net10.0</TargetFramework>\r\n  </PropertyGroup>\r\n</Project>")]
+    [InlineData("packages.lock.json",
+        "{\"version\": 1, \"dependencies\": {\"Some.Package\": {\"version\": \"1.0.0\"}}}\n",
+        "{\"version\": 1, \"dependencies\": {\"Some.Package\": {\"version\": \"1.0.1\"}}}",
+        "{\"version\": 1, \"dependencies\": {\"Some.Package\": {\"version\": \"1.0.1\"}}}\n")]
+    [InlineData("packages.lock.json",
+        "{\"version\": 1, \"dependencies\": {\"Some.Package\": {\"version\": \"1.0.0\"}}}",
+        "{\"version\": 1, \"dependencies\": {\"Some.Package\": {\"version\": \"1.0.1\"}}}\n",
+        "{\"version\": 1, \"dependencies\": {\"Some.Package\": {\"version\": \"1.0.1\"}}}")]
+    [InlineData("packages.lock.json",
+        "{\"version\": 1, \"dependencies\": {\"Some.Package\": {\"version\": \"1.0.0\"}}}\r\n",
+        "{\"version\": 1, \"dependencies\": {\"Some.Package\": {\"version\": \"1.0.1\"}}}",
+        "{\"version\": 1, \"dependencies\": {\"Some.Package\": {\"version\": \"1.0.1\"}}}\r\n")]
+    [InlineData(".config/dotnet-tools.json",
+        "{\"version\": 1, \"tools\": {\"dotnet-ef\": {\"version\": \"9.0.100\"}}}\n",
+        "{\"version\": 1, \"tools\": {\"dotnet-ef\": {\"version\": \"9.0.200\"}}}",
+        "{\"version\": 1, \"tools\": {\"dotnet-ef\": {\"version\": \"9.0.200\"}}}\n")]
+    [InlineData(".config/dotnet-tools.json",
+        "{\"version\": 1, \"tools\": {\"dotnet-ef\": {\"version\": \"9.0.100\"}}}",
+        "{\"version\": 1, \"tools\": {\"dotnet-ef\": {\"version\": \"9.0.200\"}}}\n",
+        "{\"version\": 1, \"tools\": {\"dotnet-ef\": {\"version\": \"9.0.200\"}}}")]
+    [InlineData(".config/dotnet-tools.json",
+        "{\"version\": 1, \"tools\": {\"dotnet-ef\": {\"version\": \"9.0.100\"}}}\r\n",
+        "{\"version\": 1, \"tools\": {\"dotnet-ef\": {\"version\": \"9.0.200\"}}}",
+        "{\"version\": 1, \"tools\": {\"dotnet-ef\": {\"version\": \"9.0.200\"}}}\r\n")]
+    public async Task PreservesFinalNewLineStateInReportedContentAndRestore(
+        string relativePath,
+        string originalContent,
+        string modifiedContent,
+        string expectedReportedContent)
+    {
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            ("project.csproj", "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup></Project>")
+        );
+
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new TestLogger();
+        var filePath = Path.Combine(tempDirectory.DirectoryPath, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+        File.WriteAllText(filePath, originalContent);
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+
+        var discoveryResult = new WorkspaceDiscoveryResult()
+        {
+            Path = "/",
+            Projects = [
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = relativePath == "packages.lock.json" ? ["packages.lock.json"] : [],
+                }
+            ],
+            DotNetToolsJson = relativePath == ".config/dotnet-tools.json"
+                ? new DotNetToolsJsonDiscoveryResult()
+                {
+                    FilePath = ".config/dotnet-tools.json",
+                    Dependencies = [],
+                }
+                : null,
+        };
+
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
+        await tracker.StartTrackingAsync(discoveryResult);
+
+        File.WriteAllText(filePath, modifiedContent);
+
+        var updatedFiles = await tracker.StopTrackingAsync(restoreOriginalContents: true);
+
+        Assert.Single(updatedFiles);
+        Assert.Equal(expectedReportedContent, updatedFiles[0].Content);
+        Assert.Equal(originalContent, File.ReadAllText(filePath));
+    }
+
     [Fact]
     public async Task GetInitiallyExistingFiles_FindsAllEditableFileTypes()
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/FinalNewLineHandlingTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/FinalNewLineHandlingTests.cs
@@ -1,0 +1,60 @@
+using static NuGetUpdater.Core.Utilities.EOLHandling;
+using static NuGetUpdater.Core.Utilities.FinalNewLineHandling;
+
+using Xunit;
+
+namespace NuGetUpdater.Core.Test.Utilities;
+
+public class FinalNewLineHandlingTests
+{
+    [Theory]
+    [InlineData("line1\nline2\n", true)]
+    [InlineData("line1\rline2\r", true)]
+    [InlineData("line1\r\nline2\r\n", true)]
+    [InlineData("line1\nline2", false)]
+    [InlineData("line1\rline2", false)]
+    [InlineData("line1\r\nline2", false)]
+    [InlineData("", false)]
+    public void HasFinalNewLineTests(string content, bool expected)
+    {
+        var actual = content.HasFinalNewLine();
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("line1\nline2", true, EOLType.LF, "line1\nline2\n")]
+    [InlineData("line1\rline2", true, EOLType.CR, "line1\rline2\r")]
+    [InlineData("line1\r\nline2", true, EOLType.CRLF, "line1\r\nline2\r\n")]
+    [InlineData("line1\nline2\n", false, EOLType.LF, "line1\nline2")]
+    [InlineData("line1\rline2\r", false, EOLType.CR, "line1\rline2")]
+    [InlineData("line1\r\nline2\r\n", false, EOLType.CRLF, "line1\r\nline2")]
+    [InlineData("\n", false, EOLType.LF, "")]
+    [InlineData("\r", false, EOLType.CR, "")]
+    [InlineData("\r\n", false, EOLType.CRLF, "")]
+    [InlineData("\n", true, EOLType.LF, "\n")]
+    [InlineData("\r", true, EOLType.CR, "\r")]
+    [InlineData("\r\n", true, EOLType.CRLF, "\r\n")]
+    [InlineData("", false, EOLType.LF, "")]
+    [InlineData("", false, EOLType.CR, "")]
+    [InlineData("", false, EOLType.CRLF, "")]
+    [InlineData("", true, EOLType.LF, "\n")]
+    [InlineData("", true, EOLType.CR, "\r")]
+    [InlineData("", true, EOLType.CRLF, "\r\n")]
+    public void SetFinalNewLineTests(string content, bool setFinalNewLine, EOLType desiredEOL, string expected)
+    {
+        var actual = content.SetFinalNewLine(setFinalNewLine, desiredEOL);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SetFinalNewLineWithInvalidEol()
+    {
+        // Assemble
+        var content = "line1\nline2";
+        var setFinalNewLine = true;
+        var desiredEOL = (EOLType)999; // Invalid EOLType
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => content.SetFinalNewLine(setFinalNewLine, desiredEOL));
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
@@ -15,6 +15,7 @@ public class ModifiedFilesTracker
     private readonly ILogger _logger;
 
     private readonly Dictionary<string, string> _originalDependencyFileContents = [];
+    private readonly Dictionary<string, bool> _originalDependencyFileFinalNewLines = [];
     private readonly Dictionary<string, EOLType> _originalDependencyFileEOFs = [];
     private readonly Dictionary<string, bool> _originalDependencyFileBOMs = [];
     private string[] _nonProjectFiles = [];
@@ -87,6 +88,7 @@ public class ModifiedFilesTracker
             var content = await File.ReadAllTextAsync(localFullPath);
             var rawContent = await File.ReadAllBytesAsync(localFullPath);
             _originalDependencyFileContents[repoFullPath] = content;
+            _originalDependencyFileFinalNewLines[repoFullPath] = content.HasFinalNewLine();
             _originalDependencyFileEOFs[repoFullPath] = content.GetPredominantEOL();
             _originalDependencyFileBOMs[repoFullPath] = rawContent.HasBOM();
         }
@@ -140,6 +142,7 @@ public class ModifiedFilesTracker
             var originalContent = _originalDependencyFileContents[repoFullPath];
             var updatedContent = await File.ReadAllTextAsync(localFullPath);
 
+            updatedContent = updatedContent.SetFinalNewLine(_originalDependencyFileFinalNewLines[repoFullPath], _originalDependencyFileEOFs[repoFullPath]);
             updatedContent = updatedContent.SetEOL(_originalDependencyFileEOFs[repoFullPath]);
             var updatedRawContent = updatedContent.SetBOM(_originalDependencyFileBOMs[repoFullPath]);
             await File.WriteAllBytesAsync(localFullPath, updatedRawContent);
@@ -165,6 +168,7 @@ public class ModifiedFilesTracker
                 if (restoreOriginalContents)
                 {
                     var originalRawContent = originalContent
+                        .SetFinalNewLine(_originalDependencyFileFinalNewLines[repoFullPath], _originalDependencyFileEOFs[repoFullPath])
                         .SetEOL(_originalDependencyFileEOFs[repoFullPath])
                         .SetBOM(_originalDependencyFileBOMs[repoFullPath]);
                     await File.WriteAllBytesAsync(localFullPath, originalRawContent);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/FinalNewLineHandling.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/FinalNewLineHandling.cs
@@ -1,0 +1,51 @@
+using static NuGetUpdater.Core.Utilities.EOLHandling;
+
+namespace NuGetUpdater.Core.Utilities;
+
+public static class FinalNewLineHandling
+{
+    /// <summary>
+    /// Determines if a string has a trailing newline character (either '\n' or '\r').
+    /// </summary>
+    /// <param name="content">The string to check.</param>
+    /// <returns>A boolean indicating whether the string has a trailing newline character.</returns>
+    public static bool HasFinalNewLine(this string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return false;
+        }
+
+        return content.EndsWith('\n') || content.EndsWith('\r');
+    }
+
+    /// <summary>
+    /// Ensures a string either ends with the given line ending, or has any trailing line endings removed.
+    /// </summary>
+    /// <param name="content">The target string.</param>
+    /// <param name="setFinalNewLine">True to append <paramref name="desiredEOL"/> if missing; false to strip trailing newlines.</param>
+    /// <param name="desiredEOL">The line ending to append when <paramref name="setFinalNewLine"/> is true.</param>
+    /// <returns>The content with its final newline state set as requested.</returns>
+    public static string SetFinalNewLine(this string content, bool setFinalNewLine, EOLType desiredEOL)
+    {
+        if (content.HasFinalNewLine())
+        {
+            return setFinalNewLine ? content : content.TrimEnd('\r', '\n');
+        }
+
+        if (!setFinalNewLine)
+        {
+            return content;
+        }
+
+        var newLine = desiredEOL switch
+        {
+            EOLType.LF => "\n",
+            EOLType.CR => "\r",
+            EOLType.CRLF => "\r\n",
+            _ => throw new ArgumentOutOfRangeException(nameof(desiredEOL)),
+        };
+
+        return content + newLine;
+    }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

This change ensures that the original final newline state for NuGet dependency files is preserved when Dependabot updates or restores them. The goal is to avoid introducing unnecessary content changes when rewriting files, while still preserving the existing line ending style and BOM metadata.

This affects file updates where a modified file could otherwise lose a final newline unexpectedly, which can create noisy diffs and change file formatting semantics.

### Anything you want to highlight for special attention from reviewers?

The implementation reuses the existing EOL and BOM handling flow and adds explicit tracking for whether a file originally ended with a newline. That keeps the fix focused on preserving file formatting without changing unrelated update behaviour.

### How will you know you've accomplished your goal?

The change is covered by new unit tests that verify:
- detection of whether content has a final newline
- adding or removing a final newline while preserving the requested EOL style
- behaviour across LF, CR, and CRLF content

These tests demonstrate that updated files and restored files keep the same final newline state as the original content.

### Checklist

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
