### PR TITLE
Stop sanitizing Bundler lockfile metadata

### DIFF
--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -209,7 +209,7 @@ module Dependabot
       sig { returns(T::Array[String]) }
       def fetch_path_gemspec_paths
         if lockfile
-          parsed_lockfile = CachedLockfileParser.parse(T.must(sanitized_lockfile_content))
+          parsed_lockfile = CachedLockfileParser.parse(T.must(T.must(lockfile).content))
           parsed_lockfile.specs
                          .select { |s| s.source.instance_of?(::Bundler::Source::Path) }
                          .map { |s| s.source.path }.uniq
@@ -235,14 +235,6 @@ module Dependabot
           fetch_child_gemfiles(file: T.must(gemfile), previously_fetched_files: []),
           T.nilable(T::Array[DependencyFile])
         )
-      end
-
-      # TODO: Stop sanitizing the lockfile once we have bundler 2 installed
-
-      sig { returns T.nilable(String) }
-      def sanitized_lockfile_content
-        regex = FileUpdater::LockfileUpdater::LOCKFILE_ENDING
-        lockfile&.content&.gsub(regex, "")
       end
 
       sig do

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -280,8 +280,6 @@ module Dependabot
           FileUtils.mkdir_p(Pathname.new(path).dirname)
           File.write(path, file.content)
         end
-
-        File.write(T.must(lockfile).name, sanitized_lockfile_content) if lockfile
       end
 
       sig { override.void }
@@ -350,7 +348,7 @@ module Dependabot
       sig { returns(::Bundler::LockfileParser) }
       def parsed_lockfile
         @parsed_lockfile ||= T.let(
-          CachedLockfileParser.parse(sanitized_lockfile_content),
+          CachedLockfileParser.parse(T.must(T.must(lockfile).content)),
           T.nilable(::Bundler::LockfileParser)
         )
       end
@@ -388,13 +386,6 @@ module Dependabot
         return true if groups.include?("default")
 
         groups.any? { |g| g.include?("prod") }
-      end
-
-      # TODO: Stop sanitizing the lockfile once we have bundler 2 installed
-      sig { returns(String) }
-      def sanitized_lockfile_content
-        regex = FileUpdater::LockfileUpdater::LOCKFILE_ENDING
-        T.must(T.must(lockfile).content).gsub(regex, "")
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -131,7 +131,7 @@ module Dependabot
         sig { void }
         def write_temporary_dependency_files
           File.write(T.must(gemfile).name, prepared_gemfile_content(T.must(gemfile)))
-          File.write(T.must(lockfile).name, sanitized_lockfile_body)
+          File.write(T.must(lockfile).name, T.must(T.must(lockfile).content))
 
           write_gemspecs(top_level_gemspecs)
           write_ruby_version_file
@@ -352,7 +352,7 @@ module Dependabot
                                        .dependency_name || File.basename(path, ".gemspec")
 
           gemspec_specs =
-            CachedLockfileParser.parse(sanitized_lockfile_body).specs
+            CachedLockfileParser.parse(T.must(T.must(lockfile).content)).specs
                                 .select { |s| s.name == gem_name && gemspec_sources.include?(s.source.class) }
 
           gemspec_specs.first&.version&.to_s || "0.0.1"
@@ -396,13 +396,6 @@ module Dependabot
           @lockfile ||=
             dependency_files.find { |f| f.name == "Gemfile.lock" } ||
             dependency_files.find { |f| f.name == "gems.locked" }
-        end
-
-        # TODO: Stop sanitizing the lockfile once we have bundler 2 installed
-        sig { returns(String) }
-        def sanitized_lockfile_body
-          content = T.must(lockfile).content
-          T.must(content).gsub(LOCKFILE_ENDING, "")
         end
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -329,7 +329,7 @@ module Dependabot
           return "0.0.1" unless lockfile
 
           gemspec_specs =
-            CachedLockfileParser.parse(sanitized_lockfile_content).specs
+            CachedLockfileParser.parse(T.must(T.must(lockfile).content)).specs
                                 .select { |s| gemspec_sources.include?(s.source.class) }
 
           gem_name =
@@ -343,13 +343,6 @@ module Dependabot
           spec&.version&.to_s || gemspec_specs.first&.version&.to_s || "0.0.1"
         end
         # rubocop:enable Metrics/PerceivedComplexity
-
-        # TODO: Stop sanitizing the lockfile once we have bundler 2 installed
-        sig { returns(String) }
-        def sanitized_lockfile_content
-          re = FileUpdater::LockfileUpdater::LOCKFILE_ENDING
-          T.must(T.must(lockfile).content).gsub(re, "")
-        end
       end
     end
   end

--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -211,12 +211,6 @@ module Dependabot
             dependency_files.find { |f| f.name == "gems.locked" }
         end
 
-        sig { returns(String) }
-        def sanitized_lockfile_body
-          re = FileUpdater::LockfileUpdater::LOCKFILE_ENDING
-          T.must(T.must(lockfile).content).gsub(re, "")
-        end
-
         sig { void }
         def write_temporary_dependency_files
           dependency_files.each do |file|
@@ -224,8 +218,6 @@ module Dependabot
             FileUtils.mkdir_p(Pathname.new(path).dirname)
             File.write(path, file.content)
           end
-
-          File.write(T.must(lockfile).name, sanitized_lockfile_body) if lockfile
         end
 
         sig { override.returns(String) }

--- a/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb
@@ -20,6 +20,35 @@ RSpec.describe Dependabot::Bundler::FileUpdater::LockfileUpdater do
 
   let(:updated_lockfile_content) { updater.updated_lockfile_content }
 
+  describe "with lockfile metadata" do
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "business",
+        version: "1.5.0",
+        previous_version: "1.4.0",
+        requirements: [],
+        previous_requirements: [],
+        package_manager: "bundler"
+      )
+    end
+    let(:files) { bundler_project_dependency_files("explicit_ruby_in_lockfile") }
+    let(:lockfile) { files.find { |file| file.name == "Gemfile.lock" } }
+    let(:temporary_lockfile_contents) { [] }
+
+    before do
+      allow(Dependabot::Bundler::NativeHelpers).to receive(:run_bundler_subprocess) do
+        temporary_lockfile_contents << File.read("Gemfile.lock")
+
+        lockfile.content.sub("business (1.4.0)", "business (1.5.0)")
+      end
+    end
+
+    it "passes the complete lockfile to the native helper" do
+      expect(updated_lockfile_content).to include("business (1.5.0)")
+      expect(temporary_lockfile_contents).to eq([lockfile.content])
+    end
+  end
+
   describe "with lockfiles that include checksums" do
     let(:dependency) do
       Dependabot::Dependency.new(


### PR DESCRIPTION
Removes the `LOCKFILE_ENDING` strip that deleted the `RUBY VERSION` / `BUNDLED WITH` trailer before handing the lockfile to the native Bundler helper and before in-process `Bundler::LockfileParser` calls. This dates back to the Bundler 1 era; the accompanying TODOs said to remove it once Bundler 2 was installed. Dependabot now ships Bundler 2 and 4, and Bundler 1 support has been removed.

Closes #5742.

## Why it is safe to stop sanitizing

- The native helper resolves through the `Bundler::Definition` API (`build`, `resolve_remotely!`, and `to_lock`), not the `bundle` CLI, so `SelfManager` does not auto-switch based on `BUNDLED WITH`.
- Dependabot selects the helper Bundler major from the lockfile's `BUNDLED WITH` value through `Helpers.bundler_version`, so the helper already uses the matching lockfile-format family. The old Bundler 1 versus Bundler 2 compatibility concern no longer applies.
- Preserving these sections lets modern Bundler interpret the complete lockfile instead of treating it like an older lockfile format.

## What changed

- pass complete lockfiles, including `RUBY VERSION` and `BUNDLED WITH`, to Bundler and the cached lockfile parser
- remove sanitization from all five affected fetcher, parser, updater, and update-checker paths
- remove two lockfile rewrites that became redundant once sanitized content was no longer being substituted
- add regression coverage proving the native helper receives the complete original lockfile

`LOCKFILE_ENDING` and `replace_lockfile_ending` are intentionally retained. Dependabot still restores the user's original `RUBY VERSION` and `BUNDLED WITH` ending after an update, avoiding unrelated Bundler-version churn. Bundler checksum metadata continues to be handled by the existing targeted post-processing.

## Tests

All tests ran inside the Bundler container.

- `bin/test bundler spec/dependabot/bundler/file_fetcher_spec.rb spec/dependabot/bundler/file_parser_spec.rb spec/dependabot/bundler/file_updater/lockfile_updater_spec.rb spec/dependabot/bundler/update_checker/file_preparer_spec.rb spec/dependabot/bundler/update_checker/force_updater_spec.rb` (211 examples, 0 failures)
- `bin/test bundler` (893 examples, 0 failures, 7 pending)
- review follow-up: parser and force-updater specs (116 examples, 0 failures on rerun after an unrelated Git cache hardlink flake)
- changed-file RuboCop (no offenses)
- CI Sorbet checks (passing)