### PR TITLE
Bundler: stop sanitizing the lockfile

### DIFF
--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -209,7 +209,7 @@ module Dependabot
       sig { returns(T::Array[String]) }
       def fetch_path_gemspec_paths
         if lockfile
-          parsed_lockfile = CachedLockfileParser.parse(T.must(sanitized_lockfile_content))
+          parsed_lockfile = CachedLockfileParser.parse(T.must(T.must(lockfile).content))
           parsed_lockfile.specs
                          .select { |s| s.source.instance_of?(::Bundler::Source::Path) }
                          .map { |s| s.source.path }.uniq
@@ -235,14 +235,6 @@ module Dependabot
           fetch_child_gemfiles(file: T.must(gemfile), previously_fetched_files: []),
           T.nilable(T::Array[DependencyFile])
         )
-      end
-
-      # TODO: Stop sanitizing the lockfile once we have bundler 2 installed
-
-      sig { returns T.nilable(String) }
-      def sanitized_lockfile_content
-        regex = FileUpdater::LockfileUpdater::LOCKFILE_ENDING
-        lockfile&.content&.gsub(regex, "")
       end
 
       sig do

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -281,7 +281,7 @@ module Dependabot
           File.write(path, file.content)
         end
 
-        File.write(T.must(lockfile).name, sanitized_lockfile_content) if lockfile
+        File.write(T.must(lockfile).name, T.must(T.must(lockfile).content)) if lockfile
       end
 
       sig { override.void }
@@ -350,7 +350,7 @@ module Dependabot
       sig { returns(::Bundler::LockfileParser) }
       def parsed_lockfile
         @parsed_lockfile ||= T.let(
-          CachedLockfileParser.parse(sanitized_lockfile_content),
+          CachedLockfileParser.parse(T.must(T.must(lockfile).content)),
           T.nilable(::Bundler::LockfileParser)
         )
       end
@@ -388,13 +388,6 @@ module Dependabot
         return true if groups.include?("default")
 
         groups.any? { |g| g.include?("prod") }
-      end
-
-      # TODO: Stop sanitizing the lockfile once we have bundler 2 installed
-      sig { returns(String) }
-      def sanitized_lockfile_content
-        regex = FileUpdater::LockfileUpdater::LOCKFILE_ENDING
-        T.must(T.must(lockfile).content).gsub(regex, "")
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
+++ b/bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb
@@ -131,7 +131,7 @@ module Dependabot
         sig { void }
         def write_temporary_dependency_files
           File.write(T.must(gemfile).name, prepared_gemfile_content(T.must(gemfile)))
-          File.write(T.must(lockfile).name, sanitized_lockfile_body)
+          File.write(T.must(lockfile).name, T.must(T.must(lockfile).content))
 
           write_gemspecs(top_level_gemspecs)
           write_ruby_version_file
@@ -352,7 +352,7 @@ module Dependabot
                                        .dependency_name || File.basename(path, ".gemspec")
 
           gemspec_specs =
-            CachedLockfileParser.parse(sanitized_lockfile_body).specs
+            CachedLockfileParser.parse(T.must(T.must(lockfile).content)).specs
                                 .select { |s| s.name == gem_name && gemspec_sources.include?(s.source.class) }
 
           gemspec_specs.first&.version&.to_s || "0.0.1"
@@ -396,13 +396,6 @@ module Dependabot
           @lockfile ||=
             dependency_files.find { |f| f.name == "Gemfile.lock" } ||
             dependency_files.find { |f| f.name == "gems.locked" }
-        end
-
-        # TODO: Stop sanitizing the lockfile once we have bundler 2 installed
-        sig { returns(String) }
-        def sanitized_lockfile_body
-          content = T.must(lockfile).content
-          T.must(content).gsub(LOCKFILE_ENDING, "")
         end
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/file_preparer.rb
@@ -329,7 +329,7 @@ module Dependabot
           return "0.0.1" unless lockfile
 
           gemspec_specs =
-            CachedLockfileParser.parse(sanitized_lockfile_content).specs
+            CachedLockfileParser.parse(T.must(T.must(lockfile).content)).specs
                                 .select { |s| gemspec_sources.include?(s.source.class) }
 
           gem_name =
@@ -343,13 +343,6 @@ module Dependabot
           spec&.version&.to_s || gemspec_specs.first&.version&.to_s || "0.0.1"
         end
         # rubocop:enable Metrics/PerceivedComplexity
-
-        # TODO: Stop sanitizing the lockfile once we have bundler 2 installed
-        sig { returns(String) }
-        def sanitized_lockfile_content
-          re = FileUpdater::LockfileUpdater::LOCKFILE_ENDING
-          T.must(T.must(lockfile).content).gsub(re, "")
-        end
       end
     end
   end

--- a/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/force_updater.rb
@@ -211,12 +211,6 @@ module Dependabot
             dependency_files.find { |f| f.name == "gems.locked" }
         end
 
-        sig { returns(String) }
-        def sanitized_lockfile_body
-          re = FileUpdater::LockfileUpdater::LOCKFILE_ENDING
-          T.must(T.must(lockfile).content).gsub(re, "")
-        end
-
         sig { void }
         def write_temporary_dependency_files
           dependency_files.each do |file|
@@ -225,7 +219,7 @@ module Dependabot
             File.write(path, file.content)
           end
 
-          File.write(T.must(lockfile).name, sanitized_lockfile_body) if lockfile
+          File.write(T.must(lockfile).name, T.must(T.must(lockfile).content)) if lockfile
         end
 
         sig { override.returns(String) }


### PR DESCRIPTION
Removes the `LOCKFILE_ENDING` strip that deleted the `RUBY VERSION` / `BUNDLED WITH` trailer before handing the lockfile to the native Bundler helper (and before in-process `Bundler::LockfileParser` calls). This dates back to the Bundler 1 era; the accompanying `TODO`s said to remove it "once we have bundler 2 installed" — which has long been true (we now ship Bundler 2 and 4, and Bundler 1 is gone).

Fixes #5742.

## Why it's safe to stop sanitizing

- The native helper resolves via the `Bundler::Definition` API directly (`build` / `resolve_remotely!` / `to_lock`), **not** the `bundle` CLI, so `SelfManager`'s `BUNDLED WITH` auto-switch never fires.
- The helper's Bundler major is selected from the lockfile's `BUNDLED WITH` (`Helpers.bundler_version`), so the running Bundler already matches the lockfile format. The old Bundler-1-vs-2 format concern no longer exists.

## What changed

Removed the sanitization from all five sites (there were more than the single one referenced in the issue) and inlined the raw lockfile content, deleting the stale `TODO`s:

- `file_updater/lockfile_updater.rb`
- `file_parser.rb`
- `update_checker/force_updater.rb`
- `file_fetcher.rb`
- `update_checker/file_preparer.rb`

`LOCKFILE_ENDING` and `replace_lockfile_ending` are intentionally **kept** — that method still restores the user's *original* `BUNDLED WITH` / `RUBY VERSION` after an update, which is how Dependabot avoids managing the Bundler version. That's a separate concern from the input-side sanitization this issue was about.

## Validation

All run inside the bundler container:

| Check | Result |
|---|---|
| Baseline, targeted integration specs (strip present) | 304 examples, 0 failures |
| Strip removed, same specs | 304 examples, 0 failures |
| Strip removed, full bundler suite | 892 examples, 0 failures, 7 pending |
| Final code, targeted + `update_checker_spec` | 413 examples, 0 failures |
| `rubocop` (5 files) | no offenses |
| `srb tc` | No errors |

---

This change was created using Claude Opus 4.8.