### PR TITLE
hex: Characterize helper update behavior

### DIFF
--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -155,6 +155,71 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
       end
     end
 
+    context "with a project-defined deps.update alias" do
+      let(:mixfile_fixture_name) { "deps_update_alias" }
+      let(:lockfile_fixture_name) { "minor_version" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "phoenix",
+          version: "1.3.0",
+          requirements: [{
+            file: "mix.exs",
+            requirement: "~> 1.3.0",
+            groups: [],
+            source: nil
+          }],
+          previous_version: "1.2.5",
+          previous_requirements: [{
+            file: "mix.exs",
+            requirement: "~> 1.2.1",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "hex"
+        )
+      end
+
+      it "updates the lockfile without invoking the alias" do
+        expect(updated_lockfile_content).to include %({:hex, :phoenix, "1.3)
+      end
+    end
+
+    context "when dependency resolution fails" do
+      let(:mixfile_fixture_name) { "unresolvable" }
+      let(:lockfile_fixture_name) { "minor_version" }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "phoenix",
+          version: "1.3.0",
+          requirements: [{
+            file: "mix.exs",
+            requirement: "~> 1.3.0",
+            groups: [],
+            source: nil
+          }],
+          previous_version: "1.2.5",
+          previous_requirements: [{
+            file: "mix.exs",
+            requirement: "~> 1.2.1",
+            groups: [],
+            source: nil
+          }],
+          package_manager: "hex"
+        )
+      end
+
+      it "leaves the input files and temporary directory unchanged" do
+        original_contents = files.to_h { |file| [file.name, file.content.dup] }
+        original_tmp_entries = Dir.entries(tmp_path)
+
+        expect { updated_lockfile_content }
+          .to raise_error(Dependabot::DependencyFileNotResolvable)
+
+        expect(files.to_h { |file| [file.name, file.content] }).to eq(original_contents)
+        expect(Dir.entries(tmp_path)).to eq(original_tmp_entries)
+      end
+    end
+
     context "with upgrade to transitive dependencies" do
       let(:mixfile_fixture_name) { "deep_upgrade" }
       let(:lockfile_fixture_name) { "deep_upgrade" }

--- a/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
@@ -124,6 +124,15 @@ RSpec.describe Dependabot::Hex::UpdateChecker::VersionResolver do
       end
     end
 
+    context "with a project-defined deps.update alias" do
+      let(:mixfile_fixture_name) { "deps_update_alias" }
+
+      it "resolves without invoking the alias" do
+        expect(latest_resolvable_version).to be > Gem::Version.new("1.3.5")
+        expect(latest_resolvable_version).to be < Gem::Version.new("1.4.0")
+      end
+    end
+
     context "when the environments for another dependency diverge" do
       # In this example, updating `credo` would add its sub-dependency,
       # `poison`, to the `dev` environment, but the Mixfile explicitly specifies

--- a/hex/spec/fixtures/mixfiles/deps_update_alias
+++ b/hex/spec/fixtures/mixfiles/deps_update_alias
@@ -1,0 +1,31 @@
+defmodule DependabotTest.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dependabot_test,
+      version: "0.1.0",
+      elixir: "~> 1.5",
+      aliases: aliases(),
+      start_permanent: Mix.env == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp aliases do
+    [
+      "deps.update": fn _args -> raise "project deps.update alias was invoked" end
+    ]
+  end
+
+  defp deps do
+    [
+      {:plug, "~> 1.3.0"},
+      {:phoenix, "~> 1.2.1"}
+    ]
+  end
+end


### PR DESCRIPTION
## Summary

- add a Mix fixture whose project-defined `deps.update` alias raises if invoked
- verify version resolution and lockfile updates bypass that project alias
- verify a real failed dependency resolution leaves caller-owned files and temporary state unchanged

This is a test-only baseline for #7945. It intentionally does not change the Hex toolchain or helper protocol; those will follow separately.

## Test plan

- `bin/test hex rspec spec/dependabot/hex/update_checker/version_resolver_spec.rb spec/dependabot/hex/file_updater/lockfile_updater_spec.rb` (30 examples, 0 failures)
- `bin/test hex rubocop` (43 files, no offenses)
- `bin/test hex` (278 examples, 0 failures, 1 expected pending example because `HEX_PM_ORGANIZATION_TOKEN` is unset)
