### PR TITLE
Type shared JVM requirement readers

### DIFF
--- a/maven/lib/dependabot/maven/shared/shared_metadata_finder.rb
+++ b/maven/lib/dependabot/maven/shared/shared_metadata_finder.rb
@@ -170,12 +170,12 @@ module Dependabot
 
         sig { overridable.returns(String) }
         def maven_repo_url
-          source = dependency.requirements
-                             .find { |r| r.fetch(:source) }&.fetch(:source)
+          requirement = dependency.requirements.find(&:source)
+          return central_repo_url unless requirement
 
-          source&.fetch(:url, nil) ||
-            source&.fetch("url", nil) ||
-            central_repo_url
+          raise TypeError, "Maven repository source must be a hash" if requirement.source_hash.nil?
+
+          requirement.source_string("url") || central_repo_url
         end
 
         sig { overridable.returns(String) }

--- a/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/shared/shared_package_details_fetcher.rb
@@ -83,8 +83,9 @@ module Dependabot
         def dependency_files_url(repository_url, version)
           _, artifact_id = dependency_parts
           base_url = dependency_base_url(repository_url)
-          type = dependency.requirements.first&.dig(:metadata, :packaging_type) || "jar"
-          classifier = dependency.requirements.first&.dig(:metadata, :classifier)
+          requirement = dependency.requirements.first
+          type = requirement&.metadata_string("packaging_type") || "jar"
+          classifier = requirement&.metadata_string("classifier")
           actual_classifier = classifier.nil? ? "" : "-#{classifier}"
 
           "#{base_url}/#{version}/#{artifact_id}-#{version}#{actual_classifier}.#{type}"
@@ -350,7 +351,7 @@ module Dependabot
               # the consumer POM omits <type>, causing the parser to default to "jar".
               # Only fall back when there's no classifier (classifier artifacts are specific).
               next false unless response.status == 404
-              next false if dependency.requirements.first&.dig(:metadata, :classifier)
+              next false if dependency.requirements.first&.metadata_string("classifier")
 
               pom_response = Dependabot::RegistryClient.head(
                 url: dependency_pom_url(url, version),

--- a/maven/lib/dependabot/maven/shared/shared_version_finder.rb
+++ b/maven/lib/dependabot/maven/shared/shared_version_finder.rb
@@ -108,7 +108,7 @@ module Dependabot
           return true if dependency.numeric_version&.prerelease?
 
           dependency.requirements.any? do |req|
-            req_string = T.cast(req.fetch(:requirement), T.nilable(String)).to_s
+            req_string = req.requirement_string.to_s
             req_string.split(",").any? do |segment|
               normalized = segment.strip.gsub(/\A[\[\(]\s*/, "")
                                   .gsub(/\s*[\]\)]\z/, "")

--- a/maven/spec/dependabot/maven/shared/shared_metadata_finder_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_metadata_finder_spec.rb
@@ -131,6 +131,14 @@ RSpec.describe Dependabot::Maven::Shared::SharedMetadataFinder do
       let(:maven_response) { fixture("poms", "mockito-core-2.11.0.xml") }
 
       it { is_expected.to eq("https://github.com/mockito/mockito") }
+
+      context "when the source has string keys" do
+        let(:dependency_source) do
+          { "type" => "maven_repo", "url" => "https://custom.registry.org/maven2" }
+        end
+
+        it { is_expected.to eq("https://github.com/mockito/mockito") }
+      end
     end
 
     context "when the Maven link resolves to a redirect" do

--- a/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/shared/shared_package_details_fetcher_spec.rb
@@ -128,6 +128,29 @@ RSpec.describe Dependabot::Maven::Shared::SharedPackageDetailsFetcher do
       end
     end
 
+    context "with string-keyed metadata" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: dependency_version,
+          requirements: [{
+            requirement: "23.3-jre",
+            file: "pom.xml",
+            groups: ["dependencies"],
+            source: nil,
+            metadata: { "packaging_type" => "aar", "classifier" => "sources" }
+          }],
+          package_manager: "maven"
+        )
+      end
+
+      it "uses the packaging type and classifier" do
+        url = client.dependency_files_url(maven_central, version)
+
+        expect(url).to eq("#{maven_central}/com/google/guava/guava/23.6-jre/guava-23.6-jre-sources.aar")
+      end
+    end
+
     context "without packaging_type metadata" do
       let(:dependency) do
         Dependabot::Dependency.new(


### PR DESCRIPTION
### What are you trying to accomplish?

Maven, Gradle, and SBT share code that still reads `DependencyRequirement` entries with `dig` and `fetch`.

This PR moves the shared metadata finder, package-details fetcher, and version finder to the typed readers for repository URL, packaging type, classifier, and requirement strings. It also covers string-keyed nested source and metadata hashes.

### Anything you want to highlight for special attention from reviewers?

No source still falls back to Maven Central. A present but non-hash JVM repository source now raises `TypeError`; the old code also failed on that shape, but with `NoMethodError`.

`SharedVersionFinder` was already `typed: strong`. The other two files have unrelated strong-mode errors and remain strict.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 317 to 312 errors, with none left in the shared files.

The focused shared Maven suite passes with 208 examples. The full Maven, Gradle, and SBT suites also pass at the top of the stack.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
