### PR TITLE
Type Maven requirement access

### DIFF
--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -506,13 +506,14 @@ module Dependabot
         merged = []
         used_indices = Set.new
         requirements.each_with_index do |dep_scan_req, i|
-          next if used_indices.include?(i) || dep_scan_req.dig(:metadata, :pom_file).nil?
+          pom_file = dep_scan_req.metadata_string("pom_file")
+          next if used_indices.include?(i) || pom_file.nil?
 
           # Look for another requirement where pom_file matches property_source
           match_index = requirements.find_index.with_index do |parsing_req, j|
             j > i &&
               !used_indices.include?(j) &&
-              dep_scan_req.dig(:metadata, :pom_file) == parsing_req.fetch(:file)
+              pom_file == parsing_req.file
           end
 
           if match_index
@@ -522,11 +523,11 @@ module Dependabot
             # We prefer file and requirement properties from parsed requirements,
             # because they include correct file and not evaluated property value.
             merged_req = {
-              requirement: parsing_req[:requirement],
-              file: parsing_req[:file],
-              groups: [*dep_scan_req[:groups], *parsing_req[:groups]].uniq.compact,
-              source: dep_scan_req[:source],
-              metadata: merge_metadata(dep_scan_req[:metadata], parsing_req[:metadata])
+              requirement: parsing_req.requirement,
+              file: parsing_req.file,
+              groups: [*dep_scan_req.groups, *parsing_req.groups].uniq.compact,
+              source: dep_scan_req.source,
+              metadata: merge_metadata(T.must(dep_scan_req.metadata), T.must(parsing_req.metadata))
             }
 
             merged << Dependabot::DependencyRequirement.create(merged_req)
@@ -545,9 +546,9 @@ module Dependabot
       # Merge metadata from two requirements, combining all keys
       sig do
         params(
-          metadata1: T::Hash[Symbol, Object],
-          metadata2: T::Hash[Symbol, Object]
-        ).returns(T::Hash[Symbol, Object])
+          metadata1: Dependabot::DependencyRequirement::ObjectHash,
+          metadata2: Dependabot::DependencyRequirement::ObjectHash
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
       end
       def merge_metadata(metadata1, metadata2)
         metadata1.merge(metadata2) do |_key, old_value, new_value|

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -67,11 +67,11 @@ module Dependabot
 
         # Loop through each changed requirement and update the files
         reqs.each do |new_req, old_req|
-          raise "Bad req match" unless new_req[:file] == T.must(old_req)[:file]
-          next if new_req[:requirement] == T.must(old_req)[:requirement]
+          raise "Bad req match" unless new_req.file == T.must(old_req).file
+          next if new_req.requirement == T.must(old_req).requirement
 
-          file_name = T.let(new_req.fetch(:file) || new_req.dig(:metadata, :pom_file), String)
-          if new_req.dig(:metadata, :property_name)
+          file_name = T.must(new_req.file || new_req.metadata_string("pom_file"))
+          if new_req.metadata_string("property_name")
             files = update_pomfiles_for_property_change(files, new_req)
             pom = files.find { |f| f.name == file_name }
             files[T.must(files.index(pom))] =
@@ -95,13 +95,13 @@ module Dependabot
           .returns(T::Array[Dependabot::DependencyFile])
       end
       def update_pomfiles_for_property_change(pomfiles, req)
-        property_name = req.fetch(:metadata).fetch(:property_name)
+        property_name = T.must(req.metadata_string("property_name"))
 
         PropertyValueUpdater.new(dependency_files: pomfiles)
                             .update_pomfiles_for_property_change(
                               property_name: property_name,
-                              callsite_pom: T.must(pomfiles.find { |f| f.name == req.fetch(:file) }),
-                              updated_value: req.fetch(:requirement)
+                              callsite_pom: T.must(pomfiles.find { |f| f.name == req.file }),
+                              updated_value: T.must(req.requirement_string)
                             )
       end
 
@@ -254,11 +254,11 @@ module Dependabot
           .returns(String)
       end
       def updated_file_declaration(old_declaration, previous_req, requirement)
-        original_req_string = previous_req.fetch(:requirement)
+        original_req_string = T.must(previous_req.requirement_string)
 
         old_declaration.gsub(
           /(?<=\s|>)#{Regexp.quote(original_req_string)}(?=\s|<)/,
-          requirement.fetch(:requirement)
+          T.must(requirement.requirement_string)
         )
       end
 
@@ -333,7 +333,7 @@ module Dependabot
         artifact_id.text = dependency.name.split(":").last
         dependency_node.add_text("\n#{current_indentation_level}")
         version = REXML::Element.new("version", dependency_node)
-        version.text = requirement.fetch(:requirement)
+        version.text = T.must(requirement.requirement_string)
         dependency_node.add_text("\n#{parent_indentation_level}")
       end
 

--- a/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
+++ b/maven/lib/dependabot/maven/file_updater/declaration_finder.rb
@@ -20,12 +20,10 @@ module Dependabot
               <path>.*?</path>|
               <artifactItem>.*?</artifactItem>
             }mx
-        Requirement = T.type_alias { T.any(Dependabot::DependencyRequirement, T::Hash[Symbol, Object]) }
-
         sig { returns(Dependabot::Dependency) }
         attr_reader :dependency
 
-        sig { returns(Requirement) }
+        sig { returns(Dependabot::DependencyRequirement) }
         attr_reader :declaring_requirement
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }
@@ -35,13 +33,16 @@ module Dependabot
           params(
             dependency: Dependabot::Dependency,
             dependency_files: T::Array[Dependabot::DependencyFile],
-            declaring_requirement: Requirement
+            declaring_requirement: Dependabot::DependencyRequirement::Input
           ).void
         end
         def initialize(dependency:, dependency_files:, declaring_requirement:)
           @dependency = dependency
           @dependency_files = dependency_files
-          @declaring_requirement = declaring_requirement
+          @declaring_requirement = T.let(
+            Dependabot::DependencyRequirement.create(declaring_requirement),
+            Dependabot::DependencyRequirement
+          )
           @declaration_strings = T.let(nil, T.nilable(T::Array[String]))
           @property_value_finder = T.let(nil, T.nilable(Maven::FileParser::PropertyValueFinder))
         end
@@ -62,7 +63,7 @@ module Dependabot
 
         sig { returns(Dependabot::DependencyFile) }
         def declaring_pom
-          filename = declaring_requirement.fetch(:file) || declaring_requirement.dig(:metadata, :pom_file)
+          filename = declaring_requirement.file || declaring_requirement.metadata_string("pom_file")
           declaring_pom = dependency_files.find { |f| f.name == filename }
           return declaring_pom if declaring_pom
 
@@ -90,7 +91,7 @@ module Dependabot
             next false unless classifier_matches?(node)
             next false unless node_name == dependency_name
             next false unless packaging_type_matches?(node)
-            next false unless declaring_requirement.fetch(:groups) == ["plugin"] || scope_matches?(node)
+            next false unless declaring_requirement.groups == ["plugin"] || scope_matches?(node)
 
             declaring_requirement_matches?(node)
           end
@@ -115,7 +116,7 @@ module Dependabot
         def declaring_requirement_matches?(node)
           node_requirement = node.at_css("version")&.content&.strip
 
-          if declaring_requirement.dig(:metadata, :property_name)
+          if (declaring_property_name = declaring_requirement.metadata_string("property_name"))
             return false unless node_requirement
 
             property_name =
@@ -124,15 +125,15 @@ module Dependabot
               &.named_captures
               &.fetch("property")
 
-            property_name == declaring_requirement[:metadata][:property_name]
+            property_name == declaring_property_name
           else
-            node_requirement == declaring_requirement.fetch(:requirement)
+            node_requirement == declaring_requirement.requirement_string
           end
         end
 
         sig { params(node: Nokogiri::XML::Document).returns(T::Boolean) }
         def packaging_type_matches?(node)
-          type = declaring_requirement.dig(:metadata, :packaging_type)
+          type = declaring_requirement.metadata_string("packaging_type")
           type == packaging_type(node)
         end
 
@@ -141,13 +142,13 @@ module Dependabot
           return true unless node.at_xpath("./*/classifier")
 
           classifier = evaluated_value(node.at_xpath("./*/classifier").content.strip)
-          dep_classifier = dependency.requirements.first&.dig(:metadata, :classifier)
+          dep_classifier = dependency.requirements.first&.metadata_string("classifier")
           classifier == dep_classifier
         end
 
         sig { params(node: Nokogiri::XML::Document).returns(T::Boolean) }
         def scope_matches?(node)
-          dependency_type = declaring_requirement.fetch(:groups)
+          dependency_type = declaring_requirement.groups
 
           node_type = dependency_scope(node) == "test" ? ["test"] : []
 

--- a/maven/lib/dependabot/maven/package/package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/package/package_details_fetcher.rb
@@ -123,8 +123,8 @@ module Dependabot
         # Returns the POM file for the dependency, if it exists.
         sig { returns(T.nilable(Dependabot::DependencyFile)) }
         def pom
-          filename = dependency.requirements.first&.fetch(:file) ||
-                     dependency.requirements.first&.dig(:metadata, :pom_file)
+          requirement = dependency.requirements.first
+          filename = requirement&.file || requirement&.metadata_string("pom_file")
           dependency_files.find { |f| f.name == filename }
         end
       end

--- a/maven/lib/dependabot/maven/update_checker.rb
+++ b/maven/lib/dependabot/maven/update_checker.rb
@@ -107,7 +107,7 @@ module Dependabot
       def updated_requirements
         property_names =
           declarations_using_a_property
-          .map { |req| req.dig(:metadata, :property_name) }
+          .filter_map { |req| req.metadata_string("property_name") }
 
         RequirementsUpdater.new(
           requirements: dependency.requirements,
@@ -120,8 +120,8 @@ module Dependabot
       sig { override.returns(T::Boolean) }
       def requirements_unlocked_or_can_be?
         declarations_using_a_property.none? do |requirement|
-          prop_name = requirement.dig(:metadata, :property_name)
-          pom = dependency_files.find { |f| f.name == requirement[:file] }
+          prop_name = requirement.metadata_string("property_name")
+          pom = dependency_files.find { |f| f.name == requirement.file }
 
           return false unless prop_name && pom
 
@@ -217,17 +217,16 @@ module Dependabot
       sig { returns(T::Boolean) }
       def version_comes_from_multi_dependency_property?
         declarations_using_a_property.any? do |requirement|
-          property_name = requirement.fetch(:metadata).fetch(:property_name)
-          property_source = requirement.fetch(:metadata)
-                                       .fetch(:property_source)
+          property_name = T.must(requirement.metadata_string("property_name"))
+          property_source = requirement.metadata_string("property_source")
 
           all_property_based_dependencies.any? do |dep|
             next false if dep.name == dependency.name
 
             dep.requirements.any? do |req|
-              next unless req.dig(:metadata, :property_name) == property_name
+              next unless req.metadata_string("property_name") == property_name
 
-              req.dig(:metadata, :property_source) == property_source
+              req.metadata_string("property_source") == property_source
             end
           end
         end
@@ -237,7 +236,7 @@ module Dependabot
       def declarations_using_a_property
         @declarations_using_a_property ||=
           dependency.requirements
-                    .select { |req| req.dig(:metadata, :property_name) }
+                    .select { |req| req.metadata_string("property_name") }
       end
 
       sig { returns(T::Array[Dependabot::Dependency]) }
@@ -247,14 +246,14 @@ module Dependabot
             dependency_files: dependency_files,
             source: nil
           ).parse.select do |dep|
-            dep.requirements.any? { |req| req.dig(:metadata, :property_name) }
+            dep.requirements.any? { |req| req.metadata_string("property_name") }
           end
       end
 
       sig { returns(T::Boolean) }
       def version_comes_from_project_parent_version?
         declarations_using_a_property.any? do |requirement|
-          requirement.dig(:metadata, :property_name) == "project.parent.version"
+          requirement.metadata_string("property_name") == "project.parent.version"
         end
       end
     end

--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -122,9 +122,9 @@ module Dependabot
               source: nil
             ).parse.select do |dep|
               dep.requirements.any? do |r|
-                next unless r.dig(:metadata, :property_name) == property_name
+                next unless r.metadata_string("property_name") == property_name
 
-                r.dig(:metadata, :property_source) == property_source
+                r.metadata_string("property_source") == property_source
               end
             end,
             T.nilable(T::Array[Dependabot::Dependency])
@@ -135,8 +135,8 @@ module Dependabot
         def property_name
           @property_name ||= T.let(
             dependency.requirements
-                      .find { |r| r.dig(:metadata, :property_name) }
-                      &.dig(:metadata, :property_name),
+                      .find { |r| r.metadata_string("property_name") }
+                      &.metadata_string("property_name"),
             T.nilable(String)
           )
 
@@ -149,8 +149,8 @@ module Dependabot
         def property_source
           @property_source ||= T.let(
             dependency.requirements
-                      .find { |r| r.dig(:metadata, :property_name) == property_name }
-                      &.dig(:metadata, :property_source),
+                      .find { |r| r.metadata_string("property_name") == property_name }
+                      &.metadata_string("property_source"),
             T.nilable(String)
           )
         end
@@ -192,10 +192,10 @@ module Dependabot
         sig { params(dep: Dependabot::Dependency).returns(String) }
         def current_property_value(dep)
           declaring_requirement = declaring_property_requirement(dep)
-          callsite_pom = dependency_files.find { |f| f.name == declaring_requirement.fetch(:file) }
+          callsite_pom = dependency_files.find { |f| f.name == declaring_requirement.file }
           unless callsite_pom
             raise DependencyFileNotEvaluatable,
-                  "POM not found: #{declaring_requirement.fetch(:file)} for property #{property_name}"
+                  "POM not found: #{declaring_requirement.file} for property #{property_name}"
           end
 
           property_value =
@@ -212,9 +212,9 @@ module Dependabot
         def declaring_property_requirement(dep)
           declaring_requirement =
             dep.requirements.find do |r|
-              next false unless r.dig(:metadata, :property_name) == property_name
+              next false unless r.metadata_string("property_name") == property_name
 
-              r.dig(:metadata, :property_source) == property_source
+              r.metadata_string("property_source") == property_source
             end
 
           return declaring_requirement if declaring_requirement

--- a/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
@@ -54,14 +54,15 @@ module Dependabot
           # requirement at index `i` to correspond to the previous requirement
           # at the same index.
           requirements.map do |req|
-            next req if req.fetch(:requirement).nil?
-            next req if req.fetch(:requirement).include?(",")
+            requirement = req.requirement_string
+            next req if requirement.nil?
+            next req if requirement.include?(",")
 
-            property_name = req.dig(:metadata, :property_name)
+            property_name = req.metadata_string("property_name")
             next req if property_name && !properties_to_update.include?(property_name)
 
-            new_req = update_requirement(req[:requirement])
-            next req if new_req == req[:requirement]
+            new_req = update_requirement(requirement)
+            next req if new_req == requirement
 
             Dependabot::DependencyRequirement.create(req.merge(requirement: new_req, source: updated_source))
           end

--- a/maven/spec/dependabot/maven/file_updater/declaration_finder_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater/declaration_finder_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe Dependabot::Maven::FileUpdater::DeclarationFinder do
   let(:dependency_version) { "4.5.3" }
   let(:dependency_metadata) { { packaging_type: "jar" } }
   let(:declaring_requirement) do
-    {
+    Dependabot::DependencyRequirement.create(
       requirement: dependency_version,
       file: "pom.xml",
       groups: groups,
       source: nil,
       metadata: dependency_metadata
-    }
+    )
   end
   let(:dependency_files) { [pom] }
   let(:pom) do

--- a/maven/spec/dependabot/maven/update_checker/requirements_updater_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/requirements_updater_spec.rb
@@ -7,7 +7,7 @@ require "dependabot/maven/update_checker/requirements_updater"
 RSpec.describe Dependabot::Maven::UpdateChecker::RequirementsUpdater do
   let(:updater) do
     described_class.new(
-      requirements: requirements,
+      requirements: requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) },
       latest_version: latest_version,
       source_url: "new_url",
       properties_to_update: []


### PR DESCRIPTION
### What are you trying to accomplish?

Migrate Maven's remaining requirement consumers to `DependencyRequirement` readers across parsing, file updates, declaration lookup, package details, and update checking.

Property, POM-file, packaging, classifier, groups, file, and requirement fields now cross a typed boundary. Parser requirement merges preserve the original source, group union, and mixed-key metadata.

### Anything you want to highlight for special attention from reviewers?

`DeclarationFinder` still accepts the existing hash-compatible input shape, but wraps it immediately. A few tests also passed plain hashes directly into typed helpers, bypassing `Dependency`; those now match the production contract.

The two remaining `fetch(:file)` calls in these files read property-detail hashes, not dependency requirements.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 312 to 276 errors, with none left in Maven.

The full Maven suite passes with 754 examples. Sorbet and RuboCop are clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
