### PR TITLE
Type Gradle requirement access

### DIFF
--- a/gradle/lib/dependabot/gradle/distributions.rb
+++ b/gradle/lib/dependabot/gradle/distributions.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/dependency_requirement"
@@ -14,7 +14,7 @@ module Dependabot
       sig { params(requirements: T::Array[Dependabot::DependencyRequirement]).returns(T::Boolean) }
       def self.distribution_requirements?(requirements)
         requirements.any? do |req|
-          req.dig(:source, :type) == DISTRIBUTION_DEPENDENCY_TYPE
+          req.source_string("type") == DISTRIBUTION_DEPENDENCY_TYPE
         end
       end
     end

--- a/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
+++ b/gradle/lib/dependabot/gradle/file_parser/repositories_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -74,10 +74,10 @@ module Dependabot
                          .reject { |new_req, old_req| new_req == old_req }
         # Loop through each changed requirement and update the buildfiles
         reqs.each do |new_req, old_req|
-          raise "Bad req match" if old_req.nil? || T.let(new_req[:file], String) != T.let(old_req[:file], String)
-          next if T.let(new_req[:requirement], String) == T.let(old_req[:requirement], String)
+          raise "Bad req match" if old_req.nil? || new_req.file != old_req.file
+          next if new_req.requirement == old_req.requirement
 
-          buildfile = files.find { |f| f.name == T.let(new_req.fetch(:file), String) }
+          buildfile = files.find { |f| f.name == new_req.file }
 
           # Currently, Dependabot assumes that Gradle projects using Gradle submodules are all in a single
           # repo. However, some projects are actually using git submodule references for the Gradle submodules.
@@ -88,10 +88,9 @@ module Dependabot
 
           raise DependencyFileNotResolvable, "No build file found to update the dependency" if buildfile.nil?
 
-          metadata = symbol_object_hash(T.cast(new_req[:metadata], T.nilable(Object)))
-          if metadata && metadata[:property_name].is_a?(String)
+          if new_req.metadata_string("property_name")
             files = update_files_for_property_change(files, old_req, new_req)
-          elsif metadata && symbol_object_hash(metadata[:dependency_set])
+          elsif new_req.metadata_string_hash("dependency_set")
             files = update_files_for_dep_set_change(files, old_req, new_req)
           else
             files[T.must(files.index(buildfile))] = update_version_in_buildfile(dependency, buildfile, old_req, new_req)
@@ -170,47 +169,45 @@ module Dependabot
       sig do
         params(
           buildfiles: T::Array[Dependabot::DependencyFile],
-          old_req: T::Hash[Symbol, Object],
-          new_req: T::Hash[Symbol, Object]
+          old_req: Dependabot::DependencyRequirement,
+          new_req: Dependabot::DependencyRequirement
         )
           .returns(T::Array[Dependabot::DependencyFile])
       end
       def update_files_for_property_change(buildfiles, old_req, new_req)
         files = buildfiles.dup
-        metadata = symbol_object_hash_value(new_req, :metadata)
-        property_name = string_value(metadata, :property_name)
-        file = string_value(new_req, :file)
+        property_name = T.must(new_req.metadata_string("property_name"))
+        file = T.must(new_req.file)
         buildfile = T.must(files.find { |f| f.name == file })
 
         PropertyValueUpdater.new(dependency_files: files)
                             .update_files_for_property_change(
                               property_name: property_name,
                               callsite_buildfile: buildfile,
-                              previous_value: string_value(old_req, :requirement),
-                              updated_value: string_value(new_req, :requirement)
+                              previous_value: T.must(old_req.requirement_string),
+                              updated_value: T.must(new_req.requirement_string)
                             )
       end
 
       sig do
         params(
           buildfiles: T::Array[Dependabot::DependencyFile],
-          old_req: T::Hash[Symbol, Object],
-          new_req: T::Hash[Symbol, Object]
+          old_req: Dependabot::DependencyRequirement,
+          new_req: Dependabot::DependencyRequirement
         )
           .returns(T::Array[Dependabot::DependencyFile])
       end
       def update_files_for_dep_set_change(buildfiles, old_req, new_req)
         files = buildfiles.dup
-        metadata = symbol_object_hash_value(new_req, :metadata)
-        dependency_set = symbol_string_hash_value(metadata, :dependency_set)
-        buildfile = T.must(files.find { |f| f.name == string_value(new_req, :file) })
+        dependency_set = T.must(new_req.metadata_string_hash("dependency_set"))
+        buildfile = T.must(files.find { |f| f.name == new_req.file })
 
         DependencySetUpdater.new(dependency_files: files)
                             .update_files_for_dep_set_change(
                               dependency_set: dependency_set,
                               buildfile: buildfile,
-                              previous_requirement: string_value(old_req, :requirement),
-                              updated_requirement: string_value(new_req, :requirement)
+                              previous_requirement: T.must(old_req.requirement_string),
+                              updated_requirement: T.must(new_req.requirement_string)
                             )
       end
 
@@ -218,8 +215,8 @@ module Dependabot
         params(
           dependency: Dependabot::Dependency,
           buildfile: Dependabot::DependencyFile,
-          previous_req: T::Hash[Symbol, Object],
-          requirement: T::Hash[Symbol, Object]
+          previous_req: Dependabot::DependencyRequirement,
+          requirement: Dependabot::DependencyRequirement
         )
           .returns(Dependabot::DependencyFile)
       end
@@ -249,13 +246,13 @@ module Dependabot
       sig do
         params(
           dependency: Dependabot::Dependency,
-          requirement: T::Hash[Symbol, Object]
+          requirement: Dependabot::DependencyRequirement
         ).returns(T::Array[String])
       end
       def original_buildfile_declarations(dependency, requirement)
         # This implementation is limited to declarations that appear on a
         # single line.
-        file = string_value(requirement, :file)
+        file = T.must(requirement.file)
         buildfile = T.must(buildfiles.find { |f| f.name == file })
 
         T.must(buildfile.content).lines.select do |line|
@@ -266,11 +263,7 @@ module Dependabot
             dep_parts = dependency.name.split(":")
             next false unless line.include?(T.must(dep_parts.first)) || line.include?(T.must(dep_parts.last))
           elsif file.end_with?(".properties")
-            source = requirement[:source]
-            property = T.let(nil, T.nilable(String))
-            source_hash = symbol_object_hash(source)
-            source_property = source_hash&.[](:property)
-            property = source_property if source_property.is_a?(String)
+            property = requirement.source_string("property")
             next false unless property && line.start_with?(property)
           elsif file.end_with?(".toml")
             next false unless line.include?(dependency.name)
@@ -280,7 +273,7 @@ module Dependabot
             next false unless line.match?(name_regex)
           end
 
-          line.include?(string_value(requirement, :requirement))
+          line.include?(T.must(requirement.requirement_string))
         end
       end
       # rubocop:enable Metrics/AbcSize
@@ -315,55 +308,15 @@ module Dependabot
       sig do
         params(
           original_buildfile_declaration: String,
-          previous_req: T::Hash[Symbol, Object],
-          requirement: T::Hash[Symbol, Object]
+          previous_req: Dependabot::DependencyRequirement,
+          requirement: Dependabot::DependencyRequirement
         ).returns(String)
       end
       def updated_buildfile_declaration(original_buildfile_declaration, previous_req, requirement)
-        original_req_string = string_value(previous_req, :requirement)
-        new_req_string = string_value(requirement, :requirement)
+        original_req_string = T.must(previous_req.requirement_string)
+        new_req_string = T.must(requirement.requirement_string)
 
         original_buildfile_declaration.gsub(original_req_string, new_req_string)
-      end
-
-      sig { params(hash: T::Hash[Symbol, Object], key: Symbol).returns(String) }
-      def string_value(hash, key)
-        value = hash.fetch(key)
-        raise TypeError, "Expected #{key} to be a String" unless value.is_a?(String)
-
-        value
-      end
-
-      sig { params(hash: T::Hash[Symbol, Object], key: Symbol).returns(T::Hash[Symbol, Object]) }
-      def symbol_object_hash_value(hash, key)
-        value = hash.fetch(key)
-        raise TypeError, "Expected #{key} to be a Hash" unless value.is_a?(Hash)
-
-        value
-      end
-
-      sig { params(hash: T::Hash[Symbol, Object], key: Symbol).returns(T::Hash[Symbol, String]) }
-      def symbol_string_hash_value(hash, key)
-        value = hash.fetch(key)
-        raise TypeError, "Expected #{key} to be a Hash" unless value.is_a?(Hash)
-
-        result = T.let({}, T::Hash[Symbol, String])
-        value.each_pair do |hash_key_object, hash_value_object|
-          hash_key = T.cast(hash_key_object, T.nilable(Object))
-          hash_value = T.cast(hash_value_object, T.nilable(Object))
-          raise TypeError, "Expected #{key} keys and values to be Symbols and Strings" unless hash_key.is_a?(Symbol) &&
-                                                                                              hash_value.is_a?(String)
-
-          result[hash_key] = hash_value
-        end
-        result
-      end
-
-      sig { params(value: T.nilable(Object)).returns(T.nilable(T::Hash[Symbol, Object])) }
-      def symbol_object_hash(value)
-        return unless value.is_a?(Hash)
-
-        value
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/gradle/lib/dependabot/gradle/file_updater/wrapper/command_builder.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/wrapper/command_builder.rb
@@ -79,19 +79,19 @@ module Dependabot
 
           sig { returns(String) }
           def version
-            T.let(T.must(@requirements[0])[:requirement], String)
+            T.must(T.must(@requirements[0]).requirement_string)
           end
 
           sig { returns(T.nilable(String)) }
           def checksum
             return nil unless @requirements.size > 1
 
-            T.let(T.must(@requirements[1])[:requirement], String)
+            T.must(T.must(@requirements[1]).requirement_string)
           end
 
           sig { returns(T.nilable(String)) }
           def distribution_type
-            url = T.let(T.must(@requirements[0])[:source], T::Hash[Symbol, String])[:url]
+            url = T.must(@requirements[0]).source_string("url")
             # Anchor to the `-bin.zip` / `-all.zip` filename suffix so a path segment such as a
             # mirror host (e.g. https://binaries.example.com/...) can't false-match `bin`/`all`.
             url&.match(/-(bin|all)\.zip/)&.captures&.first

--- a/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater/wrapper_updater.rb
@@ -59,7 +59,7 @@ module Dependabot
 
           # we only run this updater if the build file has a requirement for this dependency
           target_requirements = dependency.requirements.select do |req|
-            T.let(req[:file], String) == build_file.name
+            req.file == build_file.name
           end
           return [] unless target_requirements.any?
 

--- a/gradle/lib/dependabot/gradle/metadata_finder.rb
+++ b/gradle/lib/dependabot/gradle/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -66,11 +66,12 @@ module Dependabot
 
       sig { override.returns(String) }
       def maven_repo_url
-        source = dependency.requirements
-                           .find { |r| r.fetch(:source) }&.fetch(:source)
+        requirement = dependency.requirements.find(&:source)
+        return Gradle::FileParser::RepositoriesFinder::CENTRAL_REPO_URL unless requirement
 
-        source&.fetch(:url, nil) ||
-          source&.fetch("url") ||
+        raise TypeError, "Gradle repository source must be a hash" if requirement.source_hash.nil?
+
+        requirement.source_string("url") ||
           Gradle::FileParser::RepositoriesFinder::CENTRAL_REPO_URL
       end
 
@@ -81,12 +82,12 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def plugin?
-        dependency.requirements.any? { |r| r.fetch(:groups).include? "plugins" }
+        dependency.requirements.any? { |r| r.groups&.include?("plugins") }
       end
 
       sig { returns(T::Boolean) }
       def kotlin_plugin?
-        plugin? && dependency.requirements.any? { |r| r.fetch(:groups).include? "kotlin" }
+        plugin? && dependency.requirements.any? { |r| r.groups&.include?("kotlin") }
       end
     end
   end

--- a/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
@@ -346,7 +346,7 @@ module Dependabot
         def dependency_repository_details
           requirement_files =
             dependency.requirements
-                      .map { |r| r.fetch(:file) }
+                      .filter_map(&:file)
                       .map { |nm| dependency_files.find { |f| f.name == nm } }
 
           @dependency_repository_details ||=
@@ -396,7 +396,7 @@ module Dependabot
 
         sig { returns(T.nilable(Dependabot::DependencyFile)) }
         def pom
-          filename = T.must(dependency.requirements.first).fetch(:file)
+          filename = T.must(dependency.requirements.first).file
           dependency_files.find { |f| f.name == filename }
         end
 
@@ -425,12 +425,12 @@ module Dependabot
 
         sig { returns(T::Boolean) }
         def plugin?
-          dependency.requirements.any? { |r| r.fetch(:groups).include? "plugins" }
+          dependency.requirements.any? { |r| r.groups&.include?("plugins") }
         end
 
         sig { returns(T.nilable(T::Boolean)) }
         def kotlin_plugin?
-          plugin? && dependency.requirements.any? { |r| r.fetch(:groups).include? "kotlin" }
+          plugin? && dependency.requirements.any? { |r| r.groups&.include?("kotlin") }
         end
 
         sig { returns(T::Boolean) }

--- a/gradle/lib/dependabot/gradle/update_checker.rb
+++ b/gradle/lib/dependabot/gradle/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -206,34 +206,30 @@ module Dependabot
             next false if dep.name == dependency.name
 
             dep.requirements.any? do |req|
-              req.dig(:metadata, :property_name) == property_name
+              req.metadata_string("property_name") == property_name
             end
           end
         end
       end
 
-      sig { params(requirement: T::Hash[Symbol, Object]).returns(T.nilable(String)) }
+      sig { params(requirement: Dependabot::DependencyRequirement).returns(T.nilable(String)) }
       def property_name_from_requirement(requirement)
-        metadata = requirement[:metadata]
-        return unless metadata.is_a?(Hash)
-
-        property_name = metadata[:property_name]
-        property_name if property_name.is_a?(String)
+        requirement.metadata_string("property_name")
       end
 
       sig { returns(T::Boolean) }
       def version_comes_from_dependency_set?
         dependency.requirements.any? do |req|
-          req.dig(:metadata, :dependency_set)
+          req.metadata_string_hash("dependency_set")
         end
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, Object]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def declarations_using_a_property
         @declarations_using_a_property ||= T.let(
           dependency.requirements
-                    .select { |req| req.dig(:metadata, :property_name) },
-          T.nilable(T::Array[T::Hash[Symbol, Object]])
+                    .select { |req| req.metadata_string("property_name") },
+          T.nilable(T::Array[Dependabot::DependencyRequirement])
         )
       end
 
@@ -244,7 +240,7 @@ module Dependabot
             dependency_files: dependency_files,
             source: nil
           ).parse.select do |dep|
-            dep.requirements.any? { |req| req.dig(:metadata, :property_name) }
+            dep.requirements.any? { |req| req.metadata_string("property_name") }
           end,
           T.nilable(T::Array[Dependabot::Dependency])
         )

--- a/gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/multi_dependency_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -50,7 +50,7 @@ module Dependabot
           @dependencies_to_update = T.let(nil, T.nilable(T::Array[Dependabot::Dependency]))
           @property_name = T.let(nil, T.nilable(String))
           @dependency_set = T.let(nil, T.nilable(T::Hash[Symbol, String]))
-          @updated_requirements = T.let({}, T::Hash[String, T::Array[T::Hash[Symbol, Object]]])
+          @updated_requirements = T.let({}, T::Hash[String, T::Array[Dependabot::DependencyRequirement]])
         end
         sig { returns(T::Boolean) }
         def update_possible?
@@ -128,8 +128,8 @@ module Dependabot
               source: nil
             ).parse.select do |dep|
               dep.requirements.any? do |r|
-                tmp_p_name = r.dig(:metadata, :property_name)
-                tmp_dep_set = r.dig(:metadata, :dependency_set)
+                tmp_p_name = r.metadata_string("property_name")
+                tmp_dep_set = r.metadata_string_hash("dependency_set")
                 next true if property_name && tmp_p_name == property_name
 
                 dependency_set && tmp_dep_set == dependency_set
@@ -140,18 +140,18 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def property_name
           @property_name ||= dependency.requirements
-                                       .find { |r| r.dig(:metadata, :property_name) }
-                                       &.dig(:metadata, :property_name)
+                                       .find { |r| r.metadata_string("property_name") }
+                                       &.metadata_string("property_name")
         end
 
         sig { returns(T.nilable(T::Hash[Symbol, String])) }
         def dependency_set
           @dependency_set ||= dependency.requirements
-                                        .find { |r| r.dig(:metadata, :dependency_set) }
-                                        &.dig(:metadata, :dependency_set)
+                                        .find { |r| r.metadata_string_hash("dependency_set") }
+                                        &.metadata_string_hash("dependency_set")
         end
 
-        sig { params(dep: Dependabot::Dependency).returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig { params(dep: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements(dep)
           @updated_requirements[dep.name] ||=
             RequirementsUpdater.new(

--- a/gradle/lib/dependabot/gradle/update_checker/requirements_updater.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/requirements_updater.rb
@@ -61,13 +61,14 @@ module Dependabot
           # requirement at index `i` to correspond to the previous requirement
           # at the same index.
           requirements.map do |req|
-            next req if req.fetch(:requirement).nil?
-            next req if req.fetch(:requirement).include?(",")
+            requirement = req.requirement_string
+            next req if requirement.nil?
+            next req if requirement.include?(",")
 
-            property_name = req.dig(:metadata, :property_name)
+            property_name = req.metadata_string("property_name")
             next req if property_name && !properties_to_update.include?(property_name)
 
-            new_req = update_requirement(req[:requirement])
+            new_req = update_requirement(requirement)
             Dependabot::DependencyRequirement.create(req.merge(requirement: new_req, source: updated_source))
           end
         end
@@ -124,33 +125,52 @@ module Dependabot
           distribution_url = T.let(nil, T.nilable(String))
 
           requirements.map do |req|
-            source = req[:source]
+            source = req.source_hash
             next req unless source
 
-            case source[:property]
+            case req.source_string("property")
             when "distributionUrl"
-              requirement = req[:requirement]
+              requirement = T.must(req.requirement_string)
               version = update_exact_requirement(requirement)
-              distribution_url = source[:url].gsub(requirement, version)
+              distribution_url = T.must(req.source_string("url")).gsub(requirement, version)
+              updated_source = set_source_string(source.dup, "url", distribution_url)
 
               Dependabot::DependencyRequirement.create(
                 req.merge(
                   requirement: version,
-                  source: source.merge(url: distribution_url)
+                  source: updated_source
                 )
               )
             when "distributionSha256Sum"
               checksum_url, checksum = Gradle::Package::DistributionsFetcher.resolve_checksum(T.must(distribution_url))
+              updated_source = set_source_string(source.dup, "url", checksum_url)
               Dependabot::DependencyRequirement.create(
                 req.merge(
                   requirement: checksum,
-                  source: source.merge(url: checksum_url)
+                  source: updated_source
                 )
               )
             else
               next req
             end
           end
+        end
+
+        sig do
+          params(
+            source: Dependabot::DependencyRequirement::ObjectHash,
+            key: String,
+            value: T.nilable(String)
+          ).returns(Dependabot::DependencyRequirement::ObjectHash)
+        end
+        def set_source_string(source, key, value)
+          symbol_key = key.to_sym
+          if source.key?(key) && !source.key?(symbol_key)
+            source[key] = value
+          else
+            source[symbol_key] = value
+          end
+          source
         end
 
         sig { override.returns(T::Class[Version]) }

--- a/gradle/spec/dependabot/gradle/file_updater/wrapper/command_builder_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater/wrapper/command_builder_spec.rb
@@ -8,7 +8,7 @@ require "dependabot/gradle/version"
 RSpec.describe Dependabot::Gradle::FileUpdater::Wrapper::CommandBuilder do
   subject(:args) do
     described_class.new(
-      requirements: requirements,
+      requirements: requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) },
       original_properties: original_properties,
       gradle_version: gradle_version
     ).build

--- a/gradle/spec/dependabot/gradle/update_checker/requirements_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/requirements_updater_spec.rb
@@ -7,7 +7,7 @@ require "dependabot/gradle/update_checker/requirements_updater"
 RSpec.describe Dependabot::Gradle::UpdateChecker::RequirementsUpdater do
   let(:updater) do
     described_class.new(
-      requirements: requirements,
+      requirements: requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) },
       latest_version: latest_version,
       source_url: "new_url",
       properties_to_update: []


### PR DESCRIPTION
### What are you trying to accomplish?

Replace Gradle's requirement-shaped `T::Hash[Symbol, Object]` parameters and hash reads with `DependencyRequirement` across distributions, file and wrapper updates, metadata, package details, and update checking.

### Anything you want to highlight for special attention from reviewers?

Wrapper requirements keep their order: version first, optional checksum second. Distribution updates preserve the complete source hash and its nested key style while changing only URL or checksum data.

Tests that called wrapper or requirements helpers with plain hashes now pass real `DependencyRequirement` entries.

Five files move to `typed: strong`: distributions, repositories finder, metadata finder, update checker, and multi-dependency updater. The three file-updater/wrapper files were already strong.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 276 to 241 errors, with none left in Gradle.

The full Gradle suite passes with 674 examples. Sorbet and RuboCop are clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

