### PR TITLE
Type SBT requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 991
+# Offense count: 975
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -386,7 +386,6 @@ Sorbet/ForbidTUntyped:
     - "rakelib/support/helpers.rb"
     - "rust_toolchain/lib/dependabot/rust_toolchain/update_checker/latest_version_finder.rb"
     - "sbt/lib/dependabot/sbt/file_fetcher.rb"
-    - "sbt/lib/dependabot/sbt/file_updater.rb"
     - "sbt/lib/dependabot/sbt/package/package_details_fetcher.rb"
     - "sbt/lib/dependabot/sbt/update_checker.rb"
     - "silent/lib/dependabot/silent/file_updater.rb"

--- a/sbt/lib/dependabot/sbt/file_updater.rb
+++ b/sbt/lib/dependabot/sbt/file_updater.rb
@@ -57,8 +57,8 @@ module Dependabot
                          .reject { |new_req, old_req| new_req == old_req }
 
         reqs.each do |new_req, old_req|
-          raise "Bad req match" unless new_req[:file] == T.must(old_req)[:file]
-          next if new_req[:requirement] == T.must(old_req)[:requirement]
+          raise "Bad req match" unless new_req.file == T.must(old_req).file
+          next if new_req.requirement == T.must(old_req).requirement
 
           files = apply_requirement_update(files, dependency, new_req, T.must(old_req))
         end
@@ -70,21 +70,21 @@ module Dependabot
         params(
           files: T::Array[Dependabot::DependencyFile],
           dependency: Dependabot::Dependency,
-          new_req: T::Hash[Symbol, T.untyped],
-          old_req: T::Hash[Symbol, T.untyped]
+          new_req: Dependabot::DependencyRequirement,
+          old_req: Dependabot::DependencyRequirement
         ).returns(T::Array[Dependabot::DependencyFile])
       end
       def apply_requirement_update(files, dependency, new_req, old_req)
-        if new_req.dig(:metadata, :property_name)
+        if new_req.metadata_string("property_name")
           update_files_for_property_change(files, old_req, new_req)
-        elsif T.let(new_req[:file], String).end_with?("build.properties")
+        elsif T.must(new_req.file).end_with?("build.properties")
           update_build_properties(files, old_req, new_req)
         elsif scala_version_requirement?(new_req)
-          file = T.must(files.find { |f| f.name == new_req[:file] })
+          file = T.must(files.find { |f| f.name == new_req.file })
           idx = T.must(files.index(file))
           files.dup.tap { |updated| updated[idx] = update_scala_version(file, old_req, new_req) }
         else
-          file = T.must(files.find { |f| f.name == new_req[:file] })
+          file = T.must(files.find { |f| f.name == new_req.file })
           idx = T.must(files.index(file))
           files.dup.tap { |updated| updated[idx] = update_version_in_buildfile(dependency, file, old_req, new_req) }
         end
@@ -93,34 +93,34 @@ module Dependabot
       sig do
         params(
           files: T::Array[Dependabot::DependencyFile],
-          old_req: T::Hash[Symbol, T.untyped],
-          new_req: T::Hash[Symbol, T.untyped]
+          old_req: Dependabot::DependencyRequirement,
+          new_req: Dependabot::DependencyRequirement
         ).returns(T::Array[Dependabot::DependencyFile])
       end
       def update_files_for_property_change(files, old_req, new_req)
-        property_name = T.let(new_req.dig(:metadata, :property_name), String)
-        callsite = T.must(files.find { |f| f.name == new_req[:file] })
+        property_name = T.must(new_req.metadata_string("property_name"))
+        callsite = T.must(files.find { |f| f.name == new_req.file })
 
         PropertyValueUpdater.new(dependency_files: files)
                             .update_files_for_property_change(
                               property_name: property_name,
                               callsite_buildfile: callsite,
-                              previous_value: T.let(old_req.fetch(:requirement), String),
-                              updated_value: T.let(new_req.fetch(:requirement), String)
+                              previous_value: T.must(old_req.requirement_string),
+                              updated_value: T.must(new_req.requirement_string)
                             )
       end
 
       sig do
         params(
           files: T::Array[Dependabot::DependencyFile],
-          old_req: T::Hash[Symbol, T.untyped],
-          new_req: T::Hash[Symbol, T.untyped]
+          old_req: Dependabot::DependencyRequirement,
+          new_req: Dependabot::DependencyRequirement
         ).returns(T::Array[Dependabot::DependencyFile])
       end
       def update_build_properties(files, old_req, new_req)
-        file = T.must(files.find { |f| f.name == new_req[:file] })
-        old_version = T.let(old_req.fetch(:requirement), String)
-        new_version = T.let(new_req.fetch(:requirement), String)
+        file = T.must(files.find { |f| f.name == new_req.file })
+        old_version = T.must(old_req.requirement_string)
+        new_version = T.must(new_req.requirement_string)
 
         updated_content = T.must(file.content).sub(
           /(sbt\.version\s*=\s*)#{Regexp.quote(old_version)}/,
@@ -138,13 +138,13 @@ module Dependabot
       sig do
         params(
           file: Dependabot::DependencyFile,
-          old_req: T::Hash[Symbol, T.untyped],
-          new_req: T::Hash[Symbol, T.untyped]
+          old_req: Dependabot::DependencyRequirement,
+          new_req: Dependabot::DependencyRequirement
         ).returns(Dependabot::DependencyFile)
       end
       def update_scala_version(file, old_req, new_req)
-        old_version = T.let(old_req.fetch(:requirement), String)
-        new_version = T.let(new_req.fetch(:requirement), String)
+        old_version = T.must(old_req.requirement_string)
+        new_version = T.must(new_req.requirement_string)
 
         updated_content = T.must(file.content).sub(
           /(#{SCALA_VERSION_DECL})#{Regexp.quote(old_version)}(")/,
@@ -160,8 +160,8 @@ module Dependabot
         params(
           dependency: Dependabot::Dependency,
           buildfile: Dependabot::DependencyFile,
-          previous_req: T::Hash[Symbol, T.untyped],
-          requirement: T::Hash[Symbol, T.untyped]
+          previous_req: Dependabot::DependencyRequirement,
+          requirement: Dependabot::DependencyRequirement
         ).returns(Dependabot::DependencyFile)
       end
       def update_version_in_buildfile(dependency, buildfile, previous_req, requirement)
@@ -182,18 +182,18 @@ module Dependabot
       sig do
         params(
           dependency: Dependabot::Dependency,
-          requirement: T::Hash[Symbol, T.untyped]
+          requirement: Dependabot::DependencyRequirement
         ).returns(T::Array[String])
       end
       def original_buildfile_declarations(dependency, requirement)
-        buildfile = T.must(dependency_files.find { |f| f.name == T.let(requirement.fetch(:file), String) })
+        buildfile = T.must(dependency_files.find { |f| f.name == requirement.file })
         group, artifact = dependency_group_and_artifact(dependency)
 
         T.must(buildfile.content).lines.select do |line|
           next false unless line.include?(group)
           next false unless line.include?(artifact)
 
-          line.include?(T.let(requirement.fetch(:requirement), String))
+          line.include?(T.must(requirement.requirement_string))
         end
       end
 
@@ -212,13 +212,13 @@ module Dependabot
       sig do
         params(
           old_declaration: String,
-          previous_req: T::Hash[Symbol, T.untyped],
-          requirement: T::Hash[Symbol, T.untyped]
+          previous_req: Dependabot::DependencyRequirement,
+          requirement: Dependabot::DependencyRequirement
         ).returns(String)
       end
       def updated_buildfile_declaration(old_declaration, previous_req, requirement)
-        original_req_string = T.let(previous_req.fetch(:requirement), String)
-        new_req_string = T.let(requirement.fetch(:requirement), String)
+        original_req_string = T.must(previous_req.requirement_string)
+        new_req_string = T.must(requirement.requirement_string)
 
         old_declaration.gsub(
           /"#{Regexp.quote(original_req_string)}"/,
@@ -226,9 +226,9 @@ module Dependabot
         )
       end
 
-      sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+      sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
       def scala_version_requirement?(req)
-        req.dig(:metadata, :property_source) == "scalaVersion"
+        req.metadata_string("property_source") == "scalaVersion"
       end
     end
   end

--- a/sbt/lib/dependabot/sbt/package/package_details_fetcher.rb
+++ b/sbt/lib/dependabot/sbt/package/package_details_fetcher.rb
@@ -140,7 +140,7 @@ module Dependabot
         # SBT plugins are identified by having "plugins" in their groups.
         sig { returns(T::Boolean) }
         def sbt_plugin?
-          dependency.requirements.any? { |req| req.fetch(:groups, []).include?("plugins") }
+          dependency.requirements.any? { |req| req.groups&.include?("plugins") }
         end
 
         # SBT 1.x plugins use Scala 2.12; SBT 2.x plugins use Scala 3.

--- a/sbt/lib/dependabot/sbt/update_checker.rb
+++ b/sbt/lib/dependabot/sbt/update_checker.rb
@@ -51,7 +51,7 @@ module Dependabot
       def updated_requirements
         property_names =
           declarations_using_a_property
-          .filter_map { |req| req.dig(:metadata, :property_name) }
+          .filter_map { |req| req.metadata_string("property_name") }
 
         RequirementsUpdater.new(
           requirements: dependency.requirements,
@@ -132,8 +132,8 @@ module Dependabot
       sig { returns(T::Boolean) }
       def version_comes_from_multi_dependency_property?
         declarations_using_a_property.any? do |requirement|
-          property_name = requirement.dig(:metadata, :property_name)
-          property_source = requirement.dig(:metadata, :property_source)
+          property_name = requirement.metadata_string("property_name")
+          property_source = requirement.metadata_string("property_source")
 
           next false unless property_name
 
@@ -141,20 +141,20 @@ module Dependabot
             next false if dep.name == dependency.name
 
             dep.requirements.any? do |req|
-              next unless req.dig(:metadata, :property_name) == property_name
+              next unless req.metadata_string("property_name") == property_name
 
-              req.dig(:metadata, :property_source) == property_source
+              req.metadata_string("property_source") == property_source
             end
           end
         end
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def declarations_using_a_property
         @declarations_using_a_property ||= T.let(
           dependency.requirements
-                    .select { |req| req.dig(:metadata, :property_name) },
-          T.nilable(T::Array[T::Hash[Symbol, T.untyped]])
+                    .select { |req| req.metadata_string("property_name") },
+          T.nilable(T::Array[Dependabot::DependencyRequirement])
         )
       end
 
@@ -165,7 +165,7 @@ module Dependabot
             dependency_files: dependency_files,
             source: nil
           ).parse.select do |dep|
-            dep.requirements.any? { |req| req.dig(:metadata, :property_name) }
+            dep.requirements.any? { |req| req.metadata_string("property_name") }
           end,
           T.nilable(T::Array[Dependabot::Dependency])
         )

--- a/sbt/lib/dependabot/sbt/update_checker/requirements_updater.rb
+++ b/sbt/lib/dependabot/sbt/update_checker/requirements_updater.rb
@@ -47,13 +47,14 @@ module Dependabot
           return requirements unless latest_version
 
           requirements.map do |req|
-            next req if req.fetch(:requirement).nil?
-            next req if req.fetch(:requirement).include?(",")
+            requirement = req.requirement_string
+            next req if requirement.nil?
+            next req if requirement.include?(",")
 
-            property_name = req.dig(:metadata, :property_name)
+            property_name = req.metadata_string("property_name")
             next req if property_name && !properties_to_update.include?(property_name)
 
-            new_req = update_requirement(req[:requirement])
+            new_req = update_requirement(requirement)
             Dependabot::DependencyRequirement.create(req.merge(requirement: new_req, source: updated_source))
           end
         end

--- a/sbt/spec/dependabot/sbt/update_checker/requirements_updater_spec.rb
+++ b/sbt/spec/dependabot/sbt/update_checker/requirements_updater_spec.rb
@@ -7,7 +7,7 @@ require "dependabot/sbt/update_checker/requirements_updater"
 RSpec.describe Dependabot::Sbt::UpdateChecker::RequirementsUpdater do
   let(:updater) do
     described_class.new(
-      requirements: requirements,
+      requirements: requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) },
       latest_version: latest_version,
       source_url: "https://repo.maven.apache.org/maven2",
       properties_to_update: properties_to_update


### PR DESCRIPTION
### What are you trying to accomplish?

Finish the JVM-family migration by typing SBT's file updater, property coordination, requirements updater, and plugin-group reads.

This includes the requirement-shaped signatures that did not appear in the temporary generic experiment because they were already declared as untyped hashes.

### Anything you want to highlight for special attention from reviewers?

The dynamic version-detail hashes in `update_checker.rb` and repository-detail hashes in `package_details_fetcher.rb` are unrelated and remain unchanged. Those files stay on the exclusion list.

`sbt/file_updater.rb` loses all 14 of its `T.untyped` tokens and leaves the list. The update checker loses two requirement-array tokens but retains its three version-detail tokens.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 241 to 233 errors. Across the stack it drops from 317 to 233.

`ForbidTUntyped` drops from 991 to 975 across one fewer excluded file. The full SBT suite passes with 161 examples; Maven and Gradle pass with 754 and 674. Sorbet, RuboCop, and the ratchet are clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
