### PR TITLE
Don't omit the `Release notes` section if the release name includes more periods than the release version

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/release_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/release_finder.rb
@@ -198,15 +198,9 @@ module Dependabot
         sig { params(releases: T::Array[ReleaseType], conservative: T::Boolean).returns(T::Array[ReleaseType]) }
         def filter_releases_using_previous_version(releases, conservative:)
           releases.reject do |release|
-            cleaned_tag = release.tag_name.gsub(/^[^0-9]*/, "")
-            cleaned_name = release.name&.gsub(/^[^0-9]*/, "")
-            dot_count = [cleaned_tag, cleaned_name].compact.reject(&:empty?)
-                                                   .map { |nm| nm.chars.count(".") }.max
+            next false if release_tag_matches_version?(release, new_version)
 
-            tag_version = [cleaned_tag, cleaned_name].compact.reject(&:empty?)
-                                                     .select { |nm| version_class.correct?(nm) }
-                                                     .select { |nm| nm.chars.count(".") == dot_count }
-                                                     .map { |nm| version_class.new(nm) }.max
+            tag_version = possible_versions(release).max
 
             next conservative unless tag_version
 
@@ -221,15 +215,9 @@ module Dependabot
           updated_version = version_class.new(new_version)
 
           releases.reject do |release|
-            cleaned_tag = release.tag_name.gsub(/^[^0-9]*/, "")
-            cleaned_name = release.name&.gsub(/^[^0-9]*/, "")
-            dot_count = [cleaned_tag, cleaned_name].compact.reject(&:empty?)
-                                                   .map { |nm| nm.chars.count(".") }.max
+            next false if release_tag_matches_version?(release, new_version)
 
-            tag_version = [cleaned_tag, cleaned_name].compact.reject(&:empty?)
-                                                     .select { |nm| version_class.correct?(nm) }
-                                                     .select { |nm| nm.chars.count(".") == dot_count }
-                                                     .map { |nm| version_class.new(nm) }.min
+            tag_version = possible_versions(release).min
 
             next conservative unless tag_version
 
@@ -237,6 +225,26 @@ module Dependabot
             # (e.g., if two major versions are being maintained)
             tag_version > updated_version
           end
+        end
+
+        sig { params(release: ReleaseType).returns(T::Array[Dependabot::Version]) }
+        def possible_versions(release)
+          candidates = [release.tag_name, release.name].compact
+                                                       .map { |name| name.gsub(/^[^0-9]*/, "") }
+                                                       .reject(&:empty?)
+                                                       .select { |name| version_class.correct?(name) }
+          dot_count = candidates.map { |name| name.chars.count(".") }.max
+          return [] unless dot_count
+
+          candidates.select { |name| name.chars.count(".") == dot_count }
+                    .map { |name| version_class.new(name) }
+        end
+
+        sig { params(release: ReleaseType, version: T.nilable(String)).returns(T::Boolean) }
+        def release_tag_matches_version?(release, version)
+          return false unless version
+
+          release.tag_name.gsub(/^[^0-9]*/, "") == version.gsub(/^[^0-9]*/, "")
         end
 
         sig { returns(T.nilable(ReleaseType)) }

--- a/common/spec/dependabot/metadata_finders/base/release_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/release_finder_spec.rb
@@ -221,6 +221,42 @@ RSpec.describe Dependabot::MetadataFinders::Base::ReleaseFinder do
               end
             end
 
+            context "when the release name contains another dotted version" do
+              let(:github_response) do
+                releases = JSON.parse(fixture("github", "business_releases.json"))
+                releases.find { |release| release.fetch("tag_name") == "v1.8.0" }
+                        .store("name", "v1.8.0 - bump to Ruby 3.3")
+                releases.to_json
+              end
+
+              it "uses the release matched by the updated version" do
+                expect(releases_text)
+                  .to eq(
+                    "## v1.8.0 - bump to Ruby 3.3\n" \
+                    "- Add 2018-2027 TARGET holiday defintions\n" \
+                    "- Add 2018-2027 Bankgirot holiday defintions"
+                  )
+              end
+            end
+
+            context "when the release name looks like a different version" do
+              let(:github_response) do
+                releases = JSON.parse(fixture("github", "business_releases.json"))
+                releases.find { |release| release.fetch("tag_name") == "v1.8.0" }
+                        .store("name", "v1.8.0.1")
+                releases.to_json
+              end
+
+              it "uses the release matched by the updated version" do
+                expect(releases_text)
+                  .to eq(
+                    "## v1.8.0.1\n" \
+                    "- Add 2018-2027 TARGET holiday defintions\n" \
+                    "- Add 2018-2027 Bankgirot holiday defintions"
+                  )
+              end
+            end
+
             context "when the release is blank" do
               let(:dependency_version) { "1.7.0" }
               let(:dependency_previous_version) { "1.7.0.beta" }
@@ -303,6 +339,23 @@ RSpec.describe Dependabot::MetadataFinders::Base::ReleaseFinder do
                   "## v1.7.0.alpha\n" \
                   "No release notes provided."
                 )
+            end
+
+            context "when an intermediate release name contains another dotted version" do
+              let(:dependency_previous_version) { "1.5.0" }
+              let(:github_response) do
+                releases = JSON.parse(fixture("github", "business_releases.json"))
+                releases.find { |release| release.fetch("tag_name") == "v1.6.0" }
+                        .store("name", "v1.6.0 - supports Ruby 3.3")
+                releases.to_json
+              end
+
+              it "uses the valid release tag when filtering" do
+                expect(releases_text).to include(
+                  "## v1.6.0 - supports Ruby 3.3",
+                  "Mad props to @greysteil and "
+                )
+              end
             end
 
             context "when all versions are blank or nil" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #4959.

ReleaseFinder currently calculates the maximum period count across both a release tag and its display name before checking whether either value is a valid ecosystem version. A descriptive name such as `v0.34.0 - bump to Go 1.18` can therefore make the valid `v0.34.0` tag fail the period-count heuristic and remove its release notes from the pull request.

This change prevents a release whose tag directly matches the updated version from being rejected by the version heuristics. For other releases, it calculates the period count only from candidates accepted by the ecosystem version class.

### Implementation shape

The production diff looks larger than the behavioral change because the candidate parsing that was duplicated in the lower- and upper-bound filters has been extracted into `possible_versions`. Conceptually, there are only two behavior changes:

1. **Protect the known target release.** Both boundary filters retain a release when its tag directly matches the requested updated version. The tag is stronger evidence than an editorial display name, so a title such as `v0.34.0 - bump to Go 1.18` cannot cause the already-identified target release to be rejected.
2. **Validate candidates before counting periods.** Only tag or title values accepted by the ecosystem version class may determine the maximum period count. An invalid descriptive title can no longer increase that count and disqualify an otherwise valid tag.

The extracted helper otherwise preserves the existing behavior: the lower-bound filter still takes the maximum candidate version, and the upper-bound filter still takes the minimum candidate version.

This PR does not change release fetching, release ordering, positional slicing, monorepo prefix filtering, endpoint lookup, git-ref handling, ecosystem version parsing, or the existing `min`/`max` policy for ambiguous intermediate releases.

### Anything you want to highlight for special attention from reviewers?

This is intentionally narrower than replacing the shared release-version resolver. Release metadata and version semantics vary substantially across ecosystems, and the existing logic also supports title-based versions, monorepo prefixes, maintained release lines, and git refs.

The change preserves the existing handling for ambiguous intermediate releases while ensuring stronger exact-tag evidence wins and invalid display names cannot influence candidate precision.

### How will you know you have accomplished your goal?

Focused regression coverage verifies:

- an exact updated tag is retained when its display name mentions another dotted version;
- an exact updated tag is retained when its display name itself looks like a different valid version;
- an intermediate release uses its valid tag when its descriptive name is not a valid version;
- existing ReleaseFinder behavior, including `Fix #123`, JasperReports, monorepo, and numeric-prefix cases, remains green.

Validation:

- `bin/test common spec/dependabot/metadata_finders/base/release_finder_spec.rb` (35 examples, 0 failures)

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass. CI will run the complete suite.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.