### PR TITLE
Extend POM Last-Modified cooldown fallback to all Maven artifacts

### DIFF
--- a/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
@@ -149,7 +149,7 @@ module Dependabot
           release_date = nil unless release_date.is_a?(Time)
           hydrated_release = build_release_with_date(release, release_date)
 
-          return hydrated_release if hydrated_release.released_at || !plugin?
+          return hydrated_release if hydrated_release.released_at
 
           build_release_with_date(hydrated_release, version_release_date_fallback(release.version.to_s))
         end
@@ -172,7 +172,7 @@ module Dependabot
         end
 
         sig { params(repository_url: String, version: String).returns(String) }
-        def plugin_version_pom_url(repository_url, version)
+        def version_pom_url(repository_url, version)
           group_id, artifact_id = group_and_artifact_ids
           group_id = "#{Dependabot::Gradle::MetadataFinder::KOTLIN_PLUGIN_REPO_PREFIX}.#{group_id}" if kotlin_plugin?
           pom_filename = "#{artifact_id}-#{version}.pom"
@@ -444,7 +444,7 @@ module Dependabot
             dependency_name: dependency.name,
             repositories: repositories,
             forbidden_urls: T.must(forbidden_urls),
-            pom_url_builder: ->(repository_url, version) { plugin_version_pom_url(repository_url, version) }
+            pom_url_builder: ->(repository_url, version) { version_pom_url(repository_url, version) }
           )
         end
 

--- a/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/package/package_details_fetcher.rb
@@ -149,7 +149,7 @@ module Dependabot
           release_date = nil unless release_date.is_a?(Time)
           hydrated_release = build_release_with_date(release, release_date)
 
-          return hydrated_release if hydrated_release.released_at
+          return hydrated_release if hydrated_release.released_at || distribution?
 
           build_release_with_date(hydrated_release, version_release_date_fallback(release.version.to_s))
         end

--- a/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
@@ -348,7 +348,19 @@ RSpec.describe Dependabot::Gradle::Package::PackageDetailsFetcher do
     end
 
     context "with a non-plugin dependency" do
-      it "does not attempt pom last-modified fallback when release date is missing" do
+      let(:guava_pom_url) do
+        "https://repo.maven.apache.org/maven2/" \
+          "com/google/guava/guava/23.3-jre/guava-23.3-jre.pom"
+      end
+
+      it "uses pom last-modified fallback when release date is missing" do
+        stub_request(:get, "https://repo.maven.apache.org/maven2/com/google/guava/guava/")
+          .to_return(status: 200, body: "<html><body></body></html>")
+        stub_request(:head, guava_pom_url).to_return(
+          status: 200,
+          headers: { "Last-Modified" => "Tue, 03 Oct 2017 19:00:00 GMT" }
+        )
+
         release = Dependabot::Package::PackageRelease.new(
           version: version_class.new("23.3-jre"),
           url: "https://repo.maven.apache.org/maven2"
@@ -356,8 +368,8 @@ RSpec.describe Dependabot::Gradle::Package::PackageDetailsFetcher do
 
         hydrated_release = packagedetailsfetcher.fetch_release_metadata(release: release)
 
-        expect(hydrated_release.released_at).to be_nil
-        expect(WebMock).not_to have_requested(:head, /.*/)
+        expect(hydrated_release.released_at).to eq(Time.utc(2017, 10, 3, 19, 0, 0))
+        expect(a_request(:head, guava_pom_url)).to have_been_made.once
       end
     end
 

--- a/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
+++ b/gradle/spec/dependabot/gradle/package/package_details_fetcher_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe Dependabot::Gradle::Package::PackageDetailsFetcher do
 
       it "uses pom last-modified fallback when release date is missing" do
         stub_request(:get, "https://repo.maven.apache.org/maven2/com/google/guava/guava/")
-          .to_return(status: 200, body: "<html><body></body></html>")
+          .to_return(status: 404)
         stub_request(:head, guava_pom_url).to_return(
           status: 200,
           headers: { "Last-Modified" => "Tue, 03 Oct 2017 19:00:00 GMT" }
@@ -370,6 +370,46 @@ RSpec.describe Dependabot::Gradle::Package::PackageDetailsFetcher do
 
         expect(hydrated_release.released_at).to eq(Time.utc(2017, 10, 3, 19, 0, 0))
         expect(a_request(:head, guava_pom_url)).to have_been_made.once
+      end
+    end
+
+    context "with a gradle distribution dependency" do
+      let(:dependency_name) { "gradle-distribution" }
+      let(:dependency_version) { "8.5-rc-3" }
+      let(:dependency_requirements) do
+        [{
+          requirement: "8.5-rc-3",
+          file: "gradle/wrapper/gradle-wrapper.properties",
+          source: {
+            type: "gradle-distribution",
+            url: "https://services.gradle.org/distributions/gradle-8.5-rc-3-bin.zip"
+          },
+          groups: []
+        }]
+      end
+
+      before do
+        stub_request(:get, "https://services.gradle.org/versions/all")
+          .to_return(
+            status: 200,
+            body: fixture("gradle_distributions_metadata", "versions_all.json")
+          )
+        stub_request(:get, "https://services.gradle.org/gradle-distribution//maven-metadata.xml")
+          .to_return(status: 404)
+        stub_request(:get, "https://services.gradle.org/gradle-distribution//")
+          .to_return(status: 404)
+      end
+
+      it "does not attempt the pom last-modified fallback" do
+        release = Dependabot::Package::PackageRelease.new(
+          version: version_class.new("8.5-rc-3"),
+          url: Dependabot::Gradle::Distributions::DISTRIBUTION_REPOSITORY_URL
+        )
+
+        hydrated_release = packagedetailsfetcher.fetch_release_metadata(release: release)
+
+        expect(hydrated_release.released_at).to be_nil
+        expect(WebMock).not_to have_requested(:head, /.*/)
       end
     end
 

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -752,6 +752,57 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       end
     end
 
+    context "with cooldown and missing listing dates for a non-plugin dependency" do
+      let(:cooldown_options) do
+        Dependabot::Package::ReleaseCooldownOptions.new(
+          default_days: 3,
+          semver_major_days: 3,
+          semver_minor_days: 3,
+          semver_patch_days: 3,
+          include: [],
+          exclude: []
+        )
+      end
+      let(:maven_central_html_url) do
+        "https://repo.maven.apache.org/maven2/com/google/guava/guava/"
+      end
+      let(:guava_pom_url) do
+        "https://repo.maven.apache.org/maven2/" \
+          "com/google/guava/guava/23.6-jre/guava-23.6-jre.pom"
+      end
+
+      before do
+        allow(Time).to receive(:now).and_return(Time.parse("2026-05-13T17:30:00.000Z"))
+        stub_request(:get, maven_central_html_url).to_return(status: 404)
+        stub_request(:head, guava_pom_url).to_return(
+          status: 200,
+          headers: { "Last-Modified" => "Mon, 11 May 2026 10:08:43 GMT" }
+        )
+      end
+
+      it "loads fallback release dates lazily during cooldown filtering" do
+        logger = instance_double(Logger, info: nil, debug: nil)
+        allow(Dependabot).to receive(:logger).and_return(logger)
+
+        release = Dependabot::Package::PackageRelease.new(
+          version: version_class.new("23.6-jre"),
+          url: "https://repo.maven.apache.org/maven2"
+        )
+
+        finder.send(:in_cooldown_period?, release)
+
+        expect(a_request(:head, guava_pom_url)).to have_been_made.once
+        expect(logger).to have_received(:info).with(
+          "Using POM Last-Modified fallback release dates for com.google.guava:guava " \
+          "from https://repo.maven.apache.org/maven2"
+        )
+        expect(logger).to have_received(:debug).with(
+          "Using POM Last-Modified fallback for com.google.guava:guava version 23.6-jre " \
+          "from https://repo.maven.apache.org/maven2: 2026-05-11 10:08:43 UTC"
+        )
+      end
+    end
+
     context "with a plugin" do
       let(:dependency_requirements) do
         [{

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -768,7 +768,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
       end
       let(:guava_pom_url) do
         "https://repo.maven.apache.org/maven2/" \
-          "com/google/guava/guava/23.6-jre/guava-23.6-jre.pom"
+          "com/google/guava/guava/23.5-jre/guava-23.5-jre.pom"
       end
 
       before do
@@ -785,7 +785,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
         allow(Dependabot).to receive(:logger).and_return(logger)
 
         release = Dependabot::Package::PackageRelease.new(
-          version: version_class.new("23.6-jre"),
+          version: version_class.new("23.5-jre"),
           url: "https://repo.maven.apache.org/maven2"
         )
 
@@ -797,7 +797,7 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
           "from https://repo.maven.apache.org/maven2"
         )
         expect(logger).to have_received(:debug).with(
-          "Using POM Last-Modified fallback for com.google.guava:guava version 23.6-jre " \
+          "Using POM Last-Modified fallback for com.google.guava:guava version 23.5-jre " \
           "from https://repo.maven.apache.org/maven2: 2026-05-11 10:08:43 UTC"
         )
       end


### PR DESCRIPTION
### What are you trying to accomplish?

The POM `Last-Modified` fallback for resolving release dates during cooldown filtering (introduced in #15006) was gated behind a `plugin?` check, limiting it to Gradle plugin dependencies only.

This meant that non-plugin Maven artifacts (e.g. BOMs, libraries) hosted on registries that don't serve HTML directory listings — such as Google Artifact Registry (GAR) — had **all versions** filtered out by the cooldown filter due to missing release dates, completely preventing dependency updates.

GAR returns 404 for directory listing URLs (`GET .../artifact-name/`), so neither the Maven Central HTML parsing nor the Artifactory-style parsing (#14938) can extract per-version timestamps. However, GAR does serve individual POM files with valid `Last-Modified` headers — the existing fallback mechanism works correctly, it was just never invoked for non-plugin artifacts.

### Anything you want to highlight for special attention from reviewers?

Fixes: https://github.com/dependabot/dependabot-core/issues/15802

The change is minimal:
1. Removed the `|| !plugin?` guard from `fetch_release_metadata` so the POM `Last-Modified` fallback applies to all Maven artifacts when release dates cannot be resolved from directory listings
2. Renamed `plugin_version_pom_url` → `version_pom_url` since it now serves all artifact types (the underlying `group_and_artifact_ids` method already handled non-plugin artifacts correctly)
3. Updated and added specs to cover the new behavior

**Related issues/PRs:**
- #14271 — cooldown + private Artifactory registry (fixed by #14938)
- #14991 — cooldown + Gradle plugins (fixed by #15006)
- #15802 — cooldown + non-plugin Maven artifacts on GAR (this PR)

### How will you know you've accomplished your goal?

Dependabot will successfully resolve release dates for non-plugin Maven artifacts from Google Artifact Registry via the POM `Last-Modified` header fallback, allowing cooldown filtering to work correctly instead of filtering out all versions.

Before this fix, the logs show:
```
Release date not available for version 2.1.5 - filtering out
Filtered out (cooldown) : 2.1.5
Release date not available for version 2.1.4 - filtering out
Filtered out (cooldown) : 2.1.4
...
```

After this fix, Dependabot will use `HEAD` requests to resolve release dates from POM files and evaluate cooldown correctly:
```
Using POM Last-Modified fallback release dates for com.example:artifact from https://europe-west2-maven.pkg.dev/...
```

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.