### PR TITLE
common: support argv commands with safe fingerprints

### DIFF
--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -83,7 +83,8 @@ module Dependabot
         stdin_data: T.nilable(String),
         stderr_to_stdout: T::Boolean,
         timeout: Integer,
-        output_observer: OutputObserver
+        output_observer: OutputObserver,
+        fingerprint: T.nilable(String)
       ).returns([T.nilable(String), T.nilable(String), T.nilable(ProcessStatus), Float])
     end
     def self.capture3_with_timeout(
@@ -91,7 +92,8 @@ module Dependabot
       stdin_data: nil,
       stderr_to_stdout: false,
       timeout: TIMEOUTS::DEFAULT,
-      output_observer: nil
+      output_observer: nil,
+      fingerprint: nil
     )
       stdout = T.let("", String)
       stderr = T.let("", String)
@@ -102,14 +104,15 @@ module Dependabot
       begin
         T.unsafe(Open3).popen3(*env_cmd) do |stdin, stdout_io, stderr_io, wait_thr| # rubocop:disable Metrics/BlockLength
           pid = wait_thr.pid
-          command_string = command_string_for_logging(env_cmd)
+          command_string = fingerprint || command_string_for_logging(env_cmd)
           log_level = short_git_config_command?(command_string) ? :debug : :info
-          sanitized_env_cmd = if env_cmd.first.is_a?(Hash)
-                                [SharedHelpers.send(:sanitize_env_for_logging, env_cmd.first), *env_cmd[1..]]
-                              else
-                                env_cmd
-                              end
-          command_for_log = sanitized_env_cmd.join(" ")
+          command_for_log = if fingerprint
+                              fingerprint
+                            elsif env_cmd.first.is_a?(Hash)
+                              [SharedHelpers.send(:sanitize_env_for_logging, env_cmd.first), *env_cmd[1..]].join(" ")
+                            else
+                              env_cmd.join(" ")
+                            end
           Dependabot.logger.public_send(log_level, "Started process PID: #{pid} with command: #{command_for_log}")
 
           # Write to stdin if input data is provided
@@ -205,7 +208,7 @@ module Dependabot
       end
 
       elapsed_time = Time.now - start_time
-      log_level = short_git_config_command?(command_string_for_logging(env_cmd)) ? :debug : :info
+      log_level = short_git_config_command?(fingerprint || command_string_for_logging(env_cmd)) ? :debug : :info
       Dependabot.logger.public_send(log_level, "Total execution time: #{elapsed_time.round(2)} seconds")
       [stdout, stderr, status, elapsed_time]
     end

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -464,7 +464,7 @@ module Dependabot
     # rubocop:disable Metrics/PerceivedComplexity
     sig do
       params(
-        command: String,
+        command: T.any(String, T::Array[String]),
         allow_unsafe_shell_command: T::Boolean,
         cwd: T.nilable(String),
         env: T.nilable(T::Hash[String, String]),
@@ -485,17 +485,22 @@ module Dependabot
       output_observer: nil
     )
       start = Time.now
-      cmd = allow_unsafe_shell_command ? command : escape_command(command)
+      cmd = if command.is_a?(Array) || allow_unsafe_shell_command
+              command
+            else
+              escape_command(command)
+            end
 
-      puts cmd if ENV["DEBUG_HELPERS"] == "true"
+      puts(fingerprint || Array(cmd).join(" ")) if ENV["DEBUG_HELPERS"] == "true"
 
       opts = {}
       opts[:chdir] = cwd if cwd
 
-      env_cmd = [env || {}, cmd, opts].compact
+      env_cmd = [env || {}, *Array(cmd), opts]
       kwargs = {
         stderr_to_stdout: stderr_to_stdout,
-        timeout: timeout
+        timeout: timeout,
+        fingerprint: fingerprint
       }
       kwargs[:output_observer] = output_observer if output_observer
 
@@ -511,7 +516,7 @@ module Dependabot
       return stdout || "" if process&.success?
 
       error_context = {
-        command: cmd,
+        command: fingerprint || (command.is_a?(Array) ? Shellwords.join(command) : cmd),
         fingerprint: fingerprint,
         time_taken: time_taken,
         process_exit_value: process.to_s

--- a/common/spec/dependabot/command_helpers_spec.rb
+++ b/common/spec/dependabot/command_helpers_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Dependabot::CommandHelpers do
         expect(stdout).to eq("This is a successful command.\n")
         expect(stderr).to eq("")
         expect(status.exitstatus).to eq(0)
-        expect(elapsed_time).to be > 0
+        expect(elapsed_time).to be_positive
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe Dependabot::CommandHelpers do
         expect(stdout).to eq("")
         expect(stderr).to eq("This is an error message.\n")
         expect(status.exitstatus).to eq(1)
-        expect(elapsed_time).to be > 0
+        expect(elapsed_time).to be_positive
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Dependabot::CommandHelpers do
         expect(stdout).to eq("")
         expect(stderr).to include("No such file or directory - non_existent_command") if stderr
         expect(status).to be_nil
-        expect(elapsed_time).to be > 0
+        expect(elapsed_time).to be_positive
       end
     end
 
@@ -179,6 +179,18 @@ RSpec.describe Dependabot::CommandHelpers do
         expect(logger).to have_received(:info).with(a_string_including("Started process PID"))
         expect(logger).to have_received(:info).with(a_string_including("Process PID"))
         expect(logger).to have_received(:info).with(a_string_including("Total execution time"))
+      end
+
+      it "uses the fingerprint without logging command arguments or environment" do
+        described_class.capture3_with_timeout(
+          [{ "HEX_API_KEY" => "secret-key" }, success_cmd, "secret-argument"],
+          timeout: timeout,
+          fingerprint: "safe-command <argument>"
+        )
+
+        expect(logger).to have_received(:info).with(a_string_including("safe-command <argument>"))
+        expect(logger).not_to have_received(:info).with(a_string_including("secret-key"))
+        expect(logger).not_to have_received(:info).with(a_string_including("secret-argument"))
       end
     end
 

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -276,6 +276,29 @@ RSpec.describe Dependabot::SharedHelpers do
       end
     end
 
+    context "with an argument array" do
+      let(:arguments) { [RbConfig.ruby, "-e", "puts ARGV", "argument with spaces", "$(echo unsafe)"] }
+
+      it "preserves argument boundaries without shell expansion" do
+        expect(described_class.run_shell_command(arguments)).to eq("argument with spaces\n$(echo unsafe)\n")
+      end
+    end
+
+    context "with a fingerprint" do
+      let(:arguments) { [RbConfig.ruby, "-e", "abort ARGV.fetch(0)", "secret-key"] }
+
+      it "uses the fingerprint instead of command arguments in error context" do
+        run_command = lambda do
+          described_class.run_shell_command(arguments, fingerprint: "mix hex.repo add <credentials>")
+        end
+
+        expect(&run_command).to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed) do |error|
+          expect(error.error_context[:command]).to eq("mix hex.repo add <credentials>")
+          expect(error.error_context.to_s).not_to include("secret-key")
+        end
+      end
+    end
+
     context "when the subprocess exits" do
       let(:command) { File.join(spec_root, "helpers/test/error_bash") }
 


### PR DESCRIPTION
## Why

The Hex CLI migration needs two capabilities from common code:

1. Preserve argument boundaries when invoking Mix/Hex commands.
2. Keep credential flags such as `--key` and `--auth-key` out of subprocess logs and error metadata.

## Changes

- Allow `Dependabot::SharedHelpers.run_shell_command` to accept `Array[String]` and pass it directly to `Open3` as argv.
- Forward the existing `fingerprint:` value to subprocess lifecycle logging.
- Prefer the fingerprint in debug output and subprocess error context.
- Add focused coverage for argument boundaries, shell expansion avoidance, and credential masking.

## Deliberately deferred

This PR does not change timeout semantics, output capture limits, output observers, process termination, process groups, or environment inheritance. Those are not required for the first Hex CLI migration and can be considered independently if a concrete need arises.

## Validation

- `bin/test common spec/dependabot/command_helpers_spec.rb spec/dependabot/shared_helpers_spec.rb` (77 examples, 0 failures)
- `bin/test common` (2,107 examples, 0 failures)
- `bin/test common rubocop` (196 files, no offenses)
- `bundle exec srb tc` (no errors)