### PR TITLE
Use metadata sources when sanitizing mentions

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer.rb
@@ -4,6 +4,7 @@
 require "commonmarker"
 require "sorbet-runtime"
 require "strscan"
+require "uri"
 require "dependabot/pull_request_creator/message_builder"
 
 module Dependabot
@@ -13,6 +14,9 @@ module Dependabot
         extend T::Sig
 
         GITHUB_USERNAME = /[a-z0-9]+(-[a-z0-9]+)*/i
+        GITLAB_USERNAME = /[a-z0-9](?:[a-z0-9_.-]*[a-z0-9_-])?/i
+        GITHUB_HOST = "github.com"
+        GITLAB_HOST = "gitlab.com"
         GITHUB_REF_REGEX = %r{
           (?:https?://)?
           github\.com/(?<repo>#{GITHUB_USERNAME}/[^/\s]+)/
@@ -20,9 +24,6 @@ module Dependabot
         }x
         # [^/\s#]+ means one or more characters not matching (^) the class /, whitespace (\s), or #
         GITHUB_NWO_REGEX = %r{(?<repo>#{GITHUB_USERNAME}/[^/\s#]+)#(?<number>\d+)}
-        MENTION_REGEX = %r{(?<![A-Za-z0-9`~])@#{GITHUB_USERNAME}/?}
-        # regex to match a team mention on github
-        TEAM_MENTION_REGEX = %r{(?<![A-Za-z0-9`~])@(?<org>#{GITHUB_USERNAME})/(?<team>#{GITHUB_USERNAME})/?}
         # End of string
         EOS_REGEX = /\z/
 
@@ -49,9 +50,18 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         attr_reader :github_redirection_service
 
-        sig { params(github_redirection_service: T.nilable(String)).void }
-        def initialize(github_redirection_service:)
+        sig { returns(T.nilable(String)) }
+        attr_reader :metadata_source_url
+
+        sig do
+          params(
+            github_redirection_service: T.nilable(String),
+            metadata_source_url: T.nilable(String)
+          ).void
+        end
+        def initialize(github_redirection_service:, metadata_source_url: nil)
           @github_redirection_service = github_redirection_service
+          @metadata_source_url = metadata_source_url
         end
 
         sig { params(text: String, unsafe: T::Boolean, format_html: T::Boolean).returns(String) }
@@ -90,7 +100,7 @@ module Dependabot
         def sanitize_mentions(doc)
           doc.walk do |node|
             if node.type == :text &&
-               node.string_content.match?(MENTION_REGEX)
+               node.string_content.match?(mention_regex)
               nodes = if parent_node_link?(node)
                         build_mention_link_text_nodes(node.string_content)
                       else
@@ -111,10 +121,10 @@ module Dependabot
         def sanitize_team_mentions(doc)
           doc.walk do |node|
             if node.type == :text &&
-               node.string_content.match?(TEAM_MENTION_REGEX)
+               node.string_content.match?(team_mention_regex)
               if parent_node_link?(node)
                 # Preserve text node formatting while preventing notifications with zero-width space
-                node.string_content = node.string_content.gsub(TEAM_MENTION_REGEX) do |match|
+                node.string_content = node.string_content.gsub(team_mention_regex) do |match|
                   insert_zero_width_space_in_mention(match)
                 end
               else
@@ -189,9 +199,9 @@ module Dependabot
           scan = StringScanner.new(text)
 
           until scan.eos?
-            line = scan.scan_until(MENTION_REGEX) ||
+            line = scan.scan_until(mention_regex) ||
                    scan.scan_until(EOS_REGEX)
-            line_match = T.must(line).match(MENTION_REGEX)
+            line_match = T.must(line).match(mention_regex)
             mention = line_match&.to_s
             text_node = Commonmarker::Node.new(:text)
 
@@ -199,7 +209,7 @@ module Dependabot
               text_node.string_content = line_match.pre_match
               nodes << text_node
               nodes << create_link_node(
-                "https://github.com/#{mention.tr('@', '')}", mention.to_s
+                "#{mention_profile_base_url}/#{mention.delete_prefix('@')}", mention.to_s
               )
             else
               text_node.string_content = line
@@ -216,9 +226,9 @@ module Dependabot
 
           scan = StringScanner.new(text)
           until scan.eos?
-            line = scan.scan_until(TEAM_MENTION_REGEX) ||
+            line = scan.scan_until(team_mention_regex) ||
                    scan.scan_until(EOS_REGEX)
-            line_match = T.must(line).match(TEAM_MENTION_REGEX)
+            line_match = T.must(line).match(team_mention_regex)
             mention = line_match&.to_s
             text_node = Commonmarker::Node.new(:text)
 
@@ -233,6 +243,36 @@ module Dependabot
           end
 
           nodes
+        end
+
+        sig { returns(Regexp) }
+        def mention_regex
+          %r{(?<![A-Za-z0-9`~])@#{mention_username_regex}/?}
+        end
+
+        sig { returns(Regexp) }
+        def team_mention_regex
+          username_regex = mention_username_regex
+          %r{(?<![A-Za-z0-9`~])@(?<org>#{username_regex})/(?<team>#{username_regex})/?}
+        end
+
+        sig { returns(Regexp) }
+        def mention_username_regex
+          metadata_source_host == GITLAB_HOST ? GITLAB_USERNAME : GITHUB_USERNAME
+        end
+
+        sig { returns(String) }
+        def mention_profile_base_url
+          "https://#{metadata_source_host == GITLAB_HOST ? GITLAB_HOST : GITHUB_HOST}"
+        end
+
+        sig { returns(T.nilable(String)) }
+        def metadata_source_host
+          return unless metadata_source_url
+
+          URI.parse(T.must(metadata_source_url)).host&.downcase
+        rescue URI::InvalidURIError
+          nil
         end
 
         sig { params(text: String).returns(T::Array[Commonmarker::Node]) }

--- a/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/metadata_presenter.rb
@@ -85,13 +85,11 @@ module Dependabot
         def vulnerabilities_cascade
           return "" unless vulnerabilities_fixed&.any?
 
-          msg = ""
-          T.must(vulnerabilities_fixed).each do |v|
-            msg += serialized_vulnerability_details(v)
+          msg = T.must(vulnerabilities_fixed).map do |vulnerability|
+            details = sanitize_template_tags(serialized_vulnerability_details(vulnerability))
+            sanitize_links_and_mentions(details, metadata_source_url: vulnerability["source_url"])
           end
-
-          msg = sanitize_template_tags(msg)
-          msg = sanitize_links_and_mentions(msg)
+          msg = msg.join
 
           build_details_tag(summary: "Vulnerabilities fixed", body: msg)
         end
@@ -109,7 +107,7 @@ module Dependabot
             base_url: source_url + "/blob/HEAD/"
           )
           msg = sanitize_template_tags(msg)
-          msg = sanitize_links_and_mentions(msg)
+          msg = sanitize_links_and_mentions(msg, metadata_source_url: releases_url)
 
           build_details_tag(summary: "Release notes", body: msg)
         end
@@ -125,7 +123,7 @@ module Dependabot
           msg = link_issues(text: msg)
           msg = fix_relative_links(text: msg, base_url: changelog_url)
           msg = sanitize_template_tags(msg)
-          msg = sanitize_links_and_mentions(msg)
+          msg = sanitize_links_and_mentions(msg, metadata_source_url: changelog_url)
 
           build_details_tag(summary: "Changelog", body: msg)
         end
@@ -141,7 +139,7 @@ module Dependabot
           msg = link_issues(text: msg)
           msg = fix_relative_links(text: msg, base_url: upgrade_guide_url)
           msg = sanitize_template_tags(msg)
-          msg = sanitize_links_and_mentions(msg)
+          msg = sanitize_links_and_mentions(msg, metadata_source_url: upgrade_guide_url)
 
           build_details_tag(summary: "Upgrade guide", body: msg)
         end
@@ -170,7 +168,7 @@ module Dependabot
               "- See full diff in [compare view](#{commits_url})\n"
             end
           msg = link_issues(text: msg)
-          msg = sanitize_links_and_mentions(msg)
+          msg = sanitize_links_and_mentions(msg, metadata_source_url: commits_url)
 
           build_details_tag(summary: "Commits", body: msg)
         end
@@ -317,10 +315,19 @@ module Dependabot
           !%w(bitbucket codecommit).include?(source.provider)
         end
 
-        sig { params(text: String, unsafe: T::Boolean).returns(String) }
-        def sanitize_links_and_mentions(text, unsafe: false)
+        sig do
+          params(
+            text: String,
+            unsafe: T::Boolean,
+            metadata_source_url: T.nilable(String)
+          ).returns(String)
+        end
+        def sanitize_links_and_mentions(text, unsafe: false, metadata_source_url: source_url)
           LinkAndMentionSanitizer
-            .new(github_redirection_service: github_redirection_service)
+            .new(
+              github_redirection_service: github_redirection_service,
+              metadata_source_url: metadata_source_url
+            )
             .sanitize_links_and_mentions(text: text, unsafe: unsafe, format_html: source_provider_supports_html?)
         end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb
@@ -7,10 +7,14 @@ require "dependabot/pull_request_creator/message_builder/" \
 
 RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSanitizer do
   subject(:sanitizer) do
-    described_class.new(github_redirection_service: github_redirection_service)
+    described_class.new(
+      github_redirection_service: github_redirection_service,
+      metadata_source_url: metadata_source_url
+    )
   end
 
   let(:github_redirection_service) { "github-redirect.com" }
+  let(:metadata_source_url) { nil }
 
   describe "#sanitize_links_and_mentions" do
     subject(:sanitize_links_and_mentions) do
@@ -35,6 +39,30 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
           expect(sanitize_links_and_mentions).to eq(
             "<p>Great work <a href=\"https://github.com/greysteil-work\">" \
             "<code>@\u200Bgreysteil-work</code></a>!</p>\n"
+          )
+        end
+      end
+
+      context "when the metadata source is GitLab" do
+        let(:metadata_source_url) { "https://gitlab.com/dependabot/dependabot" }
+        let(:text) { "Great work @first.last and @first_last!" }
+
+        it "uses GitLab profile links and username syntax" do
+          expect(sanitize_links_and_mentions).to eq(
+            "<p>Great work <a href=\"https://gitlab.com/first.last\">" \
+            "<code>@\u200Bfirst.last</code></a> and " \
+            "<a href=\"https://gitlab.com/first_last\"><code>@\u200Bfirst_last</code></a>!</p>\n"
+          )
+        end
+      end
+
+      context "when the metadata source is unknown" do
+        let(:metadata_source_url) { "https://registry.example.com/packages/business" }
+
+        it "falls back to a GitHub profile link" do
+          expect(sanitize_links_and_mentions).to eq(
+            "<p>Great work <a href=\"https://github.com/greysteil\">" \
+            "<code>@\u200Bgreysteil</code></a>!</p>\n"
           )
         end
       end
@@ -211,6 +239,17 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::LinkAndMentionSan
           expect(sanitize_links_and_mentions).to eq(
             "<p>Thanks <code>@\u200Bdependabot/reviewers</code></p>\n"
           )
+        end
+
+        context "when the metadata source is GitLab" do
+          let(:metadata_source_url) { "https://gitlab.com/dependabot/dependabot" }
+          let(:text) { "Thanks @dependabot_org/release.team" }
+
+          it "uses GitLab username syntax" do
+            expect(sanitize_links_and_mentions).to eq(
+              "<p>Thanks <code>@\u200Bdependabot_org/release.team</code></p>\n"
+            )
+          end
         end
       end
 

--- a/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb
@@ -56,6 +56,61 @@ RSpec.describe namespace::MetadataPresenter do
   let(:github_redirection_service) { "redirect.github.com" }
 
   describe "#to_s" do
+    context "with metadata from multiple providers" do
+      before do
+        allow(metadata_finder)
+          .to receive_messages(
+            releases_url: "https://gitlab.com/org/business/-/releases",
+            releases_text: "Thanks @release.author!",
+            changelog_url: "https://github.com/org/business/blob/main/CHANGELOG.md",
+            changelog_text: "Thanks @changelog-author!"
+          )
+      end
+
+      it "uses each section's metadata source for mention links" do
+        expect(presenter.to_s)
+          .to include('href="https://gitlab.com/release.author"')
+          .and include('href="https://github.com/changelog-author"')
+      end
+    end
+
+    context "with generated metadata" do
+      before do
+        allow(metadata_finder)
+          .to receive_messages(
+            source_url: "https://gitlab.com/org/business",
+            maintainer_changes: "New maintainer: @release_manager"
+          )
+      end
+
+      it "uses the dependency source for mention links" do
+        expect(presenter.to_s).to include('href="https://gitlab.com/release_manager"')
+      end
+    end
+
+    context "with vulnerabilities from multiple providers" do
+      let(:vulnerabilities_fixed) do
+        [
+          {
+            "source_name" => "GitLab Advisory Database",
+            "source_url" => "https://gitlab.com/security/advisories/1",
+            "description" => "Reported by @security.researcher"
+          },
+          {
+            "source_name" => "GitHub Advisory Database",
+            "source_url" => "https://github.com/advisories/GHSA-1234",
+            "description" => "Reported by @github-researcher"
+          }
+        ]
+      end
+
+      it "uses each advisory source for mention links" do
+        expect(presenter.to_s)
+          .to include('href="https://gitlab.com/security.researcher"')
+          .and include('href="https://github.com/github-researcher"')
+      end
+    end
+
     context "with a changelog that requires truncation" do
       before do
         allow(metadata_finder)


### PR DESCRIPTION
### What are you trying to accomplish?

Use the source of each metadata section when converting mentions into profile links. Metadata fetched from `gitlab.com` links mentions to GitLab and supports GitLab username syntax, while GitHub and unknown sources preserve the existing GitHub behavior.

Release notes, changelogs, upgrade guides, and commits use their section URLs. Generated metadata falls back to the dependency source, and vulnerability descriptions use each advisory source.

Fixes #5729.

### Anything you want to highlight for special attention from reviewers?

Provider selection and username parsing stay centralized in `LinkAndMentionSanitizer`; `MetadataPresenter` only supplies the nearest provenance URL. This keeps later provider support localized.

This intentionally recognizes only `github.com` and `gitlab.com`. Unknown and self-hosted sources fall back to GitHub for backward compatibility. Explicit GitHub issue and pull request links, bare issue-reference linking, Bitbucket, and Azure DevOps behavior are unchanged in this PR.

Stacked follow-ups apply the same provider signal to issue shorthand:

- #15806 generates canonical GitLab work-item URLs for unqualified references.
- #15807 handles qualified references such as `owner/repo#19`.

### How will you know you've accomplished your goal?

The tests cover GitHub fallback, GitLab user and team syntax, mixed-provider metadata sections, generated metadata fallback, and advisories from multiple providers. Existing exact message-rendering coverage remains green.

Validation run in Docker:

- `bin/test common spec/dependabot/pull_request_creator/message_builder/link_and_mention_sanitizer_spec.rb spec/dependabot/pull_request_creator/message_builder/metadata_presenter_spec.rb`
- `bin/test common spec/dependabot/pull_request_creator/message_builder_spec.rb`
- RuboCop on all four changed files
- `bundle exec srb tc` against the mounted repository using the development image

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.