### PR TITLE
Use GitLab issue paths in metadata links

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/issue_linker.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/issue_linker.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "uri"
 require "dependabot/pull_request_creator/message_builder"
 
 module Dependabot
@@ -59,12 +60,21 @@ module Dependabot
                        end
 
               if source
-                "[#{repo ? (repo + tag) : tag}](#{source}/issues/#{number})"
+                "[#{repo ? (repo + tag) : tag}](#{source}#{issue_path(source)}/#{number})"
               else
                 issue_link
               end
             end
           end
+        end
+
+        private
+
+        sig { params(source: String).returns(String) }
+        def issue_path(source)
+          URI.parse(source).host&.downcase == "gitlab.com" ? "/-/work_items" : "/issues"
+        rescue URI::InvalidURIError
+          "/issues"
         end
       end
     end

--- a/common/spec/dependabot/pull_request_creator/message_builder/issue_linker_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/issue_linker_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::IssueLinker do
   describe "#link_issues" do
     subject(:link_issues) { issue_linker.link_issues(text: text) }
 
+    context "with a GitLab source" do
+      subject(:issue_linker) do
+        described_class.new(source_url: "https://gitlab.com/a/b")
+      end
+
+      let(:text) { "This is a #19 link" }
+
+      it "uses the GitLab work item path" do
+        expect(link_issues)
+          .to eq("This is a [#19](https://gitlab.com/a/b/-/work_items/19) link")
+      end
+    end
+
     context "with an absolute link" do
       let(:text) { "This is just [#12](https://example.com) text" }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Use GitLab's canonical `/-/work_items/:number` path when linking unqualified issue references from metadata whose dependency source is on `gitlab.com`. GitHub and unknown sources use `/issues/:number`.

Related:
- https://github.com/dependabot/dependabot-core/issues/5729

### Anything you want to highlight for special attention from reviewers?

This PR intentionally covers only unqualified references such as `#19`. Qualified references such as `owner/repo#19` are handled by the stacked follow-up #15807.

Provider selection is based on the dependency source hostname. Only `gitlab.com` selects the GitLab work-item path; all other sources follow the GitHub path policy.

### How will you know you've accomplished your goal?

A focused regression spec demonstrates that a GitLab source produces `https://gitlab.com/a/b/-/work_items/19`, while the GitHub and fallback expectations remain green.

Validation run in Docker:

- `bin/test common spec/dependabot/pull_request_creator/message_builder/issue_linker_spec.rb` (11 examples)
- `bin/test common spec/dependabot/pull_request_creator/message_builder_spec.rb` (132 examples)
- RuboCop on both changed files

The local development image currently lacks the `srb` executable, so the PR's Sorbet workflow is the authoritative typecheck.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.