### PR TITLE
Use metadata sources for qualified issue links

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder/issue_linker.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder/issue_linker.rb
@@ -54,7 +54,7 @@ module Dependabot
                      &.fetch("repo", nil)
 
               source = if repo
-                         "https://github.com/#{repo}"
+                         "#{qualified_reference_base_url}/#{repo}"
                        elsif source_url
                          source_url
                        end
@@ -75,6 +75,15 @@ module Dependabot
           URI.parse(source).host&.downcase == "gitlab.com" ? "/-/work_items" : "/issues"
         rescue URI::InvalidURIError
           "/issues"
+        end
+
+        sig { returns(String) }
+        def qualified_reference_base_url
+          return "https://github.com" unless source_url
+
+          URI.parse(T.must(source_url)).host&.downcase == "gitlab.com" ? "https://gitlab.com" : "https://github.com"
+        rescue URI::InvalidURIError
+          "https://github.com"
         end
       end
     end

--- a/common/spec/dependabot/pull_request_creator/message_builder/issue_linker_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder/issue_linker_spec.rb
@@ -17,11 +17,37 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder::IssueLinker do
         described_class.new(source_url: "https://gitlab.com/a/b")
       end
 
-      let(:text) { "This is a #19 link" }
+      context "with an unqualified reference" do
+        let(:text) { "This is a #19 link" }
 
-      it "uses the GitLab work item path" do
-        expect(link_issues)
-          .to eq("This is a [#19](https://gitlab.com/a/b/-/work_items/19) link")
+        it "uses the GitLab work item path" do
+          expect(link_issues)
+            .to eq("This is a [#19](https://gitlab.com/a/b/-/work_items/19) link")
+        end
+      end
+
+      context "with a qualified reference" do
+        let(:text) { "This is an other/repo#19 link" }
+
+        it "uses the metadata source provider" do
+          expect(link_issues).to eq(
+            "This is an [other/repo#19](https://gitlab.com/other/repo/-/work_items/19) link"
+          )
+        end
+      end
+    end
+
+    context "with an unsupported source" do
+      subject(:issue_linker) do
+        described_class.new(source_url: "https://registry.example.com/a/b")
+      end
+
+      let(:text) { "This is an other/repo#19 link" }
+
+      it "falls back to GitHub for qualified references" do
+        expect(link_issues).to eq(
+          "This is an [other/repo#19](https://github.com/other/repo/issues/19) link"
+        )
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Interpret qualified issue shorthand such as `other/repo#19` using the metadata source provider. GitLab metadata links that shorthand to `https://gitlab.com/other/repo/-/work_items/19`; GitHub and unsupported sources use GitHub issue URLs.

Related:
- https://github.com/dependabot/dependabot-core/issues/5729

### Anything you want to highlight for special attention from reviewers?

Qualified shorthand does not contain a hostname, so this PR treats metadata provenance as the provider signal. Unknown and unsupported sources fall back to GitHub for backward compatibility.

This intentionally preserves the two-segment `owner/repo#number` grammar. Supporting nested GitLab namespaces would expand parsing behavior and can be considered separately with representative metadata examples.

### How will you know you've accomplished your goal?

Focused tests cover qualified and unqualified GitLab references, GitHub behavior, and unsupported-source fallback. Existing message rendering remains green.

Validation run in Docker:

- `bin/test common spec/dependabot/pull_request_creator/message_builder/issue_linker_spec.rb` (13 examples)
- `bin/test common spec/dependabot/pull_request_creator/message_builder_spec.rb` (132 examples)
- RuboCop on both changed files

The local development image currently lacks the `srb` executable, so the PR's Sorbet workflow is the authoritative typecheck.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.