### PR TITLE
Validate pip update candidates with native resolver

### DIFF
--- a/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "fileutils"
 require "pathname"
 require "toml-rb"
 require "sorbet-runtime"
@@ -13,6 +14,9 @@ require "dependabot/python/package/package_registry_finder"
 require "dependabot/python/update_checker"
 require "dependabot/python/update_checker/latest_version_finder"
 require "dependabot/python/file_parser/python_requirement_parser"
+require "dependabot/python/file_updater/requirement_replacer"
+require "dependabot/python/authed_url_builder"
+require "dependabot/shared_helpers"
 
 module Dependabot
   module Python
@@ -22,6 +26,9 @@ module Dependabot
       # rubocop:disable Metrics/ClassLength
       class PipVersionResolver
         extend T::Sig
+
+        PIP_REPORT_FILENAME = "dependabot-pip-report.json"
+        RESOLUTION_ERROR_PATTERN = /ResolutionImpossible|No matching distribution found/
 
         require_relative "pip_version_resolver/marker_evaluator"
 
@@ -69,7 +76,7 @@ module Dependabot
         def latest_resolvable_version
           candidate = latest_version_finder.latest_version(language_version: language_version_manager.python_version)
           return candidate if candidate.nil?
-          return candidate if compatible_with_pinned_pyproject_dependencies?(candidate)
+          return candidate if compatible_with_pinned_pyproject_dependencies?(candidate) && pip_resolvable?(candidate)
 
           nil
         end
@@ -85,7 +92,7 @@ module Dependabot
           candidate = latest_version_finder
                       .lowest_security_fix_version(language_version: language_version_manager.python_version)
           return candidate if candidate.nil?
-          return candidate if compatible_with_pinned_pyproject_dependencies?(candidate)
+          return candidate if compatible_with_pinned_pyproject_dependencies?(candidate) && pip_resolvable?(candidate)
 
           nil
         end
@@ -140,6 +147,156 @@ module Dependabot
         sig { returns(MarkerEvaluator) }
         def marker_evaluator
           @marker_evaluator ||= MarkerEvaluator.new
+        end
+
+        sig { params(candidate: Dependabot::Version).returns(T::Boolean) }
+        def pip_resolvable?(candidate)
+          requirement = pip_requirement
+          return true unless requirement
+
+          SharedHelpers.in_a_temporary_directory do
+            SharedHelpers.with_git_configured(credentials: credentials) do
+              write_dependency_files(candidate: candidate, requirement: requirement)
+              language_version_manager.install_required_python
+              SharedHelpers.run_shell_command(
+                pip_resolver_command,
+                fingerprint: pip_resolver_fingerprint,
+                stderr_to_stdout: true
+              )
+
+              pip_report_includes_candidate?(candidate)
+            end
+          end
+        rescue SharedHelpers::HelperSubprocessFailed => e
+          return false if e.message.match?(RESOLUTION_ERROR_PATTERN)
+
+          Dependabot.logger.warn("Failed to validate #{dependency.name} #{candidate} with pip: #{e.message}")
+          true
+        end
+
+        sig { returns(T.nilable(Dependabot::DependencyRequirement)) }
+        def pip_requirement
+          return unless dependency.requirements.one?
+
+          requirement = T.must(dependency.requirements.first)
+          return unless requirement.file&.end_with?(".txt")
+          return unless requirement.source.nil? && requirement.requirement_string
+
+          file = dependency_files.find { |dependency_file| dependency_file.name == requirement.file }
+          return unless pip_compatible_requirement_file?(file, requirement)
+
+          requirement
+        end
+
+        sig do
+          params(
+            file: T.nilable(Dependabot::DependencyFile),
+            requirement: Dependabot::DependencyRequirement
+          ).returns(T::Boolean)
+        end
+        def pip_compatible_requirement_file?(file, requirement)
+          return false unless file&.content
+
+          content = T.must(file.content)
+          return false if content.include?("--hash=")
+
+          requirement_declaration_present?(file, requirement)
+        end
+
+        sig do
+          params(candidate: Dependabot::Version, requirement: Dependabot::DependencyRequirement).void
+        end
+        def write_dependency_files(candidate:, requirement:)
+          dependency_files.each do |file|
+            next unless file.content
+
+            FileUtils.mkdir_p(File.dirname(file.name))
+            content = if file.name == requirement.file
+                        updated_requirement_content(file, requirement, candidate)
+                      else
+                        file.content
+                      end
+            File.write(file.name, content)
+          end
+          File.write(".python-version", language_version_manager.python_major_minor)
+        end
+
+        sig do
+          params(
+            file: Dependabot::DependencyFile,
+            requirement: Dependabot::DependencyRequirement,
+            candidate: Dependabot::Version
+          ).returns(String)
+        end
+        def updated_requirement_content(file, requirement, candidate)
+          FileUpdater::RequirementReplacer.new(
+            content: T.must(file.content),
+            dependency_name: dependency.name,
+            old_requirement: requirement.requirement_string,
+            new_requirement: "==#{candidate}"
+          ).updated_content
+        end
+
+        sig do
+          params(
+            file: Dependabot::DependencyFile,
+            requirement: Dependabot::DependencyRequirement
+          ).returns(T::Boolean)
+        end
+        def requirement_declaration_present?(file, requirement)
+          expected_requirement = T.must(requirement.requirement_string).gsub(/\s/, "")
+          T.must(file.content).each_line.any? do |line|
+            parsed = RequirementParser.parse(line)
+            next false unless parsed
+
+            parsed[:normalised_name] == NameNormaliser.normalise(dependency.name) &&
+              parsed[:requirement]&.gsub(/\s/, "") == expected_requirement
+          end
+        end
+
+        sig { returns(String) }
+        def pip_resolver_command
+          requirements_file = T.must(T.must(pip_requirement).file)
+          options = ["--dry-run", "--ignore-installed", "--report #{PIP_REPORT_FILENAME}", *pip_index_options]
+          "pyenv exec pip install #{options.join(' ')} -r #{SharedHelpers.escape_command(requirements_file)}"
+        end
+
+        sig { returns(String) }
+        def pip_resolver_fingerprint
+          "pyenv exec pip install --dry-run --ignore-installed --report <report> <index_options> -r <requirements_file>"
+        end
+
+        sig { returns(T::Array[String]) }
+        def pip_index_options
+          credentials.filter_map do |credential|
+            next unless credential["type"] == "python_index"
+
+            option = credential.replaces_base? ? "--index-url" : "--extra-index-url"
+            "#{option}=#{AuthedUrlBuilder.authed_url(credential: credential)}"
+          end
+        end
+
+        sig { params(candidate: Dependabot::Version).returns(T::Boolean) }
+        def pip_report_includes_candidate?(candidate)
+          report = T.cast(JSON.parse(File.read(PIP_REPORT_FILENAME)), T::Hash[String, Object])
+          installs_obj = report["install"]
+          return false unless installs_obj.is_a?(Array)
+
+          installs_obj.any? do |entry|
+            install = T.cast(entry, T.nilable(Object))
+            next false unless install.is_a?(Hash)
+
+            metadata = T.cast(install["metadata"], T.nilable(Object))
+            next false unless metadata.is_a?(Hash)
+
+            name = T.cast(metadata["name"], T.nilable(Object))
+            version = T.cast(metadata["version"], T.nilable(Object))
+            name.is_a?(String) && version.is_a?(String) &&
+              NameNormaliser.normalise(name) == NameNormaliser.normalise(dependency.name) &&
+              Python::Version.new(version) == candidate
+          end
+        rescue JSON::ParserError, Errno::ENOENT
+          false
         end
 
         sig { params(candidate: Dependabot::Version).returns(T::Boolean) }

--- a/python/spec/dependabot/python/update_checker/pip_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_version_resolver_spec.rb
@@ -73,6 +73,117 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipVersionResolver do
   describe "#latest_resolvable_version" do
     subject(:latest_resolvable_version) { resolver.latest_resolvable_version }
 
+    context "when pip can resolve the latest version" do
+      let(:rewritten_requirements) { [] }
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4\n"
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_call_original
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command)
+          .with(a_string_matching(/pyenv exec pip install .*--dry-run.*--report/), any_args) do
+            rewritten_requirements << File.read("requirements.txt")
+            File.write(
+              "dependabot-pip-report.json",
+              JSON.dump(
+                "install" => [{ "metadata" => { "name" => "Django", "version" => "3.2.4" } }]
+              )
+            )
+          end
+      end
+
+      it "checks a temporary requirement updated to the candidate version" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.4"))
+        expect(rewritten_requirements).to contain_exactly(include("django==3.2.4"))
+        expect(Dependabot::SharedHelpers)
+          .to have_received(:run_shell_command)
+          .with(a_string_matching(/pyenv exec pip install .*--dry-run.*--report/), any_args)
+      end
+    end
+
+    context "when pip cannot resolve the latest version" do
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4\n"
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_call_original
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command)
+          .with(a_string_matching(/pyenv exec pip install .*--dry-run.*--report/), any_args)
+          .and_raise(
+            Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "ERROR: ResolutionImpossible",
+              error_context: {}
+            )
+          )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the pip report does not include the candidate version" do
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4\n"
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_call_original
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command)
+          .with(a_string_matching(/pyenv exec pip install .*--dry-run.*--report/), any_args) do
+            File.write(
+              "dependabot-pip-report.json",
+              JSON.dump(
+                "install" => [{ "metadata" => { "name" => "Django", "version" => "3.2.3" } }]
+              )
+            )
+          end
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the requirement file contains hashes" do
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4 --hash=sha256:abc123\n"
+        )
+      end
+
+      before { allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_call_original }
+
+      it "preserves the existing candidate without invoking pip" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.4"))
+        expect(Dependabot::SharedHelpers)
+          .not_to have_received(:run_shell_command)
+          .with(a_string_matching(/pyenv exec pip install/), any_args)
+      end
+    end
+
+    context "when the requirement declaration is absent" do
+      before { allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_call_original }
+
+      it "preserves the existing candidate without invoking pip" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.4"))
+        expect(Dependabot::SharedHelpers)
+          .not_to have_received(:run_shell_command)
+          .with(a_string_matching(/pyenv exec pip install/), any_args)
+      end
+    end
+
     context "with no indication of the Python version" do
       let(:dependency_files) { [requirements_file] }
 


### PR DESCRIPTION
## Summary

Use pip's native resolver to validate candidate versions for simple `requirements.txt` updates before Dependabot returns them as resolvable.

- rewrite the target declaration to the candidate in a temporary project
- run `pip install --dry-run --ignore-installed --report`
- verify the report contains the exact target package and candidate version
- pass Python index and Git credentials through the existing credential helpers
- preserve the existing metadata-only behavior for unsupported requirement shapes, hashed files, and unexpected helper failures

This is intentionally an incremental step related to #4934. It does **not** implement Dependabot's complete `:all` unlock contract or the multi-file dependency rewrite result that contract requires.

## Tests

- `bin/test python spec/dependabot/python/update_checker/pip_version_resolver_spec.rb`
- `bin/test python rubocop lib/dependabot/python/update_checker/pip_version_resolver.rb spec/dependabot/python/update_checker/pip_version_resolver_spec.rb`
- `bundle exec srb tc`

The full Python RuboCop run still reports two pre-existing `Style/NumericPredicate` offenses in `pyproject_files_parser_spec.rb`; the touched files pass cleanly.