### PR TITLE
common: redact key environment variables

### DIFF
--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -556,8 +556,7 @@ module Dependabot
       return nil if env.nil?
 
       env.transform_keys(&:to_s).each_with_object({}) do |(key, value), result|
-        # Only redact if the key contains "TOKEN" (case-insensitive)
-        result[key] = if key.match?(/TOKEN/i)
+        result[key] = if key.match?(/TOKEN|(?:^|_)KEY\z/i)
                         "<redacted>"
                       else
                         value

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -739,16 +739,22 @@ RSpec.describe Dependabot::SharedHelpers do
       expect(sanitized["registry"]).to eq("https://jfrogghdemo.jfrog.io/artifactory/api/npm/db-dependabot-local/")
     end
 
-    it "does not redact non-token keys" do
+    it "redacts keys ending in a KEY segment" do
       env = {
         "SHORT_KEY" => "short",
+        "hex_api_key" => "api-key",
+        "COREPACK_INTEGRITY_KEYS" => "integrity-config",
+        "KEY_PATH" => "/path/to/key",
         "LONG_VALUE" => "a" * 50,
         "SOME_TOKEN" => "should-be-redacted"
       }
 
       sanitized = described_class.sanitize_env_for_logging(env)
 
-      expect(sanitized["SHORT_KEY"]).to eq("short")
+      expect(sanitized["SHORT_KEY"]).to eq("<redacted>")
+      expect(sanitized["hex_api_key"]).to eq("<redacted>")
+      expect(sanitized["COREPACK_INTEGRITY_KEYS"]).to eq("integrity-config")
+      expect(sanitized["KEY_PATH"]).to eq("/path/to/key")
       expect(sanitized["LONG_VALUE"]).to eq("a" * 50)
       expect(sanitized["SOME_TOKEN"]).to eq("<redacted>")
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Prevent credential-bearing environment variables such as `HEX_API_KEY` from appearing in subprocess debug and lifecycle logs.

The shared sanitizer already redacts names containing `TOKEN`. This extends it to redact `KEY` only when it is a complete final environment-name segment (`KEY` or `*_KEY`). It deliberately does not use a broad `/KEY/i` match, so non-secret diagnostic variables such as `COREPACK_INTEGRITY_KEYS` and `KEY_PATH` remain visible.

### Anything you want to highlight for special attention from reviewers?

The existing `SHORT_KEY` negative assertion came from #13832, where it was added as a control for the then-new TOKEN-only name matcher. Before changing it, I traced that commit and its precursor #13719; I found no production requirement that `SHORT_KEY` remain visible. The narrower terminal-segment rule preserves the original preference for name-based classification without hiding every variable whose name happens to contain KEY.

This is a standalone common change and does not use the deprecated `HEX_REPOS_KEY`.

### How will you know you have accomplished your goal?

- `bin/test common spec/dependabot/shared_helpers_spec.rb`: 64 examples, 0 failures
- `bin/test common`: 2,104 examples, 0 failures
- Changed-file RuboCop: 2 files inspected, no offenses
- `bundle exec srb tc` in Docker: no errors

Full common RuboCop continues to report three existing `Style/NumericPredicate` offenses in `common/spec/dependabot/command_helpers_spec.rb`; this branch does not modify that file.