### PR TITLE
hex: use Mix CLI for lockfile updates

### DIFF
--- a/hex/helpers/lib/configure_credentials.exs
+++ b/hex/helpers/lib/configure_credentials.exs
@@ -1,0 +1,15 @@
+Mix.ensure_application!(:hex)
+
+credential = System.fetch_env!("DEPENDABOT_HEX_CREDENTIAL_TOKEN")
+
+args = Enum.drop_while(System.argv(), &(&1 == "--"))
+
+case args do
+  ["organization", organization] ->
+    Mix.Task.get!("hex.organization").run(["auth", organization, "--key", credential])
+
+  ["repository", repo, url, fingerprint] ->
+    args = ["add", repo, url, "--auth-key", credential]
+    args = if fingerprint == "", do: args, else: args ++ ["--fetch-public-key", fingerprint]
+    Mix.Task.get!("hex.repo").run(args)
+end

--- a/hex/helpers/lib/do_update.exs
+++ b/hex/helpers/lib/do_update.exs
@@ -1,35 +1,8 @@
-# Log to stderr instead of stdout
-:logger.remove_handler(:default)
-:logger.add_handler(:to_stderr, :logger_std_h, %{config: %{type: :standard_error}})
-
-# This is necessary because we can't specify :extra_applications to have :hex in other mixfiles.
 Mix.ensure_application!(:hex)
 
 dependency =
   System.argv()
+  |> Enum.drop_while(&(&1 == "--"))
   |> List.first()
-  |> String.to_atom()
 
-# Fetch dependencies that needs updating
-{dependency_lock, rest_lock} = Map.split(Mix.Dep.Lock.read(), [dependency])
-Mix.Dep.Fetcher.by_name([dependency], dependency_lock, rest_lock, [])
-
-args = [
-  "deps.get",
-  "--no-compile",
-  "--no-elixir-version-check",
-]
-
-result =
-  case System.cmd("mix", args, env: %{"MIX_EXS" => nil}, stderr_to_stdout: true) do
-    {_results, 0} ->
-      File.read("mix.lock")
-
-    {results, _code} ->
-      {:error, results}
-  end
-
-result
-|> :erlang.term_to_binary()
-|> Base.encode64()
-|> IO.write()
+Mix.Task.get!("deps.update").run([dependency, "--no-archives-check"])

--- a/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
@@ -7,7 +7,6 @@ require "dependabot/hex/file_updater"
 require "dependabot/hex/file_updater/mixfile_updater"
 require "dependabot/hex/file_updater/mixfile_sanitizer"
 require "dependabot/hex/file_updater/mixfile_requirement_updater"
-require "dependabot/hex/credential_helpers"
 require "dependabot/hex/native_helpers"
 require "dependabot/hex/version"
 require "dependabot/shared_helpers"
@@ -17,6 +16,8 @@ module Dependabot
     class FileUpdater
       class LockfileUpdater
         extend T::Sig
+
+        CREDENTIAL_TOKEN_ENV = "DEPENDABOT_HEX_CREDENTIAL_TOKEN"
 
         sig do
           params(
@@ -37,15 +38,16 @@ module Dependabot
           @updated_lockfile_content ||=
             SharedHelpers.in_a_temporary_directory do
               write_temporary_dependency_files
+              FileUtils.cp(elixir_helper_configure_credentials_path, "configure_credentials.exs")
               FileUtils.cp(elixir_helper_do_update_path, "do_update.exs")
 
               SharedHelpers.with_git_configured(credentials: credentials) do
-                SharedHelpers.run_helper_subprocess(
-                  env: mix_env,
-                  command: "mix run #{elixir_helper_path}",
-                  function: "get_updated_lockfile",
-                  args: [Dir.pwd, dependency.name, CredentialHelpers.hex_credentials(credentials)]
+                configure_hex_credentials
+                run_mix_command(
+                  mix_run_command("do_update.exs", dependency.name),
+                  fingerprint: "mix run do_update.exs #{dependency.name}"
                 )
+                File.read("mix.lock")
               end
             end
 
@@ -94,11 +96,80 @@ module Dependabot
             raise Dependabot::PrivateSourceAuthenticationFailure, name
           end
 
-          if error.message.include?("JSON") || error.message.include?("parse")
-            raise Dependabot::DependencyFileNotResolvable, "Failed to parse response from Hex helper: #{error.message}"
-          end
-
           raise Dependabot::DependencyFileNotResolvable, "Failed to update lockfile: #{error.message}"
+        end
+
+        sig { void }
+        def configure_hex_credentials
+          credentials.each do |credential|
+            case credential["type"]
+            when "hex_organization"
+              configure_hex_organization(credential)
+            when "hex_repository"
+              configure_hex_repository(credential)
+            end
+          end
+        end
+
+        sig { params(credential: Dependabot::Credential).void }
+        def configure_hex_organization(credential)
+          organization = required_credential_value(credential, "organization")
+          token = required_credential_value(credential, "token", source: organization)
+          run_mix_command(
+            mix_run_command("configure_credentials.exs", "organization", organization),
+            fingerprint: "mix run configure_credentials.exs organization #{organization}",
+            env: { CREDENTIAL_TOKEN_ENV => token }
+          )
+        end
+
+        sig { params(credential: Dependabot::Credential).void }
+        def configure_hex_repository(credential)
+          repo = required_credential_value(credential, "repo")
+          url = required_credential_value(credential, "url", source: repo)
+          auth_key = required_credential_value(credential, "auth_key", source: repo)
+          public_key_fingerprint = credential["public_key_fingerprint"] || ""
+
+          run_mix_command(
+            mix_run_command("configure_credentials.exs", "repository", repo, url, public_key_fingerprint),
+            fingerprint: "mix run configure_credentials.exs repository #{repo}",
+            env: { CREDENTIAL_TOKEN_ENV => auth_key }
+          )
+        end
+
+        sig do
+          params(
+            credential: Dependabot::Credential,
+            key: String,
+            source: T.nilable(String)
+          ).returns(String)
+        end
+        def required_credential_value(credential, key, source: nil)
+          value = credential[key]
+          return value if value.is_a?(String) && !value.empty?
+
+          raise SharedHelpers::HelperSubprocessFailed.new(
+            message: "Missing credentials for \"#{source || value}\"",
+            error_context: {}
+          )
+        end
+
+        sig do
+          params(
+            command: T::Array[String],
+            fingerprint: String,
+            env: T::Hash[String, String]
+          ).void
+        end
+        def run_mix_command(command, fingerprint:, env: {})
+          SharedHelpers.run_shell_command(command, env: mix_env.merge(env), fingerprint: fingerprint)
+        end
+
+        sig { params(script: String, args: String).returns(T::Array[String]) }
+        def mix_run_command(script, *args)
+          [
+            "mix", "run", "--no-deps-check", "--no-start", "--no-compile",
+            "--no-elixir-version-check", script, "--", *args
+          ]
         end
 
         sig { void }
@@ -162,19 +233,19 @@ module Dependabot
         sig { returns(T::Hash[String, String]) }
         def mix_env
           {
-            "MIX_EXS" => File.join(NativeHelpers.hex_helpers_dir, "mix.exs"),
+            "HEX_HOME" => File.join(Dir.pwd, ".hex"),
             "MIX_QUIET" => "1"
           }
         end
 
         sig { returns(String) }
-        def elixir_helper_path
-          File.join(NativeHelpers.hex_helpers_dir, "lib/run.exs")
+        def elixir_helper_do_update_path
+          File.join(NativeHelpers.hex_helpers_dir, "lib/do_update.exs")
         end
 
         sig { returns(String) }
-        def elixir_helper_do_update_path
-          File.join(NativeHelpers.hex_helpers_dir, "lib/do_update.exs")
+        def elixir_helper_configure_credentials_path
+          File.join(NativeHelpers.hex_helpers_dir, "lib/configure_credentials.exs")
         end
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
+++ b/hex/spec/dependabot/hex/file_updater/lockfile_updater_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
 
     context "when SharedHelpers::HelperSubprocessFailed is raised" do
       before do
-        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
           .and_raise(Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                        message: error_message,
                        error_context: {}
@@ -260,17 +260,6 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
           expect { updated_lockfile_content }
             .to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
               expect(error.source).to eq("dependabot")
-            end
-        end
-      end
-
-      context "with JSON parsing error" do
-        let(:error_message) { "Failed to parse JSON response from helper" }
-
-        it "raises a DependencyFileNotResolvable error" do
-          expect { updated_lockfile_content }
-            .to raise_error(Dependabot::DependencyFileNotResolvable) do |error|
-              expect(error.message).to include("Failed to parse response from Hex helper")
             end
         end
       end
@@ -439,26 +428,30 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
       end
 
       before do
-        # Check if private registry is reachable (may be down with 503)
-        # If unavailable, mock the subprocess to simulate expected behavior
-        response = Net::HTTP.get_response(URI.parse("#{private_registry_url}/public_key"))
-        raise "Registry unavailable: #{response.code}" if response.code.to_i >= 500
-      rescue StandardError
-        # Registry not reachable (503 Service Unavailable or network error), mock the subprocess
-        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
           .and_call_original
 
-        # Mock as if registry is reachable for lockfile update
-        # Return updated lockfile with new version and checksum
         updated_lockfile = <<~LOCKFILE
           %{
             "jason": {:hex, :jason, "1.1.0", "99aa691404239cf4f6dbd4f44a2b208e45c98ed4df55ecca2bee58a6e3e2a1c4", [:mix], [], "dependabot", "b96c400e04b7b765c0854c05a4966323e90c0d11fee0483b1567cda079abb205"},
           }
         LOCKFILE
 
-        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-          .with(hash_including(function: "get_updated_lockfile"))
-          .and_return(updated_lockfile)
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(
+            array_including("mix", "run", "configure_credentials.exs", "repository", "dependabot"),
+            hash_including(
+              env: hash_including(
+                "DEPENDABOT_HEX_CREDENTIAL_TOKEN" => "d6fc2b6n6h7katic6vuq6k5e2csahcm4"
+              )
+            )
+          )
+          .and_return("")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(array_including("mix", "run", "do_update.exs", "jason"), anything) do
+            File.write("mix.lock", updated_lockfile)
+            ""
+          end
       end
 
       it "updates the dependency version in the lockfile" do
@@ -466,6 +459,136 @@ RSpec.describe Dependabot::Hex::FileUpdater::LockfileUpdater do
         expect(updated_lockfile_content).not_to include(
           "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2"
         )
+      end
+
+      it "configures the repository without exposing its auth key" do
+        updated_lockfile_content
+
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          array_including(
+            "configure_credentials.exs",
+            "--",
+            "repository",
+            "dependabot",
+            private_registry_url,
+            ""
+          ),
+          hash_including(
+            fingerprint: "mix run configure_credentials.exs repository dependabot",
+            env: hash_including(
+              "HEX_HOME" => end_with("/.hex"),
+              "DEPENDABOT_HEX_CREDENTIAL_TOKEN" => "d6fc2b6n6h7katic6vuq6k5e2csahcm4"
+            )
+          )
+        )
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
+          .with(array_including("configure_credentials.exs"), anything) do |command, options|
+          expect(command).not_to include("d6fc2b6n6h7katic6vuq6k5e2csahcm4")
+          expect(options.fetch(:fingerprint)).not_to include("d6fc2b6n6h7katic6vuq6k5e2csahcm4")
+        end
+      end
+    end
+
+    context "with Hex organization credentials" do
+      let(:credentials) do
+        Dependabot::Credential.new(
+          {
+            "type" => "hex_organization",
+            "organization" => "dependabot",
+            "token" => "organization-secret-token"
+          }
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, **|
+          File.write("mix.lock", lockfile.content) if command.include?("do_update.exs")
+          ""
+        end
+      end
+
+      it "configures the organization without exposing its token" do
+        updated_lockfile_content
+
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          array_including("configure_credentials.exs", "--", "organization", "dependabot"),
+          hash_including(
+            fingerprint: "mix run configure_credentials.exs organization dependabot",
+            env: hash_including(
+              "HEX_HOME" => end_with("/.hex"),
+              "DEPENDABOT_HEX_CREDENTIAL_TOKEN" => "organization-secret-token"
+            )
+          )
+        )
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
+          .with(array_including("configure_credentials.exs"), anything) do |command, options|
+          expect(command).not_to include("organization-secret-token")
+          expect(options.fetch(:fingerprint)).not_to include("organization-secret-token")
+        end
+      end
+    end
+
+    context "with a repository public key fingerprint" do
+      let(:credentials) do
+        Dependabot::Credential.new(
+          {
+            "type" => "hex_repository",
+            "repo" => "dependabot",
+            "url" => "https://repo.example.com",
+            "auth_key" => "repository-secret-key",
+            "public_key_fingerprint" => "SHA256:public-key-fingerprint"
+          }
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, **|
+          File.write("mix.lock", lockfile.content) if command.include?("do_update.exs")
+          ""
+        end
+      end
+
+      it "forwards the fingerprint without exposing the auth key" do
+        updated_lockfile_content
+
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          array_including(
+            "configure_credentials.exs",
+            "--",
+            "repository",
+            "dependabot",
+            "https://repo.example.com",
+            "SHA256:public-key-fingerprint"
+          ),
+          hash_including(
+            fingerprint: "mix run configure_credentials.exs repository dependabot",
+            env: hash_including("DEPENDABOT_HEX_CREDENTIAL_TOKEN" => "repository-secret-key")
+          )
+        )
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command)
+          .with(array_including("configure_credentials.exs"), anything) do |command, options|
+          expect(command).not_to include("repository-secret-key")
+          expect(options.fetch(:fingerprint)).not_to include("repository-secret-key")
+        end
+      end
+    end
+
+    context "with incomplete Hex credentials" do
+      let(:credentials) do
+        Dependabot::Credential.new(
+          {
+            "type" => "hex_repository",
+            "repo" => "dependabot",
+            "url" => "https://repo.example.com"
+          }
+        )
+      end
+
+      it "raises a private source authentication error" do
+        expect { updated_lockfile_content }
+          .to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
+            expect(error.source).to eq("dependabot")
+          end
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Move Hex lockfile updates away from the helper's encoded Erlang-term stdout protocol as one part of #7945.

This change:
- invokes the public `deps.update` Mix task with argv boundaries preserved;
- reads the resulting `mix.lock` from the temporary project directory;
- configures organization and repository credentials through `hex.organization auth` and `hex.repo add`;
- passes credential secrets only through `DEPENDABOT_HEX_CREDENTIAL_TOKEN`;
- isolates Hex configuration with a temporary `HEX_HOME`;
- uses diagnostic fingerprints that exclude credential tokens, auth keys, and repository URLs.

### Anything you want to highlight for special attention from reviewers?

This is stacked on #15804, which adds argv command and explicit fingerprint support to `SharedHelpers.run_shell_command`.

The helper calls `Mix.Task.get!("deps.update").run/1` directly so project aliases named `deps.update` are not executed. The existing alias characterization remains covered.

Mix 1.20.3's `deps.update` parser requires the dependency before `--no-archives-check`; placing the undocumented parser switch first causes the dependency to be discarded.

Repository public keys are fetched through Hex's supported `--fetch-public-key FINGERPRINT` option only when a fingerprint is supplied.

### How will you know you've accomplished your goal?

- `bin/test hex spec/dependabot/hex/file_updater/lockfile_updater_spec.rb` (22 examples, 0 failures)
- `bin/test hex` (281 examples, 0 failures, 1 existing environment-dependent pending example)
- changed-file RuboCop (no offenses)
- `mix format --check-formatted` for both helper scripts
- `mix compile --warnings-as-errors`

Sorbet was not available in the Hex development image (`bundle exec srb tc` reported that the executable was missing); CI will run the repository Sorbet job.

### Checklist

- [x] I have run the complete ecosystem test suite to ensure tests and linters pass.
- [x] I have thoroughly tested my code changes, including credential command boundaries and secret exclusion.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes.
- [x] I have ensured that the code is documented through focused characterization tests.
