### PR TITLE
hex: use Mix CLI for update checks

### DIFF
--- a/hex/helpers/lib/check_update.exs
+++ b/hex/helpers/lib/check_update.exs
@@ -36,12 +36,8 @@ defmodule UpdateChecker do
   end
 
   defp do_resolution(dependency_name) do
-    # Fetch dependencies that needs updating
-    {dependency_lock, rest_lock} =
-      Map.split(Mix.Dep.Lock.read(), [String.to_atom(dependency_name)])
-
     try do
-      Mix.Dep.Fetcher.by_name([dependency_name], dependency_lock, rest_lock, [])
+      Mix.Task.get!("deps.update").run([dependency_name, "--no-archives-check"])
 
       {:ok, :resolution_successful}
     rescue
@@ -50,30 +46,21 @@ defmodule UpdateChecker do
   end
 end
 
-[dependency_name] = System.argv()
+[dependency_name] = Enum.drop_while(System.argv(), &(&1 == "--"))
 
-result =
-  case UpdateChecker.run(dependency_name) do
-    {:ok, version} ->
-      {:ok, version}
+case UpdateChecker.run(dependency_name) do
+  {:ok, version} ->
+    File.write!(".dependabot-result", version)
 
-    {:error, %Version.InvalidRequirementError{} = error}  ->
-      {:error, "Invalid requirement: #{error.requirement}"}
+  {:error, %Version.InvalidRequirementError{} = error} ->
+    Mix.raise("Invalid requirement: #{error.requirement}")
 
-    {:error, %Mix.Error{} = error} ->
-      {:error, "Dependency resolution failed: #{error.message}"}
+  {:error, %Mix.Error{} = error} ->
+    Mix.raise("Dependency resolution failed: #{error.message}")
 
-    {:error, :dependency_resolution_timed_out} ->
-      # We do nothing here because Hex is already printing out a message in stdout
-      nil
+  {:error, :dependency_resolution_timed_out} ->
+    Mix.raise("Dependency resolution timed out")
 
-    {:error, error} ->
-      {:error, "Unknown error in check_update: #{inspect(error)}"}
-  end
-
-if not is_nil(result) do
-  result
-  |> :erlang.term_to_binary()
-  |> Base.encode64()
-  |> IO.write()
+  {:error, error} ->
+    Mix.raise("Unknown error in check_update: #{inspect(error)}")
 end

--- a/hex/lib/dependabot/hex/credential_helpers.rb
+++ b/hex/lib/dependabot/hex/credential_helpers.rb
@@ -3,36 +3,114 @@
 
 require "sorbet-runtime"
 
+require "dependabot/hex/native_helpers"
+require "dependabot/shared_helpers"
+
 module Dependabot
   module Hex
     module CredentialHelpers
       extend T::Sig
 
-      sig { params(credentials: T::Array[Dependabot::Credential]).returns(T::Array[Dependabot::Credential]) }
-      def self.hex_credentials(credentials)
-        organization_credentials(credentials) + repo_credentials(credentials)
+      CREDENTIAL_TOKEN_ENV = "DEPENDABOT_HEX_CREDENTIAL_TOKEN"
+
+      sig do
+        params(
+          credentials: T::Array[Dependabot::Credential],
+          env: T::Hash[String, String]
+        ).void
+      end
+      def self.configure(credentials:, env:)
+        credentials.each do |credential|
+          case credential["type"]
+          when "hex_organization"
+            configure_organization(credential, env)
+          when "hex_repository"
+            configure_repository(credential, env)
+          end
+        end
       end
 
-      sig { params(credentials: T.untyped).returns(T::Array[Dependabot::Credential]) }
-      def self.organization_credentials(credentials)
-        defaults = Dependabot::Credential.new({ "organization" => "", "token" => "" })
-        keys = %w(type organization token)
-
-        credentials
-          .select { |cred| cred["type"] == "hex_organization" }
-          .flat_map { |cred| defaults.merge(cred).slice(*keys).values }
+      sig { returns(String) }
+      def self.configure_credentials_path
+        File.join(NativeHelpers.hex_helpers_dir, "lib/configure_credentials.exs")
       end
-      sig { params(credentials: T::Array[Dependabot::Credential]).returns(T::Array[Dependabot::Credential]) }
-      def self.repo_credentials(credentials)
-        # Credentials are serialized as an array that may not have optional fields. Using a
-        # default ensures that the array is always the same length, even if values are empty.
-        defaults = Dependabot::Credential.new({ "url" => "", "auth_key" => "", "public_key_fingerprint" => "" })
-        keys = %w(type repo url auth_key public_key_fingerprint)
 
-        credentials
-          .select { |cred| cred["type"] == "hex_repository" }
-          .flat_map { |cred| defaults.merge(cred).slice(*keys).values }
+      sig do
+        params(
+          credential: Dependabot::Credential,
+          env: T::Hash[String, String]
+        ).void
       end
+      def self.configure_organization(credential, env)
+        organization = required_value(credential, "organization", source: credential["type"])
+        token = required_value(credential, "token", source: organization)
+
+        run_mix_command(
+          mix_run_command("configure_credentials.exs", "organization", organization),
+          fingerprint: "mix run configure_credentials.exs organization #{organization}",
+          env: env.merge(CREDENTIAL_TOKEN_ENV => token)
+        )
+      end
+      private_class_method :configure_organization
+
+      sig do
+        params(
+          credential: Dependabot::Credential,
+          env: T::Hash[String, String]
+        ).void
+      end
+      def self.configure_repository(credential, env)
+        repo = required_value(credential, "repo", source: credential["type"])
+        url = required_value(credential, "url", source: repo)
+        auth_key = required_value(credential, "auth_key", source: repo)
+        public_key_fingerprint = credential["public_key_fingerprint"] || ""
+
+        run_mix_command(
+          mix_run_command("configure_credentials.exs", "repository", repo, url, public_key_fingerprint),
+          fingerprint: "mix run configure_credentials.exs repository #{repo}",
+          env: env.merge(CREDENTIAL_TOKEN_ENV => auth_key)
+        )
+      end
+      private_class_method :configure_repository
+
+      sig do
+        params(
+          credential: Dependabot::Credential,
+          key: String,
+          source: T.nilable(String)
+        ).returns(String)
+      end
+      def self.required_value(credential, key, source: nil)
+        value = credential[key]
+        return value if value.is_a?(String) && !value.empty?
+
+        raise SharedHelpers::HelperSubprocessFailed.new(
+          message: "Missing credentials for \"#{source}\"",
+          error_context: {}
+        )
+      end
+      private_class_method :required_value
+
+      sig do
+        params(
+          command: T::Array[String],
+          fingerprint: String,
+          env: T::Hash[String, String]
+        ).void
+      end
+      def self.run_mix_command(command, fingerprint:, env:)
+        SharedHelpers.run_shell_command(command, env: env, fingerprint: fingerprint)
+      end
+      private_class_method :run_mix_command
+
+      sig { params(script: String, args: String).returns(T::Array[String]) }
+      def self.mix_run_command(script, *args)
+        [
+          "mix", "run", "--no-deps-check", "--no-start", "--no-compile",
+          "--no-elixir-version-check", script, "--", *args
+        ]
+      end
+      private_class_method :mix_run_command
     end
   end
 end

--- a/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
@@ -7,6 +7,7 @@ require "dependabot/hex/file_updater"
 require "dependabot/hex/file_updater/mixfile_updater"
 require "dependabot/hex/file_updater/mixfile_sanitizer"
 require "dependabot/hex/file_updater/mixfile_requirement_updater"
+require "dependabot/hex/credential_helpers"
 require "dependabot/hex/native_helpers"
 require "dependabot/hex/version"
 require "dependabot/shared_helpers"
@@ -16,8 +17,6 @@ module Dependabot
     class FileUpdater
       class LockfileUpdater
         extend T::Sig
-
-        CREDENTIAL_TOKEN_ENV = "DEPENDABOT_HEX_CREDENTIAL_TOKEN"
 
         sig do
           params(
@@ -38,11 +37,11 @@ module Dependabot
           @updated_lockfile_content ||=
             SharedHelpers.in_a_temporary_directory do
               write_temporary_dependency_files
-              FileUtils.cp(elixir_helper_configure_credentials_path, "configure_credentials.exs")
+              FileUtils.cp(CredentialHelpers.configure_credentials_path, "configure_credentials.exs")
               FileUtils.cp(elixir_helper_do_update_path, "do_update.exs")
 
               SharedHelpers.with_git_configured(credentials: credentials) do
-                configure_hex_credentials
+                CredentialHelpers.configure(credentials: credentials, env: mix_env)
                 run_mix_command(
                   mix_run_command("do_update.exs", dependency.name),
                   fingerprint: "mix run do_update.exs #{dependency.name}"
@@ -97,60 +96,6 @@ module Dependabot
           end
 
           raise Dependabot::DependencyFileNotResolvable, "Failed to update lockfile: #{error.message}"
-        end
-
-        sig { void }
-        def configure_hex_credentials
-          credentials.each do |credential|
-            case credential["type"]
-            when "hex_organization"
-              configure_hex_organization(credential)
-            when "hex_repository"
-              configure_hex_repository(credential)
-            end
-          end
-        end
-
-        sig { params(credential: Dependabot::Credential).void }
-        def configure_hex_organization(credential)
-          organization = required_credential_value(credential, "organization")
-          token = required_credential_value(credential, "token", source: organization)
-          run_mix_command(
-            mix_run_command("configure_credentials.exs", "organization", organization),
-            fingerprint: "mix run configure_credentials.exs organization #{organization}",
-            env: { CREDENTIAL_TOKEN_ENV => token }
-          )
-        end
-
-        sig { params(credential: Dependabot::Credential).void }
-        def configure_hex_repository(credential)
-          repo = required_credential_value(credential, "repo")
-          url = required_credential_value(credential, "url", source: repo)
-          auth_key = required_credential_value(credential, "auth_key", source: repo)
-          public_key_fingerprint = credential["public_key_fingerprint"] || ""
-
-          run_mix_command(
-            mix_run_command("configure_credentials.exs", "repository", repo, url, public_key_fingerprint),
-            fingerprint: "mix run configure_credentials.exs repository #{repo}",
-            env: { CREDENTIAL_TOKEN_ENV => auth_key }
-          )
-        end
-
-        sig do
-          params(
-            credential: Dependabot::Credential,
-            key: String,
-            source: T.nilable(String)
-          ).returns(String)
-        end
-        def required_credential_value(credential, key, source: nil)
-          value = credential[key]
-          return value if value.is_a?(String) && !value.empty?
-
-          raise SharedHelpers::HelperSubprocessFailed.new(
-            message: "Missing credentials for \"#{source || value}\"",
-            error_context: {}
-          )
         end
 
         sig do
@@ -241,11 +186,6 @@ module Dependabot
         sig { returns(String) }
         def elixir_helper_do_update_path
           File.join(NativeHelpers.hex_helpers_dir, "lib/do_update.exs")
-        end
-
-        sig { returns(String) }
-        def elixir_helper_configure_credentials_path
-          File.join(NativeHelpers.hex_helpers_dir, "lib/configure_credentials.exs")
         end
 
         sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -17,6 +17,8 @@ module Dependabot
       class VersionResolver
         extend T::Sig
 
+        RESULT_FILE = ".dependabot-result"
+
         sig do
           params(
             dependency: Dependabot::Dependency,
@@ -62,9 +64,10 @@ module Dependabot
           latest_resolvable_version =
             SharedHelpers.in_a_temporary_directory do
               write_temporary_sanitized_dependency_files
-              FileUtils.cp(elixir_helper_check_update_path, "check_update.exs")
+              copy_elixir_helpers
 
               SharedHelpers.with_git_configured(credentials: credentials) do
+                CredentialHelpers.configure(credentials: credentials, env: mix_env)
                 run_elixir_update_checker
               end
             end
@@ -79,13 +82,12 @@ module Dependabot
 
         sig { returns(String) }
         def run_elixir_update_checker
-          SharedHelpers.run_helper_subprocess(
+          SharedHelpers.run_shell_command(
+            mix_run_command("check_update.exs", dependency.name),
             env: mix_env,
-            command: "mix run #{elixir_helper_path}",
-            function: "get_latest_resolvable_version",
-            args: [Dir.pwd, dependency.name, CredentialHelpers.hex_credentials(credentials)],
-            stderr_to_stdout: true
+            fingerprint: "mix run check_update.exs #{dependency.name}"
           )
+          File.read(RESULT_FILE)
         end
 
         sig do
@@ -120,12 +122,6 @@ module Dependabot
             raise Dependabot::PrivateSourceAuthenticationFailure, name
           end
 
-          # TODO: Catch the warnings as part of the Elixir module. This happens
-          # when elixir throws warnings from the manifest files that end up in
-          # stdout and cause run_helper_subprocess to fail parsing the result as
-          # JSON.
-          return error_result(error) if includes_result?(error)
-
           # Ignore dependencies which don't resolve due to mis-matching
           # environment specifications.
           # TODO: Update the environment specifications instead
@@ -146,7 +142,8 @@ module Dependabot
         sig { params(message: String).returns(T::Boolean) }
         def new_private_organization_authentication_error?(message)
           message.include?("Failed to exchange API key for OAuth token") ||
-            message.include?("No authenticated user found. Do you want to authenticate now?")
+            message.include?("No authenticated user found. Do you want to authenticate now?") ||
+            message.include?("Failed to authenticate against organization repository")
         end
 
         sig { returns(T.nilable(String)) }
@@ -161,58 +158,35 @@ module Dependabot
           )&.named_captures&.fetch("organization", nil)
         end
 
-        sig do
-          params(error: Dependabot::SharedHelpers::HelperSubprocessFailed).returns(
-            T.any(
-              Dependabot::Version,
-              String,
-              T::Boolean
-            )
-          )
-        end
-        def error_result(error)
-          return false unless includes_result?(error)
-
-          result_json = error.message.split("\n").last
-          result = JSON.parse(T.must(result_json))["result"]
-          return version_class.new(result) if version_class.correct?(result)
-
-          result
-        end
-
-        sig { params(error: Dependabot::SharedHelpers::HelperSubprocessFailed).returns(T::Boolean) }
-        def includes_result?(error)
-          result = error.message.split("\n").last
-          return false unless result
-
-          JSON.parse(result).key?("result")
-        rescue JSON::ParserError
-          false
-        end
-
         sig { returns(T.any(T::Boolean, Dependabot::Version, String)) }
         def check_original_requirements_resolvable
           SharedHelpers.in_a_temporary_directory do
             write_temporary_sanitized_dependency_files(prepared: false)
-            FileUtils.cp(
-              elixir_helper_check_update_path,
-              "check_update.exs"
-            )
+            copy_elixir_helpers
 
             SharedHelpers.with_git_configured(credentials: credentials) do
+              CredentialHelpers.configure(credentials: credentials, env: mix_env)
               run_elixir_update_checker
             end
           end
 
           true
         rescue SharedHelpers::HelperSubprocessFailed => e
-          # TODO: Catch the warnings as part of the Elixir module. This happens
-          # when elixir throws warnings from the manifest files that end up in
-          # stdout and cause run_helper_subprocess to fail parsing the result as
-          # JSON.
-          return error_result(e) if includes_result?(e)
-
           raise Dependabot::DependencyFileNotResolvable, e.message
+        end
+
+        sig { void }
+        def copy_elixir_helpers
+          FileUtils.cp(CredentialHelpers.configure_credentials_path, "configure_credentials.exs")
+          FileUtils.cp(elixir_helper_check_update_path, "check_update.exs")
+        end
+
+        sig { params(script: String, args: String).returns(T::Array[String]) }
+        def mix_run_command(script, *args)
+          [
+            "mix", "run", "--no-deps-check", "--no-start", "--no-compile",
+            "--no-elixir-version-check", script, "--", *args
+          ]
         end
 
         sig { params(prepared: T::Boolean).void }
@@ -244,14 +218,9 @@ module Dependabot
         sig { returns(T::Hash[String, String]) }
         def mix_env
           {
-            "MIX_EXS" => File.join(NativeHelpers.hex_helpers_dir, "mix.exs"),
+            "HEX_HOME" => File.join(Dir.pwd, ".hex"),
             "MIX_QUIET" => "1"
           }
-        end
-
-        sig { returns(String) }
-        def elixir_helper_path
-          File.join(NativeHelpers.hex_helpers_dir, "lib/run.exs")
         end
 
         sig { returns(String) }

--- a/hex/spec/dependabot/hex/credential_helpers_spec.rb
+++ b/hex/spec/dependabot/hex/credential_helpers_spec.rb
@@ -5,37 +5,165 @@ require "spec_helper"
 require "dependabot/hex/credential_helpers"
 
 RSpec.describe Dependabot::Hex::CredentialHelpers do
-  describe ".organization_credentials" do
-    subject(:organization_credentials) { described_class.organization_credentials(credentials) }
+  describe ".configure" do
+    subject(:configure) { described_class.configure(credentials: credentials, env: env) }
 
-    let(:credentials) do
-      [
-        Dependabot::Credential.new(
-          { "type" => "hex_organization", "organization" => "organization",
-            "token" => "token" }
-        )
-      ]
+    let(:env) { { "HEX_HOME" => "/tmp/dependabot-hex-home", "MIX_QUIET" => "1" } }
+
+    before do
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_return("")
     end
 
-    it "populates the credentials with default properties" do
-      expect(organization_credentials).to eq(%w(hex_organization organization token))
+    context "with organization credentials" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "hex_organization",
+              "organization" => "organization",
+              "token" => "organization-secret-token"
+            }
+          )
+        ]
+      end
+
+      it "uses hex.organization without putting the token in argv or the fingerprint" do
+        configure
+
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          array_including("configure_credentials.exs", "--", "organization", "organization"),
+          hash_including(
+            env: env.merge("DEPENDABOT_HEX_CREDENTIAL_TOKEN" => "organization-secret-token"),
+            fingerprint: "mix run configure_credentials.exs organization organization"
+          )
+        ) do |command, options|
+          expect(command).not_to include("organization-secret-token")
+          expect(options.fetch(:fingerprint)).not_to include("organization-secret-token")
+        end
+      end
+    end
+
+    context "with repository credentials" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "hex_repository",
+              "repo" => "private",
+              "url" => "https://repo.example.com",
+              "auth_key" => "repository-secret-key",
+              "public_key_fingerprint" => "SHA256:public-key-fingerprint"
+            }
+          )
+        ]
+      end
+
+      it "uses hex.repo without putting the auth key or URL in the fingerprint" do
+        configure
+
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          array_including(
+            "configure_credentials.exs",
+            "--",
+            "repository",
+            "private",
+            "https://repo.example.com",
+            "SHA256:public-key-fingerprint"
+          ),
+          hash_including(
+            env: env.merge("DEPENDABOT_HEX_CREDENTIAL_TOKEN" => "repository-secret-key"),
+            fingerprint: "mix run configure_credentials.exs repository private"
+          )
+        ) do |command, options|
+          expect(command).not_to include("repository-secret-key")
+          expect(options.fetch(:fingerprint)).not_to include("repository-secret-key", "https://repo.example.com")
+        end
+      end
+    end
+
+    context "with unrelated credentials" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "git_source",
+              "host" => "github.com",
+              "username" => "x-access-token",
+              "password" => "token"
+            }
+          )
+        ]
+      end
+
+      it "does not run a Hex credential task" do
+        configure
+
+        expect(Dependabot::SharedHelpers).not_to have_received(:run_shell_command)
+      end
+    end
+
+    context "with incomplete repository credentials" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "hex_repository",
+              "repo" => "private",
+              "url" => "https://repo.example.com"
+            }
+          )
+        ]
+      end
+
+      it "raises a helper error naming the repository" do
+        expect { configure }
+          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed, 'Missing credentials for "private"')
+      end
+    end
+
+    context "with incomplete organization credentials" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "hex_organization",
+              "organization" => "organization"
+            }
+          )
+        ]
+      end
+
+      it "raises a helper error naming the organization" do
+        expect { configure }
+          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed, 'Missing credentials for "organization"')
+      end
+    end
+
+    context "with a missing credential name" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "hex_repository",
+              "url" => "https://repo.example.com",
+              "auth_key" => "repository-secret-key"
+            }
+          )
+        ]
+      end
+
+      it "raises a helper error without exposing another credential value" do
+        expect { configure }
+          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed, 'Missing credentials for "hex_repository"')
+      end
     end
   end
 
-  describe ".repo_credentials" do
-    subject(:repo_credentials) { described_class.repo_credentials(credentials) }
-
-    let(:credentials) do
-      [
-        Dependabot::Credential.new(
-          { "type" => "hex_repository", "url" => "url", "auth_key" => "auth_key",
-            "public_key_fingerprint" => "public_key_fingerprint" }
-        )
-      ]
-    end
-
-    it "populates the credentials with default properties" do
-      expect(repo_credentials).to eq(%w(hex_repository url auth_key public_key_fingerprint))
+  describe ".configure_credentials_path" do
+    it "returns the packaged public task helper" do
+      expect(described_class.configure_credentials_path).to eq(
+        File.join(Dependabot::Hex::NativeHelpers.hex_helpers_dir, "lib/configure_credentials.exs")
+      )
     end
   end
 end

--- a/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
@@ -124,6 +124,31 @@ RSpec.describe Dependabot::Hex::UpdateChecker::VersionResolver do
       end
     end
 
+    context "when the update helper writes a result alongside stdout output" do
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+          .and_raise("legacy helper protocol invoked")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .and_call_original
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(array_including("mix", "run", "check_update.exs", "plug"), anything) do
+            File.write(".dependabot-result", "1.3.6")
+            "warning from mix.exs"
+          end
+      end
+
+      it "reads the version from the filesystem using an isolated Hex home" do
+        expect(latest_resolvable_version).to eq(Dependabot::Hex::Version.new("1.3.6"))
+        expect(Dependabot::SharedHelpers).to have_received(:run_shell_command).with(
+          array_including("mix", "run", "check_update.exs", "--", "plug"),
+          hash_including(
+            env: hash_including("HEX_HOME" => end_with("/.hex")),
+            fingerprint: "mix run check_update.exs plug"
+          )
+        )
+      end
+    end
+
     context "with a deps.update alias" do
       let(:mixfile_fixture_name) { "deps_update_alias" }
 

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -611,10 +611,16 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         end
 
         before do
-          # Mock successful version resolution from private registry
-          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-            .with(hash_including(function: "get_latest_resolvable_version"))
-            .and_return("1.1.0")
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .and_call_original
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .with(array_including("configure_credentials.exs"), anything)
+            .and_return("")
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .with(array_including("check_update.exs"), anything) do
+              File.write(".dependabot-result", "1.1.0")
+              ""
+            end
         end
 
         it "returns the expected version" do
@@ -635,9 +641,10 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         end
 
         before do
-          # Mock subprocess to raise authentication failure with bad credentials
-          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-            .with(hash_including(function: "get_latest_resolvable_version"))
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .and_call_original
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .with(array_including("configure_credentials.exs"), anything)
             .and_raise(
               Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                 message: "Downloading public key for repo \"dependabot\" failed: {:error, :econnrefused}",
@@ -670,10 +677,16 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         end
 
         before do
-          # Mock successful version resolution with correct fingerprint
-          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-            .with(hash_including(function: "get_latest_resolvable_version"))
-            .and_return("1.1.0")
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .and_call_original
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .with(array_including("configure_credentials.exs"), anything)
+            .and_return("")
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .with(array_including("check_update.exs"), anything) do
+              File.write(".dependabot-result", "1.1.0")
+              ""
+            end
         end
 
         it "returns the expected version" do
@@ -695,9 +708,10 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         end
 
         before do
-          # Mock subprocess to raise fingerprint mismatch error
-          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-            .with(hash_including(function: "get_latest_resolvable_version"))
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .and_call_original
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .with(array_including("configure_credentials.exs"), anything)
             .and_raise(
               Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                 message: "Public key fingerprint mismatch for repo \"dependabot\"",
@@ -729,12 +743,10 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         end
 
         before do
-          # Simulate the error produced by the Elixir helper when
-          # Hex.Repo.get_public_key/1 returns data in the wrong tuple order,
-          # causing `key` to be a headers map that :public_key.pem_decode/1
-          # cannot decode.
-          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-            .with(hash_including(function: "get_latest_resolvable_version"))
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .and_call_original
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .with(array_including("configure_credentials.exs"), anything)
             .and_raise(
               Dependabot::SharedHelpers::HelperSubprocessFailed.new(
                 message: 'Failed to decode public key for repo "dependabot"',
@@ -770,10 +782,16 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
         end
 
         before do
-          # Mock successful version resolution with both org and repo credentials
-          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-            .with(hash_including(function: "get_latest_resolvable_version"))
-            .and_return("1.1.0")
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .and_call_original
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .with(array_including("configure_credentials.exs"), anything)
+            .and_return("")
+          allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+            .with(array_including("check_update.exs"), anything) do
+              File.write(".dependabot-result", "1.1.0")
+              ""
+            end
         end
 
         it "returns the expected version" do


### PR DESCRIPTION
### What are you trying to accomplish?

Move Hex resolvable-version checks away from the generic helper's JSON-over-stdin and encoded Erlang-term stdout protocol as another part of #7945.

This change:
- invokes the public `deps.update` Mix task module with argv boundaries preserved;
- writes the resolved version to `.dependabot-result` and reads it from the temporary project directory;
- makes Mix warnings and other stdout output irrelevant to result parsing;
- isolates Hex configuration with a temporary `HEX_HOME`;
- consolidates organization and repository setup in `CredentialHelpers` using `hex.organization auth` and `hex.repo add`;
- passes tokens and auth keys only through `DEPENDABOT_HEX_CREDENTIAL_TOKEN`;
- removes the update checker's remaining dependency on `run.exs` and its credential serializer.

### Anything you want to highlight for special attention from reviewers?

This is stacked on #15813, which migrates lockfile updates and introduces the public credential task script.

The helper calls `Mix.Task.get!("deps.update").run/1` directly, preserving the existing characterization that project aliases named `deps.update` must not execute. The dependency remains before `--no-archives-check` because Mix 1.20.3's task parser otherwise discards it.

Successful results use a filesystem artifact, while normal Mix failures still exit nonzero and flow through the existing Ruby authentication and resolvability mappings. The fallback that checks whether the original requirements resolve is preserved.

Credential setup is extracted from the lockfile updater in this stacked change so both paths use one supported Hex CLI implementation and one secret-handling policy.

### How will you know you've accomplished your goal?

- focused credential and lockfile specs: 29 examples, 0 failures
- focused version resolver specs: 11 examples, 0 failures
- update checker specs: 70 examples, 0 failures, 1 existing environment-dependent pending example
- full Hex suite: 287 examples, 0 failures, 1 existing environment-dependent pending example
- changed-file RuboCop: no offenses
- `mix format --check-formatted` for the changed helper scripts
- `mix compile --warnings-as-errors`

Sorbet could not start in the Hex development image because `/home/dependabot` does not contain a Gemfile; CI will run the repository Sorbet job.

### Checklist

- [x] I have run the complete ecosystem test suite to ensure tests and linters pass.
- [x] I have thoroughly tested the filesystem result boundary, alias bypass, warning output, credential handling, and error mapping.
- [x] I have written a clear and descriptive commit message.
- [x] I have provided a detailed description of the changes.
- [x] I have preserved the existing behavioral characterizations.
