### PR TITLE
Select compatible pip versions with native resolver

### DIFF
--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -32,6 +32,28 @@ module Dependabot
           ).fetch
         end
 
+        sig do
+          params(language_version: T.nilable(T.any(String, Dependabot::Version)))
+            .returns(T::Array[Dependabot::Version])
+        end
+        def eligible_versions(language_version: nil)
+          releases = available_versions || []
+          releases = filter_yanked_versions(releases)
+          releases = filter_by_cooldown(releases)
+          releases = filter_unsupported_versions(releases, language_version)
+          releases = filter_prerelease_versions(releases)
+          releases = filter_ignored_versions(releases)
+          releases = apply_post_fetch_latest_versions_filter(releases)
+          releases.map(&:version).uniq
+        end
+
+        sig { returns(T::Array[Dependabot::Version]) }
+        def resolver_excluded_versions
+          releases = available_versions || []
+          filtered_releases = filter_by_cooldown(filter_ignored_versions(releases))
+          (releases.map(&:version) - filtered_releases.map(&:version)).uniq
+        end
+
         sig { override.returns(T::Boolean) }
         def cooldown_enabled?
           return false if cooldown_options.nil?

--- a/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
@@ -2,11 +2,16 @@
 # frozen_string_literal: true
 
 require "json"
+require "fileutils"
 require "pathname"
+require "shellwords"
 require "toml-rb"
 require "sorbet-runtime"
 require "excon"
 require "dependabot/registry_client"
+require "dependabot/shared_helpers"
+require "dependabot/python/authed_url_builder"
+require "dependabot/python/file_updater/requirement_replacer"
 require "dependabot/python/language_version_manager"
 require "dependabot/python/name_normaliser"
 require "dependabot/python/package/package_registry_finder"
@@ -22,6 +27,11 @@ module Dependabot
       # rubocop:disable Metrics/ClassLength
       class PipVersionResolver
         extend T::Sig
+
+        PIP_REPORT_FILENAME = "dependabot-pip-report.json"
+        RESOLUTION_ERROR_PATTERN = /ResolutionImpossible|No matching distribution found/
+        LOWER_BOUND_OPERATORS = %w(> >= ~>).freeze
+        LowerBound = T.type_alias { [String, Gem::Version] }
 
         require_relative "pip_version_resolver/marker_evaluator"
 
@@ -67,8 +77,17 @@ module Dependabot
 
         sig { returns(T.nilable(Dependabot::Version)) }
         def latest_resolvable_version
-          candidate = latest_version_finder.latest_version(language_version: language_version_manager.python_version)
-          return candidate if candidate.nil?
+          eligible_versions = latest_version_finder.eligible_versions(
+            language_version: language_version_manager.python_version
+          )
+          policy_candidate = eligible_versions.max
+          return if policy_candidate.nil?
+
+          candidate = pip_resolvable_version(
+            policy_candidate: policy_candidate,
+            requirement_string: resolver_requirement(policy_candidate, eligible_versions)
+          )
+          return unless candidate && eligible_versions.include?(candidate)
           return candidate if compatible_with_pinned_pyproject_dependencies?(candidate)
 
           nil
@@ -85,6 +104,12 @@ module Dependabot
           candidate = latest_version_finder
                       .lowest_security_fix_version(language_version: language_version_manager.python_version)
           return candidate if candidate.nil?
+
+          resolved_candidate = pip_resolvable_version(
+            policy_candidate: candidate,
+            requirement_string: "==#{candidate}"
+          )
+          return unless resolved_candidate == candidate
           return candidate if compatible_with_pinned_pyproject_dependencies?(candidate)
 
           nil
@@ -140,6 +165,257 @@ module Dependabot
         sig { returns(MarkerEvaluator) }
         def marker_evaluator
           @marker_evaluator ||= MarkerEvaluator.new
+        end
+
+        sig do
+          params(
+            policy_candidate: Dependabot::Version,
+            requirement_string: String
+          ).returns(T.nilable(Dependabot::Version))
+        end
+        def pip_resolvable_version(policy_candidate:, requirement_string:)
+          requirement = pip_requirement
+          return policy_candidate unless requirement
+
+          SharedHelpers.in_a_temporary_directory do
+            SharedHelpers.with_git_configured(credentials: credentials) do
+              write_dependency_files(requirement: requirement, requirement_string: requirement_string)
+              language_version_manager.install_required_python
+              SharedHelpers.run_shell_command(
+                pip_resolver_command(requirement, allow_prereleases: policy_candidate.prerelease?),
+                allow_unsafe_shell_command: true,
+                env: pip_environment,
+                fingerprint: pip_resolver_fingerprint,
+                stderr_to_stdout: true
+              )
+
+              pip_report_version
+            end
+          end
+        rescue SharedHelpers::HelperSubprocessFailed => e
+          return nil if e.message.match?(RESOLUTION_ERROR_PATTERN)
+
+          raise
+        end
+
+        sig { returns(T.nilable(LowerBound)) }
+        def resolver_lower_bound
+          current_version = dependency.numeric_version
+          return [">", current_version] if current_version
+
+          lower_bounds = dependency.requirements.filter_map { |requirement| lower_bound_for(requirement) }
+          lower_bounds.max_by { |_, version| version }
+        end
+
+        sig { params(requirement: Dependabot::DependencyRequirement).returns(T.nilable(LowerBound)) }
+        def lower_bound_for(requirement)
+          requirement_string = requirement.requirement_string
+          return unless requirement_string
+
+          parsed_requirement = Python::Requirement.new(requirement_string)
+          lower_bounds = parsed_requirement.requirements.filter_map do |operator, version|
+            [operator, version] if LOWER_BOUND_OPERATORS.include?(operator)
+          end
+          operator, version = lower_bounds.max_by { |_, bound_version| bound_version }
+          return unless operator && version
+
+          [operator == ">" ? ">" : ">=", version]
+        rescue Gem::Requirement::BadRequirementError
+          nil
+        end
+
+        sig do
+          params(
+            policy_candidate: Dependabot::Version,
+            eligible_versions: T::Array[Dependabot::Version]
+          ).returns(String)
+        end
+        def resolver_requirement(policy_candidate, eligible_versions)
+          requirements = ["<=#{policy_candidate}"]
+          lower_bound = resolver_lower_bound
+          requirements.unshift("#{lower_bound[0]}#{lower_bound[1]}") if lower_bound
+          requirements.concat(excluded_version_requirements(policy_candidate, eligible_versions))
+          requirements.join(",")
+        end
+
+        sig do
+          params(
+            policy_candidate: Dependabot::Version,
+            eligible_versions: T::Array[Dependabot::Version]
+          ).returns(T::Array[String])
+        end
+        def excluded_version_requirements(policy_candidate, eligible_versions)
+          lower_bound = resolver_lower_bound
+          excluded_versions = latest_version_finder.resolver_excluded_versions
+
+          excluded_versions.filter_map do |version|
+            next unless version_within_resolver_bounds?(version, policy_candidate, lower_bound)
+            next if eligible_versions.include?(version)
+
+            "!=#{version}"
+          end
+        end
+
+        sig do
+          params(
+            version: Dependabot::Version,
+            policy_candidate: Dependabot::Version,
+            lower_bound: T.nilable(LowerBound)
+          ).returns(T::Boolean)
+        end
+        def version_within_resolver_bounds?(version, policy_candidate, lower_bound)
+          return false if version > policy_candidate
+          return true unless lower_bound
+
+          operator, bound_version = lower_bound
+          version > bound_version || (operator != ">" && version == bound_version)
+        end
+
+        sig { returns(T.nilable(Dependabot::DependencyRequirement)) }
+        def pip_requirement
+          return unless dependency.requirements.one?
+
+          requirement = T.must(dependency.requirements.first)
+          return unless requirement.file&.end_with?(".txt")
+          return unless requirement.source.nil? && requirement.requirement_string
+
+          file = dependency_files.find { |dependency_file| dependency_file.name == requirement.file }
+          return unless pip_compatible_requirement_file?(file, requirement)
+
+          requirement
+        end
+
+        sig do
+          params(
+            file: T.nilable(Dependabot::DependencyFile),
+            requirement: Dependabot::DependencyRequirement
+          ).returns(T::Boolean)
+        end
+        def pip_compatible_requirement_file?(file, requirement)
+          return false unless file&.content
+
+          content = T.must(file.content)
+          return false if content.include?("--hash=")
+          return false if content.match?(/^\s*-(?:r|c|requirement|constraint)(?:\s+|=)["']/)
+
+          requirement_declaration_present?(file, requirement)
+        end
+
+        sig do
+          params(
+            requirement: Dependabot::DependencyRequirement,
+            requirement_string: String
+          ).void
+        end
+        def write_dependency_files(requirement:, requirement_string:)
+          dependency_files.each do |file|
+            next unless file.content
+
+            FileUtils.mkdir_p(File.dirname(file.name))
+            content = if file.name == requirement.file
+                        updated_requirement_content(file, requirement, requirement_string)
+                      else
+                        file.content
+                      end
+            File.write(file.name, content)
+          end
+          File.write(".python-version", language_version_manager.python_major_minor)
+        end
+
+        sig do
+          params(
+            file: Dependabot::DependencyFile,
+            requirement: Dependabot::DependencyRequirement,
+            requirement_string: String
+          ).returns(String)
+        end
+        def updated_requirement_content(file, requirement, requirement_string)
+          FileUpdater::RequirementReplacer.new(
+            content: T.must(file.content),
+            dependency_name: dependency.name,
+            old_requirement: requirement.requirement_string,
+            new_requirement: requirement_string
+          ).updated_content
+        end
+
+        sig do
+          params(
+            file: Dependabot::DependencyFile,
+            requirement: Dependabot::DependencyRequirement
+          ).returns(T::Boolean)
+        end
+        def requirement_declaration_present?(file, requirement)
+          expected_requirement = T.must(requirement.requirement_string).gsub(/\s/, "")
+          T.must(file.content).each_line.any? do |line|
+            parsed = RequirementParser.parse(line)
+            next false unless parsed
+
+            parsed[:normalised_name] == NameNormaliser.normalise(dependency.name) &&
+              parsed[:requirement]&.gsub(/\s/, "") == expected_requirement
+          end
+        end
+
+        sig do
+          params(
+            requirement: Dependabot::DependencyRequirement,
+            allow_prereleases: T::Boolean
+          ).returns(String)
+        end
+        def pip_resolver_command(requirement, allow_prereleases:)
+          command = [
+            "pyenv", "exec", "pip", "install", "--dry-run", "--ignore-installed",
+            "--report", PIP_REPORT_FILENAME
+          ]
+          command << "--pre" if allow_prereleases
+          requirements_file = T.must(requirement.file)
+          Shellwords.join([*command, "-r", requirements_file])
+        end
+
+        sig { returns(String) }
+        def pip_resolver_fingerprint
+          "pyenv exec pip install --dry-run --ignore-installed --report <report> -r <requirements_file>"
+        end
+
+        sig { returns(T::Hash[String, String]) }
+        def pip_environment
+          index_credentials = credentials.select { |credential| credential["type"] == "python_index" }
+          environment = T.let({}, T::Hash[String, String])
+
+          base_credential = index_credentials.find(&:replaces_base?)
+          environment["PIP_INDEX_URL"] = AuthedUrlBuilder.authed_url(credential: base_credential) if base_credential
+
+          extra_index_urls = index_credentials.reject(&:replaces_base?).map do |credential|
+            AuthedUrlBuilder.authed_url(credential: credential)
+          end
+          environment["PIP_EXTRA_INDEX_URL"] = extra_index_urls.join(" ") if extra_index_urls.any?
+
+          environment
+        end
+
+        sig { returns(T.nilable(Dependabot::Version)) }
+        def pip_report_version
+          report = T.cast(JSON.parse(File.read(PIP_REPORT_FILENAME)), T::Hash[String, Object])
+          installs_obj = report["install"]
+          return unless installs_obj.is_a?(Array)
+
+          installs_obj.each do |entry|
+            install = T.cast(entry, T.nilable(Object))
+            next unless install.is_a?(Hash)
+
+            metadata = T.cast(install["metadata"], T.nilable(Object))
+            next unless metadata.is_a?(Hash)
+
+            name = T.cast(metadata["name"], T.nilable(Object))
+            version = T.cast(metadata["version"], T.nilable(Object))
+            next unless name.is_a?(String) && version.is_a?(String)
+            next unless NameNormaliser.normalise(name) == NameNormaliser.normalise(dependency.name)
+
+            return Python::Version.new(version)
+          end
+
+          nil
+        rescue JSON::ParserError, Errno::ENOENT
+          nil
         end
 
         sig { params(candidate: Dependabot::Version).returns(T::Boolean) }

--- a/python/spec/dependabot/python/update_checker/pip_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_version_resolver_spec.rb
@@ -73,6 +73,237 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipVersionResolver do
   describe "#latest_resolvable_version" do
     subject(:latest_resolvable_version) { resolver.latest_resolvable_version }
 
+    context "when the latest version conflicts with another requirement" do
+      let(:rewritten_requirements) { [] }
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4\ndjango-filter==23.5\n"
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command) do |command, **_args|
+          next "" unless command.include?("pip install")
+
+          rewritten_requirements << File.read("requirements.txt")
+          File.write(
+            "dependabot-pip-report.json",
+            JSON.dump(
+              "install" => [{ "metadata" => { "name" => "Django", "version" => "3.2.3" } }]
+            )
+          )
+          ""
+        end
+      end
+
+      it "returns the newest version selected by pip" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.3"))
+        expect(rewritten_requirements).to contain_exactly(include("django>1.2.4,<=3.2.4"))
+      end
+    end
+
+    context "when a version below the policy ceiling is ignored" do
+      let(:ignored_versions) { ["==3.2.3"] }
+      let(:rewritten_requirements) { [] }
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4\ndjango-filter==23.5\n"
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command) do |command, **_args|
+          next "" unless command.include?("pip install")
+
+          rewritten_requirements << File.read("requirements.txt")
+          File.write(
+            "dependabot-pip-report.json",
+            JSON.dump(
+              "install" => [{ "metadata" => { "name" => "Django", "version" => "3.2.2" } }]
+            )
+          )
+          ""
+        end
+      end
+
+      it "excludes the ignored version from pip's candidate range" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.2"))
+        expect(rewritten_requirements).to contain_exactly(include("!=3.2.3"))
+      end
+    end
+
+    context "when the existing requirement has a lower bound" do
+      let(:dependency_version) { nil }
+      let(:dependency_requirements) do
+        [{
+          file: "requirements.txt",
+          requirement: ">=2.0,<3.0",
+          groups: [],
+          source: nil
+        }]
+      end
+      let(:rewritten_requirements) { [] }
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django>=2.0,<3.0\ndjango-filter==23.5\n"
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command) do |command, **_args|
+          next "" unless command.include?("pip install")
+
+          rewritten_requirements << File.read("requirements.txt")
+          File.write(
+            "dependabot-pip-report.json",
+            JSON.dump(
+              "install" => [{ "metadata" => { "name" => "Django", "version" => "3.2.3" } }]
+            )
+          )
+          ""
+        end
+      end
+
+      it "does not allow pip to select a downgrade" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.3"))
+        expect(rewritten_requirements).to contain_exactly(include("django>=2.0,<=3.2.4"))
+      end
+    end
+
+    context "when no policy-eligible version resolves" do
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4\ndjango-filter==23.5\n"
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command) do |command, **_args|
+          next "" unless command.include?("pip install")
+
+          raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+            message: "ERROR: ResolutionImpossible",
+            error_context: {}
+          )
+        end
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with authenticated Python indexes" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://private.example.com/simple",
+              "token" => "private-user:private-password",
+              "replaces-base" => true
+            }
+          ),
+          Dependabot::Credential.new(
+            {
+              "type" => "python_index",
+              "index-url" => "https://extra.example.com/simple",
+              "token" => "extra-user:extra-password"
+            }
+          )
+        ]
+      end
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4\n"
+        )
+      end
+      let(:pip_commands) { [] }
+      let(:pip_environments) { [] }
+
+      before do
+        %w(private extra).each do |index|
+          stub_request(:get, %r{https://#{index}\.example\.com/(?:pypi/django/json|simple/django/)})
+            .to_return(status: 200, body: pypi_response)
+        end
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command) do |command, **args|
+          next "" unless command.include?("pip install")
+
+          pip_commands << command
+          pip_environments << args.fetch(:env)
+          File.write(
+            "dependabot-pip-report.json",
+            JSON.dump(
+              "install" => [{ "metadata" => { "name" => "Django", "version" => "3.2.4" } }]
+            )
+          )
+          ""
+        end
+      end
+
+      it "passes index credentials outside the logged command" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.4"))
+        expect(pip_commands.length).to eq(1)
+        expect(pip_commands.first).not_to include("private-user", "private-password")
+        expect(pip_environments).to contain_exactly(
+          include(
+            "PIP_INDEX_URL" => "https://private-user:private-password@private.example.com/simple",
+            "PIP_EXTRA_INDEX_URL" => "https://extra-user:extra-password@extra.example.com/simple"
+          )
+        )
+      end
+    end
+
+    context "when the requirement file contains hashes" do
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4 --hash=sha256:abc123\n"
+        )
+      end
+
+      before { allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_call_original }
+
+      it "uses the policy candidate without invoking pip" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.4"))
+        expect(Dependabot::SharedHelpers)
+          .not_to have_received(:run_shell_command)
+          .with(a_string_matching(/pip install/), any_args)
+      end
+    end
+
+    context "when the dependency has declarations in multiple files" do
+      let(:dependency_requirements) do
+        [
+          { file: "requirements.txt", requirement: "==1.2.4", groups: [], source: nil },
+          { file: "constraints.txt", requirement: "==1.2.4", groups: [], source: nil }
+        ]
+      end
+      let(:dependency_files) do
+        [
+          requirements_file,
+          Dependabot::DependencyFile.new(name: "constraints.txt", content: "django==1.2.4\n")
+        ]
+      end
+
+      before { allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_call_original }
+
+      it "uses the policy candidate without invoking pip" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.4"))
+        expect(Dependabot::SharedHelpers)
+          .not_to have_received(:run_shell_command)
+          .with(a_string_matching(/pip install/), any_args)
+      end
+    end
+
     context "with no indication of the Python version" do
       let(:dependency_files) { [requirements_file] }
 
@@ -122,6 +353,37 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipVersionResolver do
           vulnerable_versions: ["<= 2.1.0"]
         )
       ]
+    end
+
+    context "when the lowest safe version is resolvable" do
+      let(:rewritten_requirements) { [] }
+      let(:requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements.txt",
+          content: "django==1.2.4\n"
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command) do |command, **_args|
+          next "" unless command.include?("pip install")
+
+          rewritten_requirements << File.read("requirements.txt")
+          File.write(
+            "dependabot-pip-report.json",
+            JSON.dump(
+              "install" => [{ "metadata" => { "name" => "Django", "version" => "2.1.1" } }]
+            )
+          )
+          ""
+        end
+      end
+
+      it "checks the exact lowest safe version" do
+        expect(lowest_resolvable_security_fix_version).to eq(Gem::Version.new("2.1.1"))
+        expect(rewritten_requirements).to contain_exactly(include("django==2.1.1"))
+      end
     end
 
     it { is_expected.to eq(Gem::Version.new("2.1.1")) }


### PR DESCRIPTION
## Summary

Fix:
* #4934.

For eligible standalone `requirements.txt` updates, let pip choose the newest target version compatible with every other unchanged requirement in one backtracking resolution.

Dependabot still owns release policy and source editing:

- filter releases using yanked, cooldown, `Requires-Python`, prerelease, ignored-version, and security policy
- rewrite only the target declaration to a bounded resolver range
- preserve the current lower bound and exclude ignored/cooldown releases
- accept only a pip-reported version from the policy-eligible release set
- use the existing requirement editor for the final source-preserving update

Authenticated Python indexes are passed through `PIP_INDEX_URL` and `PIP_EXTRA_INDEX_URL`, keeping credentials out of command strings and command fingerprints.

This is a separate approach from #15809: instead of validating one exact Dependabot-selected candidate, pip can backtrack and select an older compatible release below the policy ceiling in the same invocation.

## Impact / Benefits

For eligible standalone requirements files, this removes a class of Dependabot updates that are individually policy-valid but collectively unresolvable. Instead of approximating compatibility in Ruby and potentially writing a target version that conflicts with another direct or transitive requirement, Dependabot asks pip to solve the complete graph. Pip either selects the newest compatible policy-eligible target or Dependabot produces no update from that solve.

Delegating resolution to pip also improves maintainability. Dependabot continues to own update policy and source-preserving edits, but no longer needs to reproduce pip dependency-resolution semantics in Ruby for this path. Resolver fixes and behavioral changes delivered by supported pip upgrades are inherited through the upstream implementation rather than requiring parallel changes in Dependabot.


## Scope and fallbacks

Native selection currently applies only to a dependency with one declaration in a plain, non-hashed requirements file. Hash-pinned files and dependencies with multiple declarations retain the existing selection behavior.

Security updates validate the exact lowest safe release; they do not yet retry with a higher safe release when that exact version conflicts. The flow also retains Dependabot's existing package metadata fetch before invoking pip.

## Testing

- `bin/test python spec/dependabot/python/update_checker/pip_version_resolver_spec.rb`
- `bin/test python spec/dependabot/python/update_checker`
- `bin/test python rubocop lib/dependabot/python/update_checker/latest_version_finder.rb lib/dependabot/python/update_checker/pip_version_resolver.rb spec/dependabot/python/update_checker/pip_version_resolver_spec.rb`
- `docker run --rm --workdir /home/dependabot -v "$PWD:/home/dependabot" dependabot/dependabot-core-development-python bundle exec srb tc`

Full update-checker result: 344 examples, 0 failures, 5 pending.