### PR TITLE
Cargo: use cargo update --precise for lockfile updates

### DIFF
--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -86,12 +86,26 @@ module Dependabot
               @current_dependency = dependency_to_update
               next if previous_line_already_replaced?
 
-              run_cargo_command(
-                "cargo update -p #{dependency_spec}",
-                fingerprint: "cargo update -p <dependency_spec>"
-              )
+              run_cargo_update
             end
           end
+        end
+
+        sig { void }
+        def run_cargo_update
+          run_cargo_command(
+            "cargo update -p #{dependency_spec} --precise #{dependency.version}",
+            fingerprint: "cargo update -p <dependency_spec> --precise <version>"
+          )
+        rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
+          raise unless e.message.include?("failed to select a version")
+
+          # --precise cannot introduce a new direct version while retaining the selected old version for another edge.
+          run_cargo_command(
+            "cargo update -p #{dependency_spec}",
+            fingerprint: "cargo update -p <dependency_spec>"
+          )
+          raise e unless desired_version_present?(File.read("Cargo.lock"))
         end
 
         # An earlier command in this run may already have resolved this
@@ -420,7 +434,6 @@ module Dependabot
         sig { params(file: Dependabot::DependencyFile).returns(String) }
         def prepared_manifest_content(file)
           content = updated_manifest_content(file)
-          content = pin_version(content) unless git_dependency?
           content = replace_ssh_urls(content)
           content = remove_binary_specifications(content)
           content = remove_default_run_specification(content)
@@ -440,58 +453,6 @@ module Dependabot
             dependencies: dependencies,
             manifest: file
           ).updated_manifest_content
-        end
-
-        sig { params(content: String).returns(String) }
-        def pin_version(content)
-          parsed_manifest = TomlRB.parse(content)
-
-          Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
-            next unless (req = parsed_manifest.dig(type, dependency.name))
-
-            updated_req = "=#{dependency.version}"
-
-            if req.is_a?(Hash)
-              parsed_manifest[type][dependency.name]["version"] = updated_req
-            else
-              parsed_manifest[type][dependency.name] = updated_req
-            end
-          end
-
-          pin_target_specific_dependencies!(parsed_manifest)
-
-          TomlRB.dump(parsed_manifest)
-        end
-
-        sig { params(parsed_manifest: T::Hash[String, T.anything]).void }
-        def pin_target_specific_dependencies!(parsed_manifest)
-          toml_table_or_empty(parsed_manifest.fetch("target", {})).each do |target, t_details|
-            t_details = toml_table_or_empty(t_details)
-            Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
-              toml_table_or_empty(t_details.fetch(type, {})).each do |name, requirement|
-                next unless name == dependency.name
-
-                updated_req = "=#{dependency.version}"
-
-                if T.cast(requirement, T.nilable(Object)).is_a?(Hash)
-                  toml_table_or_empty(
-                    toml_table_or_empty(
-                      toml_table_or_empty(
-                        toml_table_or_empty(parsed_manifest["target"])[target]
-                      )[type]
-                    )[name]
-                  )["version"] =
-                    updated_req
-                else
-                  toml_table_or_empty(
-                    toml_table_or_empty(
-                      toml_table_or_empty(parsed_manifest["target"])[target]
-                    )[type]
-                  )[name] = updated_req
-                end
-              end
-            end
-          end
         end
 
         sig { params(content: String).returns(String) }
@@ -578,12 +539,6 @@ module Dependabot
             end
 
           lockfile_content
-        end
-
-        sig { params(value: T.anything).returns(T::Hash[String, T.anything]) }
-        def toml_table_or_empty(value)
-          obj = T.cast(value, T.nilable(Object))
-          obj.is_a?(Hash) ? obj : {}
         end
 
         sig { returns(String) }

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -98,7 +98,12 @@ module Dependabot
             fingerprint: "cargo update -p <dependency_spec> --precise <version>"
           )
         rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
-          raise unless e.message.include?("failed to select a version")
+          raise unless split_graph_conflict?(e)
+
+          fallback_files = split_graph_manifest_files
+          raise if fallback_files.empty?
+
+          pin_split_graph_manifest_requirements(fallback_files)
 
           # --precise cannot introduce a new direct version while retaining the selected old version for another edge.
           run_cargo_command(
@@ -106,6 +111,13 @@ module Dependabot
             fingerprint: "cargo update -p <dependency_spec>"
           )
           raise e unless desired_version_present?(File.read("Cargo.lock"))
+        end
+
+        sig { params(error: Dependabot::SharedHelpers::HelperSubprocessFailed).returns(T::Boolean) }
+        def split_graph_conflict?(error)
+          !git_dependency? &&
+            error.message.include?("failed to select a version") &&
+            error.message.include?(dependency.name)
         end
 
         # An earlier command in this run may already have resolved this
@@ -455,6 +467,58 @@ module Dependabot
           ).updated_manifest_content
         end
 
+        sig { returns(T::Array[Dependabot::DependencyFile]) }
+        def split_graph_manifest_files
+          manifest_files.select do |file|
+            dependency.requirements.any? { |requirement| requirement[:file] == file.name }
+          end
+        end
+
+        sig { params(files: T::Array[Dependabot::DependencyFile]).void }
+        def pin_split_graph_manifest_requirements(files)
+          files.each do |file|
+            File.write(file.name, pin_version(prepared_manifest_content(file)))
+          end
+        end
+
+        sig { params(content: String).returns(String) }
+        def pin_version(content)
+          parsed_manifest = TomlRB.parse(content)
+
+          Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
+            next unless (requirement = parsed_manifest.dig(type, dependency.name))
+
+            if requirement.is_a?(Hash)
+              parsed_manifest[type][dependency.name]["version"] = "=#{dependency.version}"
+            else
+              parsed_manifest[type][dependency.name] = "=#{dependency.version}"
+            end
+          end
+
+          pin_target_specific_dependencies!(parsed_manifest)
+          TomlRB.dump(parsed_manifest)
+        end
+
+        sig { params(parsed_manifest: T::Hash[String, T.anything]).void }
+        def pin_target_specific_dependencies!(parsed_manifest)
+          toml_table_or_empty(parsed_manifest.fetch("target", {})).each do |target, target_details|
+            target_details = toml_table_or_empty(target_details)
+            Cargo::FileParser::DEPENDENCY_TYPES.each do |type|
+              toml_table_or_empty(target_details.fetch(type, {})).each do |name, requirement|
+                next unless name == dependency.name
+
+                dependencies = toml_table_or_empty(toml_table_or_empty(parsed_manifest["target"])[target])
+                if T.cast(requirement, T.nilable(Object)).is_a?(Hash)
+                  toml_table_or_empty(toml_table_or_empty(dependencies[type])[name])["version"] =
+                    "=#{dependency.version}"
+                else
+                  toml_table_or_empty(dependencies[type])[name] = "=#{dependency.version}"
+                end
+              end
+            end
+          end
+        end
+
         sig { params(content: String).returns(String) }
         def replace_ssh_urls(content)
           git_ssh_requirements_to_swap.each do |ssh_url, https_url|
@@ -539,6 +603,12 @@ module Dependabot
             end
 
           lockfile_content
+        end
+
+        sig { params(value: T.anything).returns(T::Hash[String, T.anything]) }
+        def toml_table_or_empty(value)
+          object = T.cast(value, T.nilable(Object))
+          object.is_a?(Hash) ? object : {}
         end
 
         sig { returns(String) }

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
         .not_to(change { Dir.entries(tmp_path) })
     end
 
+    it "asks Cargo to update to the exact dependency version" do
+      expect(updater).to receive(:run_cargo_command).with(
+        "cargo update -p time:0.1.38 --precise 0.1.40",
+        fingerprint: "cargo update -p <dependency_spec> --precise <version>"
+      ).and_call_original
+
+      updated_lockfile_content
+    end
+
     it { expect { updated_lockfile_content }.not_to output.to_stdout }
 
     context "when using a toolchain file that is too old" do
@@ -87,8 +96,8 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
         expect { updater.updated_lockfile_content }
           .to raise_error do |error|
             expect(error)
-              .to be_a(Dependabot::SharedHelpers::HelperSubprocessFailed)
-            expect(error.message).to include("failed to select a version")
+              .to be_a(Dependabot::DependencyFileNotResolvable)
+            expect(error.message).to eq("time")
           end
       end
 
@@ -201,6 +210,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
       context "with a target-specific dependency" do
         let(:manifest_fixture_name) { "target_dependency" }
         let(:lockfile_fixture_name) { "target_dependency" }
+        let(:dependency_version) { "0.1.38" }
         let(:dependency_previous_version) { "0.1.12" }
         let(:requirements) do
           [{
@@ -221,7 +231,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
 
         it "updates the dependency version in the lockfile" do
           expect(updated_lockfile_content)
-            .to include(%(name = "time"\nversion = "0.1.40"))
+            .to include(%(name = "time"\nversion = "0.1.38"))
         end
       end
 
@@ -325,7 +335,10 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
             expect(updated_lockfile_content).to include(%(name = "getrandom"\nversion = "0.2.18"))
             expect(updated_lockfile_content).to include(%(name = "getrandom"\nversion = "0.4.3"))
             expect(commands).to eq(
-              ["cargo update -p getrandom:0.2.17", "cargo update -p getrandom:0.4.2"]
+              [
+                "cargo update -p getrandom:0.2.17 --precise 0.2.18",
+                "cargo update -p getrandom:0.4.2 --precise 0.4.3"
+              ]
             )
           end
 
@@ -351,7 +364,7 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
             it "skips the consumed package specification" do
               expect(updated_lockfile_content).to include(%(name = "getrandom"\nversion = "0.2.18"))
               expect(updated_lockfile_content).to include(%(name = "getrandom"\nversion = "0.4.3"))
-              expect(commands).to eq(["cargo update -p getrandom:0.2.17"])
+              expect(commands).to eq(["cargo update -p getrandom:0.2.17 --precise 0.2.18"])
             end
           end
         end
@@ -479,10 +492,24 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
         let(:previous_requirements) do
           [{ file: "Cargo.toml", requirement: "=0.52.0", groups: ["dependencies"], source: nil }]
         end
+        let(:commands) { [] }
+
+        before do
+          allow(updater).to receive(:run_cargo_command).and_wrap_original do |method, command, fingerprint:|
+            commands << command
+            method.call(command, fingerprint: fingerprint)
+          end
+        end
 
         it "accepts the update when Cargo keeps the old line for other dependents" do
           expect(updated_lockfile_content).to include(%(name = "windows-sys"\nversion = "0.59.0"))
           expect(updated_lockfile_content).to include(%(name = "windows-sys"\nversion = "0.52.0"))
+          expect(commands).to eq(
+            [
+              "cargo update -p windows-sys:0.52.0 --precise 0.59.0",
+              "cargo update -p windows-sys:0.52.0"
+            ]
+          )
         end
       end
 
@@ -562,6 +589,15 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
         it "updates the dependency version in the lockfile" do
           expect(updated_lockfile_content)
             .to include("utf8-ranges#be9b8dfcaf449453cbf83ac85260ee80323f4f77")
+        end
+
+        it "asks Cargo to update to the exact git revision" do
+          expect(updater).to receive(:run_cargo_command).with(
+            "cargo update -p utf8-ranges:1.0.0 --precise be9b8dfcaf449453cbf83ac85260ee80323f4f77",
+            fingerprint: "cargo update -p <dependency_spec> --precise <version>"
+          ).and_call_original
+
+          updated_lockfile_content
         end
 
         context "when the tracked reference resolves to a different commit" do
@@ -1160,8 +1196,8 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
             [{ file: "Cargo.toml", requirement: "99.0.0", groups: [], source: nil }]
           end
 
-          it "raises HelperSubprocessFailed" do
-            expect { result }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+          it "raises DependencyFileNotResolvable" do
+            expect { result }.to raise_error(Dependabot::DependencyFileNotResolvable, "time")
           end
         end
       end

--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -233,6 +233,38 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
           expect(updated_lockfile_content)
             .to include(%(name = "time"\nversion = "0.1.38"))
         end
+
+        context "when Cargo reports a split-graph conflict" do
+          let(:lockfile_body) do
+            super() + <<~LOCKFILE
+
+              [[package]]
+              name = "time"
+              version = "0.1.38"
+              source = "registry+https://github.com/rust-lang/crates.io-index"
+            LOCKFILE
+          end
+          let(:fallback_manifest_contents) { [] }
+
+          before do
+            allow(updater).to receive(:run_cargo_command) do |command, **|
+              if command.include?("--precise")
+                raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                  message: 'failed to select a version for the requirement `time = "<=0.1.12"`',
+                  error_context: {}
+                )
+              end
+
+              fallback_manifest_contents << File.read("Cargo.toml")
+            end
+          end
+
+          it "exact-pins the target-specific requirement before the fallback" do
+            updated_lockfile_content
+
+            expect(fallback_manifest_contents).to contain_exactly(a_string_including('time = "=0.1.38"'))
+          end
+        end
       end
 
       context "with a blank requirement" do
@@ -510,6 +542,48 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
               "cargo update -p windows-sys:0.52.0"
             ]
           )
+        end
+
+        context "when the desired version is already locked for another dependent" do
+          let(:requirements) do
+            [{ file: "Cargo.toml", requirement: "0.59", groups: ["dependencies"], source: nil }]
+          end
+          let(:lockfile_body) do
+            super() + <<~LOCKFILE
+
+              [[package]]
+              name = "windows-sys"
+              version = "0.59.0"
+              source = "registry+https://github.com/rust-lang/crates.io-index"
+              checksum = "1e38bc4d79ed67fd075bcc251a1c39b32f1776a048167c60a3a49e89265ef463"
+            LOCKFILE
+          end
+          let(:fallback_manifest_contents) { [] }
+
+          before do
+            allow(updater).to receive(:run_cargo_command) do |command, **|
+              commands << command
+              if command.include?("--precise")
+                raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                  message: 'failed to select a version for the requirement `windows-sys = "^0.52"`',
+                  error_context: {}
+                )
+              end
+
+              fallback_manifest_contents << File.read("Cargo.toml")
+            end
+          end
+
+          it "exact-pins the updated edge before allowing Cargo to split the graph" do
+            expect(updated_lockfile_content).to include(%(name = "windows-sys"\nversion = "0.59.0"))
+            expect(fallback_manifest_contents).to contain_exactly(a_string_including('windows-sys = "=0.59.0"'))
+            expect(commands).to eq(
+              [
+                "cargo update -p windows-sys:0.52.0 --precise 0.59.0",
+                "cargo update -p windows-sys:0.52.0"
+              ]
+            )
+          end
         end
       end
 


### PR DESCRIPTION
Use Cargo's native `cargo update --precise` support to select the version or git revision already chosen by the update checker, instead of temporarily rewriting manifest requirements to exact versions in Ruby for every update.

The update strategy is:

1. Use `--precise` for git updates, passing the SHA selected during update checking directly to Cargo.
2. Use `--precise` for transitive and lockfile-only registry updates, where there may be no manifest declaration to pin.
3. Use `--precise` for ordinary direct registry updates, avoiding Ruby assumptions about top-level and target-specific dependency table shapes.
4. When Cargo reports that the selected old package cannot be replaced because another dependency edge still requires it, do not use `--precise` for the retry. Exact-pin only the relevant temporary manifest requirement and run a regular package update, allowing Cargo to introduce the requested direct version while retaining the old version for the other edge.

Case 4 cannot use `--precise`: `cargo update -p name:old --precise new` means replacing that selected locked package with `new`. If another edge still requires `old`, Cargo correctly rejects the replacement rather than splitting the graph. A regular update against an exact-pinned direct requirement lets Cargo produce both versions. This fallback is limited to direct registry dependencies with a matching manifest and preserves the retained-multi-version behavior covered by #15668.

This also closes two races:

- Git dependencies cannot silently resolve to a later commit when a branch or tag advances between check time and update time.
- On the split-graph fallback, a desired version already present for another dependent cannot mask the targeted edge resolving to a newer compatible release; the targeted temporary manifest edge is exact-pinned before Cargo retries.

The temporary Cargo workspace remains because Cargo reads and updates files on disk. Exact-version TOML rewriting is no longer the default update mechanism and is retained only for the graph-splitting exception Cargo's `--precise` semantics cannot express.

Fixes #6427

## Validation

- `bin/test cargo` (610 examples, 0 failures)
- `bin/test cargo spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb` (57 examples, 0 failures)
- `bin/test cargo rubocop` (46 files, no offenses)
- `git diff --check`

Sorbet was not available in the Cargo development image: the image does not contain the root bundle or an `srb` executable.
