### PR TITLE
hex: remove legacy helper test references

### DIFF
--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -367,8 +367,6 @@ RSpec.describe Dependabot::Hex::FileParser do
 
     context "when the parser helper writes a result alongside stdout output" do
       before do
-        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-          .and_raise("legacy helper protocol invoked")
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
           .and_call_original
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)

--- a/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker/version_resolver_spec.rb
@@ -126,8 +126,6 @@ RSpec.describe Dependabot::Hex::UpdateChecker::VersionResolver do
 
     context "when the update helper writes a result alongside stdout output" do
       before do
-        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-          .and_raise("legacy helper protocol invoked")
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
           .and_call_original
         allow(Dependabot::SharedHelpers).to receive(:run_shell_command)


### PR DESCRIPTION
### What are you trying to accomplish?

Remove the final Hex references to `run_helper_subprocess` after the stacked migration deletes `run.exs` and all production callers.

The filesystem-result tests remain intact. This only removes negative stubs that raise if the retired helper API is called.

### Anything you want to highlight for special attention from reviewers?

This is intentionally the final PR in the migration stack, based on #15817. Keeping these guards in the earlier PRs makes those layers safer to revise independently; once the complete stack is applied, they no longer protect a live code path or add meaningful coverage.

After this change, there are no `run_helper_subprocess` references anywhere under `hex/`.

### How will you know you've accomplished your goal?

- affected parser and resolver specs: 49 examples, 0 failures
- changed-file RuboCop: no offenses
- repository search confirms zero `run_helper_subprocess` references under `hex/`

### Checklist

- [x] I have run the relevant tests and linters.
- [x] I have limited the change to obsolete test setup.
- [x] I have preserved the filesystem-result behavior coverage.
