### PR TITLE
Resolve hash-pinned requirements with native pip

### DIFF
--- a/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_version_resolver.rb
@@ -31,6 +31,9 @@ module Dependabot
         PIP_REPORT_FILENAME = "dependabot-pip-report.json"
         RESOLUTION_ERROR_PATTERN = /ResolutionImpossible|No matching distribution found/
         LOWER_BOUND_OPERATORS = %w(> >= ~>).freeze
+        PIP_REQUIREMENT_FILE_EXTENSIONS = %w(.txt .in).freeze
+        HASH_OPTION_PATTERN = /(?:[ \t]*\\[ \t]*\r?\n[ \t]*|[ \t]+)--hash=[^\s\\]+/
+        REQUIRE_HASHES_PATTERN = /^\s*--require-hashes(?:\s+#.*)?\r?\n?/
         LowerBound = T.type_alias { [String, Gem::Version] }
 
         require_relative "pip_version_resolver/marker_evaluator"
@@ -295,7 +298,6 @@ module Dependabot
           return false unless file&.content
 
           content = T.must(file.content)
-          return false if content.include?("--hash=")
           return false if content.match?(/^\s*-(?:r|c|requirement|constraint)(?:\s+|=)["']/)
 
           requirement_declaration_present?(file, requirement)
@@ -312,26 +314,35 @@ module Dependabot
             next unless file.content
 
             FileUtils.mkdir_p(File.dirname(file.name))
+            resolver_content = resolver_file_content(file)
             content = if file.name == requirement.file
-                        updated_requirement_content(file, requirement, requirement_string)
+                        updated_requirement_content(resolver_content, requirement, requirement_string)
                       else
-                        file.content
+                        resolver_content
                       end
             File.write(file.name, content)
           end
           File.write(".python-version", language_version_manager.python_major_minor)
         end
 
+        sig { params(file: Dependabot::DependencyFile).returns(String) }
+        def resolver_file_content(file)
+          content = T.must(file.content)
+          return content unless file.name.end_with?(*PIP_REQUIREMENT_FILE_EXTENSIONS)
+
+          content.gsub(HASH_OPTION_PATTERN, "").gsub(REQUIRE_HASHES_PATTERN, "")
+        end
+
         sig do
           params(
-            file: Dependabot::DependencyFile,
+            content: String,
             requirement: Dependabot::DependencyRequirement,
             requirement_string: String
           ).returns(String)
         end
-        def updated_requirement_content(file, requirement, requirement_string)
+        def updated_requirement_content(content, requirement, requirement_string)
           FileUpdater::RequirementReplacer.new(
-            content: T.must(file.content),
+            content: content,
             dependency_name: dependency.name,
             old_requirement: requirement.requirement_string,
             new_requirement: requirement_string

--- a/python/spec/dependabot/python/update_checker/pip_version_resolver_spec.rb
+++ b/python/spec/dependabot/python/update_checker/pip_version_resolver_spec.rb
@@ -266,17 +266,51 @@ RSpec.describe Dependabot::Python::UpdateChecker::PipVersionResolver do
       let(:requirements_file) do
         Dependabot::DependencyFile.new(
           name: "requirements.txt",
-          content: "django==1.2.4 --hash=sha256:abc123\n"
+          content: <<~REQUIREMENTS
+            --require-hashes
+            -r requirements/base.txt
+            django==1.2.4 \\
+                --hash=sha256:django-wheel \\
+                --hash=sha256:django-sdist
+          REQUIREMENTS
         )
       end
+      let(:dependency_files) { [requirements_file, base_requirements_file, python_version_file] }
+      let(:base_requirements_file) do
+        Dependabot::DependencyFile.new(
+          name: "requirements/base.txt",
+          content: "urllib3==1.26.20 --hash=sha256:urllib3-wheel\n"
+        )
+      end
+      let(:resolver_files) { [] }
 
-      before { allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_call_original }
+      before do
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_shell_command) do |command, **_args|
+          next "" unless command.include?("pip install")
 
-      it "uses the policy candidate without invoking pip" do
-        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.4"))
-        expect(Dependabot::SharedHelpers)
-          .not_to have_received(:run_shell_command)
-          .with(a_string_matching(/pip install/), any_args)
+          resolver_files << {
+            requirements: File.read("requirements.txt"),
+            base: File.read("requirements/base.txt")
+          }
+          File.write(
+            "dependabot-pip-report.json",
+            JSON.dump(
+              "install" => [{ "metadata" => { "name" => "Django", "version" => "3.2.3" } }]
+            )
+          )
+          ""
+        end
+      end
+
+      it "resolves with hash-free temporary requirement files" do
+        expect(latest_resolvable_version).to eq(Gem::Version.new("3.2.3"))
+        expect(resolver_files).to contain_exactly(
+          {
+            requirements: "-r requirements/base.txt\ndjango>1.2.4,<=3.2.4\n",
+            base: "urllib3==1.26.20\n"
+          }
+        )
       end
     end
 


### PR DESCRIPTION
## Summary

Stacked on #15815.

Extend native pip candidate selection to hash-pinned requirements files by creating hash-free shadow copies solely for resolution:

- copy the fetched `.txt` and `.in` requirements graph into the temporary resolver directory
- remove `--hash` options and `--require-hashes` directives from those temporary copies
- apply #15815's bounded target requirement after sanitization
- let pip select the newest recursively compatible policy-eligible version
- leave the source files untouched so the existing final updater remains responsible for pinning and hash regeneration

The public resolver spec covers a multiline target with multiple hashes, graph-wide `--require-hashes`, and an included requirements file using inline hashes. It asserts the exact temporary graph passed to pip.

## Impact / Benefits

This expands the native-resolution guarantee from #15815 to hash-pinned requirements graphs. For these files, Dependabot no longer has to select a version without recursive compatibility information merely because pip hash-checking mode prevents a ranged solve. The hash-free shadow graph lets upstream pip reject incompatible candidates or backtrack to the newest compatible policy-eligible release before the real files are edited and their hashes regenerated.

The change also keeps hash handling separate from dependency solving: Dependabot prepares temporary resolver input and preserves or regenerates the final source representation, while pip remains responsible for resolution semantics. As supported pip versions evolve, resolver fixes and behavioral changes are inherited from upstream instead of being independently reimplemented in Ruby.


## Testing

- `bin/test python spec/dependabot/python/update_checker/pip_version_resolver_spec.rb`
- `bin/test python rubocop lib/dependabot/python/update_checker/pip_version_resolver.rb spec/dependabot/python/update_checker/pip_version_resolver_spec.rb`
- `docker run --rm --workdir /home/dependabot -v "$PWD:/home/dependabot" dependabot/dependabot-core-development-python bundle exec srb tc`

Resolver result: 17 examples, 0 failures.