### PR TITLE
hex: isolate lockfile parsing

### DIFF
--- a/hex/helpers/lib/check_update.exs
+++ b/hex/helpers/lib/check_update.exs
@@ -1,3 +1,5 @@
+Code.require_file("lockfile.exs", __DIR__)
+
 # Log to stderr instead of stdout
 :logger.remove_handler(:default)
 :logger.add_handler(:to_stderr, :logger_std_h, %{config: %{type: :standard_error}})
@@ -13,14 +15,10 @@ defmodule UpdateChecker do
     case Task.yield(task, 30000) || Task.shutdown(task) do
       {:ok, {:ok, :resolution_successful}} ->
         # Read the new lock
-        {updated_lock, _updated_rest_lock} =
-          Map.split(Mix.Dep.Lock.read(), [String.to_atom(dependency_name)])
-
-        # Get the new dependency version
         version =
-          updated_lock
-          |> Map.get(String.to_atom(dependency_name))
-          |> elem(2)
+          Dependabot.Hex.Lockfile.read!()
+          |> Map.fetch!(dependency_name)
+          |> Dependabot.Hex.Lockfile.resolved_version!()
 
         {:ok, version}
 

--- a/hex/helpers/lib/lockfile.exs
+++ b/hex/helpers/lib/lockfile.exs
@@ -1,0 +1,46 @@
+defmodule Dependabot.Hex.Lockfile do
+  def read! do
+    Mix.Project.config()
+    |> Keyword.get(:lockfile, "mix.lock")
+    |> read!()
+  end
+
+  def read!(path) do
+    quoted =
+      path
+      |> File.read!()
+      |> parse!(path)
+
+    unless Macro.quoted_literal?(quoted) do
+      raise ArgumentError, "#{path} must contain only literal data"
+    end
+
+    {lock, _binding} = Code.eval_quoted(quoted, [], file: path)
+
+    unless is_map(lock) do
+      raise ArgumentError, "#{path} must contain a map"
+    end
+
+    Map.new(lock, fn
+      {name, entry} when is_atom(name) -> {Atom.to_string(name), entry}
+      {name, entry} when is_binary(name) -> {name, entry}
+    end)
+  end
+
+  def resolved_version!(lock)
+      when is_tuple(lock) and tuple_size(lock) >= 3 and elem(lock, 0) in [:hex, :git] and
+             is_binary(elem(lock, 2)) do
+    elem(lock, 2)
+  end
+
+  def resolved_version!(lock) do
+    raise ArgumentError, "unsupported mix.lock entry: #{inspect(lock)}"
+  end
+
+  defp parse!(contents, path) do
+    case Code.string_to_quoted(contents, file: path, emit_warnings: false) do
+      {:ok, quoted} -> quoted
+      {:error, error} -> raise ArgumentError, "could not parse #{path}: #{inspect(error)}"
+    end
+  end
+end

--- a/hex/helpers/test/lockfile_test.exs
+++ b/hex/helpers/test/lockfile_test.exs
@@ -1,0 +1,84 @@
+Code.require_file("../lib/lockfile.exs", __DIR__)
+
+defmodule Dependabot.Hex.LockfileTest do
+  use ExUnit.Case, async: true
+
+  alias Dependabot.Hex.Lockfile
+
+  setup do
+    directory =
+      Path.join(System.tmp_dir!(), "dependabot-lockfile-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(directory)
+    on_exit(fn -> File.rm_rf!(directory) end)
+
+    %{directory: directory}
+  end
+
+  test "reads a literal lock map", %{directory: directory} do
+    path = Path.join(directory, "mix.lock")
+
+    File.write!(path, ~S(%{"plug": {:hex, :plug, "1.3.6", "checksum", [:mix], [], "hexpm"}}))
+
+    assert %{"plug" => {:hex, :plug, "1.3.6", "checksum", [:mix], [], "hexpm"}} =
+             Lockfile.read!(path)
+  end
+
+  test "reads the project's configured lockfile", %{directory: directory} do
+    File.write!(Path.join(directory, "mix.exs"), """
+    defmodule LockfileFixture.MixProject do
+      use Mix.Project
+
+      def project do
+        [app: :lockfile_fixture, version: "0.1.0", lockfile: "custom.lock"]
+      end
+    end
+    """)
+
+    File.write!(
+      Path.join(directory, "custom.lock"),
+      ~S(%{"plug": {:hex, :plug, "1.3.6", "checksum", [:mix], [], "hexpm"}})
+    )
+
+    lock =
+      Mix.Project.in_project(:lockfile_fixture, directory, fn _project ->
+        Lockfile.read!()
+      end)
+
+    assert Map.has_key?(lock, "plug")
+  end
+
+  test "extracts versions from current and legacy Hex locks" do
+    current = {:hex, :plug, "1.15.3", "old", [:mix], [], "hexpm", "outer"}
+    legacy = {:hex, :plug, "1.3.6", "checksum", [:mix], []}
+
+    assert Lockfile.resolved_version!(current) == "1.15.3"
+    assert Lockfile.resolved_version!(legacy) == "1.3.6"
+  end
+
+  test "extracts revisions from Git locks" do
+    lock =
+      {:git, "https://github.com/elixir-plug/plug.git", String.duplicate("a", 40), [tag: "v1.0"]}
+
+    assert Lockfile.resolved_version!(lock) == String.duplicate("a", 40)
+  end
+
+  test "rejects executable lockfile expressions without evaluating them", %{directory: directory} do
+    path = Path.join(directory, "mix.lock")
+    marker = Path.join(directory, "executed")
+
+    File.write!(path, """
+    %{"plug" => (File.write!(#{inspect(marker)}, "yes"); {:hex, :plug, "1.0.0"})}
+    """)
+
+    assert_raise ArgumentError, ~r/only literal data/, fn -> Lockfile.read!(path) end
+    refute File.exists?(marker)
+  end
+
+  test "rejects literal data that is not a map", %{directory: directory} do
+    path = Path.join(directory, "mix.lock")
+    File.write!(path, "[]")
+
+    assert_raise ArgumentError, ~r/must contain a map/, fn -> Lockfile.read!(path) end
+  end
+end

--- a/hex/helpers/test/test_helper.exs
+++ b/hex/helpers/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -179,6 +179,7 @@ module Dependabot
         def copy_elixir_helpers
           FileUtils.cp(CredentialHelpers.configure_credentials_path, "configure_credentials.exs")
           FileUtils.cp(elixir_helper_check_update_path, "check_update.exs")
+          FileUtils.cp(elixir_helper_lockfile_path, "lockfile.exs")
         end
 
         sig { params(script: String, args: String).returns(T::Array[String]) }
@@ -226,6 +227,11 @@ module Dependabot
         sig { returns(String) }
         def elixir_helper_check_update_path
           File.join(NativeHelpers.hex_helpers_dir, "lib/check_update.exs")
+        end
+
+        sig { returns(String) }
+        def elixir_helper_lockfile_path
+          File.join(NativeHelpers.hex_helpers_dir, "lib/lockfile.exs")
         end
       end
     end


### PR DESCRIPTION
## Summary

- replace the hidden `Mix.Dep.Lock.read/0` call with documented `Code` and `Mix.Project` APIs
- isolate the still-undocumented `mix.lock` tuple layout behind a focused adapter
- preserve configured lockfile paths and current/legacy Hex and Git lock entries
- reject executable lockfile expressions before evaluation

## Impact

This removes the update path's dependency on a private Mix function and concentrates lock-format compatibility in one small, tested module. Future lock layout changes can be handled at that boundary instead of leaking through update logic, while existing projects retain support for custom lockfile paths, legacy Hex entries, and Git revisions. Literal-only parsing also makes the lock reader's trust boundary explicit.

This does not claim that `mix.lock` tuple layouts are public API. It narrows that unavoidable compatibility dependency to one tested module.

## Validation

- `bin/test hex spec/dependabot/hex/update_checker/version_resolver_spec.rb`
- `bin/test --workdir hex/helpers hex mix test`
- `bin/test --workdir hex/helpers hex mix format --check-formatted lib/lockfile.exs lib/check_update.exs test/test_helper.exs test/lockfile_test.exs`
- `bin/test hex bundle exec rubocop lib/dependabot/hex/update_checker/version_resolver.rb spec/dependabot/hex/update_checker/version_resolver_spec.rb`
- `srb tc --ignore=dependabot-updater/spec/` in the Hex development container (the extra ignore accounts for updater being renamed inside the container)