### PR TITLE
hex: inspect project dependency declarations

### DIFF
--- a/hex/helpers/lib/parse_deps.exs
+++ b/hex/helpers/lib/parse_deps.exs
@@ -1,126 +1,129 @@
+Code.require_file("lockfile.exs", __DIR__)
+
 # Log to stderr instead of stdout
 :logger.remove_handler(:default)
 :logger.add_handler(:to_stderr, :logger_std_h, %{config: %{type: :standard_error}})
 
 defmodule Parser do
-  @allowed_scms [Hex.SCM, Mix.SCM.Git, Mix.SCM.Path]
-
   def run do
     # This is necessary because we can't specify :extra_applications to have :hex in other mixfiles.
     Mix.ensure_application!(:hex)
 
-    with {:ok, deps} <- converge_deps() do
-      result =
-        for %Mix.Dep{scm: scm} = dep <- deps,
-            scm in @allowed_scms,
-            expanded_dep <- expand_deps(dep) do
-          build_dependency(expanded_dep.opts[:lock], expanded_dep)
-        end
+    root = File.cwd!()
+    lock = read_lockfile()
 
-      {:ok, result}
+    dependencies =
+      project_dependencies(lock, root) ++ umbrella_dependencies(lock, root)
+
+    {:ok, dependencies}
+  rescue
+    error ->
+      {:error, Exception.format_banner(:error, error, __STACKTRACE__)}
+  end
+
+  defp read_lockfile do
+    path = Keyword.get(Mix.Project.config(), :lockfile, "mix.lock")
+
+    if File.exists?(path), do: Dependabot.Hex.Lockfile.read!(path), else: %{}
+  end
+
+  defp umbrella_dependencies(lock, root) do
+    Mix.Project.apps_paths()
+    |> Kernel.||(%{})
+    |> Enum.flat_map(fn {app, path} ->
+      Mix.Project.in_project(app, path, fn _project ->
+        project_dependencies(lock, root)
+      end)
+    end)
+  end
+
+  defp project_dependencies(lock, root) do
+    from =
+      Mix.Project.project_file()
+      |> Path.expand()
+      |> Path.relative_to(root)
+
+    Mix.Project.config()
+    |> Keyword.get(:deps, [])
+    |> Enum.flat_map(&build_dependency(&1, lock, from))
+  end
+
+  defp build_dependency(declaration, lock, from) do
+    {name, requirement, opts} = parse_declaration(declaration)
+
+    if local_dependency?(opts) do
+      []
+    else
+      source = git_source(opts)
+      locked_version = locked_version(lock, name)
+
+      [
+        %{
+          name: name,
+          package_name: opts[:hex] || name,
+          from: from,
+          version: if(source, do: nil, else: locked_version),
+          groups: parse_groups(opts[:only]),
+          checksum: if(source, do: locked_version),
+          requirement: normalise_requirement(requirement),
+          source: source,
+          top_level: true
+        }
+      ]
     end
   end
 
-  defp converge_deps do
-    {:ok, Mix.Dep.Converger.converge()}
-  rescue
-    e ->
-      {:error, Exception.format_banner(:error, e, __STACKTRACE__)}
-  end
+  defp parse_declaration({name, opts}) when is_atom(name) and is_list(opts),
+    do: {name, nil, opts}
 
-  defp build_dependency(nil, dep) do
-    %{
-      name: dep.app,
-      package_name: dep.opts[:hex] || dep.app,
-      from: Path.relative_to_cwd(dep.from),
-      groups: [],
-      requirement: normalise_requirement(dep.requirement),
-      top_level: dep.top_level || umbrella_top_level_dep?(dep)
-    }
-  end
+  defp parse_declaration({name, requirement}) when is_atom(name),
+    do: {name, requirement, []}
 
-  defp build_dependency(lock, dep) do
-    {version, checksum, source} = parse_lock(lock)
-    groups = parse_groups(dep.opts[:only])
+  defp parse_declaration({name, requirement, opts}) when is_atom(name) and is_list(opts),
+    do: {name, requirement, opts}
 
-    %{
-      name: dep.app,
-      package_name: dep.opts[:hex] || dep.app,
-      from: Path.relative_to_cwd(dep.from),
-      version: version,
-      groups: groups,
-      checksum: checksum,
-      requirement: normalise_requirement(dep.requirement),
-      source: source,
-      top_level: dep.top_level || umbrella_top_level_dep?(dep)
-    }
+  defp local_dependency?(opts), do: opts[:path] || opts[:in_umbrella]
+
+  defp locked_version(lock, name) do
+    case Map.fetch(lock, Atom.to_string(name)) do
+      {:ok, entry} -> Dependabot.Hex.Lockfile.resolved_version!(entry)
+      :error -> nil
+    end
   end
 
   defp parse_groups(nil), do: []
   defp parse_groups(only) when is_list(only), do: only
   defp parse_groups(only), do: [only]
 
-  # path dependency
-  defp expand_deps(%{scm: Mix.SCM.Path, opts: opts} = dep) do
-    cond do
-      # umbrella dependency - ignore
-      opts[:in_umbrella] ->
-        []
-
-      # umbrella application
-      opts[:from_umbrella] ->
-        Enum.reject(dep.deps, fn dep -> dep.opts[:in_umbrella] end)
-
-      true ->
-        []
-    end
-  end
-
-  # hex, git dependency
-  defp expand_deps(%{scm: scm} = dep) when scm in [Hex.SCM, Mix.SCM.Git], do: [dep]
-
-  defp umbrella_top_level_dep?(dep) do
-    if Mix.Project.umbrella?() do
-      apps_paths = Path.expand(Mix.Project.config()[:apps_path], File.cwd!())
-      String.contains?(Path.dirname(Path.dirname(dep.from)), apps_paths)
-    else
-      false
-    end
-  end
-
-  defp parse_lock({:git, repo_url, checksum, opts}),
-    do: {nil, checksum, git_source(repo_url, opts)}
-
-  defp parse_lock(tuple) when elem(tuple, 0) == :hex do
-    destructure [:hex, _app, version, _old_checksum, _managers, _deps, _repo, checksum],
-                Tuple.to_list(tuple)
-
-    {version, checksum, nil}
-  end
-
-  defp normalise_requirement(req) do
-    req
+  defp normalise_requirement(requirement) do
+    requirement
     |> maybe_regex_to_str()
     |> empty_str_to_nil()
   end
 
-  defp maybe_regex_to_str(%Regex{} = s), do: Regex.source(s)
-  defp maybe_regex_to_str(s), do: s
+  defp maybe_regex_to_str(%Regex{} = requirement), do: Regex.source(requirement)
+  defp maybe_regex_to_str(requirement), do: requirement
 
   defp empty_str_to_nil(""), do: nil
-  defp empty_str_to_nil(s), do: s
+  defp empty_str_to_nil(requirement), do: requirement
 
-  def git_source(repo_url, opts) do
-    ref = opts[:ref] || opts[:tag]
-    ref = if is_list(ref), do: to_string(ref), else: ref
+  defp git_source(opts) do
+    url = opts[:git] || github_url(opts[:github])
 
-    %{
-      type: "git",
-      url: repo_url,
-      branch: opts[:branch],
-      ref: ref
-    }
+    if url do
+      ref = opts[:ref] || opts[:tag]
+
+      %{
+        type: "git",
+        url: url,
+        branch: opts[:branch],
+        ref: if(is_list(ref), do: to_string(ref), else: ref)
+      }
+    end
   end
+
+  defp github_url(nil), do: nil
+  defp github_url(repository), do: "https://github.com/#{repository}.git"
 end
 
 case Parser.run() do

--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -76,6 +76,7 @@ module Dependabot
           write_sanitized_supporting_files
           File.write("mix.lock", lockfile&.content) if lockfile
           FileUtils.cp(elixir_helper_parse_deps_path, "parse_deps.exs")
+          FileUtils.cp(elixir_helper_lockfile_path, "lockfile.exs")
 
           SharedHelpers.run_shell_command(
             mix_run_command("parse_deps.exs"),
@@ -132,6 +133,11 @@ module Dependabot
       sig { returns(String) }
       def elixir_helper_parse_deps_path
         File.join(NativeHelpers.hex_helpers_dir, "lib/parse_deps.exs")
+      end
+
+      sig { returns(String) }
+      def elixir_helper_lockfile_path
+        File.join(NativeHelpers.hex_helpers_dir, "lib/lockfile.exs")
       end
 
       sig { override.void }


### PR DESCRIPTION
## Summary

- replace hidden `Mix.Dep` and `Mix.Dep.Converger` graph inspection with documented `Mix.Project` configuration APIs
- derive dependency requirements, groups, package aliases, Git sources, and umbrella ownership from documented declaration forms
- preserve lock resolution through the isolated lock-format adapter introduced by the parent PR
- remove dependencies on hidden SCM module identities and `Mix.Dep` struct fields

## Impact

Dependency discovery now follows the project declarations users author rather than Mix's internal converged graph representation. This substantially reduces the number of private structs, fields, algorithms, and SCM implementation identities that can break when Mix or Hex changes internally. The parser keeps its established output for version requirements, environment groups, Hex aliases, Git dependencies, and umbrella projects while becoming easier to reason about and maintain.

This uses documented project APIs plus the isolated lock-format adapter. It does not claim that `mix.lock` tuple layouts are public API.

## Validation

- `bin/test hex spec/dependabot/hex/file_parser_spec.rb` (38 examples)
- `bin/test --workdir hex/helpers hex mix test`
- `bin/test --workdir hex/helpers hex mix format --check-formatted lib/parse_deps.exs lib/lockfile.exs lib/check_update.exs test/test_helper.exs test/lockfile_test.exs`
- `bin/test hex bundle exec rubocop lib/dependabot/hex/file_parser.rb spec/dependabot/hex/file_parser_spec.rb`
- `bundle exec srb tc --ignore=dependabot-updater/spec/` in the Hex development container
- hidden-module source audit for `Mix.Dep`, `Mix.Dep.Converger`, `Mix.Dep.Lock`, hidden SCM identities, and Hex internals