### PR TITLE
hex: use supported runtime metadata APIs

### DIFF
--- a/hex/helpers/lib/package_manager_versions.exs
+++ b/hex/helpers/lib/package_manager_versions.exs
@@ -1,0 +1,12 @@
+case Application.load(:hex) do
+  :ok -> :ok
+  {:error, {:already_loaded, :hex}} -> :ok
+  {:error, reason} -> raise "could not load Hex: #{inspect(reason)}"
+end
+
+%{
+  hex: Application.spec(:hex, :vsn) |> to_string(),
+  elixir: System.version()
+}
+|> JSON.encode!()
+|> IO.write()

--- a/hex/helpers/lib/parse_deps.exs
+++ b/hex/helpers/lib/parse_deps.exs
@@ -62,12 +62,10 @@ defmodule Parser do
           name: name,
           package_name: opts[:hex] || name,
           from: from,
-          version: if(source, do: nil, else: locked_version),
+          version: locked_version,
           groups: parse_groups(opts[:only]),
-          checksum: if(source, do: locked_version),
           requirement: normalise_requirement(requirement),
-          source: source,
-          top_level: true
+          source: source
         }
       ]
     end

--- a/hex/lib/dependabot/hex/file_parser.rb
+++ b/hex/lib/dependabot/hex/file_parser.rb
@@ -33,12 +33,10 @@ module Dependabot
         dependency_set = DependencySet.new
 
         dependency_details.each do |dep|
-          git_dependency = dep["source"]&.fetch("type") == "git"
-
           dependency_set <<
             Dependency.new(
               name: dep["name"],
-              version: git_dependency ? dep["checksum"] : dep["version"],
+              version: dep["version"],
               requirements: [{
                 requirement: dep["requirement"],
                 groups: dep["groups"],
@@ -178,26 +176,32 @@ module Dependabot
 
       sig { returns(String) }
       def hex_version
-        T.must(T.must(hex_info).fetch(:hex_version))
+        version_info.fetch("hex")
       end
 
       sig { returns(String) }
       def elixir_version
-        T.must(T.must(hex_info).fetch(:elixir_version))
+        version_info.fetch("elixir")
       end
 
-      sig { returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
-      def hex_info
-        @hex_info ||= T.let(
-          begin
-            version = SharedHelpers.run_shell_command("mix hex.info")
-            {
-              hex_version: version.match(/Hex: \s*(\d+\.\d+(.\d+)*)/)&.captures&.first,
-              elixir_version: version.match(/Elixir: \s*(\d+\.\d+(.\d+)*)/)&.captures&.first
-            }
-          end,
-          T.nilable(T::Hash[Symbol, T.nilable(String)])
+      sig { returns(T::Hash[String, String]) }
+      def version_info
+        @version_info ||= T.let(
+          JSON.parse(
+            SharedHelpers.run_shell_command(
+              [
+                "mix", "run", "--no-mix-exs", "--no-start", "--no-compile",
+                elixir_helper_package_manager_versions_path
+              ]
+            )
+          ),
+          T.nilable(T::Hash[String, String])
         )
+      end
+
+      sig { returns(String) }
+      def elixir_helper_package_manager_versions_path
+        File.join(NativeHelpers.hex_helpers_dir, "lib/package_manager_versions.exs")
       end
     end
   end

--- a/hex/spec/dependabot/hex/file_parser_spec.rb
+++ b/hex/spec/dependabot/hex/file_parser_spec.rb
@@ -380,10 +380,8 @@ RSpec.describe Dependabot::Hex::FileParser do
                   from: "mix.exs",
                   version: "1.3.5",
                   groups: [],
-                  checksum: "checksum",
                   requirement: "~> 1.3.0",
-                  source: nil,
-                  top_level: true
+                  source: nil
                 }]
               )
             )

--- a/hex/spec/dependabot/hex/native_helpers_spec.rb
+++ b/hex/spec/dependabot/hex/native_helpers_spec.rb
@@ -1,0 +1,25 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/hex/native_helpers"
+
+RSpec.describe Dependabot::Hex::NativeHelpers do
+  let(:helper_paths) do
+    Dir.glob(File.join(described_class.hex_helpers_dir, "lib/*.exs"))
+  end
+
+  it "does not depend on removed hidden APIs" do
+    forbidden_apis = [
+      /\bMix\.Dep(?:\.|\b)/,
+      /\bMix\.SCM\.(?:Git|Path)\b/,
+      /\bHex\.(?:SCM|Mix|Utils)\b/
+    ]
+
+    aggregate_failures do
+      helper_paths.product(forbidden_apis).each do |path, forbidden_api|
+        expect(File.read(path)).not_to match(forbidden_api), "#{path} references #{forbidden_api.inspect}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- replace regex parsing of human-readable `mix hex.info` output with structured JSON from documented `System.version/0` and `Application.spec/2` APIs
- use one resolved `version` field for both Hex versions and Git revisions, removing redundant `checksum` and unused `top_level` helper fields
- add a regression audit that prevents shipped helpers from returning to the removed hidden Mix dependency, SCM implementation, and Hex internal namespaces

## Impact

Runtime metadata discovery no longer depends on the wording or formatting of command-line output, making it resilient to presentation changes in Hex. The smaller helper schema removes duplicate concepts at the Elixir/Ruby boundary, and the regression audit turns the intended supported-API boundary into an executable constraint so future helper changes cannot silently reintroduce the removed internals.

Together with the parent PRs, this leaves dependency inspection on documented project APIs plus the isolated lock-format adapter. It does not claim that `mix.lock` tuple layouts are public API.

## Validation

- `bin/test hex spec/dependabot/hex/file_parser_spec.rb spec/dependabot/hex/native_helpers_spec.rb` (39 examples)
- `bin/test --workdir hex/helpers hex mix test` (6 tests)
- `bin/test --workdir hex/helpers hex mix format --check-formatted lib/package_manager_versions.exs lib/parse_deps.exs lib/lockfile.exs lib/check_update.exs test/test_helper.exs test/lockfile_test.exs`
- `bin/test hex bundle exec rubocop lib/dependabot/hex/file_parser.rb spec/dependabot/hex/file_parser_spec.rb spec/dependabot/hex/native_helpers_spec.rb`
- `bundle exec srb tc --ignore=dependabot-updater/spec/` in the rebuilt Hex development container