### PR TITLE
Add dependency group subgroup naming helpers

### DIFF
--- a/common/lib/dependabot/dependency_group.rb
+++ b/common/lib/dependabot/dependency_group.rb
@@ -87,6 +87,22 @@ module Dependabot
       }.to_yaml.delete_prefix("---\n")
     end
 
+    sig { params(parent_name: String, dependency_name: String).returns(String) }
+    def self.subgroup_name(parent_name:, dependency_name:)
+      "#{parent_name}/#{dependency_name}"
+    end
+
+    sig do
+      params(subgroup_name: String, dependency_name: String)
+        .returns(T.nilable(String))
+    end
+    def self.parent_name_from_subgroup(subgroup_name:, dependency_name:)
+      suffix = "/#{dependency_name}"
+      return unless subgroup_name.end_with?(suffix)
+
+      subgroup_name.delete_suffix(suffix)
+    end
+
     private
 
     sig { params(dependency_name: String).returns(T::Boolean) }

--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -111,6 +111,11 @@ RSpec.describe Dependabot::DependencyGroup do
         )
       ).to eq("frontend")
     end
+
+    it "returns nil when the dependency suffix does not match" do
+      expect(described_class.parent_name_from_subgroup(subgroup_name: "frontend/react", dependency_name: "rails"))
+        .to be_nil
+    end
   end
 
   describe "#dependencies" do

--- a/common/spec/dependabot/dependency_group_spec.rb
+++ b/common/spec/dependabot/dependency_group_spec.rb
@@ -86,6 +86,33 @@ RSpec.describe Dependabot::DependencyGroup do
     end
   end
 
+  describe ".subgroup_name" do
+    it "builds a subgroup name for a normal dependency" do
+      expect(described_class.subgroup_name(parent_name: "frontend", dependency_name: "react")).to eq("frontend/react")
+    end
+
+    it "builds a subgroup name for a scoped dependency" do
+      expect(described_class.subgroup_name(parent_name: "frontend", dependency_name: "@scope/business"))
+        .to eq("frontend/@scope/business")
+    end
+  end
+
+  describe ".parent_name_from_subgroup" do
+    it "extracts the parent name for a normal dependency" do
+      expect(described_class.parent_name_from_subgroup(subgroup_name: "frontend/react", dependency_name: "react"))
+        .to eq("frontend")
+    end
+
+    it "extracts the parent name for a scoped dependency" do
+      expect(
+        described_class.parent_name_from_subgroup(
+          subgroup_name: "frontend/@scope/business",
+          dependency_name: "@scope/business"
+        )
+      ).to eq("frontend")
+    end
+  end
+
   describe "#dependencies" do
     context "when no dependencies are assigned to the group" do
       it "returns an empty list" do

--- a/updater/lib/dependabot/dependency_group_engine.rb
+++ b/updater/lib/dependabot/dependency_group_engine.rb
@@ -232,7 +232,10 @@ module Dependabot
         matching_deps = dependencies.select { |dep| parent_group.contains?(dep) }
 
         matching_deps.group_by(&:name).each do |dep_name, deps|
-          subgroup_name = "#{parent_group.name}/#{dep_name}"
+          subgroup_name = Dependabot::DependencyGroup.subgroup_name(
+            parent_name: parent_group.name,
+            dependency_name: dep_name
+          )
           existing_subgroup = @dependency_groups.find { |g| g.name == subgroup_name }
 
           if existing_subgroup


### PR DESCRIPTION
### What are you trying to accomplish?

Centralize dependency subgroup naming and parsing in a shared abstraction. This gives subgroup producers and consumers a consistent naming contract and correctly handles dependency names that contain `/`, including scoped packages such as `@scope/business`.

### Anything you want to highlight for special attention from reviewers?

The parent name is recovered by removing the complete dependency-name suffix rather than splitting on `/`. This preserves scoped dependency names and avoids coupling callers to the subgroup name’s internal string format.

### How will you know you've accomplished your goal?

Unit tests verify that subgroup names can be constructed and their parent names recovered for both ordinary and scoped dependency names. Dynamic subgroup creation also uses the shared naming contract while retaining its existing output format and behavior.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
