### PR TITLE
Add branch name formatting error type to updater_error_details

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -246,6 +246,11 @@ module Dependabot
         "error-type": "dependency_file_not_resolvable",
         "error-detail": { message: error.message }
       }
+    when Dependabot::BranchNameFormattingError
+      {
+        "error-type": "branch_name_formatting_error",
+        "error-detail": { message: error.message }
+      }
     when Dependabot::BlockedDependencyVersion
       {
         "error-type": "blocked_dependency_version",
@@ -508,6 +513,8 @@ module Dependabot
   class InvalidGitAuthToken < DependabotError; end
 
   class RefNamespaceConflictError < DependabotError; end
+
+  class BranchNameFormattingError < DependabotError; end
 
   #####################
   # Repo level errors #

--- a/common/lib/dependabot/pull_request_creator/branch_name_template.rb
+++ b/common/lib/dependabot/pull_request_creator/branch_name_template.rb
@@ -11,7 +11,7 @@ module Dependabot
     class BranchNameTemplate
       extend T::Sig
 
-      class Error < Dependabot::DependabotError; end
+      class Error < Dependabot::BranchNameFormattingError; end
 
       SOLO_PLACEHOLDERS = %w(prefix package_manager directory target_branch dependency version name).freeze
       GROUP_PLACEHOLDERS = %w(prefix package_manager directory target_branch group_name name).freeze

--- a/common/spec/dependabot/pull_request_creator/branch_name_template_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/branch_name_template_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "dependabot/errors"
 require "dependabot/pull_request_creator/branch_name_template"
 
 RSpec.describe Dependabot::PullRequestCreator::BranchNameTemplate do
@@ -273,6 +274,21 @@ RSpec.describe Dependabot::PullRequestCreator::BranchNameTemplate do
 
         expect(result).to eq("dependabot/develop/lodash")
       end
+    end
+  end
+
+  describe "Error" do
+    it "is a Dependabot::BranchNameFormattingError" do
+      expect(described_class::Error.new).to be_a(Dependabot::BranchNameFormattingError)
+    end
+
+    it "is surfaced as a branch_name_formatting_error via updater_error_details" do
+      error = described_class::Error.new("Malformed or unclosed braces detected.")
+
+      details = Dependabot.updater_error_details(error)
+
+      expect(details.error_type).to eq("branch_name_formatting_error")
+      expect(details.error_detail).to eq({ message: "Malformed or unclosed braces detected." })
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
When a customer configures an invalid branch name template (e.g. malformed/unclosed braces or unknown placeholders), `Dependabot::PullRequestCreator::BranchNameTemplate` raises during branch name rendering. Previously this error subclassed the generic `Dependabot::DependabotError`, so it surfaced as an unhandled/unknown crash (visible in Sentry) rather than as an actionable user configuration error.

This PR introduces a dedicated error type so the failure can be recognized and surfaced back to the user as a configuration problem:

- Adds `Dependabot::BranchNameFormattingError < DependabotError`.
- Reparents `BranchNameTemplate::Error` to inherit from `BranchNameFormattingError`, so all existing template validation failures (malformed braces, unknown placeholders, invalid Git refs, etc.) automatically become the new type.
- Maps the new error in `Dependabot.updater_error_details` to a stable `error-type` of `branch_name_formatting_error` with a `message` detail.

The corresponding UI/display changes will be made separately in `dependabot-api`, which can now rescue `Dependabot::BranchNameFormattingError` (or match the `branch_name_formatting_error` error-type).
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
**Backward compatibility:** `BranchNameTemplate::Error` remains a valid constant and is now a subclass of `BranchNameFormattingError`, so any existing references and raises continue to work unchanged.
- The error mapping was added to `updater_error_details` for the updater PR-creation path; the reported Sentry trace originates in `dependabot-api`, which will consume the new error class directly.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- New specs in `common/spec/dependabot/pull_request_creator/branch_name_template_spec.rb` verify:
  - `BranchNameTemplate::Error` is a `Dependabot::BranchNameFormattingError`.
  - `Dependabot.updater_error_details` maps it to `error_type: "branch_name_formatting_error"` with the expected message detail.
- Existing template validation specs continue to pass unchanged, confirming behavior is preserved.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
