### PR TITLE
Type Python requirement consumers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 970
+# Offense count: 951
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -372,7 +372,6 @@ Sorbet/ForbidTUntyped:
     - "python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb"
     - "python/lib/dependabot/python/file_updater/pipfile_file_updater.rb"
     - "python/lib/dependabot/python/file_updater/poetry_file_updater.rb"
-    - "python/lib/dependabot/python/file_updater/poetry_file_updater/pep621_updater.rb"
     - "python/lib/dependabot/python/file_updater/pyproject_preparer.rb"
     - "python/lib/dependabot/python/language_version_manager.rb"
     - "python/lib/dependabot/python/metadata_finder.rb"

--- a/python/lib/dependabot/python/file_updater.rb
+++ b/python/lib/dependabot/python/file_updater.rb
@@ -46,7 +46,7 @@ module Dependabot
         changed_reqs = reqs.zip(dependencies.flat_map(&:previous_requirements))
                            .reject { |(new_req, old_req)| new_req == old_req }
                            .map(&:first)
-        changed_req_files = changed_reqs.map { |r| r.fetch(:file) }
+        changed_req_files = changed_reqs.filter_map(&:file)
 
         # If there are no requirements then this is a sub-dependency. It
         # must come from one of Pipenv, Poetry or pip-tools, and can't come

--- a/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pip_compile_file_updater.rb
@@ -194,9 +194,9 @@ module Dependabot
         def update_uncompiled_files(updated_files)
           updated_filenames = updated_files.map(&:name)
           old_reqs = T.must(T.must(dependency).previous_requirements)
-                      .reject { |r| updated_filenames.include?(r[:file]) }
+                      .reject { |r| updated_filenames.include?(r.file) }
           new_reqs = T.must(dependency).requirements
-                      .reject { |r| updated_filenames.include?(r[:file]) }
+                      .reject { |r| updated_filenames.include?(r.file) }
 
           return [] if new_reqs.none?
 
@@ -324,15 +324,15 @@ module Dependabot
           return file.content unless file.name.end_with?(".in")
 
           old_req = T.must(T.must(dependency).previous_requirements)
-                     .find { |r| r[:file] == file.name }
+                     .find { |r| r.file == file.name }
 
           return file.content unless old_req
-          return file.content if old_req == "==#{T.must(dependency).version}"
+          return file.content if old_req.requirement_string == "==#{T.must(dependency).version}"
 
           RequirementReplacer.new(
             content: T.must(file.content),
             dependency_name: T.must(dependency).name,
-            old_requirement: old_req[:requirement],
+            old_requirement: old_req.requirement_string,
             new_requirement: "==#{T.must(dependency).version}",
             index_urls: @index_urls
           ).updated_content
@@ -343,17 +343,17 @@ module Dependabot
           return file.content unless file.name.end_with?(".in")
 
           old_req = T.must(T.must(dependency).previous_requirements)
-                     .find { |r| r[:file] == file.name }
+                     .find { |r| r.file == file.name }
           new_req = T.must(dependency).requirements
-                     .find { |r| r[:file] == file.name }
-          return file.content unless old_req&.fetch(:requirement)
+                     .find { |r| r.file == file.name }
+          return file.content unless old_req&.requirement_string
           return file.content if old_req == new_req
 
           RequirementReplacer.new(
             content: T.must(file.content),
             dependency_name: T.must(dependency).name,
-            old_requirement: old_req[:requirement],
-            new_requirement: T.must(new_req)[:requirement],
+            old_requirement: old_req.requirement_string,
+            new_requirement: T.must(T.must(new_req).requirement_string),
             index_urls: @index_urls
           ).updated_content
         end
@@ -674,7 +674,7 @@ module Dependabot
         def filenames_to_compile
           files_from_reqs =
             T.must(dependency).requirements
-             .map { |r| r[:file] }
+             .filter_map(&:file)
              .select { |fn| fn.end_with?(".in") }
 
           files_from_compiled_files =

--- a/python/lib/dependabot/python/file_updater/pipfile_manifest_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_manifest_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/python/file_updater"
@@ -53,15 +53,15 @@ module Dependabot
 
           # Loop through each changed requirement
           reqs.each do |new_req, old_req|
-            raise "Bad req match" unless new_req[:file] == T.must(old_req)[:file]
-            next if new_req[:requirement] == T.must(old_req)[:requirement]
-            next unless new_req[:file] == manifest.name
+            raise "Bad req match" unless new_req.file == T.must(old_req).file
+            next if new_req.requirement == T.must(old_req).requirement
+            next unless new_req.file == manifest.name
 
             updated_content = update_manifest_req(
               content: updated_content,
               dep: dependency,
-              old_req: T.must(old_req).fetch(:requirement),
-              new_req: new_req.fetch(:requirement)
+              old_req: T.must(T.must(old_req).requirement_string),
+              new_req: T.must(new_req.requirement_string)
             )
           end
 
@@ -118,7 +118,7 @@ module Dependabot
           changed_requirements =
             dependency.requirements - T.must(dependency.previous_requirements)
 
-          changed_requirements.any? { |f| f[:file] == manifest.name }
+          changed_requirements.any? { |f| f.file == manifest.name }
         end
       end
     end

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -99,7 +99,7 @@ module Dependabot
           updated_content = content.dup
 
           dependency.requirements.zip(T.must(dependency.previous_requirements)).each do |new_r, old_r|
-            next unless new_r[:file] == pyproject&.name && T.must(old_r)[:file] == pyproject&.name
+            next unless new_r.file == pyproject&.name && T.must(old_r).file == pyproject&.name
 
             updated_content = replace_dep(dependency, T.must(updated_content), new_r, T.must(old_r))
           end
@@ -109,7 +109,7 @@ module Dependabot
           updated_content
         end
 
-        sig { params(dep: Dependabot::Dependency, content: String, new_r: T::Hash[Symbol, T.untyped], old_r: T::Hash[Symbol, T.untyped]).returns(String) }
+        sig { params(dep: Dependabot::Dependency, content: String, new_r: Dependabot::DependencyRequirement, old_r: Dependabot::DependencyRequirement).returns(String) }
         def replace_dep(dep, content, new_r, old_r)
           return update_git_tag(dep, content, new_r, old_r) if git_dependency?(new_r) && git_dependency?(old_r)
 
@@ -119,10 +119,10 @@ module Dependabot
             content
         end
 
-        sig { params(dep: Dependabot::Dependency, content: String, new_r: T::Hash[Symbol, T.untyped], old_r: T::Hash[Symbol, T.untyped]).returns(T.nilable(String)) }
+        sig { params(dep: Dependabot::Dependency, content: String, new_r: Dependabot::DependencyRequirement, old_r: Dependabot::DependencyRequirement).returns(T.nilable(String)) }
         def replace_poetry_dep(dep, content, new_r, old_r)
-          new_req = new_r[:requirement]
-          old_req = old_r[:requirement]
+          new_req = T.must(new_r.requirement_string)
+          old_req = T.must(old_r.requirement_string)
 
           declaration_regex = declaration_regex(dep, old_r)
           declaration_match = content.match(declaration_regex)
@@ -135,10 +135,10 @@ module Dependabot
           content.sub(T.must(declaration), new_declaration)
         end
 
-        sig { params(dep: Dependabot::Dependency, content: String, new_r: T::Hash[Symbol, T.untyped], old_r: T::Hash[Symbol, T.untyped]).returns(T.nilable(String)) }
+        sig { params(dep: Dependabot::Dependency, content: String, new_r: Dependabot::DependencyRequirement, old_r: Dependabot::DependencyRequirement).returns(T.nilable(String)) }
         def replace_poetry_table_dep(dep, content, new_r, old_r)
-          old_req = old_r[:requirement]
-          new_req = new_r[:requirement]
+          old_req = T.must(old_r.requirement_string)
+          new_req = T.must(new_r.requirement_string)
           regex = table_declaration_regex(dep, new_r)
 
           return unless content.match(regex)
@@ -151,20 +151,20 @@ module Dependabot
           end
         end
 
-        sig { params(dep: Dependabot::Dependency, content: String, new_r: T::Hash[Symbol, T.untyped], old_r: T::Hash[Symbol, T.untyped]).returns(T.nilable(String)) }
+        sig { params(dep: Dependabot::Dependency, content: String, new_r: Dependabot::DependencyRequirement, old_r: Dependabot::DependencyRequirement).returns(T.nilable(String)) }
         def replace_pep621_dep(dep, content, new_r, old_r)
           Pep621Updater.new(dep: dep).replace(content, new_r, old_r)
         end
 
-        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+        sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
         def git_dependency?(req)
-          req.dig(:source, :type) == "git"
+          req.source_string("type") == "git"
         end
 
-        sig { params(dep: Dependabot::Dependency, content: String, new_r: T::Hash[Symbol, T.untyped], old_r: T::Hash[Symbol, T.untyped]).returns(String) }
+        sig { params(dep: Dependabot::Dependency, content: String, new_r: Dependabot::DependencyRequirement, old_r: Dependabot::DependencyRequirement).returns(String) }
         def update_git_tag(dep, content, new_r, old_r)
-          old_tag = old_r.dig(:source, :ref)
-          new_tag = new_r.dig(:source, :ref)
+          old_tag = old_r.source_string("ref")
+          new_tag = new_r.source_string("ref")
 
           return content if old_tag == new_tag
 
@@ -172,7 +172,7 @@ module Dependabot
           # Example: fastapi = { git = "...", extras = ["all"], tag = "0.110.0" }
           git_dep_regex = /
             ^(\s*)#{Regexp.escape(dep.name)}(\s*=\s*\{[^}]*tag\s*=\s*)
-            ["']#{Regexp.escape(old_tag)}["']([^}]*\})
+            ["']#{Regexp.escape(T.must(old_tag))}["']([^}]*\})
           /mx
 
           content.gsub(git_dep_regex) do
@@ -233,7 +233,7 @@ module Dependabot
               # Skip Git dependencies - they use tags/refs, not versions
               next if git_dependency_being_updated?(dep)
 
-              if dep.requirements.find { |r| r[:file] == pyproject&.name }
+              if dep.requirements.find { |r| r.file == pyproject&.name }
                 lock_declaration_to_new_version!(poetry_object, dep)
               else
                 create_declaration_at_new_version!(poetry_object, dep)
@@ -302,7 +302,7 @@ module Dependabot
 
         sig { params(dep: Dependabot::Dependency).returns(T::Boolean) }
         def git_dependency_being_updated?(dep)
-          dep.requirements.any? { |r| r.dig(:source, :type) == "git" }
+          dep.requirements.any? { |r| r.source_string("type") == "git" }
         end
 
         sig { params(pyproject_content: String).returns(String) }
@@ -382,17 +382,17 @@ module Dependabot
           end
         end
 
-        sig { params(dep: Dependabot::Dependency, old_req: T::Hash[Symbol, T.untyped]).returns(Regexp) }
+        sig { params(dep: Dependabot::Dependency, old_req: Dependabot::DependencyRequirement).returns(Regexp) }
         def declaration_regex(dep, old_req)
-          group = old_req[:groups].first
+          group = T.must(old_req.groups).first
 
           header_regex = "#{group}(?:\\.dependencies)?\\]\s*(?:\s*#.*?)*?"
           /#{header_regex}(?:\r?\n).*?(?<declaration>(?:^\s*|["'])#{escape(dep)}["']?\s*=[^\r\n]*)(?=\r?\n|$)/mi
         end
 
-        sig { params(dep: Dependabot::Dependency, old_req: T::Hash[Symbol, T.untyped]).returns(Regexp) }
+        sig { params(dep: Dependabot::Dependency, old_req: Dependabot::DependencyRequirement).returns(Regexp) }
         def table_declaration_regex(dep, old_req)
-          /tool\.poetry\.#{old_req[:groups].first}\.#{escape(dep)}\](?:\r?\n).*?\s*version\s* =.*?(?:\r?\n)/m
+          /tool\.poetry\.#{T.must(old_req.groups).first}\.#{escape(dep)}\](?:\r?\n).*?\s*version\s* =.*?(?:\r?\n)/m
         end
 
         sig { params(dep: Dependency).returns(String) }
@@ -410,7 +410,7 @@ module Dependabot
           changed_requirements =
             dependency.requirements - T.must(dependency.previous_requirements)
 
-          changed_requirements.any? { |f| f[:file] == file.name }
+          changed_requirements.any? { |f| f.file == file.name }
         end
 
         sig { params(file: Dependabot::DependencyFile, content: String).returns(Dependabot::DependencyFile) }

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater/pep621_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater/pep621_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -19,8 +19,8 @@ module Dependabot
           sig do
             params(
               content: String,
-              new_r: T::Hash[Symbol, T.untyped],
-              old_r: T::Hash[Symbol, T.untyped]
+              new_r: Dependabot::DependencyRequirement,
+              old_r: Dependabot::DependencyRequirement
             ).returns(T.nilable(String))
           end
           def replace(content, new_r, old_r)
@@ -96,8 +96,8 @@ module Dependabot
             params(
               content: String,
               source_req: String,
-              new_r: T::Hash[Symbol, T.untyped],
-              old_r: T::Hash[Symbol, T.untyped]
+              new_r: Dependabot::DependencyRequirement,
+              old_r: Dependabot::DependencyRequirement
             ).returns(T.nilable(String))
           end
           def replace_with_source_requirement(content, source_req, new_r, old_r)
@@ -105,7 +105,11 @@ module Dependabot
             return unless match
 
             declaration = T.must(match[:declaration])
-            new_req_str = rewrite_pep508_requirement(source_req, old_r[:requirement], new_r[:requirement])
+            new_req_str = rewrite_pep508_requirement(
+              source_req,
+              T.must(old_r.requirement_string),
+              T.must(new_r.requirement_string)
+            )
             content.sub(declaration, declaration.sub(source_req, new_req_str))
           end
 
@@ -116,13 +120,13 @@ module Dependabot
           sig do
             params(
               content: String,
-              new_r: T::Hash[Symbol, T.untyped],
-              old_r: T::Hash[Symbol, T.untyped]
+              new_r: Dependabot::DependencyRequirement,
+              old_r: Dependabot::DependencyRequirement
             ).returns(T.nilable(String))
           end
           def replace_with_normalized_requirement(content, new_r, old_r)
-            old_req = old_r[:requirement]
-            new_req = new_r[:requirement]
+            old_req = T.must(old_r.requirement_string)
+            new_req = T.must(new_r.requirement_string)
 
             match = content.match(normalized_declaration_regex(old_req))
             return unless match

--- a/python/lib/dependabot/python/file_updater/setup_file_sanitizer.rb
+++ b/python/lib/dependabot/python/file_updater/setup_file_sanitizer.rb
@@ -61,10 +61,9 @@ module Dependabot
           @install_requires_array ||=
             parsed_setup_file.dependencies.filter_map do |dep|
               first = T.must(dep.requirements.first)
-              next unless first[:groups]
-                          .include?("install_requires")
+              next unless first.groups&.include?("install_requires")
 
-              name_with_extras(dep) + first[:requirement].to_s
+              name_with_extras(dep) + first.requirement.to_s
             end
         end
 
@@ -73,10 +72,9 @@ module Dependabot
           @setup_requires_array ||=
             parsed_setup_file.dependencies.filter_map do |dep|
               first = T.must(dep.requirements.first)
-              next unless first[:groups]
-                          .include?("setup_requires")
+              next unless first.groups&.include?("setup_requires")
 
-              name_with_extras(dep) + first[:requirement].to_s
+              name_with_extras(dep) + first.requirement.to_s
             end
         end
 
@@ -87,12 +85,13 @@ module Dependabot
               hash = {}
               parsed_setup_file.dependencies.each do |dep|
                 first = T.must(dep.requirements.first)
-                first[:groups].each do |group|
+                T.must(first.groups).each do |group|
                   next unless group.start_with?("extras_require:")
 
-                  hash[group.split(":").last] ||= []
-                  hash[group.split(":").last] <<
-                    (name_with_extras(dep) + first[:requirement].to_s)
+                  group_name = group.to_s
+                  hash[group_name.split(":").last] ||= []
+                  hash[group_name.split(":").last] <<
+                    (name_with_extras(dep) + first.requirement.to_s)
                 end
               end
 

--- a/python/lib/dependabot/python/pipenv_runner.rb
+++ b/python/lib/dependabot/python/pipenv_runner.rb
@@ -143,7 +143,7 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def lockfile_section
         if current_dependency.requirements.any?
-          T.must(current_dependency.requirements.first)[:groups].first
+          T.must(T.must(current_dependency.requirements.first).groups).first&.to_s
         else
           parsed_lockfile = JSON.parse(T.must(T.must(lockfile).content))
           Python::FileParser::DEPENDENCY_GROUP_KEYS.each do |keys|

--- a/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/pip_compile_version_resolver.rb
@@ -400,14 +400,14 @@ module Dependabot
         def update_req_file(file, updated_req)
           return T.must(file.content) unless file.name.end_with?(".in")
 
-          req = dependency.requirements.find { |r| r[:file] == file.name }
+          req = dependency.requirements.find { |r| r.file == file.name }
 
-          return T.must(file.content) + "\n#{dependency.name} #{updated_req}" unless req&.fetch(:requirement)
+          return T.must(file.content) + "\n#{dependency.name} #{updated_req}" unless req&.requirement_string
 
           Python::FileUpdater::RequirementReplacer.new(
             content: T.must(file.content),
             dependency_name: dependency.name,
-            old_requirement: req[:requirement],
+            old_requirement: req.requirement_string,
             new_requirement: updated_req
           ).updated_content
         end
@@ -426,7 +426,7 @@ module Dependabot
         def filenames_to_compile
           files_from_reqs =
             dependency.requirements
-                      .map { |r| r[:file] }
+                      .filter_map(&:file)
                       .select { |fn| fn.end_with?(".in") }
 
           files_from_compiled_files =

--- a/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
+++ b/python/lib/dependabot/python/update_checker/poetry_version_resolver.rb
@@ -333,7 +333,7 @@ module Dependabot
           end
 
           # If this is a sub-dependency, add the new requirement
-          unless dependency.requirements.find { |r| r[:file] == T.must(pyproject).name }
+          unless dependency.requirements.find { |r| r.file == T.must(pyproject).name }
             poetry_object[subdep_type] ||= {}
             poetry_object[subdep_type][dependency.name] = updated_requirement
           end


### PR DESCRIPTION
### What are you trying to accomplish?

Migrate Python-specific requirement consumers across pip-compile, Pipfile, Poetry, PEP 621, setup sanitization, pipenv, and resolver code.

### Anything you want to highlight for special attention from reviewers?

Poetry git dependencies use typed `type` and `ref` source fields. A bare registry-name source is still valid and is treated as non-git.

The update also makes two previously dead equality checks compare the requirement string rather than the requirement object. That only skips a replacement when the old and new pinned strings are already identical.

The Pipfile manifest updater and PEP 621 updater move to `typed: strong`.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 215 to 199 errors. `ForbidTUntyped` drops from 970 to 951, and the PEP 621 updater leaves the exclusion list.

The affected Python suites pass with 253 examples. The full Python suite passes at the top of the stack with 1,775 examples.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
