### PR TITLE
Type UV requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 951
+# Offense count: 949
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"

--- a/uv/lib/dependabot/uv/file_updater/compile_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/compile_file_updater.rb
@@ -178,9 +178,9 @@ module Dependabot
         def update_uncompiled_files(updated_files)
           updated_filenames = updated_files.map(&:name)
           all_old_reqs = T.must(dependency).previous_requirements
-          old_reqs = T.must(all_old_reqs).reject { |r| updated_filenames.include?(r[:file]) }
+          old_reqs = T.must(all_old_reqs).reject { |r| updated_filenames.include?(r.file) }
           all_new_reqs = T.must(dependency).requirements
-          new_reqs = all_new_reqs.reject { |r| updated_filenames.include?(r[:file]) }
+          new_reqs = all_new_reqs.reject { |r| updated_filenames.include?(r.file) }
 
           return [] if new_reqs.none?
 
@@ -283,15 +283,15 @@ module Dependabot
           return file.content unless file.name.end_with?(".in")
 
           old_req = T.must(dependency).previous_requirements
-          old_req = old_req&.find { |r| r[:file] == file.name }
+          old_req = old_req&.find { |r| r.file == file.name }
 
           return file.content unless old_req
-          return file.content if old_req == "==#{T.must(dependency).version}"
+          return file.content if old_req.requirement_string == "==#{T.must(dependency).version}"
 
           RequirementReplacer.new(
             content: T.must(file.content),
             dependency_name: T.must(dependency).name,
-            old_requirement: old_req[:requirement],
+            old_requirement: old_req.requirement_string,
             new_requirement: "==#{T.must(dependency).version}",
             index_urls: @index_urls
           ).updated_content
@@ -302,17 +302,17 @@ module Dependabot
           return file.content unless file.name.end_with?(".in")
 
           old_req = T.must(dependency).previous_requirements
-          old_req = old_req&.find { |r| r[:file] == file.name }
+          old_req = old_req&.find { |r| r.file == file.name }
           new_req = T.must(dependency).requirements
-          new_req = new_req.find { |r| r[:file] == file.name }
-          return file.content unless old_req&.fetch(:requirement)
+          new_req = new_req.find { |r| r.file == file.name }
+          return file.content unless old_req&.requirement_string
           return file.content if old_req == new_req
 
           RequirementReplacer.new(
             content: T.must(file.content),
             dependency_name: T.must(dependency).name,
-            old_requirement: old_req[:requirement],
-            new_requirement: T.must(new_req)[:requirement],
+            old_requirement: old_req.requirement_string,
+            new_requirement: T.must(T.must(new_req).requirement_string),
             index_urls: @index_urls
           ).updated_content
         end
@@ -547,7 +547,7 @@ module Dependabot
         def filenames_to_compile
           files_from_reqs =
             T.must(dependency).requirements
-             .map { |r| r[:file] }
+             .filter_map(&:file)
              .select { |fn| fn.end_with?(".in") }
 
           files_from_compiled_files =

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -84,7 +84,7 @@ module Dependabot
         def build_system_only_dependency?
           return false unless dependency
 
-          groups = T.must(dependency).requirements.flat_map { |req| req[:groups] || [] }.compact.uniq
+          groups = T.must(dependency).requirements.flat_map { |req| req.groups || [] }.compact.uniq
           return false if groups.empty?
 
           groups.all?("build-system")
@@ -133,7 +133,7 @@ module Dependabot
           updated_content = content.dup
 
           T.must(dependency).requirements.zip(T.must(T.must(dependency).previous_requirements)).each do |new_r, old_r|
-            next unless new_r[:file] == file.name && T.must(old_r)[:file] == file.name
+            next unless new_r.file == file.name && T.must(old_r).file == file.name
 
             updated_content = replace_dep(T.must(dependency), updated_content, new_r, T.must(old_r))
           end
@@ -147,13 +147,13 @@ module Dependabot
           params(
             dep: Dependabot::Dependency,
             content: String,
-            new_r: T::Hash[Symbol, T.untyped],
-            old_r: T::Hash[Symbol, T.untyped]
+            new_r: Dependabot::DependencyRequirement,
+            old_r: Dependabot::DependencyRequirement
           ).returns(String)
         end
         def replace_dep(dep, content, new_r, old_r)
-          new_req = new_r[:requirement]
-          old_req = old_r[:requirement]
+          new_req = new_r.requirement_string
+          old_req = old_r.requirement_string
           escaped_name = escape_package_name(dep.name)
 
           regex = /(["']#{escaped_name})([^"']+)(["'])/x
@@ -634,7 +634,7 @@ module Dependabot
           return false unless file
 
           dependencies.any? do |dep|
-            dep.requirements.any? { |r| r[:file] == file.name } &&
+            dep.requirements.any? { |r| r.file == file.name } &&
               requirement_changed?(file, dep)
           end
         end
@@ -647,7 +647,7 @@ module Dependabot
           changed_requirements =
             dependency.requirements - T.must(dependency.previous_requirements)
 
-          changed_requirements.any? { |f| f[:file] == T.must(file).name }
+          changed_requirements.any? { |f| f.file == T.must(file).name }
         end
 
         sig { params(file: Dependabot::DependencyFile, content: String).returns(Dependabot::DependencyFile) }
@@ -719,7 +719,7 @@ module Dependabot
         def create_or_update_lock_file?
           return true if lockfile && T.must(dependency).requirements.empty?
 
-          T.must(dependency).requirements.any? { _1[:file].end_with?(*REQUIRED_FILES) }
+          T.must(dependency).requirements.any? { |req| req.file&.end_with?(*REQUIRED_FILES) }
         end
 
         sig { returns(T::Hash[String, String]) }

--- a/uv/lib/dependabot/uv/update_checker.rb
+++ b/uv/lib/dependabot/uv/update_checker.rb
@@ -156,12 +156,13 @@ module Dependabot
         return if reqs.none?
 
         requirement = reqs.find do |r|
-          file = r[:file]
+          file = r.file
+          next false unless file
 
           file == "uv.lock" || file.end_with?("pyproject.toml") || file.end_with?(".in") || file.end_with?(".txt")
         end
 
-        requirement&.fetch(:requirement)
+        requirement&.requirement_string
       end
 
       sig { override.returns(String) }
@@ -186,7 +187,7 @@ module Dependabot
         return ">=#{dependency.version}" if dependency.version
 
         version_for_requirement =
-          requirements.filter_map { |r| r[:requirement] }
+          requirements.filter_map(&:requirement_string)
                       .reject { |req_string| req_string.start_with?("<") }
                       .select { |req_string| req_string.match?(VERSION_REGEX) }
                       .map { |req_string| req_string.match(VERSION_REGEX).to_s }

--- a/uv/lib/dependabot/uv/update_checker/pip_compile_version_resolver.rb
+++ b/uv/lib/dependabot/uv/update_checker/pip_compile_version_resolver.rb
@@ -409,14 +409,14 @@ module Dependabot
         def update_req_file(file, updated_req)
           return T.must(file.content) unless file.name.end_with?(".in")
 
-          req = dependency.requirements.find { |r| r[:file] == file.name }
+          req = dependency.requirements.find { |r| r.file == file.name }
 
-          return T.must(file.content) + "\n#{dependency.name} #{updated_req}" unless req&.fetch(:requirement)
+          return T.must(file.content) + "\n#{dependency.name} #{updated_req}" unless req&.requirement_string
 
           Uv::FileUpdater::RequirementReplacer.new(
             content: T.must(file.content),
             dependency_name: dependency.name,
-            old_requirement: req[:requirement],
+            old_requirement: req.requirement_string,
             new_requirement: updated_req
           ).updated_content
         end
@@ -454,7 +454,7 @@ module Dependabot
         def filenames_to_compile
           files_from_reqs =
             dependency.requirements
-                      .map { |r| r[:file] }
+                      .filter_map(&:file)
                       .select { |fn| fn.end_with?(".in") }
 
           files_from_compiled_files =

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -1634,7 +1634,15 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
   end
 
   describe "#replace_dep" do
-    subject(:replace_dep) { updater.send(:replace_dep, dependency, content, new_req, old_req) }
+    subject(:replace_dep) do
+      updater.send(
+        :replace_dep,
+        dependency,
+        content,
+        Dependabot::DependencyRequirement.create(new_req),
+        Dependabot::DependencyRequirement.create(old_req)
+      )
+    end
 
     let(:content) do
       <<~TOML


### PR DESCRIPTION
### What are you trying to accomplish?

Replace UV's remaining requirement hash reads in its update checker, pip-compile resolver, compile updater, and lock updater.

### Anything you want to highlight for special attention from reviewers?

Explicit-index behavior and bare registry-name string sources are unchanged. The lock updater preserves requirement order and treats nil groups as empty where it did before.

One private-method spec called `replace_dep` with plain hashes. It now passes typed requirement entries, matching production.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 199 to 183 errors. `ForbidTUntyped` drops from 951 to 949.

The focused UV suite passes with 166 examples; the full suite passes with 1,131. Sorbet and RuboCop are clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
