### PR TITLE
Type Conda requirement access

### DIFF
--- a/conda/lib/dependabot/conda/file_parser.rb
+++ b/conda/lib/dependabot/conda/file_parser.rb
@@ -15,6 +15,14 @@ module Dependabot
     class FileParser < Dependabot::FileParsers::Base
       extend T::Sig
 
+      ParsedDependency = T.type_alias do
+        {
+          name: String,
+          version: T.nilable(String),
+          requirements: T::Array[Dependabot::DependencyRequirement]
+        }
+      end
+
       sig { override.returns(T::Array[Dependabot::Dependency]) }
       def parse
         dependencies = T.let([], T::Array[Dependabot::Dependency])
@@ -99,13 +107,13 @@ module Dependabot
           parsed_dep = parse_conda_dependency_string(dep, file)
           next unless parsed_dep
 
-          name = T.cast(parsed_dep[:name], String)
+          name = parsed_dep[:name]
           next if name == "pip"
 
           parsed_dependencies << create_dependency(
             name: name,
-            version: T.cast(parsed_dep[:version], T.nilable(String)),
-            requirements: T.cast(parsed_dep[:requirements], T::Array[T::Hash[Symbol, T.anything]]),
+            version: parsed_dep[:version],
+            requirements: parsed_dep[:requirements],
             package_manager: "conda"
           )
         end
@@ -137,9 +145,9 @@ module Dependabot
           next unless parsed_dep
 
           parsed_dependencies << create_dependency(
-            name: T.cast(parsed_dep[:name], String),
-            version: T.cast(parsed_dep[:version], T.nilable(String)),
-            requirements: T.cast(parsed_dep[:requirements], T::Array[T::Hash[Symbol, T.anything]]),
+            name: parsed_dep[:name],
+            version: parsed_dep[:version],
+            requirements: parsed_dep[:requirements],
             package_manager: "pip"
           )
         end
@@ -147,9 +155,7 @@ module Dependabot
         parsed_dependencies
       end
 
-      sig do
-        params(dep_string: String, file: Dependabot::DependencyFile).returns(T.nilable(T::Hash[Symbol, T.anything]))
-      end
+      sig { params(dep_string: String, file: Dependabot::DependencyFile).returns(T.nilable(ParsedDependency)) }
       def parse_conda_dependency_string(dep_string, file)
         return nil if dep_string.nil?
 
@@ -168,7 +174,7 @@ module Dependabot
         match = normalized_dep_string.match(/^([a-zA-Z0-9_.-]+)(?:\s*(.+))?$/)
         return nil unless match
 
-        name = match[1]
+        name = T.must(match[1])
         constraint = match[2]&.strip
 
         version = extract_conda_version(constraint)
@@ -221,27 +227,25 @@ module Dependabot
           constraint: T.nilable(String),
           file: Dependabot::DependencyFile,
           channel: T.nilable(String)
-        ).returns(T::Array[T::Hash[Symbol, T.anything]])
+        ).returns(T::Array[Dependabot::DependencyRequirement])
       end
       def build_conda_requirements(constraint, file, channel = nil)
         source = channel ? { channel: channel } : nil
 
-        [{
+        [Dependabot::DependencyRequirement.create(
           requirement: constraint && !constraint.empty? ? constraint : nil,
           file: file.name,
           source: source,
           groups: ["dependencies"]
-        }]
+        )]
       end
 
-      sig do
-        params(dep_string: String, file: Dependabot::DependencyFile).returns(T.nilable(T::Hash[Symbol, T.anything]))
-      end
+      sig { params(dep_string: String, file: Dependabot::DependencyFile).returns(T.nilable(ParsedDependency)) }
       def parse_pip_dependency_string(dep_string, file)
         match = dep_string.match(/^([a-zA-Z0-9_.-]+)(?:\s*(==|>=|>|<=|<|!=|~=)\s*([0-9][a-zA-Z0-9._+-]*))?$/)
         return nil unless match
 
-        name = match[1]
+        name = T.must(match[1])
         operator = match[2]
         version = match[3]
 
@@ -259,16 +263,15 @@ module Dependabot
           end
         end
 
-        requirements = if operator && version
-                         [{
-                           requirement: "#{operator}#{version}",
-                           file: file.name,
-                           source: nil,
-                           groups: ["pip"]
-                         }]
-                       else
-                         []
-                       end
+        requirements = T.let([], T::Array[Dependabot::DependencyRequirement])
+        if operator && version
+          requirements << Dependabot::DependencyRequirement.create(
+            requirement: "#{operator}#{version}",
+            file: file.name,
+            source: nil,
+            groups: ["pip"]
+          )
+        end
 
         {
           name: name,
@@ -281,7 +284,7 @@ module Dependabot
         params(
           name: String,
           version: T.nilable(String),
-          requirements: T::Array[T::Hash[Symbol, T.anything]],
+          requirements: T::Array[Dependabot::DependencyRequirement],
           package_manager: String
         ).returns(Dependabot::Dependency)
       end

--- a/conda/lib/dependabot/conda/file_updater.rb
+++ b/conda/lib/dependabot/conda/file_updater.rb
@@ -231,9 +231,7 @@ module Dependabot
       def get_requirement_for_dependency(dependency, context)
         # Look for a requirement in the dependency's requirements array
         requirements = dependency.requirements
-        requirement = nil
-
-        requirement = requirements.first&.dig(:requirement) unless requirements.empty?
+        requirement = requirements.first&.requirement_string unless requirements.empty?
 
         return requirement if requirement && !requirement.empty?
 

--- a/conda/lib/dependabot/conda/metadata_finder.rb
+++ b/conda/lib/dependabot/conda/metadata_finder.rb
@@ -29,7 +29,7 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def pip_dependency?
-        dependency.requirements.any? { |req| req[:groups]&.include?("pip") }
+        dependency.requirements.any? { |req| req.groups&.include?("pip") }
       end
 
       sig { returns(Dependabot::Python::MetadataFinder) }

--- a/conda/lib/dependabot/conda/update_checker.rb
+++ b/conda/lib/dependabot/conda/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -50,7 +50,7 @@ module Dependabot
 
       sig { override.returns(T.nilable(T.any(String, Dependabot::Version))) }
       def latest_version
-        return nil if dependency.requirements.all? { |req| req[:requirement].nil? || req[:requirement] == "*" }
+        return nil if dependency.requirements.all? { |req| req.requirement.nil? || req.requirement == "*" }
 
         @latest_version ||= fetch_latest_version
       end

--- a/conda/lib/dependabot/conda/update_checker/latest_version_finder.rb
+++ b/conda/lib/dependabot/conda/update_checker/latest_version_finder.rb
@@ -61,7 +61,7 @@ module Dependabot
 
         sig { returns(T::Boolean) }
         def pip_dependency?
-          dependency.requirements.any? { |req| req[:groups]&.include?("pip") }
+          dependency.requirements.any? { |req| req.groups&.include?("pip") }
         end
 
         sig { returns(T.nilable(Dependabot::Package::PackageDetails)) }
@@ -115,13 +115,11 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def extract_channel_from_source
-          return nil unless dependency.requirements.first
+          requirement = dependency.requirements.first
+          return nil unless requirement
 
-          source = T.let(T.must(dependency.requirements.first)[:source], T.nilable(T::Hash[Symbol, Object]))
-          return nil unless source
-
-          channel = source[:channel]
-          return nil unless channel.is_a?(String)
+          channel = requirement.source_string("channel")
+          return nil unless channel
           return nil unless CondaRegistryClient::SUPPORTED_CHANNELS.include?(channel)
 
           channel
@@ -130,7 +128,7 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def extract_channel_from_requirement
           dependency.requirements.each do |req|
-            requirement_string = req[:requirement]
+            requirement_string = req.requirement_string
             next unless requirement_string&.include?("::")
 
             channel = requirement_string.split("::").first
@@ -185,11 +183,11 @@ module Dependabot
           )
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.anything]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def python_compatible_requirements
           dependency.requirements.map do |req|
-            req.merge(
-              requirement: convert_conda_requirement_to_pip(req[:requirement])
+            Dependabot::DependencyRequirement.create(
+              req.merge(requirement: convert_conda_requirement_to_pip(req.requirement_string))
             )
           end
         end

--- a/conda/lib/dependabot/conda/update_checker/requirements_updater.rb
+++ b/conda/lib/dependabot/conda/update_checker/requirements_updater.rb
@@ -72,10 +72,11 @@ module Dependabot
 
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_requirement(req)
-          return req unless req[:requirement]
-          return req if ["", "*"].include?(req[:requirement])
+          requirement = req.requirement_string
+          return req unless requirement
+          return req if ["", "*"].include?(requirement)
 
-          requirement_strings = req[:requirement].split(",").map(&:strip)
+          requirement_strings = requirement.split(",").map(&:strip)
           new_req = calculate_updated_requirement(req, requirement_strings)
 
           Dependabot::DependencyRequirement.create(
@@ -121,7 +122,7 @@ module Dependabot
           # For BumpVersions strategy, always update to the new version
           if update_strategy == RequirementsUpdateStrategy::BumpVersionsIfNecessary &&
              new_version_satisfies?(req)
-            return req[:requirement]
+            return T.must(req.requirement)
           end
 
           update_requirements_range(requirement_strings)
@@ -133,10 +134,10 @@ module Dependabot
           # For BumpVersions strategy, always update to the new version
           if update_strategy == RequirementsUpdateStrategy::BumpVersionsIfNecessary &&
              new_version_satisfies?(req)
-            return req[:requirement]
+            return T.must(req.requirement)
           end
 
-          bump_version_string(req[:requirement], T.must(latest_resolvable_version).to_s)
+          bump_version_string(T.must(req.requirement_string), T.must(latest_resolvable_version).to_s)
         end
 
         sig do
@@ -174,21 +175,23 @@ module Dependabot
 
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def widen_requirement(req)
-          return req unless req[:requirement]
-          return req if ["", "*"].include?(req[:requirement])
+          requirement = req.requirement_string
+          return req unless requirement
+          return req if ["", "*"].include?(requirement)
 
           # For WidenRanges, always widen to ensure proper upper bounds
           # Don't return early even if version satisfies - we want to add/update bounds
-          new_requirement = widen_requirement_string(req[:requirement])
+          new_requirement = widen_requirement_string(requirement)
           Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         end
 
         sig { params(req: Dependabot::DependencyRequirement).returns(T::Boolean) }
         def new_version_satisfies?(req)
-          return false unless req[:requirement]
+          requirement = req.requirement_string
+          return false unless requirement
 
           Conda::Requirement
-            .requirements_array(req[:requirement])
+            .requirements_array(requirement)
             .all? { |r| r.satisfied_by?(T.must(latest_resolvable_version)) }
         end
 


### PR DESCRIPTION
### What are you trying to accomplish?

Finish the Python-family migration by typing Conda's parser, file updater, metadata finder, update checker, latest-version finder, and requirements updater.

The parser now creates `DependencyRequirement` entries at the `Dependency` boundary, and Conda-to-Python translation returns typed entries.

### Anything you want to highlight for special attention from reviewers?

Wildcard requirements, pip-vs-Conda routing, channel sources, and security range behavior are unchanged.

`conda/update_checker.rb` moves to `typed: strong`. The remaining Conda files have unrelated parser/client dynamic boundaries and stay strict.

### How will you know you've accomplished your goal?

The temporary `Object` generic check drops from 183 to 167 errors. Across the stack it drops from 233 to 167.

The full Conda suite passes with 352 examples. Full Python and UV suites pass with 1,775 and 1,131 examples. The final ratchet is 975 to 949 offenses and 167 to 165 excluded files.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
