### PR TITLE
NuGet: honor PackageReference asset flags

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -1,7 +1,9 @@
+using System.Collections.Immutable;
 using System.Text;
 using System.Text.Json;
 
 using NuGet;
+using NuGet.LibraryModel;
 
 using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Run.ApiModel;
@@ -12,6 +14,136 @@ namespace NuGetUpdater.Core.Test.Analyze;
 
 public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
 {
+    [Fact]
+    public async Task FindsUpdatedVersionWhenIncompatiblePackageCompileAndRuntimeAssetsAreExcluded()
+    {
+        await TestAnalyzeAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net45"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "2.0.0", "net45"),
+            ],
+            extraFiles:
+            [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                      </PropertyGroup>
+                      <ItemGroup>
+                        <PackageReference Include="Some.Package" Version="1.0.0" ExcludeAssets="compile;runtime" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+            ],
+            discovery: new()
+            {
+                Path = "/",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "./project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies = [
+                            new(
+                                "Some.Package",
+                                "1.0.0",
+                                DependencyType.PackageReference,
+                                AssetFlags: new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase)
+                                {
+                                    ["net8.0"] = LibraryIncludeFlags.All &
+                                        ~(LibraryIncludeFlags.Compile | LibraryIncludeFlags.Runtime),
+                                }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase)),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                    },
+                ],
+            },
+            dependencyInfo: new()
+            {
+                Name = "Some.Package",
+                Version = "1.0.0",
+                IgnoredVersions = [],
+                IsVulnerable = false,
+                Vulnerabilities = [],
+            },
+            expectedResult: new()
+            {
+                UpdatedVersion = "2.0.0",
+                CanUpdate = true,
+                VersionComesFromMultiDependencyProperty = false,
+                UpdatedDependencies = [
+                    new("Some.Package", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                ],
+            }
+        );
+    }
+
+    [Fact]
+    public async Task FindsUpdatedVersionWhenPackageIsOnlyReferencedByCompatibleTargetFramework()
+    {
+        await TestAnalyzeAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "1.0.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "2.0.0", "net8.0"),
+            ],
+            extraFiles:
+            [
+                ("project.csproj", """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                      </PropertyGroup>
+                      <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+                        <PackageReference Include="Some.Package" Version="1.0.0" />
+                      </ItemGroup>
+                    </Project>
+                    """),
+            ],
+            discovery: new()
+            {
+                Path = "/",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "./project.csproj",
+                        TargetFrameworks = ["net8.0", "net9.0"],
+                        Dependencies = [
+                            new(
+                                "Some.Package",
+                                "1.0.0",
+                                DependencyType.PackageReference,
+                                TargetFrameworks: ["net8.0"]),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                    },
+                ],
+            },
+            dependencyInfo: new()
+            {
+                Name = "Some.Package",
+                Version = "1.0.0",
+                IgnoredVersions = [],
+                IsVulnerable = false,
+                Vulnerabilities = [],
+            },
+            expectedResult: new()
+            {
+                UpdatedVersion = "2.0.0",
+                CanUpdate = true,
+                VersionComesFromMultiDependencyProperty = false,
+                UpdatedDependencies = [
+                    new("Some.Package", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                ],
+            }
+        );
+    }
+
     [Fact]
     public async Task FindsUpdatedVersion()
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/DependencySolver/MSBuildDependencySolverTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/DependencySolver/MSBuildDependencySolverTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 
+using NuGet.LibraryModel;
+
 using NuGetUpdater.Core.DependencySolver;
 using NuGetUpdater.Core.Test.Utilities;
 
@@ -9,6 +11,43 @@ namespace NuGetUpdater.Core.Test.DependencySolver;
 
 public class MSBuildDependencySolverTests : TestBase
 {
+    [Fact]
+    public async Task CompatiblePackageCanUpdateWhenAnotherTopLevelPackageOmitsCompileAndRuntimeAssets()
+    {
+        await TestAsync(
+            packages: [
+                MockNuGetPackage.CreateSimplePackage("Package.To.Update", "1.0.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Package.To.Update", "2.0.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage(
+                    "Build.Only.Package",
+                    "1.0.0",
+                    "net45",
+                    [(null, [("Incompatible.Transitive.Package", "1.0.0")])]),
+                MockNuGetPackage.CreateSimplePackage("Incompatible.Transitive.Package", "1.0.0", "net45"),
+            ],
+            existingTopLevelDependencies: [
+                "Package.To.Update/1.0.0",
+                "Build.Only.Package/1.0.0",
+            ],
+            desiredDependencies: [
+                "Package.To.Update/2.0.0",
+            ],
+            targetFramework: "net8.0",
+            packageReferenceAttributes: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Build.Only.Package"] = "IncludeAssets=\"build;analyzers\"",
+            },
+            packageReferenceAssetFlags: new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Build.Only.Package"] = LibraryIncludeFlags.Build | LibraryIncludeFlags.Analyzers,
+            },
+            expectedResolvedDependencies: [
+                "Package.To.Update/2.0.0",
+                "Build.Only.Package/1.0.0",
+            ]
+        );
+    }
+
     [Fact]
     public async Task DependencyConflictsCanBeResolvedNewUpdatingTopLevelPackage()
     {
@@ -383,6 +422,7 @@ public class MSBuildDependencySolverTests : TestBase
                 // available packages
                 MockNuGetPackage.CreateSimplePackage("Microsoft.EntityFrameworkCore", "8.0.0", "net8.0", [(null, [("Microsoft.EntityFrameworkCore.Analyzers", "8.0.0"), ("Microsoft.Extensions.Caching.Memory", "[8.0.0]")])]),
                 MockNuGetPackage.CreateSimplePackage("Microsoft.EntityFrameworkCore.Analyzers", "8.0.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Extensions.Caching.Memory", "8.0.0", "net8.0"),
             ],
             existingTopLevelDependencies: [
                 "Microsoft.EntityFrameworkCore/7.0.11",
@@ -594,7 +634,9 @@ public class MSBuildDependencySolverTests : TestBase
         ImmutableArray<string> desiredDependencies,
         string targetFramework,
         ImmutableArray<string> expectedResolvedDependencies,
-        MockNuGetPackage[]? packages = null
+        MockNuGetPackage[]? packages = null,
+        IReadOnlyDictionary<string, string>? packageReferenceAttributes = null,
+        IReadOnlyDictionary<string, LibraryIncludeFlags>? packageReferenceAssetFlags = null
     )
     {
         // arrange
@@ -606,7 +648,7 @@ public class MSBuildDependencySolverTests : TestBase
                     <TargetFramework>{targetFramework}</TargetFramework>
                   </PropertyGroup>
                   <ItemGroup>
-                    {string.Join("\n    ", existingTopLevelDependencies.Select(d => $@"<PackageReference Include=""{d.Split('/')[0]}"" Version=""{d.Split('/')[1]}"" />"))}
+                    {string.Join("\n    ", existingTopLevelDependencies.Select(CreatePackageReference))}
                   </ItemGroup>
                 </Project>
                 """)
@@ -619,8 +661,8 @@ public class MSBuildDependencySolverTests : TestBase
 
         // act
         var resolvedDependencies = await msbuildDepSolver.SolveAsync(
-            [.. existingTopLevelDependencies.Select(d => new Dependency(d.Split('/')[0], d.Split('/')[1], DependencyType.PackageReference))],
-            [.. desiredDependencies.Select(d => new Dependency(d.Split('/')[0], d.Split('/')[1], DependencyType.PackageReference))],
+            [.. existingTopLevelDependencies.Select(CreateDependency)],
+            [.. desiredDependencies.Select(CreateDependency)],
             targetFramework
         );
 
@@ -628,5 +670,28 @@ public class MSBuildDependencySolverTests : TestBase
         Assert.NotNull(resolvedDependencies);
         var actualResolvedDependencyStrings = resolvedDependencies.Value.Select(d => $"{d.Name}/{d.Version}");
         AssertEx.Equal(expectedResolvedDependencies, actualResolvedDependencyStrings);
+
+        string CreatePackageReference(string dependency)
+        {
+            var parts = dependency.Split('/');
+            var attributes = packageReferenceAttributes is not null &&
+                packageReferenceAttributes.TryGetValue(parts[0], out var configuredAttributes)
+                ? configuredAttributes
+                : null;
+            return $"""<PackageReference Include="{parts[0]}" Version="{parts[1]}"{(attributes is null ? string.Empty : $" {attributes}")} />""";
+        }
+
+        Dependency CreateDependency(string dependency)
+        {
+            var parts = dependency.Split('/');
+            var assetFlags = packageReferenceAssetFlags is not null &&
+                packageReferenceAssetFlags.TryGetValue(parts[0], out var configuredAssetFlags)
+                ? new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [targetFramework] = configuredAssetFlags,
+                }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase)
+                : null;
+            return new Dependency(parts[0], parts[1], DependencyType.PackageReference, AssetFlags: assetFlags);
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTestBase.cs
@@ -146,7 +146,11 @@ public class DiscoveryWorkerTestBase : TestBase
                     && d.Type == expectedDependency.Type
                     && d.Version == expectedDependency.Version
                     && d.IsTopLevel == expectedDependency.IsTopLevel
-                    && d.TargetFrameworks.SequenceEqual(expectedDependency.TargetFrameworks);
+                    && d.TargetFrameworks.SequenceEqual(expectedDependency.TargetFrameworks)
+                    && (expectedDependency.AssetFlags is null ||
+                        expectedDependency.AssetFlags.All(kvp =>
+                            d.AssetFlags?.TryGetValue(kvp.Key, out var actualFlags) == true &&
+                            actualFlags == kvp.Value));
             }).ToArray();
             Assert.True(matchingDependencies.Length == 1, $"""
                 Unable to find 1 dependency matching; found {matchingDependencies.Length}:
@@ -155,8 +159,16 @@ public class DiscoveryWorkerTestBase : TestBase
                     Version: {expectedDependency.Version}
                     IsTopLevel: {expectedDependency.IsTopLevel}
                     TargetFrameworks: {string.Join(", ", expectedDependency.TargetFrameworks ?? [])}
-                Found:{"\n\t"}{string.Join("\n\t", actualDependencies)}
+                    AssetFlags: {FormatAssetFlags(expectedDependency)}
+                Found:{"\n\t"}{string.Join("\n\t", actualDependencies.Select(dependency => $"{dependency}; AssetFlags: {FormatAssetFlags(dependency)}"))}
                 """);
+        }
+
+        static string FormatAssetFlags(Dependency dependency)
+        {
+            return dependency.AssetFlags is null
+                ? string.Empty
+                : string.Join(", ", dependency.AssetFlags.OrderBy(kvp => kvp.Key).Select(kvp => $"{kvp.Key}={kvp.Value}"));
         }
     }
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/DiscoveryWorkerTests.Project.cs
@@ -1,3 +1,7 @@
+using System.Collections.Immutable;
+
+using NuGet.LibraryModel;
+
 using Xunit;
 
 namespace NuGetUpdater.Core.Test.Discover;
@@ -6,6 +10,157 @@ public partial class DiscoveryWorkerTests
 {
     public class Projects : DiscoveryWorkerTestBase
     {
+        [Fact]
+        public async Task PackageReferenceAssetFlagsFlowToTransitiveDependencies()
+        {
+            var excludedCompatibilityAssets = LibraryIncludeFlags.All &
+                ~(LibraryIncludeFlags.Compile | LibraryIncludeFlags.Runtime);
+            var assetFlags = new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["net8.0"] = excludedCompatibilityAssets,
+            }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase);
+
+            await TestDiscoveryAsync(
+                packages:
+                [
+                    MockNuGetPackage.CreateSimplePackage(
+                        "Build.Only.Package",
+                        "1.0.0",
+                        "net45",
+                        [(null, [("Incompatible.Transitive.Package", "1.0.0")])]),
+                    MockNuGetPackage.CreateSimplePackage("Incompatible.Transitive.Package", "1.0.0", "net45"),
+                ],
+                workspacePath: "",
+                files:
+                [
+                    ("project.csproj", """
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFramework>net8.0</TargetFramework>
+                          </PropertyGroup>
+                          <ItemGroup>
+                            <PackageReference Include="Build.Only.Package" Version="1.0.0" ExcludeAssets="compile;runtime" />
+                          </ItemGroup>
+                        </Project>
+                        """),
+                ],
+                expectedResult: new()
+                {
+                    Path = "",
+                    Projects =
+                    [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies =
+                            [
+                                new(
+                                    "Build.Only.Package",
+                                    "1.0.0",
+                                    DependencyType.PackageReference,
+                                    TargetFrameworks: ["net8.0"],
+                                    AssetFlags: assetFlags),
+                                new(
+                                    "Incompatible.Transitive.Package",
+                                    "1.0.0",
+                                    DependencyType.Unknown,
+                                    TargetFrameworks: ["net8.0"],
+                                    IsTopLevel: false,
+                                    AssetFlags: assetFlags),
+                            ],
+                            TargetFrameworks = ["net8.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        },
+                    ],
+                }
+            );
+        }
+
+        [Fact]
+        public async Task PackageReferenceAssetFlagsAreTrackedPerTargetFramework()
+        {
+            await TestDiscoveryAsync(
+                packages:
+                [
+                    new MockNuGetPackage(
+                        "Parent.Package",
+                        "1.0.0",
+                        DependencyGroups: [(null, [("Transitive.Dependency", "2.0.0")])],
+                        Files:
+                        [
+                            ("lib/net8.0/Parent.Package.dll", []),
+                            ("lib/net9.0/Parent.Package.dll", []),
+                        ]),
+                    new MockNuGetPackage(
+                        "Transitive.Dependency",
+                        "2.0.0",
+                        Files:
+                        [
+                            ("lib/net8.0/Transitive.Dependency.dll", []),
+                            ("lib/net9.0/Transitive.Dependency.dll", []),
+                        ]),
+                ],
+                workspacePath: "",
+                files:
+                [
+                    ("project.csproj", """
+                        <Project Sdk="Microsoft.NET.Sdk">
+                          <PropertyGroup>
+                            <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                          </PropertyGroup>
+                          <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+                            <PackageReference Include="Parent.Package" Version="1.0.0" IncludeAssets="build;analyzers" />
+                          </ItemGroup>
+                          <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+                            <PackageReference Include="Parent.Package" Version="1.0.0" />
+                          </ItemGroup>
+                        </Project>
+                        """),
+                ],
+                expectedResult: new()
+                {
+                    Path = "",
+                    Projects =
+                    [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies =
+                            [
+                                new(
+                                    "Parent.Package",
+                                    "1.0.0",
+                                    DependencyType.PackageReference,
+                                    TargetFrameworks: ["net8.0", "net9.0"],
+                                    AssetFlags: new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase)
+                                    {
+                                        ["net8.0"] = LibraryIncludeFlags.Build | LibraryIncludeFlags.Analyzers,
+                                        ["net9.0"] = LibraryIncludeFlags.All,
+                                    }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase)),
+                                new(
+                                    "Transitive.Dependency",
+                                    "2.0.0",
+                                    DependencyType.Unknown,
+                                    TargetFrameworks: ["net8.0", "net9.0"],
+                                    IsTopLevel: false,
+                                    AssetFlags: new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase)
+                                    {
+                                        ["net8.0"] = LibraryIncludeFlags.Build | LibraryIncludeFlags.Analyzers,
+                                        ["net9.0"] = LibraryIncludeFlags.All,
+                                    }.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase)),
+                            ],
+                            TargetFrameworks = ["net8.0", "net9.0"],
+                            ReferencedProjectPaths = [],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        },
+                    ],
+                }
+            );
+        }
+
         [Fact]
         public async Task TargetFrameworksAreHonoredInConditions()
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/FileWriterWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Update/FileWriters/FileWriterWorkerTests.cs
@@ -60,6 +60,48 @@ public class FileWriterWorkerTests : TestBase
     }
 
     [Fact]
+    public async Task EndToEnd_ProjectReference_IncompatiblePackageWithCompileAndRuntimeAssetsExcluded()
+    {
+        await TestAsync(
+            dependencyName: "Build.Only.Package",
+            oldDependencyVersion: "1.0.0",
+            newDependencyVersion: "2.0.0",
+            projectContents: """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Build.Only.Package" Version="1.0.0" ExcludeAssets="compile;runtime" />
+                  </ItemGroup>
+                </Project>
+                """,
+            additionalFiles: [],
+            packages: [
+                MockNuGetPackage.CreateSimplePackage("Build.Only.Package", "1.0.0", "net45"),
+                MockNuGetPackage.CreateSimplePackage("Build.Only.Package", "2.0.0", "net45"),
+            ],
+            discoveryWorker: null,
+            dependencySolver: null,
+            fileWriter: null,
+            expectedProjectContents: """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Build.Only.Package" Version="2.0.0" ExcludeAssets="compile;runtime" />
+                  </ItemGroup>
+                </Project>
+                """,
+            expectedAdditionalFiles: [],
+            expectedOperations: [
+                new DirectUpdate() { DependencyName = "Build.Only.Package", NewVersion = NuGetVersion.Parse("2.0.0"), UpdatedFiles = ["/project.csproj"] }
+            ]
+        );
+    }
+
+    [Fact]
     public async Task EndToEnd_ProjectReference_ThroughProjectReferences()
     {
         // project is directly changed
@@ -267,6 +309,125 @@ public class FileWriterWorkerTests : TestBase
                   <ItemGroup>
                     <PackageReference Include="Some.Dependency" Version="1.0.0" />
                     <PackageReference Include="Transitive.Dependency" Version="3.0.0" />
+                  </ItemGroup>
+                </Project>
+                """,
+            expectedAdditionalFiles: [],
+            expectedOperations: [
+                new PinnedUpdate() { DependencyName = "Transitive.Dependency", NewVersion = NuGetVersion.Parse("3.0.0"), UpdatedFiles = ["/project.csproj"] }
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task EndToEnd_ProjectReference_PinnedTransitiveDependency_PreservesInheritedAssetFlags()
+    {
+        await TestAsync(
+            dependencyName: "Transitive.Dependency",
+            oldDependencyVersion: "2.0.0",
+            newDependencyVersion: "3.0.0",
+            projectContents: """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Build.Only.Package" Version="1.0.0" IncludeAssets="build;analyzers" />
+                  </ItemGroup>
+                </Project>
+                """,
+            additionalFiles: [],
+            packages: [
+                MockNuGetPackage.CreateSimplePackage("Build.Only.Package", "1.0.0", "net45", [(null, [("Transitive.Dependency", "2.0.0")])]),
+                MockNuGetPackage.CreateSimplePackage("Transitive.Dependency", "2.0.0", "net45"),
+                MockNuGetPackage.CreateSimplePackage("Transitive.Dependency", "3.0.0", "net45"),
+            ],
+            discoveryWorker: null,
+            dependencySolver: null,
+            fileWriter: null,
+            expectedProjectContents: """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net8.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Build.Only.Package" Version="1.0.0" IncludeAssets="build;analyzers" />
+                    <PackageReference Include="Transitive.Dependency" IncludeAssets="build;analyzers" Version="3.0.0" />
+                  </ItemGroup>
+                </Project>
+                """,
+            expectedAdditionalFiles: [],
+            expectedOperations: [
+                new PinnedUpdate() { DependencyName = "Transitive.Dependency", NewVersion = NuGetVersion.Parse("3.0.0"), UpdatedFiles = ["/project.csproj"] }
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task EndToEnd_ProjectReference_PinnedTransitiveDependency_PreservesPerFrameworkAssetFlags()
+    {
+        await TestAsync(
+            dependencyName: "Transitive.Dependency",
+            oldDependencyVersion: "2.0.0",
+            newDependencyVersion: "3.0.0",
+            projectContents: """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                  </PropertyGroup>
+                  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+                    <PackageReference Include="Parent.Package" Version="1.0.0" IncludeAssets="build;analyzers" />
+                  </ItemGroup>
+                  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+                    <PackageReference Include="Parent.Package" Version="1.0.0" />
+                  </ItemGroup>
+                </Project>
+                """,
+            additionalFiles: [],
+            packages: [
+                new MockNuGetPackage(
+                    "Parent.Package",
+                    "1.0.0",
+                    DependencyGroups: [(null, [("Transitive.Dependency", "2.0.0")])],
+                    Files:
+                    [
+                        ("lib/net8.0/Parent.Package.dll", []),
+                        ("lib/net9.0/Parent.Package.dll", []),
+                    ]),
+                new MockNuGetPackage(
+                    "Transitive.Dependency",
+                    "2.0.0",
+                    Files:
+                    [
+                        ("lib/net8.0/Transitive.Dependency.dll", []),
+                        ("lib/net9.0/Transitive.Dependency.dll", []),
+                    ]),
+                new MockNuGetPackage(
+                    "Transitive.Dependency",
+                    "3.0.0",
+                    Files:
+                    [
+                        ("lib/net8.0/Transitive.Dependency.dll", []),
+                        ("lib/net9.0/Transitive.Dependency.dll", []),
+                    ]),
+            ],
+            discoveryWorker: null,
+            dependencySolver: null,
+            fileWriter: null,
+            expectedProjectContents: """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                  </PropertyGroup>
+                  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+                    <PackageReference Include="Parent.Package" Version="1.0.0" IncludeAssets="build;analyzers" />
+                  </ItemGroup>
+                  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+                    <PackageReference Include="Parent.Package" Version="1.0.0" />
+                  </ItemGroup>
+                  <ItemGroup>
+                    <PackageReference Include="Transitive.Dependency" IncludeAssets="build;analyzers" Condition="'$(TargetFramework)' == 'net8.0'" Version="3.0.0" />
+                    <PackageReference Include="Transitive.Dependency" Condition="'$(TargetFramework)' == 'net9.0'" Version="3.0.0" />
                   </ItemGroup>
                 </Project>
                 """,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -183,6 +183,24 @@ public class MSBuildHelperTests : TestBase
     }
 
     [Fact]
+    public async Task AllPackageDependencies_OmitsPackagesOutsideRequestedTargetFramework()
+    {
+        using var temp = new TemporaryDirectory();
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(
+            [MockNuGetPackage.CreateSimplePackage("Package.A", "1.0.0", "net9.0")],
+            temp.DirectoryPath);
+
+        var actualDependencies = await MSBuildHelper.GetAllPackageDependenciesAsync(
+            temp.DirectoryPath,
+            temp.DirectoryPath,
+            "net8.0",
+            [new Dependency("Package.A", "1.0.0", DependencyType.Unknown, TargetFrameworks: ["net9.0"])],
+            new TestLogger());
+
+        Assert.Empty(actualDependencies);
+    }
+
+    [Fact]
     public async Task AllPackageDependencies_DoNotIncludeUpdateOnlyPackages()
     {
         using var temp = new TemporaryDirectory();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -78,11 +78,6 @@ public partial class AnalyzeWorker : IAnalyzeWorker
         var projectsWithDependency = discovery.Projects
             .Where(p => p.Dependencies.Any(d => d.Name.Equals(dependencyInfo.Name, StringComparison.OrdinalIgnoreCase)))
             .ToImmutableArray();
-        var projectFrameworks = projectsWithDependency
-            .SelectMany(p => p.TargetFrameworks)
-            .Distinct()
-            .Select(NuGetFramework.Parse)
-            .ToImmutableArray();
         var propertyBasedDependencies = discovery.Projects.SelectMany(p
             => p.Dependencies.Where(d => d.IsTopLevel &&
                 d.EvaluationResult?.RootPropertyName is not null)
@@ -112,20 +107,14 @@ public partial class AnalyzeWorker : IAnalyzeWorker
                     .SelectMany(md => md.DependencyNames)
                     .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)
                 : [dependencyInfo.Name];
-            var applicableTargetFrameworks = usesMultiDependencyProperty
-                ? multiDependencies
-                    .SelectMany(md => md.TargetFrameworks)
-                    .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)
-                    .Select(NuGetFramework.Parse)
-                    .ToImmutableArray()
-                : projectFrameworks;
+            var applicableCompatibilityFrameworks = GetCompatibilityFrameworks(discovery, dependenciesToUpdate);
 
             _logger.Info($"  Finding updated version.");
             updatedVersion = await FindUpdatedVersionAsync(
                 startingDirectory,
                 dependencyInfo,
                 dependenciesToUpdate,
-                applicableTargetFrameworks,
+                applicableCompatibilityFrameworks,
                 nugetContext,
                 _logger,
                 CancellationToken.None);
@@ -200,6 +189,37 @@ public partial class AnalyzeWorker : IAnalyzeWorker
                 d.IsTopLevel));
     }
 
+    private static ImmutableDictionary<string, ImmutableArray<NuGetFramework>> GetCompatibilityFrameworks(
+        WorkspaceDiscoveryResult discovery,
+        ImmutableHashSet<string> packageIds)
+    {
+        return packageIds.ToImmutableDictionary(
+            packageId => packageId,
+            packageId => discovery.Projects
+                .SelectMany(project =>
+                {
+                    var dependency = project.Dependencies.FirstOrDefault(d =>
+                        d.Name.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+                    if (dependency is null)
+                    {
+                        return [];
+                    }
+
+                    var dependencyTargetFrameworks = dependency.TargetFrameworks is { Length: > 0 }
+                        ? dependency.TargetFrameworks.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)
+                        : null;
+                    return project.TargetFrameworks
+                        .Where(targetFramework =>
+                            dependencyTargetFrameworks is null ||
+                            dependencyTargetFrameworks.Contains(targetFramework))
+                        .Where(dependency.RequiresCompatibilityCheck)
+                        .Select(NuGetFramework.Parse);
+                })
+                .Distinct()
+                .ToImmutableArray(),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
     private static Task<WorkspaceDiscoveryResult> DeserializeWorkspaceDiscoveryResultFileAsync(string path)
     {
         return DeserializeJsonFileAsync(path, nameof(WorkspaceDiscoveryResult), json => JsonSerializer.Deserialize<WorkspaceDiscoveryResult>(json, SerializerOptions));
@@ -229,13 +249,16 @@ public partial class AnalyzeWorker : IAnalyzeWorker
         string startingDirectory,
         DependencyInfo dependencyInfo,
         ImmutableHashSet<string> packageIds,
-        ImmutableArray<NuGetFramework> projectFrameworks,
+        ImmutableDictionary<string, ImmutableArray<NuGetFramework>> compatibilityFrameworks,
         NuGetContext nugetContext,
         ILogger logger,
         CancellationToken cancellationToken)
     {
+        var dependencyFrameworks = compatibilityFrameworks.GetValueOrDefault(
+            dependencyInfo.Name,
+            []);
         var versionResult = await VersionFinder.GetVersionsAsync(
-            projectFrameworks,
+            dependencyFrameworks,
             dependencyInfo,
             DateTimeOffset.UtcNow,
             nugetContext,
@@ -246,7 +269,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
             packageIds,
             dependencyInfo.Version,
             versionResult,
-            projectFrameworks,
+            compatibilityFrameworks,
             findLowestVersion: dependencyInfo.IsVulnerable,
             nugetContext,
             logger,
@@ -257,7 +280,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
         ImmutableHashSet<string> packageIds,
         string versionString,
         VersionResult versionResult,
-        ImmutableArray<NuGetFramework> projectFrameworks,
+        ImmutableDictionary<string, ImmutableArray<NuGetFramework>> compatibilityFrameworks,
         bool findLowestVersion,
         NuGetContext nugetContext,
         ILogger logger,
@@ -279,7 +302,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
             versionString,
             versionResult,
             orderedVersions,
-            projectFrameworks,
+            compatibilityFrameworks,
             nugetContext,
             logger,
             cancellationToken);
@@ -290,7 +313,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
         string versionString,
         VersionResult versionResult,
         IEnumerable<NuGetVersion> orderedVersions,
-        ImmutableArray<NuGetFramework> projectFrameworks,
+        ImmutableDictionary<string, ImmutableArray<NuGetFramework>> compatibilityFrameworks,
         NuGetContext nugetContext,
         ILogger logger,
         CancellationToken cancellationToken)
@@ -300,7 +323,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
             var isCompatible = await AreAllPackagesCompatibleAsync(
                 packageIds,
                 currentVersion,
-                projectFrameworks,
+                compatibilityFrameworks,
                 nugetContext,
                 logger,
                 cancellationToken);
@@ -308,7 +331,10 @@ public partial class AnalyzeWorker : IAnalyzeWorker
             if (!isCompatible)
             {
                 // If the current package is incompatible, then don't check for compatibility.
-                return orderedVersions.First();
+                if (packageIds.Count == 1)
+                {
+                    return orderedVersions.First();
+                }
             }
         }
 
@@ -323,7 +349,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
             var isCompatible = await AreAllPackagesCompatibleAsync(
                 packageIds,
                 version,
-                projectFrameworks,
+                compatibilityFrameworks,
                 nugetContext,
                 logger,
                 cancellationToken);
@@ -341,13 +367,19 @@ public partial class AnalyzeWorker : IAnalyzeWorker
     internal static async Task<bool> AreAllPackagesCompatibleAsync(
         ImmutableHashSet<string> packageIds,
         NuGetVersion currentVersion,
-        ImmutableArray<NuGetFramework> projectFrameworks,
+        ImmutableDictionary<string, ImmutableArray<NuGetFramework>> compatibilityFrameworks,
         NuGetContext nugetContext,
         ILogger logger,
         CancellationToken cancellationToken)
     {
         foreach (var packageId in packageIds)
         {
+            var projectFrameworks = compatibilityFrameworks.GetValueOrDefault(packageId, []);
+            if (projectFrameworks.IsEmpty)
+            {
+                continue;
+            }
+
             var isCompatible = await CompatibilityChecker.CheckAsync(
                 new(packageId, currentVersion),
                 projectFrameworks,
@@ -382,42 +414,45 @@ public partial class AnalyzeWorker : IAnalyzeWorker
             return [];
         }
 
-        var projectFrameworks = projectsWithDependency
-            .SelectMany(p => p.TargetFrameworks)
-            .Select(NuGetFramework.Parse)
-            .Distinct()
-            .Select(f => f.GetShortFolderName())
-            .ToImmutableArray();
-
-        // When updating peer dependencies, we only need to consider top-level dependencies.
-        var projectDependencyNames = projectsWithDependency
-            .SelectMany(p => p.Dependencies)
-            .Where(d => d.IsTopLevel)
-            .Select(d => d.Name)
-            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
-
-        // Determine updated peer dependencies
+        var dependencyResults = ImmutableDictionary.CreateBuilder<string, ImmutableArray<Dependency>>();
         var workspacePath = PathHelper.JoinPath(repoRoot, discovery.Path);
-        // We need any project path so the dependency finder can locate the nuget.config
-        var projectPath = Path.Combine(workspacePath, projectsWithDependency.First().FilePath);
+        foreach (var project in projectsWithDependency)
+        {
+            var projectPath = Path.Combine(workspacePath, project.FilePath);
+            var projectDependencyNames = project.Dependencies
+                .Where(d => d.IsTopLevel)
+                .Select(d => d.Name)
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            var packages = project.Dependencies
+                .Where(dependency => packageIds.Contains(dependency.Name))
+                .ToImmutableArray();
+            var packageTargetFrameworks = packages
+                .SelectMany(dependency => dependency.TargetFrameworks ?? [])
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            var targetFrameworks = packageTargetFrameworks.Count == 0
+                ? project.TargetFrameworks
+                : project.TargetFrameworks
+                    .Where(packageTargetFrameworks.Contains)
+                    .ToImmutableArray();
+            var projectDependencies = await DependencyFinder.GetDependenciesAsync(
+                repoRoot,
+                projectPath,
+                targetFrameworks,
+                packages,
+                updatedVersion,
+                nugetContext,
+                logger,
+                cancellationToken);
+            foreach (var (framework, dependencies) in projectDependencies)
+            {
+                dependencyResults[$"{project.FilePath}:{framework}"] = dependencies
+                    .Where(d => projectDependencyNames.Contains(d.Name))
+                    .ToImmutableArray();
+            }
+        }
 
-        // Create distinct list of dependencies taking the highest version of each
-        var dependencyResult = await DependencyFinder.GetDependenciesAsync(
-            repoRoot,
-            projectPath,
-            projectFrameworks,
-            packageIds,
-            updatedVersion,
-            nugetContext,
-            logger,
-            cancellationToken);
-
-        // Filter dependencies by whether any project references them
-        var dependencies = dependencyResult.GetDependencies()
-            .Where(d => projectDependencyNames.Contains(d.Name))
-            .ToImmutableArray();
-
-        return dependencies;
+        // Create distinct list of dependencies taking the highest version.
+        return dependencyResults.ToImmutable().GetDependencies();
     }
 
     internal static ImmutableArray<MultiDependency> DetermineMultiDependencyDetails(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/DependencyFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/DependencyFinder.cs
@@ -10,15 +10,20 @@ internal static class DependencyFinder
         string repoRoot,
         string projectPath,
         IEnumerable<string> frameworks,
-        ImmutableHashSet<string> packageIds,
+        ImmutableArray<Dependency> packageTemplates,
         NuGetVersion version,
         NuGetContext nugetContext,
         ILogger logger,
         CancellationToken cancellationToken)
     {
         var versionString = version.ToNormalizedString();
-        var packages = packageIds
-            .Select(id => new Dependency(id, versionString, DependencyType.Unknown))
+        var packages = packageTemplates
+            .Select(dependency => dependency with
+            {
+                Version = versionString,
+                Type = DependencyType.Unknown,
+                IsTopLevel = true,
+            })
             .ToImmutableArray();
 
         var result = ImmutableDictionary.CreateBuilder<string, ImmutableArray<Dependency>>();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/Extensions.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/Extensions.cs
@@ -16,13 +16,26 @@ internal static class Extensions
             {
                 if (dependencies.TryGetValue(dependency.Name, out Dependency? value))
                 {
-                    if (NuGetVersion.Parse(value.Version!) < NuGetVersion.Parse(dependency.Version!))
+                    var selectedDependency = NuGetVersion.Parse(value.Version!) < NuGetVersion.Parse(dependency.Version!)
+                        ? dependency
+                        : value;
+                    var assetFlags = (value.AssetFlags ?? [])
+                        .Concat(dependency.AssetFlags ?? [])
+                        .GroupBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase)
+                        .ToImmutableDictionary(
+                            group => group.Key,
+                            group => group.Select(kvp => kvp.Value).Aggregate((left, right) => left | right),
+                            StringComparer.OrdinalIgnoreCase);
+                    dependencies[dependency.Name] = selectedDependency with
                     {
-                        dependencies[dependency.Name] = dependency with
-                        {
-                            TargetFrameworks = [.. value.TargetFrameworks ?? [], .. dependency.TargetFrameworks ?? []]
-                        };
-                    }
+                        TargetFrameworks = value.TargetFrameworks
+                            .GetValueOrDefault()
+                            .Concat(dependency.TargetFrameworks.GetValueOrDefault())
+                            .Select(targetFramework => NuGetFramework.Parse(targetFramework).GetShortFolderName())
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
+                            .ToImmutableArray(),
+                        AssetFlags = assetFlags,
+                    };
                 }
                 else
                 {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Dependency.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Dependency.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 
+using NuGet.LibraryModel;
+
 using NuGetUpdater.Core.Utilities;
 
 namespace NuGetUpdater.Core;
@@ -12,7 +14,8 @@ public sealed record Dependency(
     ImmutableArray<string>? TargetFrameworks = null,
     bool IsTopLevel = true,
     bool IsUpdate = false,
-    string? InfoUrl = null) : IEquatable<Dependency>
+    string? InfoUrl = null,
+    ImmutableDictionary<string, LibraryIncludeFlags>? AssetFlags = null) : IEquatable<Dependency>
 {
     public bool Equals(Dependency? other)
     {
@@ -33,7 +36,8 @@ public sealed record Dependency(
                TargetFrameworks.SequenceEqual(other.TargetFrameworks) &&
                IsTopLevel == other.IsTopLevel &&
                IsUpdate == other.IsUpdate &&
-               InfoUrl == other.InfoUrl;
+               InfoUrl == other.InfoUrl &&
+               AssetFlagsEqual(AssetFlags, other.AssetFlags);
     }
 
     public override int GetHashCode()
@@ -47,6 +51,32 @@ public sealed record Dependency(
         hash.Add(IsTopLevel);
         hash.Add(IsUpdate);
         hash.Add(InfoUrl);
+        if (AssetFlags is not null)
+        {
+            foreach (var (targetFramework, flags) in AssetFlags.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                hash.Add(targetFramework, StringComparer.OrdinalIgnoreCase);
+                hash.Add(flags);
+            }
+        }
+
         return hash.ToHashCode();
+    }
+
+    private static bool AssetFlagsEqual(
+        ImmutableDictionary<string, LibraryIncludeFlags>? left,
+        ImmutableDictionary<string, LibraryIncludeFlags>? right)
+    {
+        if (left is null || left.Count == 0)
+        {
+            return right is null || right.Count == 0;
+        }
+
+        if (right is null || left.Count != right.Count)
+        {
+            return false;
+        }
+
+        return left.All(kvp => right.TryGetValue(kvp.Key, out var rightValue) && kvp.Value == rightValue);
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyAssetFlags.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/DependencyAssetFlags.cs
@@ -1,0 +1,28 @@
+using NuGet.LibraryModel;
+
+namespace NuGetUpdater.Core;
+
+internal static class DependencyAssetFlags
+{
+    private const LibraryIncludeFlags CompatibilityAssets =
+        LibraryIncludeFlags.Compile | LibraryIncludeFlags.Runtime;
+
+    public static LibraryIncludeFlags GetAssetFlags(this Dependency dependency, string targetFramework)
+    {
+        return dependency.AssetFlags?.GetValueOrDefault(targetFramework, LibraryIncludeFlags.All)
+            ?? LibraryIncludeFlags.All;
+    }
+
+    public static bool RequiresCompatibilityCheck(this Dependency dependency, string targetFramework)
+    {
+        return (dependency.GetAssetFlags(targetFramework) & CompatibilityAssets) != LibraryIncludeFlags.None;
+    }
+
+    public static string? GetIncludeAssetsValue(this Dependency dependency, string targetFramework)
+    {
+        var flags = dependency.GetAssetFlags(targetFramework);
+        return flags == LibraryIncludeFlags.All
+            ? null
+            : LibraryIncludeFlagUtils.GetFlagString(flags).Replace(", ", ";", StringComparison.Ordinal);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -5,6 +5,8 @@ using System.Xml.Linq;
 using Microsoft.Build.Logging.StructuredLogger;
 
 using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
 
 using NuGetUpdater.Core.Utilities;
 
@@ -97,6 +99,9 @@ internal static class SdkProjectDiscovery
 
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> explicitPackageVersionsPerProject = new(PathComparer.Instance);
         //    projectPath,               tfm,       packageName, packageVersion
+
+        Dictionary<string, Dictionary<string, Dictionary<string, LibraryIncludeFlags>>> packageAssetFlagsPerProject = new(PathComparer.Instance);
+        //    projectPath,               tfm,       packageName, effective asset flags
 
         Dictionary<string, int> packageReferenceElementCounts = new(PathComparer.Instance);
         //    projectPath, count of `<PackageReference>` elements
@@ -276,7 +281,13 @@ internal static class SdkProjectDiscovery
                             }
                             break;
                         case NamedNode namedNode when namedNode is AddItem or RemoveItem:
-                            ProcessResolvedPackageReference(namedNode, packagesPerProject, implicitlyIgnoredPackages, explicitPackageVersionsPerProject, packageReferenceElementCounts);
+                            ProcessResolvedPackageReference(
+                                namedNode,
+                                packagesPerProject,
+                                implicitlyIgnoredPackages,
+                                explicitPackageVersionsPerProject,
+                                packageAssetFlagsPerProject,
+                                packageReferenceElementCounts);
 
                             if (namedNode is AddItem addItem)
                             {
@@ -466,6 +477,7 @@ internal static class SdkProjectDiscovery
             workspacePath,
             packagesPerProject,
             explicitPackageVersionsPerProject,
+            packageAssetFlagsPerProject,
             packagesReplacedBySdkPerProject,
             implicitlyIgnoredPackages,
             resolvedProperties,
@@ -483,6 +495,7 @@ internal static class SdkProjectDiscovery
         string workspacePath,
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packagesPerProject,
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packageVersionsPerProject,
+        Dictionary<string, Dictionary<string, Dictionary<string, LibraryIncludeFlags>>> packageAssetFlagsPerProject,
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packagesReplacedBySdkPerProject,
         Dictionary<string, Dictionary<string, HashSet<string>>> implicitlyIgnoredPackagesPerProject,
         Dictionary<string, Dictionary<string, string>> resolvedProperties,
@@ -498,6 +511,7 @@ internal static class SdkProjectDiscovery
         {
             // gather some project-level information
             var implicitlyIgnoredPackagesByTfm = implicitlyIgnoredPackagesPerProject.GetValueOrDefault(projectPath, new(StringComparer.OrdinalIgnoreCase));
+            var packageAssetFlagsByTfm = packageAssetFlagsPerProject.GetValueOrDefault(projectPath, new(StringComparer.OrdinalIgnoreCase));
             var packagesByTfm = packagesPerProject[projectPath];
             if (packagesReplacedBySdkPerProject.TryGetValue(projectPath, out var packagesReplacedBySdk))
             {
@@ -528,6 +542,7 @@ internal static class SdkProjectDiscovery
 
             var projectFullDirectory = Path.GetDirectoryName(projectPath)!;
             var projectRelativePath = Path.GetRelativePath(workspacePath, projectPath);
+            var tfms = packagesByTfm.Keys.OrderBy(tfm => tfm).ToImmutableArray();
 
             var propertiesForProject = resolvedProperties.GetOrAdd(projectPath, () => new(StringComparer.OrdinalIgnoreCase));
             var assetsJson = new Lazy<JsonElement?>(() =>
@@ -542,6 +557,16 @@ internal static class SdkProjectDiscovery
                     var assetsContent = File.ReadAllText(assetsFilePath);
                     var assets = JsonDocument.Parse(assetsContent).RootElement;
                     return assets;
+                }
+
+                return null;
+            });
+            var lockFile = new Lazy<LockFile?>(() =>
+            {
+                if (propertiesForProject.TryGetValue("ProjectAssetsFile", out var assetsFilePath) &&
+                    File.Exists(assetsFilePath))
+                {
+                    return new LockFileFormat().Read(assetsFilePath);
                 }
 
                 return null;
@@ -575,11 +600,26 @@ internal static class SdkProjectDiscovery
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
             // create dependencies
-            var tfms = packagesByTfm.Keys.OrderBy(tfm => tfm).ToImmutableArray();
             var groupedDependencies = new Dictionary<string, Dependency>(StringComparer.OrdinalIgnoreCase);
             foreach (var tfm in tfms)
             {
                 var parsedTfm = NuGetFramework.Parse(tfm);
+                var directAssetFlags = packageAssetFlagsByTfm.GetValueOrDefault(tfm, new(StringComparer.OrdinalIgnoreCase));
+                Dictionary<string, LibraryIncludeFlags> effectiveAssetFlags;
+                try
+                {
+                    effectiveAssetFlags = lockFile.Value is null
+                        ? new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase)
+                        : GetEffectiveAssetFlags(
+                            lockFile.Value,
+                            parsedTfm,
+                            directAssetFlags);
+                }
+                catch (Exception ex)
+                {
+                    logger.Warn($"Unable to determine package asset flags for project [{projectRelativePath}] and target framework [{tfm}]: {ex.Message}");
+                    effectiveAssetFlags = new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase);
+                }
                 var packages = packagesByTfm[tfm];
                 var implicitlyIgnoredPackages = implicitlyIgnoredPackagesByTfm.GetValueOrDefault(tfm, new(StringComparer.OrdinalIgnoreCase));
 
@@ -637,6 +677,7 @@ internal static class SdkProjectDiscovery
                     var isTopLevel = directlyReferencedPackages.Contains(packageName) && !implicitlyIgnoredPackages.Contains(packageName);
                     var dependencyType = isTopLevel ? DependencyType.PackageReference : DependencyType.Unknown;
                     var combinedTfms = new HashSet<string>([tfm], StringComparer.OrdinalIgnoreCase);
+                    var combinedAssetFlags = ImmutableDictionary.CreateBuilder<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase);
                     if (groupedDependencies.TryGetValue(packageName, out var existingDependency) &&
                         existingDependency.Version == packageVersion &&
                         existingDependency.Type == dependencyType &&
@@ -644,10 +685,34 @@ internal static class SdkProjectDiscovery
                     {
                         // same dependency, combine tfms
                         combinedTfms.AddRange(existingDependency.TargetFrameworks);
+                        combinedAssetFlags.AddRange(existingDependency.AssetFlags ?? []);
+                    }
+
+                    var assetFlags = effectiveAssetFlags.GetValueOrDefault(
+                        packageName,
+                        LibraryIncludeFlags.All);
+                    if (assetFlags != LibraryIncludeFlags.All)
+                    {
+                        foreach (var existingTfm in combinedTfms)
+                        {
+                            combinedAssetFlags.TryAdd(existingTfm, LibraryIncludeFlags.All);
+                        }
+
+                        combinedAssetFlags[tfm] = assetFlags;
+                    }
+                    else if (combinedAssetFlags.Count > 0)
+                    {
+                        combinedAssetFlags[tfm] = assetFlags;
                     }
 
                     var normalizedTfms = combinedTfms.OrderBy(t => t).ToImmutableArray();
-                    groupedDependencies[package.Key] = new Dependency(packageName, packageVersion, dependencyType, TargetFrameworks: normalizedTfms, IsTopLevel: isTopLevel);
+                    groupedDependencies[package.Key] = new Dependency(
+                        packageName,
+                        packageVersion,
+                        dependencyType,
+                        TargetFrameworks: normalizedTfms,
+                        IsTopLevel: isTopLevel,
+                        AssetFlags: combinedAssetFlags.Count == 0 ? null : combinedAssetFlags.ToImmutable());
                 }
             }
 
@@ -788,6 +853,81 @@ internal static class SdkProjectDiscovery
         return projectDiscoveryResults.ToImmutableArray();
     }
 
+    private static Dictionary<string, LibraryIncludeFlags> GetEffectiveAssetFlags(
+        LockFile lockFile,
+        NuGetFramework targetFramework,
+        IReadOnlyDictionary<string, LibraryIncludeFlags> directAssetFlags)
+    {
+        var results = new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase);
+        var frameworkInfo = lockFile.PackageSpec?.GetTargetFramework(targetFramework);
+        if (frameworkInfo is null && directAssetFlags.Count == 0)
+        {
+            return results;
+        }
+
+        foreach (var target in lockFile.Targets.Where(t => t.TargetFramework.Equals(targetFramework)))
+        {
+            var targetResults = new Dictionary<string, LibraryIncludeFlags>(StringComparer.OrdinalIgnoreCase);
+            var libraries = target.Libraries
+                .Where(library => library.Name is not null)
+                .ToDictionary(library => library.Name!, StringComparer.OrdinalIgnoreCase);
+            var pending = new Queue<(string PackageName, LibraryIncludeFlags Flags)>();
+            foreach (var dependency in directAssetFlags)
+            {
+                pending.Enqueue((dependency.Key, dependency.Value));
+            }
+
+            foreach (var dependency in frameworkInfo?.Dependencies ?? [])
+            {
+                if (!directAssetFlags.ContainsKey(dependency.Name))
+                {
+                    pending.Enqueue((dependency.Name, dependency.IncludeType));
+                }
+            }
+
+            while (pending.TryDequeue(out var item))
+            {
+                if (targetResults.TryGetValue(item.PackageName, out var existingFlags))
+                {
+                    var combinedFlags = existingFlags | item.Flags;
+                    if (combinedFlags == existingFlags)
+                    {
+                        continue;
+                    }
+
+                    targetResults[item.PackageName] = combinedFlags;
+                }
+                else
+                {
+                    targetResults[item.PackageName] = item.Flags;
+                }
+
+                if (!libraries.TryGetValue(item.PackageName, out var library))
+                {
+                    continue;
+                }
+
+                foreach (var dependency in library.Dependencies)
+                {
+                    var includeFlags = dependency.Include.Count == 0
+                        ? LibraryIncludeFlags.All
+                        : LibraryIncludeFlagUtils.GetFlags(dependency.Include);
+                    var excludeFlags = dependency.Exclude.Count == 0
+                        ? LibraryIncludeFlags.None
+                        : LibraryIncludeFlagUtils.GetFlags(dependency.Exclude);
+                    pending.Enqueue((dependency.Id, item.Flags & includeFlags & ~excludeFlags));
+                }
+            }
+
+            foreach (var (packageName, flags) in targetResults)
+            {
+                results[packageName] = results.GetValueOrDefault(packageName) | flags;
+            }
+        }
+
+        return results;
+    }
+
     private static async Task<HashSet<string>> DirectlyReferencedPackagesFromFilePath(string fullFilePath, ILogger logger)
     {
         try
@@ -879,6 +1019,7 @@ internal static class SdkProjectDiscovery
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packagesPerProject, // projectPath -> tfm -> (packageName, packageVersion)
         Dictionary<string, Dictionary<string, HashSet<string>>> implicitlyIgnoredPackagesPerProject, // projectPath -> tfm -> packageNames
         Dictionary<string, Dictionary<string, Dictionary<string, string>>> packageVersionsPerProject, // projectPath -> tfm -> (packageName, packageVersion)
+        Dictionary<string, Dictionary<string, Dictionary<string, LibraryIncludeFlags>>> packageAssetFlagsPerProject, // projectPath -> tfm -> (packageName, effective asset flags)
         Dictionary<string, int> packageReferenceElementCounts // projectPath -> count of `<PackageReference>` elements
     )
     {
@@ -921,6 +1062,22 @@ internal static class SdkProjectDiscovery
                                 var packageVersions = packagesPerTfm.GetOrAdd(tfm, () => new(StringComparer.OrdinalIgnoreCase));
                                 packageVersions[packageName] = packageVersion;
                             }
+
+                            var includeAssets = GetChildMetadataValue(child, "IncludeAssets");
+                            var excludeAssets = GetChildMetadataValue(child, "ExcludeAssets");
+                            var includeFlags = string.IsNullOrWhiteSpace(includeAssets)
+                                ? LibraryIncludeFlags.All
+                                : LibraryIncludeFlagUtils.GetFlags(includeAssets.Split(
+                                    [';', ','],
+                                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+                            var excludeFlags = string.IsNullOrWhiteSpace(excludeAssets)
+                                ? LibraryIncludeFlags.None
+                                : LibraryIncludeFlagUtils.GetFlags(excludeAssets.Split(
+                                    [';', ','],
+                                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+                            var assetFlagsPerTfm = packageAssetFlagsPerProject.GetOrAdd(projectEvaluation.ProjectFile, () => new(StringComparer.OrdinalIgnoreCase));
+                            var assetFlags = assetFlagsPerTfm.GetOrAdd(tfm, () => new(StringComparer.OrdinalIgnoreCase));
+                            assetFlags[packageName] = includeFlags & ~excludeFlags;
                         }
                     }
                 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/FileWriterWorker.cs
@@ -169,7 +169,12 @@ public class FileWriterWorker
         var initialTopLevelDependencies = initialProjectDiscovery.Dependencies
             .Where(d => d.IsTopLevel)
             .ToImmutableArray();
-        var newDependency = new Dependency(dependencyName, newDependencyVersion.ToString(), DependencyType.Unknown);
+        var newDependency = initialRequestedDependency with
+        {
+            Version = newDependencyVersion.ToString(),
+            Type = DependencyType.Unknown,
+            IsTopLevel = true,
+        };
         var desiredDependencies = initialTopLevelDependencies.Any(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase))
             ? initialTopLevelDependencies.Select(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase) ? newDependency : d).ToImmutableArray()
             : initialTopLevelDependencies.Concat([newDependency]).ToImmutableArray();
@@ -183,6 +188,7 @@ public class FileWriterWorker
                 _logger.Warn($"Unable to solve dependency conflicts for target framework {targetFramework}.");
                 continue;
             }
+            resolvedDependencies = MergeAssetFlags(resolvedDependencies.Value, initialProjectDiscovery.Dependencies);
 
             var resolvedRequestedDependency = resolvedDependencies.Value
                 .SingleOrDefault(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase));
@@ -245,15 +251,24 @@ public class FileWriterWorker
                 var rerunTopLevelDependencies = rerunProjectDiscovery.Dependencies
                     .Where(d => d.IsTopLevel)
                     .ToImmutableArray();
+                var rerunNewDependency = candidateDependencyToUpdate with
+                {
+                    Version = newDependencyVersion.ToString(),
+                    Type = DependencyType.Unknown,
+                    IsTopLevel = true,
+                };
                 var rerunDesiredDependencies = rerunTopLevelDependencies.Any(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase))
-                    ? rerunTopLevelDependencies.Select(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase) ? newDependency : d).ToImmutableArray()
-                    : rerunTopLevelDependencies.Concat([newDependency]).ToImmutableArray();
+                    ? rerunTopLevelDependencies.Select(d => d.Name.Equals(dependencyName, StringComparison.OrdinalIgnoreCase) ? rerunNewDependency : d).ToImmutableArray()
+                    : rerunTopLevelDependencies.Concat([rerunNewDependency]).ToImmutableArray();
                 var resolvedDependenciesInThisproject = await _dependencySolver.SolveAsync(rerunTopLevelDependencies, rerunDesiredDependencies, targetFramework);
                 if (resolvedDependenciesInThisproject is null)
                 {
                     _logger.Warn($"  Unable to solve dependency conflicts for {projectRelativePath}/{targetFramework}.");
                     continue;
                 }
+                resolvedDependenciesInThisproject = MergeAssetFlags(
+                    resolvedDependenciesInThisproject.Value,
+                    rerunProjectDiscovery.Dependencies);
 
                 var updatedFiles = await TryPerformFileWritesAsync(_fileWriter, repoContentsPath, projectDirectory, rerunProjectDiscovery!, resolvedDependenciesInThisproject.Value);
                 if (updatedFiles.Length == 0)
@@ -324,6 +339,24 @@ public class FileWriterWorker
         }
 
         return [.. updateOperations];
+    }
+
+    private static ImmutableArray<Dependency> MergeAssetFlags(
+        ImmutableArray<Dependency> resolvedDependencies,
+        ImmutableArray<Dependency> discoveredDependencies)
+    {
+        var discoveredByName = discoveredDependencies.ToDictionary(
+            dependency => dependency.Name,
+            StringComparer.OrdinalIgnoreCase);
+        return resolvedDependencies
+            .Select(dependency => discoveredByName.TryGetValue(dependency.Name, out var discoveredDependency)
+                ? dependency with
+                {
+                    TargetFrameworks = discoveredDependency.TargetFrameworks,
+                    AssetFlags = discoveredDependency.AssetFlags,
+                }
+                : dependency)
+            .ToImmutableArray();
     }
 
     internal static async Task<Dictionary<string, string>> GetOriginalFileContentsAsync(DirectoryInfo repoContentsPath, DirectoryInfo initialStartingDirectory, IEnumerable<ProjectDiscoveryResult> projectDiscoveryResults)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/FileWriters/XmlFileWriter.cs
@@ -162,13 +162,28 @@ public class XmlFileWriter : IFileWriter
                 Action addItemGroup = () => { }; // adding an ItemGroup to the project isn't always necessary, but it's much easier to prepare for it here
                 var projectDocument = filesAndContents[projectRelativePath];
                 var indentation = GetDocumentIndentationCharacters(projectDocument);
+                var assetFlagTargetFrameworks = requiredPackageVersion.TargetFrameworks is { Length: > 0 }
+                    ? requiredPackageVersion.TargetFrameworks.Value
+                    : requiredPackageVersion.AssetFlags?.Keys.ToImmutableArray() ?? [];
+                var assetFlagsByFramework = assetFlagTargetFrameworks
+                    .OrderBy(targetFramework => targetFramework, StringComparer.OrdinalIgnoreCase)
+                    .Select(targetFramework => (TargetFramework: targetFramework, IncludeAssets: requiredPackageVersion.GetIncludeAssetsValue(targetFramework)))
+                    .ToArray();
+                var distinctIncludeAssets = assetFlagsByFramework
+                    .Select(item => item.IncludeAssets)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                var requiresConditionalAssetFlags = distinctIncludeAssets.Length > 1;
                 var itemGroups = projectDocument.RootSyntax.Elements
                     .Where(e => e.Name.Equals(ItemGroupElementName, StringComparison.OrdinalIgnoreCase))
                     .ToArray();
                 var itemGroupsWithPackageReferences = itemGroups
-                    .Where(e => e.Elements.Any(c => c.Name.Equals(PackageReferenceElementName, StringComparison.OrdinalIgnoreCase)))
+                    .Where(e =>
+                        e.Elements.Any(c => c.Name.Equals(PackageReferenceElementName, StringComparison.OrdinalIgnoreCase)) &&
+                        string.IsNullOrWhiteSpace(e.GetAttributeValue("Condition")))
                     .ToArray();
-                var itemGroupForInsertion = itemGroupsWithPackageReferences.LastOrDefault() ?? itemGroups.LastOrDefault();
+                var itemGroupForInsertion = itemGroupsWithPackageReferences.LastOrDefault()
+                    ?? itemGroups.LastOrDefault(e => string.IsNullOrWhiteSpace(e.GetAttributeValue("Condition")));
                 if (itemGroupForInsertion is null)
                 {
                     _logger.Info($"No `<{ItemGroupElementName}>` element found in project; adding one.");
@@ -194,6 +209,17 @@ public class XmlFileWriter : IFileWriter
                 // ...prepare a new `<PackageReference>` element...
                 var newElement = XmlExtensions.CreateSingleLineXmlElementSyntax(PackageReferenceElementName, leadingTrivia: new SyntaxList<SyntaxNode>())
                     .WithAttribute(IncludeAttributeName, requiredPackageVersion.Name);
+                var remainingConditionalAssetFlags = Array.Empty<(string TargetFramework, string? IncludeAssets)>();
+                if (!requiresConditionalAssetFlags && distinctIncludeAssets.Length == 1 && distinctIncludeAssets[0] is not null)
+                {
+                    newElement = newElement.WithAttribute("IncludeAssets", distinctIncludeAssets[0]!);
+                }
+                else if (requiresConditionalAssetFlags)
+                {
+                    var firstAssetFlags = assetFlagsByFramework[0];
+                    newElement = AddAssetFlagsAndCondition(newElement, firstAssetFlags);
+                    remainingConditionalAssetFlags = assetFlagsByFramework[1..];
+                }
 
                 // ...add the `<PackageReference>` element if and where appropriate...
                 var addPackageReferenceElementForPinnedPackages =
@@ -311,7 +337,7 @@ public class XmlFileWriter : IFileWriter
                     if (isVersionOverrideNeeded)
                     {
                         _logger.Info($"Dependency {requiredPackageVersion.Name} set to {requiredVersion} using `{VersionOverrideMetadataName}` attribute on new element in file {projectRelativePath}.");
-                        ReplaceNode(
+                        newElement = (IXmlElementSyntax)ReplaceNode(
                             projectRelativePath,
                             newElement.AsNode,
                             newElement.WithAttribute(VersionOverrideMetadataName, requiredVersion.ToString()).AsNode
@@ -603,6 +629,54 @@ public class XmlFileWriter : IFileWriter
                             newElement = (IXmlElementSyntax)ReplaceNode(projectRelativePath, newElement.AsNode, newElementWithVersion.AsNode);
                         }
                     }
+                }
+
+                if (addPackageReferenceElementForPinnedPackages &&
+                    remainingConditionalAssetFlags.Length > 0 &&
+                    updatesPerformed[requiredPackageVersion.Name])
+                {
+                    var version = newElement.GetAttributeValue(VersionMetadataName);
+                    var versionOverride = newElement.GetAttributeValue(VersionOverrideMetadataName);
+                    var additionalElements = remainingConditionalAssetFlags
+                        .Select(assetFlags =>
+                        {
+                            var element = (IXmlElementSyntax)XmlExtensions.CreateSingleLineXmlElementSyntax(
+                                PackageReferenceElementName,
+                                new SyntaxList<SyntaxNode>(),
+                                new SyntaxList<SyntaxNode>());
+                            element = (IXmlElementSyntax)element.AsNode.WithLeadingTrivia(newElement.AsNode.GetLeadingTrivia());
+                            element = element
+                                .WithAttribute(IncludeAttributeName, requiredPackageVersion.Name);
+                            element = AddAssetFlagsAndCondition(element, assetFlags);
+                            if (version is not null)
+                            {
+                                element = element.WithAttribute(VersionMetadataName, version);
+                            }
+
+                            if (versionOverride is not null)
+                            {
+                                element = element.WithAttribute(VersionOverrideMetadataName, versionOverride);
+                            }
+
+                            return element;
+                        })
+                        .ToArray();
+                    var replacementParent = newElement.Parent.AsNode.InsertNodesAfter(
+                        newElement.AsNode,
+                        additionalElements.Select(element => element.AsNode));
+                    ReplaceNode(projectRelativePath, newElement.Parent.AsNode, replacementParent);
+                }
+
+                static IXmlElementSyntax AddAssetFlagsAndCondition(
+                    IXmlElementSyntax element,
+                    (string TargetFramework, string? IncludeAssets) assetFlags)
+                {
+                    if (assetFlags.IncludeAssets is not null)
+                    {
+                        element = element.WithAttribute("IncludeAssets", assetFlags.IncludeAssets);
+                    }
+
+                    return element.WithAttribute("Condition", $"'$(TargetFramework)' == '{assetFlags.TargetFramework}'");
                 }
             }
             else

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -95,9 +95,6 @@ internal static partial class MSBuildHelper
 
         try
         {
-            string tempProjectPath = await CreateTempProjectAsync(tempDirectory, repoRoot, projectPath, targetFramework, packages, logger);
-            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(["restore", tempProjectPath], tempDirectory.FullName);
-
             // Add Dependency[] packages to List<PackageToUpdate> existingPackages
             List<PackageToUpdate> existingPackages = packages
             .Select(existingPackage => new PackageToUpdate
@@ -191,56 +188,39 @@ internal static partial class MSBuildHelper
 
             // Convert back to Dependency [], use NewVersion if available, otherwise use CurrentVersion
             List<Dependency> candidatePackages = existingPackages
-            .Select(package => new Dependency(
-                package.PackageName,
-                package.NewVersion ?? package.CurrentVersion,
-                DependencyType.Unknown,
-                null,
-                null,
-                true,
-                false
-            ))
+            .Select(package =>
+            {
+                var template = update.FirstOrDefault(d =>
+                        d.Name.Equals(package.PackageName, StringComparison.OrdinalIgnoreCase))
+                    ?? packages.FirstOrDefault(d =>
+                        d.Name.Equals(package.PackageName, StringComparison.OrdinalIgnoreCase));
+                return new Dependency(
+                    package.PackageName,
+                    package.NewVersion ?? package.CurrentVersion,
+                    DependencyType.Unknown,
+                    IsTopLevel: true,
+                    AssetFlags: template?.AssetFlags);
+            })
             .ToList();
 
             // Return as array
             var candidatePackagesArray = candidatePackages.ToImmutableArray();
 
-            var targetFrameworks = ImmutableArray.Create<NuGetFramework>(NuGetFramework.Parse(targetFramework));
-
-            var resolveProjectPath = projectPath;
-
-            if (!Path.IsPathRooted(resolveProjectPath) || !File.Exists(resolveProjectPath))
+            var tempProjectPath = await CreateTempProjectAsync(
+                tempDirectory,
+                repoRoot,
+                projectPath,
+                targetFramework,
+                candidatePackagesArray,
+                logger,
+                importDependencyTargets: false);
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetWithoutMSBuildEnvironmentVariablesAsync(
+                ["restore", tempProjectPath],
+                tempDirectory.FullName);
+            if (exitCode != 0)
             {
-                resolveProjectPath = Path.GetFullPath(Path.Join(repoRoot, resolveProjectPath));
-            }
-
-            NuGetContext nugetContext = new NuGetContext(Path.GetDirectoryName(resolveProjectPath));
-
-            // Target framework compatibility check
-            foreach (var package in candidatePackages)
-            {
-                if (package.Version is null ||
-                    !VersionRange.TryParse(package.Version, out var nuGetVersionRange))
-                {
-                    // If version is not valid, return original packages and revert
-                    return packages;
-                }
-
-                if (nuGetVersionRange.IsFloating)
-                {
-                    // If a wildcard version, the original project specified it this way and we can count on restore to do the appropriate thing
-                    continue;
-                }
-
-                var nuGetVersion = nuGetVersionRange.MinVersion; // not a wildcard, so `MinVersion` is just the version itself
-                var packageIdentity = new NuGet.Packaging.Core.PackageIdentity(package.Name, nuGetVersion);
-
-                bool isNewPackageCompatible = await CompatibilityChecker.CheckAsync(packageIdentity, targetFrameworks, nugetContext, logger, CancellationToken.None);
-                if (!isNewPackageCompatible)
-                {
-                    // If the package target framework is not compatible, return original packages and revert
-                    return packages;
-                }
+                logger.Warn($"Unable to restore resolved dependency set for {targetFramework}:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}");
+                return packages;
             }
 
             return candidatePackagesArray;
@@ -279,7 +259,7 @@ internal static partial class MSBuildHelper
         ILogger logger,
         bool usePackageDownload = false,
         bool importDependencyTargets = true
-    ) => CreateTempProjectAsync(tempDir, repoRoot, projectPath, new XElement("TargetFramework", targetFramework), packages, logger, usePackageDownload, importDependencyTargets);
+    ) => CreateTempProjectAsync(tempDir, repoRoot, projectPath, new XElement("TargetFramework", targetFramework), [targetFramework], packages, logger, usePackageDownload, importDependencyTargets);
 
     internal static Task<string> CreateTempProjectAsync(
         DirectoryInfo tempDir,
@@ -290,13 +270,14 @@ internal static partial class MSBuildHelper
         ILogger logger,
         bool usePackageDownload = false,
         bool importDependencyTargets = true
-    ) => CreateTempProjectAsync(tempDir, repoRoot, projectPath, new XElement("TargetFrameworks", string.Join(";", targetFrameworks)), packages, logger, usePackageDownload, importDependencyTargets);
+    ) => CreateTempProjectAsync(tempDir, repoRoot, projectPath, new XElement("TargetFrameworks", string.Join(";", targetFrameworks)), targetFrameworks, packages, logger, usePackageDownload, importDependencyTargets);
 
     private static async Task<string> CreateTempProjectAsync(
         DirectoryInfo tempDir,
         string repoRoot,
         string projectPath,
         XElement targetFrameworkElement,
+        IReadOnlyCollection<string> targetFrameworks,
         IReadOnlyCollection<Dependency> packages,
         ILogger logger,
         bool usePackageDownload,
@@ -346,7 +327,47 @@ internal static partial class MSBuildHelper
                 // empty `Version` attributes will cause the temporary project to not build
                 .Where(p => (p.EvaluationResult is null || p.EvaluationResult.ResultType == EvaluationResultType.Success) && !string.IsNullOrWhiteSpace(p.Version))
                 // If all PackageReferences for a package are update-only mark it as such, otherwise it can cause package incoherence errors which do not exist in the repo.
-                .Select(p => $"<{(usePackageDownload ? "PackageDownload" : "PackageReference")} {(p.IsUpdate ? "Update" : "Include")}=\"{p.Name}\" Version=\"{GetExactVersionConstraint(p.Version!)}\" />"));
+                .SelectMany(CreatePackageReferences));
+
+        IEnumerable<string> CreatePackageReferences(Dependency dependency)
+        {
+            var elementName = usePackageDownload ? "PackageDownload" : "PackageReference";
+            var identityAttribute = dependency.IsUpdate ? "Update" : "Include";
+            var baseAttributes = $"{identityAttribute}=\"{dependency.Name}\" Version=\"{GetExactVersionConstraint(dependency.Version!)}\"";
+            var dependencyTargetFrameworks = dependency.TargetFrameworks is { Length: > 0 }
+                ? dependency.TargetFrameworks.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase)
+                : null;
+            var applicableTargetFrameworks = dependencyTargetFrameworks is null
+                ? targetFrameworks
+                : targetFrameworks.Where(dependencyTargetFrameworks.Contains).ToArray();
+            if (targetFrameworks.Count > 0 && applicableTargetFrameworks.Count == 0)
+            {
+                return [];
+            }
+
+            if (usePackageDownload || targetFrameworks.Count == 0)
+            {
+                return [$"<{elementName} {baseAttributes} />"];
+            }
+
+            var valuesByFramework = applicableTargetFrameworks.ToDictionary(
+                targetFramework => targetFramework,
+                dependency.GetIncludeAssetsValue,
+                StringComparer.OrdinalIgnoreCase);
+            if (applicableTargetFrameworks.Count == targetFrameworks.Count &&
+                valuesByFramework.Values.Distinct(StringComparer.OrdinalIgnoreCase).Count() == 1)
+            {
+                var includeAssets = valuesByFramework.Values.First();
+                var assetAttribute = includeAssets is null ? string.Empty : $" IncludeAssets=\"{includeAssets}\"";
+                return [$"<{elementName} {baseAttributes}{assetAttribute} />"];
+            }
+
+            return valuesByFramework.Select(kvp =>
+            {
+                var assetAttribute = kvp.Value is null ? string.Empty : $" IncludeAssets=\"{kvp.Value}\"";
+                return $"<{elementName} {baseAttributes}{assetAttribute} Condition=\"'$(TargetFramework)' == '{kvp.Key}'\" />";
+            });
+        }
 
         var dependencyTargetsImport = importDependencyTargets
             ? $"""<Import Project="{GetFileFromRuntimeDirectory("DependencyDiscovery.targets")}" />"""


### PR DESCRIPTION
## Summary

- track effective `IncludeAssets` and `ExcludeAssets` values per target framework during NuGet discovery
- propagate asset restrictions through transitive dependencies and skip compatibility checks only when both compile and runtime assets are absent
- preserve asset metadata through analysis, dependency solving, temporary restores, and transitive package pinning
- validate final solver candidates with restore and retain conditional per-framework package references

## Tests

- `dotnet test ... --filter` focused NuGet analysis, discovery, solver, writer, and MSBuild tests: 103 passed
- full C# suite: 967 passed, 4 skipped; remaining failures were host-specific Windows line endings, unavailable `net10.0-android` reference packs, and one parallel discovery test that passes in isolation