### PR TITLE
Type Terraform requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 949
+# Offense count: 943
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -389,10 +389,8 @@ Sorbet/ForbidTUntyped:
     - "silent/lib/dependabot/silent/file_updater.rb"
     - "silent/lib/dependabot/silent/update_checker.rb"
     - "terraform/lib/dependabot/terraform/file_parser.rb"
-    - "terraform/lib/dependabot/terraform/file_updater.rb"
     - "terraform/lib/dependabot/terraform/file_updater/provider_cli_config_builder.rb"
     - "terraform/lib/dependabot/terraform/package/package_details_fetcher.rb"
-    - "terraform/lib/dependabot/terraform/update_checker.rb"
     - "uv/lib/dependabot/uv.rb"
     - "uv/lib/dependabot/uv/dependency_grapher.rb"
     - "uv/lib/dependabot/uv/file_fetcher/workspace_fetcher.rb"

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/terraform/lib/dependabot/terraform/file_updater.rb
+++ b/terraform/lib/dependabot/terraform/file_updater.rb
@@ -5,6 +5,7 @@ require "sorbet-runtime"
 
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
+require "dependabot/dependency_requirement"
 require "dependabot/errors"
 require "dependabot/terraform/file_selector"
 require "dependabot/shared_helpers"
@@ -76,7 +77,7 @@ module Dependabot
           (dependency.requirements - T.must(dependency.previous_requirements)) |
           (T.must(dependency.previous_requirements) - dependency.requirements)
 
-        changed_requirements.any? { |f| f[:file] == file.name }
+        changed_requirements.any? { |requirement| requirement.file == file.name }
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(String) }
@@ -88,17 +89,17 @@ module Dependabot
 
         # Loop through each changed requirement and update the files and lockfile
         reqs.each do |new_req, old_req|
-          raise "Bad req match" unless new_req[:file] == old_req&.fetch(:file)
-          next unless new_req.fetch(:file) == file.name
+          raise "Bad req match" unless new_req.file == old_req&.file
+          next unless new_req.file == file.name
 
-          case new_req[:source][:type]
+          source_type = T.must(new_req.source_string("type"))
+          case source_type
           when "git"
             update_git_declaration(new_req, old_req, content, file.name)
           when "registry", "provider"
             update_registry_declaration(new_req, old_req, content)
           else
-            raise "Don't know how to update a #{new_req[:source][:type]} " \
-                  "declaration!"
+            raise "Don't know how to update a #{source_type} declaration!"
           end
         end
 
@@ -107,50 +108,55 @@ module Dependabot
 
       sig do
         params(
-          new_req: T::Hash[Symbol, T.untyped],
-          old_req: T.nilable(T::Hash[Symbol, T.untyped]),
+          new_req: Dependabot::DependencyRequirement,
+          old_req: T.nilable(Dependabot::DependencyRequirement),
           updated_content: String,
           filename: String
         )
           .void
       end
       def update_git_declaration(new_req, old_req, updated_content, filename)
-        url = old_req&.dig(:source, :url)&.gsub(%r{^https://}, "")
-        tag = old_req&.dig(:source, :ref)
+        url = T.must(old_req&.source_string("url")).gsub(%r{^https://}, "")
+        old_ref = T.must(old_req&.source_string("ref"))
+        new_ref = T.must(new_req.source_string("ref"))
+        tag = old_ref
         url_regex = /#{Regexp.quote(url)}.*ref=#{Regexp.quote(tag)}/
 
         declaration_regex = git_declaration_regex(filename)
 
         updated_content.sub!(declaration_regex) do |regex_match|
           regex_match.sub(url_regex) do |url_match|
-            url_match.sub(old_req&.dig(:source, :ref), new_req[:source][:ref])
+            url_match.sub(old_ref, new_ref)
           end
         end
       end
 
       sig do
         params(
-          new_req: T::Hash[Symbol, T.untyped],
-          old_req: T.nilable(T::Hash[Symbol, T.untyped]),
+          new_req: Dependabot::DependencyRequirement,
+          old_req: T.nilable(Dependabot::DependencyRequirement),
           updated_content: String
         )
           .void
       end
       def update_registry_declaration(new_req, old_req, updated_content)
-        regex = if new_req[:source][:type] == "provider"
+        regex = if new_req.source_string("type") == "provider"
                   provider_declaration_regex(updated_content)
                 else
                   registry_declaration_regex
                 end
 
+        old_requirement = T.must(old_req&.requirement_string)
+        new_requirement = T.must(new_req.requirement_string)
+
         # Define and break down the version regex for better clarity
         version_key_pattern = /^\s*version\s*=\s*/
-        version_value_pattern = /["'].*#{Regexp.escape(old_req&.fetch(:requirement))}.*['"]/
+        version_value_pattern = /["'].*#{Regexp.escape(old_requirement)}.*['"]/
         version_regex = /#{version_key_pattern}#{version_value_pattern}/
 
         updated_content.gsub!(regex) do |regex_match|
           regex_match.sub(version_regex) do |req_line_match|
-            req_line_match.sub!(old_req&.fetch(:requirement), new_req[:requirement])
+            req_line_match.sub!(old_requirement, new_requirement)
           end
         end
       end
@@ -171,13 +177,15 @@ module Dependabot
 
       sig do
         params(
-          new_req: T::Hash[Symbol, T.untyped]
+          new_req: Dependabot::DependencyRequirement
         )
           .returns([String, String, Regexp])
       end
       def lockfile_details(new_req)
         content = T.must(lockfile).content.dup
-        provider_source = new_req[:source][:registry_hostname] + "/" + new_req[:source][:module_identifier]
+        registry_hostname = T.must(new_req.source_string("registry_hostname"))
+        module_identifier = T.must(new_req.source_string("module_identifier"))
+        provider_source = "#{registry_hostname}/#{module_identifier}"
         declaration_regex = lockfile_declaration_regex(provider_source)
 
         [T.must(content), provider_source, declaration_regex]
@@ -188,7 +196,7 @@ module Dependabot
         new_req = T.must(dependency.requirements.first)
 
         # NOTE: Only providers are included in the lockfile, modules are not
-        return unless new_req[:source][:type] == "provider"
+        return unless new_req.source_string("type") == "provider"
 
         architectures = []
         content, provider_source, declaration_regex = lockfile_details(new_req)
@@ -270,7 +278,7 @@ module Dependabot
 
         new_req = T.must(dependency.requirements.first)
         # NOTE: Only providers are included in the lockfile, modules are not
-        return unless new_req[:source][:type] == "provider"
+        return unless new_req.source_string("type") == "provider"
 
         content, provider_source, declaration_regex = lockfile_details(new_req)
         lockfile_dependency_removed = content.sub(declaration_regex, "")
@@ -353,7 +361,7 @@ module Dependabot
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def files_with_requirement
-        filenames = dependency.requirements.map { |r| r[:file] }
+        filenames = dependency.requirements.map(&:file)
         dependency_files.select { |file| filenames.include?(file.name) }
       end
 
@@ -425,8 +433,7 @@ module Dependabot
 
       sig { params(dependency: Dependabot::Dependency).returns(String) }
       def registry_host_for(dependency)
-        source = dependency.requirements.filter_map { |r| r[:source] }.first
-        source[:registry_hostname] || source["registry_hostname"] || "registry.terraform.io"
+        dependency.requirements.first&.source_string("registry_hostname") || "registry.terraform.io"
       end
 
       sig { params(provider_source: String).returns(Regexp) }

--- a/terraform/lib/dependabot/terraform/file_updater/provider_cli_config_builder.rb
+++ b/terraform/lib/dependabot/terraform/file_updater/provider_cli_config_builder.rb
@@ -75,12 +75,10 @@ module Dependabot
         def target_provider_source
           req = dependency.requirements.first
           return unless req
+          return unless req.source_string("type") == "provider"
 
-          source = req[:source]
-          return unless source && source[:type] == "provider"
-
-          hostname = source[:registry_hostname] || DEFAULT_REGISTRY
-          identifier = source[:module_identifier]
+          hostname = req.source_string("registry_hostname") || DEFAULT_REGISTRY
+          identifier = req.source_string("module_identifier")
           return unless identifier
 
           "#{hostname}/#{identifier}".downcase

--- a/terraform/lib/dependabot/terraform/metadata_finder.rb
+++ b/terraform/lib/dependabot/terraform/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/terraform/lib/dependabot/terraform/metadata_finder.rb
+++ b/terraform/lib/dependabot/terraform/metadata_finder.rb
@@ -32,16 +32,16 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_git_url
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-
-        url = info[:url] || info.fetch("url")
+        url = T.must(dependency.source_string("url", allowed_types: ["git"]))
         Source.from_url(url)
       end
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_registry_details
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-        hostname = info[:registry_hostname] || info["registry_hostname"]
+        hostname = dependency.source_string(
+          "registry_hostname",
+          allowed_types: %w(registry provider)
+        ) || RegistryClient::PUBLIC_HOSTNAME
 
         RegistryClient
           .new(hostname: hostname, credentials: credentials)

--- a/terraform/lib/dependabot/terraform/registry_client.rb
+++ b/terraform/lib/dependabot/terraform/registry_client.rb
@@ -111,7 +111,7 @@ module Dependabot
       # @return [nil, Dependabot::Source]
       sig { params(dependency: Dependabot::Dependency).returns(T.nilable(Dependabot::Source)) }
       def source(dependency:)
-        type = T.must(dependency.requirements.first)[:source][:type]
+        type = T.must(dependency.source_string("type"))
         base_url = service_url_for(service_key_for(type))
         case type
         # https://www.terraform.io/internals/module-registry-protocol#download-source-code-for-a-specific-module-version

--- a/terraform/lib/dependabot/terraform/requirements_updater.rb
+++ b/terraform/lib/dependabot/terraform/requirements_updater.rb
@@ -85,7 +85,7 @@ module Dependabot
         # requirement at index `i` to correspond to the previous requirement
         # at the same index.
         requirements.map do |req|
-          case req.dig(:source, :type)
+          case req.source_string("type")
           when "git" then update_git_requirement(req)
           when "registry", "provider" then update_registry_requirement(req)
           else req
@@ -106,20 +106,22 @@ module Dependabot
 
       sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_git_requirement(req)
-        return req unless req.dig(:source, :ref)
+        return req unless req.source_string("ref")
         return req unless tag_for_latest_version
 
-        Dependabot::DependencyRequirement.create(req.merge(source: req[:source].merge(ref: tag_for_latest_version)))
+        source = updated_source(req, "ref" => tag_for_latest_version)
+        Dependabot::DependencyRequirement.create(req.merge(source: source))
       end
 
       sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_registry_requirement(req)
-        return req if req.fetch(:requirement).nil?
+        string_req = req.requirement_string
+        return req if string_req.nil?
 
         latest = latest_version
         return req if latest.nil?
 
-        string_req = req.fetch(:requirement).strip
+        string_req = string_req.strip
         ruby_req = requirement_class.new(string_req)
         return req if ruby_req.satisfied_by?(latest)
 
@@ -133,6 +135,33 @@ module Dependabot
           end
 
         Dependabot::DependencyRequirement.create(req.merge(requirement: new_req))
+      end
+
+      sig do
+        params(
+          req: Dependabot::DependencyRequirement,
+          updates: T::Hash[String, String]
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
+      end
+      def updated_source(req, updates)
+        source = T.must(req.source_hash).dup
+        updates.each do |key, value|
+          source[source_key(source, key)] = value
+        end
+        source
+      end
+
+      sig do
+        params(
+          source: Dependabot::DependencyRequirement::ObjectHash,
+          key: String
+        ).returns(T.any(String, Symbol))
+      end
+      def source_key(source, key)
+        return key.to_sym if source.key?(key.to_sym)
+        return key if source.key?(key)
+
+        source.keys.any?(Symbol) ? key.to_sym : key
       end
 
       # Updates the version in a "~>" constraint to allow the given version

--- a/terraform/lib/dependabot/terraform/update_checker.rb
+++ b/terraform/lib/dependabot/terraform/update_checker.rb
@@ -92,13 +92,13 @@ module Dependabot
 
       sig { returns(T::Array[Dependabot::Terraform::Version]) }
       def all_module_versions
-        identifier = dependency_source_details&.fetch(:module_identifier)
+        identifier = T.must(dependency.source_string("module_identifier", allowed_types: ELIGIBLE_SOURCE_TYPES))
         registry_client.all_module_versions(identifier: identifier)
       end
 
       sig { returns(T::Array[Dependabot::Terraform::Version]) }
       def all_provider_versions
-        identifier = dependency_source_details&.fetch(:module_identifier)
+        identifier = T.must(dependency.source_string("module_identifier", allowed_types: ELIGIBLE_SOURCE_TYPES))
         registry_client.all_provider_versions(identifier: identifier)
       end
 
@@ -115,7 +115,10 @@ module Dependabot
 
       sig { returns(String) }
       def registry_hostname
-        hostname = dependency_source_details&.fetch(:registry_hostname) || RegistryClient::PUBLIC_HOSTNAME
+        hostname = dependency.source_string(
+          "registry_hostname",
+          allowed_types: ELIGIBLE_SOURCE_TYPES
+        ) || RegistryClient::PUBLIC_HOSTNAME
         return hostname unless hostname == RegistryClient::PUBLIC_HOSTNAME
 
         base_registry = credentials.find do |cred|
@@ -155,7 +158,7 @@ module Dependabot
         end
 
         dependency.requirements.any? do |req|
-          req[:requirement]&.match?(/\d-[A-Za-z0-9]/)
+          req.requirement_string&.match?(/\d-[A-Za-z0-9]/)
         end
       end
 
@@ -198,28 +201,17 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def proxy_requirement?
-        dependency.requirements.any? do |req|
-          req.fetch(:source)&.fetch(:proxy_url, nil)
-        end
+        dependency.requirements.any? { |req| req.source_string("proxy_url") }
       end
 
       sig { returns(T::Boolean) }
       def registry_dependency?
-        return false if dependency_source_details.nil?
-
-        dependency_source_details&.fetch(:type) == "registry"
+        dependency.source_string("type", allowed_types: ELIGIBLE_SOURCE_TYPES) == "registry"
       end
 
       sig { returns(T::Boolean) }
       def provider_dependency?
-        return false if dependency_source_details.nil?
-
-        dependency_source_details&.fetch(:type) == "provider"
-      end
-
-      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
-      def dependency_source_details
-        dependency.source_details(allowed_types: ELIGIBLE_SOURCE_TYPES)
+        dependency.source_string("type", allowed_types: ELIGIBLE_SOURCE_TYPES) == "provider"
       end
 
       sig { returns(T::Boolean) }

--- a/terraform/spec/dependabot/terraform/file_updater/provider_cli_config_builder_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater/provider_cli_config_builder_spec.rb
@@ -32,24 +32,24 @@ RSpec.describe Dependabot::Terraform::FileUpdater::ProviderCliConfigBuilder do
         requirement: "3.42.0",
         groups: [],
         file: "versions.tf",
-        source: {
-          type: "provider",
-          registry_hostname: "registry.terraform.io",
-          module_identifier: "hashicorp/aws"
-        }
+        source: source
       }],
       previous_requirements: [{
         requirement: "3.37.0",
         groups: [],
         file: "versions.tf",
-        source: {
-          type: "provider",
-          registry_hostname: "registry.terraform.io",
-          module_identifier: "hashicorp/aws"
-        }
+        source: source
       }],
       package_manager: "terraform"
     )
+  end
+
+  let(:source) do
+    {
+      type: "provider",
+      registry_hostname: "registry.terraform.io",
+      module_identifier: "hashicorp/aws"
+    }
   end
 
   let(:terraform_files) { [] }
@@ -165,6 +165,23 @@ RSpec.describe Dependabot::Terraform::FileUpdater::ProviderCliConfigBuilder do
         expect(config_content).to include("provider_installation {")
         expect(config_content).to include("dev_overrides {")
         expect(config_content).to include("direct {}")
+      end
+
+      context "when the target requirement source uses string keys" do
+        let(:source) do
+          {
+            "type" => "provider",
+            "registry_hostname" => "registry.terraform.io",
+            "module_identifier" => "hashicorp/aws"
+          }
+        end
+
+        it "still excludes the target provider" do
+          config_content = File.read(builder.env.fetch("TF_CLI_CONFIG_FILE"))
+
+          expect(config_content).to include("registry.terraform.io/acme-corp/nonexistent")
+          expect(config_content).not_to include("hashicorp/aws")
+        end
       end
     end
 

--- a/terraform/spec/dependabot/terraform/file_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_updater_spec.rb
@@ -405,6 +405,53 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
         end
       end
 
+      context "with string-keyed source details" do
+        let(:project_name) { "git_tags_012" }
+        let(:dependencies) do
+          [
+            Dependabot::Dependency.new(
+              name: "origin_label",
+              version: "0.4.1",
+              previous_version: "0.3.7",
+              requirements: [{
+                requirement: nil,
+                groups: [],
+                file: "main.tf",
+                source: {
+                  "type" => "git",
+                  "url" => "https://github.com/cloudposse/terraform-null-label.git",
+                  "branch" => nil,
+                  "ref" => "tags/0.4.1"
+                }
+              }],
+              previous_requirements: [{
+                requirement: nil,
+                groups: [],
+                file: "main.tf",
+                source: {
+                  "type" => "git",
+                  "url" => "https://github.com/cloudposse/terraform-null-label.git",
+                  "branch" => nil,
+                  "ref" => "tags/0.3.7"
+                }
+              }],
+              package_manager: "terraform"
+            )
+          ]
+        end
+
+        it "updates the requirement" do
+          updated_file = updated_dependency_files.find { |file| file.name == "main.tf" }
+
+          expect(updated_file.content).to include(
+            <<~DEP
+              module "origin_label" {
+                source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.4.1"
+            DEP
+          )
+        end
+      end
+
       context "with an up-to-date hcl2-based git dependency" do
         let(:project_name) { "hcl2" }
 
@@ -1751,29 +1798,33 @@ RSpec.describe Dependabot::Terraform::FileUpdater do
 
   describe "#update_registry_declaration" do
     let(:new_req) do
-      {
-        requirement: "~> 6.6.0",
-        groups: [],
-        file: "main.tf",
-        source: {
-          type: "provider",
-          registry_hostname: "registry.terraform.io",
-          module_identifier: "integrations/github"
+      Dependabot::DependencyRequirement.create(
+        {
+          requirement: "~> 6.6.0",
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "provider",
+            registry_hostname: "registry.terraform.io",
+            module_identifier: "integrations/github"
+          }
         }
-      }
+      )
     end
 
     let(:old_req) do
-      {
-        requirement: "~> 4.28.0",
-        groups: [],
-        file: "main.tf",
-        source: {
-          type: "provider",
-          registry_hostname: "registry.terraform.io",
-          module_identifier: "integrations/github"
+      Dependabot::DependencyRequirement.create(
+        {
+          requirement: "~> 4.28.0",
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "provider",
+            registry_hostname: "registry.terraform.io",
+            module_identifier: "integrations/github"
+          }
         }
-      }
+      )
     end
 
     let(:updated_content) do

--- a/terraform/spec/dependabot/terraform/metadata_finder_spec.rb
+++ b/terraform/spec/dependabot/terraform/metadata_finder_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe Dependabot::Terraform::MetadataFinder do
             groups: [],
             file: "main.tf",
             source: {
-              type: "registry",
-              registry_hostname: "registry.terraform.io",
-              module_identifier: "hashicorp/consul/aws"
+              "type" => "registry",
+              "registry_hostname" => "registry.terraform.io",
+              "module_identifier" => "hashicorp/consul/aws"
             }
           }],
           previous_requirements: [{
@@ -79,9 +79,9 @@ RSpec.describe Dependabot::Terraform::MetadataFinder do
             groups: [],
             file: "main.tf",
             source: {
-              type: "registry",
-              registry_hostname: "registry.terraform.io",
-              module_identifier: "hashicorp/consul/aws"
+              "type" => "registry",
+              "registry_hostname" => "registry.terraform.io",
+              "module_identifier" => "hashicorp/consul/aws"
             }
           }],
           package_manager: "terraform"

--- a/terraform/spec/dependabot/terraform/requirements_updater_spec.rb
+++ b/terraform/spec/dependabot/terraform/requirements_updater_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe Dependabot::Terraform::RequirementsUpdater do
 
     specify { expect(updater.updated_requirements.count).to eq(1) }
 
+    context "when the source type is malformed" do
+      let(:source) { { type: 123 } }
+
+      it "raises a type error" do
+        expect { updater.updated_requirements }.to raise_error(TypeError, "source type must be a string or nil")
+      end
+    end
+
     context "when there is no latest version" do
       let(:latest_version) { nil }
 
@@ -227,6 +235,32 @@ RSpec.describe Dependabot::Terraform::RequirementsUpdater do
 
       it "does not touch the requirement" do
         expect(updated_requirements[:requirement]).to be_nil
+      end
+
+      context "with string-keyed source details" do
+        let(:requirements) do
+          [
+            {
+              requirement: nil,
+              groups: [],
+              file: "main.tf",
+              source: {
+                "type" => "git",
+                "url" => "https://github.com/cloudposse/terraform-null-label.git",
+                "branch" => nil,
+                "ref" => "tags/0.3.7",
+                "custom" => "preserved"
+              }
+            }
+          ]
+        end
+
+        it "preserves the source payload and key style" do
+          source = updated_requirements.source_hash
+
+          expect(source).to include("ref" => "tags/0.4.1", "custom" => "preserved")
+          expect(source).not_to have_key(:ref)
+        end
       end
     end
   end

--- a/terraform/spec/dependabot/terraform/update_checker_spec.rb
+++ b/terraform/spec/dependabot/terraform/update_checker_spec.rb
@@ -441,6 +441,20 @@ RSpec.describe Dependabot::Terraform::UpdateChecker do
       end
 
       it { is_expected.to be(false) }
+
+      context "with string-keyed source details" do
+        let(:source) do
+          {
+            "type" => "git",
+            "url" => "https://github.com/cloudposse/terraform-null-label.git",
+            "branch" => nil,
+            "ref" => "tags/0.3.7",
+            "proxy_url" => "https://my.example.com"
+          }
+        end
+
+        it { is_expected.to be(false) }
+      end
     end
   end
 end


### PR DESCRIPTION
Uses typed requirement and source readers across Terraform while preserving nested source keys. Reduces Object-generic blockers from 167 to 147 and `Sorbet/ForbidTUntyped` from 949 to 943. Promotes the file updater and metadata finder to `typed: strong`.