### PR TITLE
Type OpenTofu requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 943
+# Offense count: 929
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -353,10 +353,8 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/version_selector.rb"
     - "opentofu/lib/dependabot/opentofu/file_parser.rb"
-    - "opentofu/lib/dependabot/opentofu/file_updater.rb"
     - "opentofu/lib/dependabot/opentofu/package/package_details_fetcher.rb"
     - "opentofu/lib/dependabot/opentofu/registry_client.rb"
-    - "opentofu/lib/dependabot/opentofu/update_checker.rb"
     - "opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb"
     - "pub/lib/dependabot/pub/helpers.rb"
     - "pub/lib/dependabot/pub/metadata_finder.rb"

--- a/opentofu/lib/dependabot/opentofu/file_updater.rb
+++ b/opentofu/lib/dependabot/opentofu/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -273,7 +273,7 @@ module Dependabot
         packages = client.all_provider_package_hashes(identifier: identifier, version: old_version)
         return nil unless packages
 
-        h1_to_platform = {}
+        h1_to_platform = T.let({}, T::Hash[String, String])
         packages.each do |platform, hashes|
           hashes.each do |h|
             h1_to_platform[h] = platform if h.start_with?("h1:")

--- a/opentofu/lib/dependabot/opentofu/file_updater.rb
+++ b/opentofu/lib/dependabot/opentofu/file_updater.rb
@@ -5,6 +5,7 @@ require "sorbet-runtime"
 
 require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
+require "dependabot/dependency_requirement"
 require "dependabot/errors"
 require "dependabot/opentofu/file_selector"
 require "dependabot/opentofu/registry_client"
@@ -73,7 +74,7 @@ module Dependabot
           (dependency.requirements - T.must(dependency.previous_requirements)) |
           (T.must(dependency.previous_requirements) - dependency.requirements)
 
-        changed_requirements.any? { |f| f[:file] == file.name }
+        changed_requirements.any? { |requirement| requirement.file == file.name }
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(String) }
@@ -85,14 +86,15 @@ module Dependabot
 
         # Loop through each changed requirement and update the files and lockfile
         reqs.each do |new_req, old_req|
-          raise "Bad req match" unless new_req[:file] == old_req&.fetch(:file)
-          next unless new_req.fetch(:file) == file.name
+          raise "Bad req match" unless new_req.file == old_req&.file
+          next unless new_req.file == file.name
 
-          case new_req[:source][:type]
+          source_type = T.must(new_req.source_string("type"))
+          case source_type
           when "git"
             update_git_declaration(new_req, old_req, content, file.name)
           when "registry", "provider"
-            if new_req[:source][:local_variable]
+            if new_req.source_string("local_variable")
               update_local_variable_declaration(new_req, old_req, content)
             else
               update_registry_declaration(new_req, old_req, content)
@@ -100,8 +102,7 @@ module Dependabot
           when "oci"
             update_oci_declaration(new_req, old_req, content)
           else
-            raise "Don't know how to update a #{new_req[:source][:type]} " \
-                  "declaration!"
+            raise "Don't know how to update a #{source_type} declaration!"
           end
         end
 
@@ -110,39 +111,41 @@ module Dependabot
 
       sig do
         params(
-          new_req: T::Hash[Symbol, T.untyped],
-          old_req: T.nilable(T::Hash[Symbol, T.untyped]),
+          new_req: Dependabot::DependencyRequirement,
+          old_req: T.nilable(Dependabot::DependencyRequirement),
           updated_content: String,
           filename: String
         )
           .void
       end
       def update_git_declaration(new_req, old_req, updated_content, filename)
-        url = old_req&.dig(:source, :url)&.gsub(%r{^https://}, "")
-        tag = old_req&.dig(:source, :ref)
+        url = T.must(old_req&.source_string("url")).gsub(%r{^https://}, "")
+        old_ref = T.must(old_req&.source_string("ref"))
+        new_ref = T.must(new_req.source_string("ref"))
+        tag = old_ref
         url_regex = /#{Regexp.quote(url)}.*ref=#{Regexp.quote(tag)}/
 
         declaration_regex = git_declaration_regex(filename)
 
         updated_content.sub!(declaration_regex) do |regex_match|
           regex_match.sub(url_regex) do |url_match|
-            url_match.sub(old_req&.dig(:source, :ref), new_req[:source][:ref])
+            url_match.sub(old_ref, new_ref)
           end
         end
       end
 
       sig do
         params(
-          new_req: T::Hash[Symbol, T.untyped],
-          old_req: T.nilable(T::Hash[Symbol, T.untyped]),
+          new_req: Dependabot::DependencyRequirement,
+          old_req: T.nilable(Dependabot::DependencyRequirement),
           updated_content: String
         )
           .void
       end
       def update_oci_declaration(new_req, old_req, updated_content)
-        old_tag = old_req&.dig(:source, :tag)
-        new_tag = new_req[:source][:tag]
-        artifact = old_req&.dig(:source, :artifact_identifier)
+        old_tag = old_req&.source_string("tag")
+        new_tag = new_req.source_string("tag")
+        artifact = old_req&.source_string("artifact_identifier")
         return if old_tag.nil? || new_tag.nil? || artifact.nil? || old_tag == new_tag
 
         # Scoped to this artifact's source string so unrelated modules with
@@ -156,43 +159,46 @@ module Dependabot
 
       sig do
         params(
-          new_req: T::Hash[Symbol, T.untyped],
-          old_req: T.nilable(T::Hash[Symbol, T.untyped]),
+          new_req: Dependabot::DependencyRequirement,
+          old_req: T.nilable(Dependabot::DependencyRequirement),
           updated_content: String
         )
           .void
       end
       def update_registry_declaration(new_req, old_req, updated_content)
-        regex = if new_req[:source][:type] == "provider"
+        regex = if new_req.source_string("type") == "provider"
                   provider_declaration_regex(updated_content)
                 else
                   registry_declaration_regex
                 end
 
+        old_requirement = T.must(old_req&.requirement_string)
+        new_requirement = T.must(new_req.requirement_string)
+
         # Define and break down the version regex for better clarity
         version_key_pattern = /^\s*version\s*=\s*/
-        version_value_pattern = /["'].*#{Regexp.escape(old_req&.fetch(:requirement))}.*['"]/
+        version_value_pattern = /["'].*#{Regexp.escape(old_requirement)}.*['"]/
         version_regex = /#{version_key_pattern}#{version_value_pattern}/
 
         updated_content.gsub!(regex) do |regex_match|
           regex_match.sub(version_regex) do |req_line_match|
-            req_line_match.sub!(old_req&.fetch(:requirement), new_req[:requirement])
+            req_line_match.sub!(old_requirement, new_requirement)
           end
         end
       end
 
       sig do
         params(
-          new_req: T::Hash[Symbol, T.untyped],
-          old_req: T.nilable(T::Hash[Symbol, T.untyped]),
+          new_req: Dependabot::DependencyRequirement,
+          old_req: T.nilable(Dependabot::DependencyRequirement),
           updated_content: String
         )
           .void
       end
       def update_local_variable_declaration(new_req, old_req, updated_content)
-        var_name = new_req[:source][:local_variable]
-        old_version = old_req&.fetch(:requirement)
-        new_version = new_req[:requirement]
+        var_name = T.must(new_req.source_string("local_variable"))
+        old_version = old_req&.requirement_string
+        new_version = new_req.requirement_string
         return if old_version.nil? || new_version.nil? || old_version == new_version
 
         local_var_regex = /
@@ -222,13 +228,15 @@ module Dependabot
 
       sig do
         params(
-          new_req: T::Hash[Symbol, T.untyped]
+          new_req: Dependabot::DependencyRequirement
         )
           .returns([String, String, Regexp])
       end
       def lockfile_details(new_req)
         content = T.must(lockfile).content.dup
-        provider_source = new_req[:source][:registry_hostname] + "/" + new_req[:source][:module_identifier]
+        registry_hostname = T.must(new_req.source_string("registry_hostname"))
+        module_identifier = T.must(new_req.source_string("module_identifier"))
+        provider_source = "#{registry_hostname}/#{module_identifier}"
         declaration_regex = lockfile_declaration_regex(provider_source)
 
         [T.must(content), provider_source, declaration_regex]
@@ -239,7 +247,7 @@ module Dependabot
         new_req = T.must(dependency.requirements.first)
 
         # NOTE: Only providers are included in the lockfile, modules are not
-        return unless new_req[:source][:type] == "provider"
+        return unless new_req.source_string("type") == "provider"
 
         result = lookup_hash_architecture_from_registry(new_req)
         return result if result
@@ -247,17 +255,20 @@ module Dependabot
         lookup_hash_architecture_from_cli(new_req)
       end
 
-      sig { params(new_req: T::Hash[Symbol, T.untyped]).returns(T.nilable(T::Array[Symbol])) }
+      sig do
+        params(new_req: Dependabot::DependencyRequirement)
+          .returns(T.nilable(T::Array[Symbol]))
+      end
       def lookup_hash_architecture_from_registry(new_req) # rubocop:disable Metrics/PerceivedComplexity
         content, _provider_source, declaration_regex = lockfile_details(new_req)
         existing_h1 = extract_provider_h1_hashes(content, declaration_regex)
         return nil if existing_h1.empty?
 
-        identifier = new_req[:source][:module_identifier]
+        identifier = T.must(new_req.source_string("module_identifier"))
         old_version = dependency.previous_version
         return nil unless old_version
 
-        hostname = new_req[:source][:registry_hostname] || RegistryClient::PUBLIC_HOSTNAME
+        hostname = new_req.source_string("registry_hostname") || RegistryClient::PUBLIC_HOSTNAME
         client = RegistryClient.new(hostname: hostname, credentials: credentials)
         packages = client.all_provider_package_hashes(identifier: identifier, version: old_version)
         return nil unless packages
@@ -275,7 +286,7 @@ module Dependabot
         nil
       end
 
-      sig { params(new_req: T::Hash[Symbol, T.untyped]).returns(T::Array[Symbol]) }
+      sig { params(new_req: Dependabot::DependencyRequirement).returns(T::Array[Symbol]) }
       def lookup_hash_architecture_from_cli(new_req) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
         architectures = []
         content, provider_source, declaration_regex = lockfile_details(new_req)
@@ -346,7 +357,7 @@ module Dependabot
         return if lockfile.nil?
 
         new_req = T.must(dependency.requirements.first)
-        return unless new_req[:source][:type] == "provider"
+        return unless new_req.source_string("type") == "provider"
 
         result = update_lockfile_from_registry(new_req)
         return result if result
@@ -354,17 +365,17 @@ module Dependabot
         update_lockfile_from_cli(new_req, updated_manifest_files)
       end
 
-      sig { params(new_req: T::Hash[Symbol, T.untyped]).returns(T.nilable(String)) }
+      sig { params(new_req: Dependabot::DependencyRequirement).returns(T.nilable(String)) }
       def update_lockfile_from_registry(new_req) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
         content, provider_source, declaration_regex = lockfile_details(new_req)
         platforms = architecture_type
         return nil if platforms.empty?
 
-        identifier = new_req[:source][:module_identifier]
+        identifier = T.must(new_req.source_string("module_identifier"))
         new_version = dependency.version
         return nil unless new_version
 
-        hostname = new_req[:source][:registry_hostname] || RegistryClient::PUBLIC_HOSTNAME
+        hostname = new_req.source_string("registry_hostname") || RegistryClient::PUBLIC_HOSTNAME
         client = RegistryClient.new(hostname: hostname, credentials: credentials)
         packages = client.all_provider_package_hashes(identifier: identifier, version: new_version)
         return nil unless packages
@@ -432,7 +443,7 @@ module Dependabot
 
       sig do
         params(
-          new_req: T::Hash[Symbol, T.untyped],
+          new_req: Dependabot::DependencyRequirement,
           updated_manifest_files: T::Array[Dependabot::DependencyFile]
         ).returns(T.nilable(String))
       end
@@ -509,7 +520,7 @@ module Dependabot
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def files_with_requirement
-        filenames = dependency.requirements.map { |r| r[:file] }
+        filenames = dependency.requirements.map(&:file)
         dependency_files.select { |file| filenames.include?(file.name) }
       end
 
@@ -581,8 +592,7 @@ module Dependabot
 
       sig { params(dependency: Dependabot::Dependency).returns(String) }
       def registry_host_for(dependency)
-        source = dependency.requirements.filter_map { |r| r[:source] }.first
-        source[:registry_hostname] || source["registry_hostname"] || "registry.opentofu.org"
+        dependency.requirements.first&.source_string("registry_hostname") || "registry.opentofu.org"
       end
 
       sig { params(provider_source: String).returns(Regexp) }

--- a/opentofu/lib/dependabot/opentofu/metadata_finder.rb
+++ b/opentofu/lib/dependabot/opentofu/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/opentofu/lib/dependabot/opentofu/metadata_finder.rb
+++ b/opentofu/lib/dependabot/opentofu/metadata_finder.rb
@@ -33,16 +33,13 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_git_url
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-
-        url = info[:url] || info.fetch("url")
+        url = T.must(dependency.source_string("url", allowed_types: ["git"]))
         Source.from_url(url)
       end
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_oci_details
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-        artifact_identifier = info[:artifact_identifier] || info["artifact_identifier"]
+        artifact_identifier = dependency.source_string("artifact_identifier", allowed_types: ["oci"])
         return unless artifact_identifier
 
         hostname, repo = artifact_identifier.split("/", 2)
@@ -58,8 +55,10 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_registry_details
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-        hostname = info[:registry_hostname] || info["registry_hostname"]
+        hostname = dependency.source_string(
+          "registry_hostname",
+          allowed_types: %w(registry provider)
+        ) || RegistryClient::PUBLIC_HOSTNAME
 
         RegistryClient
           .new(hostname: hostname, credentials: credentials)

--- a/opentofu/lib/dependabot/opentofu/registry_client.rb
+++ b/opentofu/lib/dependabot/opentofu/registry_client.rb
@@ -203,7 +203,7 @@ module Dependabot
       # @return [nil, Dependabot::Source]
       sig { params(dependency: Dependabot::Dependency).returns(T.nilable(Dependabot::Source)) }
       def source(dependency:)
-        type = T.must(dependency.requirements.first)[:source][:type]
+        type = T.must(dependency.source_string("type"))
         base_url = url_for_api("/registry/docs/")
         case type
         when "module", "modules", "registry"

--- a/opentofu/lib/dependabot/opentofu/requirements_updater.rb
+++ b/opentofu/lib/dependabot/opentofu/requirements_updater.rb
@@ -85,7 +85,7 @@ module Dependabot
         # requirement at index `i` to correspond to the previous requirement
         # at the same index.
         requirements.map do |req|
-          case req.dig(:source, :type)
+          case req.source_string("type")
           when "git" then update_git_requirement(req)
           when "registry", "provider" then update_registry_requirement(req)
           when "oci" then update_oci_requirement(req)
@@ -107,36 +107,39 @@ module Dependabot
 
       sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_git_requirement(req)
-        return req unless req.dig(:source, :ref)
+        return req unless req.source_string("ref")
         return req unless tag_for_latest_version
 
-        Dependabot::DependencyRequirement.create(req.merge(source: req[:source].merge(ref: tag_for_latest_version)))
+        source = updated_source(req, "ref" => tag_for_latest_version)
+        Dependabot::DependencyRequirement.create(req.merge(source: source))
       end
 
       sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_oci_requirement(req)
         return req unless defined?(@latest_version) && @latest_version
-        return req if req.dig(:source, :digest)
-        return req unless req.dig(:source, :tag)
+        return req if req.source_string("digest")
+
+        old_tag = req.source_string("tag")
+        return req unless old_tag
 
         new_tag = latest_version.to_s
-        return req if req.dig(:source, :tag) == new_tag
+        return req if old_tag == new_tag
 
+        source = updated_source(req, "tag" => new_tag, "version" => new_tag)
         Dependabot::DependencyRequirement.create(
-          req.merge(
-            source: req[:source].merge(tag: new_tag, version: new_tag)
-          )
+          req.merge(source: source)
         )
       end
 
       sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
       def update_registry_requirement(req)
-        return req if req.fetch(:requirement).nil?
+        string_req = req.requirement_string
+        return req if string_req.nil?
 
         latest = latest_version
         return req if latest.nil?
 
-        string_req = req.fetch(:requirement).strip
+        string_req = string_req.strip
         ruby_req = requirement_class.new(string_req)
         return req if ruby_req.satisfied_by?(latest)
 
@@ -150,6 +153,33 @@ module Dependabot
           end
 
         Dependabot::DependencyRequirement.create(req.merge(requirement: new_req))
+      end
+
+      sig do
+        params(
+          req: Dependabot::DependencyRequirement,
+          updates: T::Hash[String, String]
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
+      end
+      def updated_source(req, updates)
+        source = T.must(req.source_hash).dup
+        updates.each do |key, value|
+          source[source_key(source, key)] = value
+        end
+        source
+      end
+
+      sig do
+        params(
+          source: Dependabot::DependencyRequirement::ObjectHash,
+          key: String
+        ).returns(T.any(String, Symbol))
+      end
+      def source_key(source, key)
+        return key.to_sym if source.key?(key.to_sym)
+        return key if source.key?(key)
+
+        source.keys.any?(Symbol) ? key.to_sym : key
       end
 
       # Updates the version in a "~>" constraint to allow the given version

--- a/opentofu/lib/dependabot/opentofu/update_checker.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker.rb
@@ -93,13 +93,13 @@ module Dependabot
 
       sig { returns(T::Array[Dependabot::Opentofu::Version]) }
       def all_module_versions
-        identifier = dependency_source_details&.fetch(:module_identifier)
+        identifier = T.must(dependency.source_string("module_identifier", allowed_types: ELIGIBLE_SOURCE_TYPES))
         registry_client.all_module_versions(identifier: identifier)
       end
 
       sig { returns(T::Array[Dependabot::Opentofu::Version]) }
       def all_provider_versions
-        identifier = dependency_source_details&.fetch(:module_identifier)
+        identifier = T.must(dependency.source_string("module_identifier", allowed_types: ELIGIBLE_SOURCE_TYPES))
         registry_client.all_provider_versions(identifier: identifier)
       end
 
@@ -107,7 +107,10 @@ module Dependabot
       def registry_client
         @registry_client ||= T.let(
           begin
-            hostname = dependency_source_details&.fetch(:registry_hostname)
+            hostname = dependency.source_string(
+              "registry_hostname",
+              allowed_types: ELIGIBLE_SOURCE_TYPES
+            ) || RegistryClient::PUBLIC_HOSTNAME
             RegistryClient.new(hostname: hostname, credentials: credentials)
           end,
           T.nilable(Dependabot::Opentofu::RegistryClient)
@@ -144,7 +147,7 @@ module Dependabot
         end
 
         dependency.requirements.any? do |req|
-          req[:requirement]&.match?(/\d-[A-Za-z0-9]/)
+          req.requirement_string&.match?(/\d-[A-Za-z0-9]/)
         end
       end
 
@@ -192,42 +195,36 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def proxy_requirement?
-        dependency.requirements.any? do |req|
-          req.fetch(:source)&.fetch(:proxy_url, nil)
-        end
+        dependency.requirements.any? { |req| req.source_string("proxy_url") }
       end
 
       sig { returns(T::Boolean) }
       def registry_dependency?
-        return false if dependency_source_details.nil?
-
-        dependency_source_details&.fetch(:type) == "registry"
+        dependency.source_string("type", allowed_types: ELIGIBLE_SOURCE_TYPES) == "registry"
       end
 
       sig { returns(T::Boolean) }
       def provider_dependency?
-        return false if dependency_source_details.nil?
-
-        dependency_source_details&.fetch(:type) == "provider"
+        dependency.source_string("type", allowed_types: ELIGIBLE_SOURCE_TYPES) == "provider"
       end
 
       sig { returns(T::Boolean) }
       def oci_dependency?
-        return false if dependency_source_details.nil?
-
-        dependency_source_details&.fetch(:type) == "oci"
+        dependency.source_string("type", allowed_types: ELIGIBLE_SOURCE_TYPES) == "oci"
       end
 
       sig { returns(T.nilable(Dependabot::Opentofu::Version)) }
       def latest_version_for_oci_dependency
         return unless oci_dependency?
         # Digest pins are immutable; nothing to update to without a tag.
-        return if dependency_source_details&.fetch(:digest)
+        return if dependency.source_string("digest", allowed_types: ELIGIBLE_SOURCE_TYPES)
 
         @latest_oci_version = T.let(@latest_oci_version, T.nilable(Dependabot::Opentofu::Version))
         return @latest_oci_version if @latest_oci_version
 
-        identifier = T.must(dependency_source_details).fetch(:artifact_identifier)
+        identifier = T.must(
+          dependency.source_string("artifact_identifier", allowed_types: ELIGIBLE_SOURCE_TYPES)
+        )
         versions = RegistryClient.all_oci_tags(
           artifact_identifier: identifier,
           credentials: credentials
@@ -235,11 +232,6 @@ module Dependabot
         versions.reject!(&:prerelease?) unless wants_prerelease?
         versions.reject! { |v| ignore_requirements.any? { |r| r.satisfied_by?(v) } }
         @latest_oci_version = versions.max
-      end
-
-      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
-      def dependency_source_details
-        dependency.source_details(allowed_types: ELIGIBLE_SOURCE_TYPES)
       end
 
       sig { returns(T::Boolean) }

--- a/opentofu/spec/dependabot/opentofu/file_updater_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/file_updater_spec.rb
@@ -147,12 +147,12 @@ RSpec.describe Dependabot::Opentofu::FileUpdater do
               groups: [],
               file: "main.tf",
               source: {
-                type: "oci",
-                artifact_identifier: "example.com/repository-name",
-                subdirectory: nil,
-                tag: "v2.0.0",
-                digest: nil,
-                version: "v2.0.0"
+                "type" => "oci",
+                "artifact_identifier" => "example.com/repository-name",
+                "subdirectory" => nil,
+                "tag" => "v2.0.0",
+                "digest" => nil,
+                "version" => "v2.0.0"
               }
             }],
             previous_requirements: [{
@@ -160,12 +160,12 @@ RSpec.describe Dependabot::Opentofu::FileUpdater do
               groups: [],
               file: "main.tf",
               source: {
-                type: "oci",
-                artifact_identifier: "example.com/repository-name",
-                subdirectory: nil,
-                tag: "v1.0.0",
-                digest: nil,
-                version: "v1.0.0"
+                "type" => "oci",
+                "artifact_identifier" => "example.com/repository-name",
+                "subdirectory" => nil,
+                "tag" => "v1.0.0",
+                "digest" => nil,
+                "version" => "v1.0.0"
               }
             }],
             package_manager: "opentofu"
@@ -462,6 +462,53 @@ RSpec.describe Dependabot::Opentofu::FileUpdater do
             <<~DEP
               module "duplicate_label" {
                 source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.7"
+            DEP
+          )
+        end
+      end
+
+      context "with string-keyed source details" do
+        let(:project_name) { "git_tags_012" }
+        let(:dependencies) do
+          [
+            Dependabot::Dependency.new(
+              name: "origin_label",
+              version: "0.4.1",
+              previous_version: "0.3.7",
+              requirements: [{
+                requirement: nil,
+                groups: [],
+                file: "main.tf",
+                source: {
+                  "type" => "git",
+                  "url" => "https://github.com/cloudposse/terraform-null-label.git",
+                  "branch" => nil,
+                  "ref" => "tags/0.4.1"
+                }
+              }],
+              previous_requirements: [{
+                requirement: nil,
+                groups: [],
+                file: "main.tf",
+                source: {
+                  "type" => "git",
+                  "url" => "https://github.com/cloudposse/terraform-null-label.git",
+                  "branch" => nil,
+                  "ref" => "tags/0.3.7"
+                }
+              }],
+              package_manager: "opentofu"
+            )
+          ]
+        end
+
+        it "updates the requirement" do
+          updated_file = updated_dependency_files.find { |file| file.name == "main.tf" }
+
+          expect(updated_file.content).to include(
+            <<~DEP
+              module "origin_label" {
+                source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.4.1"
             DEP
           )
         end
@@ -779,10 +826,10 @@ RSpec.describe Dependabot::Opentofu::FileUpdater do
               groups: [],
               file: "main.tf",
               source: {
-                type: "registry",
-                registry_hostname: "registry.opentofu.org",
-                module_identifier: "hashicorp/consul/aws",
-                local_variable: "module_version"
+                "type" => "registry",
+                "registry_hostname" => "registry.opentofu.org",
+                "module_identifier" => "hashicorp/consul/aws",
+                "local_variable" => "module_version"
               }
             }],
             previous_requirements: [{
@@ -790,10 +837,10 @@ RSpec.describe Dependabot::Opentofu::FileUpdater do
               groups: [],
               file: "main.tf",
               source: {
-                type: "registry",
-                registry_hostname: "registry.opentofu.org",
-                module_identifier: "hashicorp/consul/aws",
-                local_variable: "module_version"
+                "type" => "registry",
+                "registry_hostname" => "registry.opentofu.org",
+                "module_identifier" => "hashicorp/consul/aws",
+                "local_variable" => "module_version"
               }
             }],
             package_manager: "opentofu"
@@ -2116,29 +2163,33 @@ RSpec.describe Dependabot::Opentofu::FileUpdater do
 
   describe "#update_registry_declaration" do
     let(:new_req) do
-      {
-        requirement: "~> 6.6.0",
-        groups: [],
-        file: "main.tf",
-        source: {
-          type: "provider",
-          registry_hostname: "registry.opentofu.org",
-          module_identifier: "integrations/github"
+      Dependabot::DependencyRequirement.create(
+        {
+          requirement: "~> 6.6.0",
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "provider",
+            registry_hostname: "registry.opentofu.org",
+            module_identifier: "integrations/github"
+          }
         }
-      }
+      )
     end
 
     let(:old_req) do
-      {
-        requirement: "~> 4.28.0",
-        groups: [],
-        file: "main.tf",
-        source: {
-          type: "provider",
-          registry_hostname: "registry.opentofu.org",
-          module_identifier: "integrations/github"
+      Dependabot::DependencyRequirement.create(
+        {
+          requirement: "~> 4.28.0",
+          groups: [],
+          file: "main.tf",
+          source: {
+            type: "provider",
+            registry_hostname: "registry.opentofu.org",
+            module_identifier: "integrations/github"
+          }
         }
-      }
+      )
     end
 
     let(:updated_content) do

--- a/opentofu/spec/dependabot/opentofu/metadata_finder_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/metadata_finder_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe Dependabot::Opentofu::MetadataFinder do
             groups: [],
             file: "main.tf",
             source: {
-              type: "registry",
-              registry_hostname: "registry.opentofu.org",
-              module_identifier: "hashicorp/consul/aws"
+              "type" => "registry",
+              "registry_hostname" => "registry.opentofu.org",
+              "module_identifier" => "hashicorp/consul/aws"
             }
           }],
           previous_requirements: [{
@@ -79,9 +79,9 @@ RSpec.describe Dependabot::Opentofu::MetadataFinder do
             groups: [],
             file: "main.tf",
             source: {
-              type: "registry",
-              registry_hostname: "registry.opentofu.org",
-              module_identifier: "hashicorp/consul/aws"
+              "type" => "registry",
+              "registry_hostname" => "registry.opentofu.org",
+              "module_identifier" => "hashicorp/consul/aws"
             }
           }],
           package_manager: "opentofu"

--- a/opentofu/spec/dependabot/opentofu/requirements_updater_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/requirements_updater_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe Dependabot::Opentofu::RequirementsUpdater do
 
     specify { expect(updater.updated_requirements.count).to eq(1) }
 
+    context "when the source type is malformed" do
+      let(:source) { { type: 123 } }
+
+      it "raises a type error" do
+        expect { updater.updated_requirements }.to raise_error(TypeError, "source type must be a string or nil")
+      end
+    end
+
     context "when there is no latest version" do
       let(:latest_version) { nil }
 
@@ -227,6 +235,71 @@ RSpec.describe Dependabot::Opentofu::RequirementsUpdater do
 
       it "does not touch the requirement" do
         expect(updated_requirements[:requirement]).to be_nil
+      end
+
+      context "with string-keyed source details" do
+        let(:requirements) do
+          [
+            {
+              requirement: nil,
+              groups: [],
+              file: "main.tf",
+              source: {
+                "type" => "git",
+                "url" => "https://github.com/cloudposse/terraform-null-label.git",
+                "branch" => nil,
+                "ref" => "tags/0.3.7",
+                "custom" => "preserved"
+              }
+            }
+          ]
+        end
+
+        it "preserves the source payload and key style" do
+          source = updated_requirements.source_hash
+
+          expect(source).to include("ref" => "tags/0.4.1", "custom" => "preserved")
+          expect(source).not_to have_key(:ref)
+        end
+      end
+    end
+
+    context "when dealing with an OCI requirement" do
+      let(:latest_version) { "v2.0.0" }
+      let(:requirements) do
+        [{
+          requirement: nil,
+          groups: [],
+          file: "main.tf",
+          source: {
+            "type" => "oci",
+            "artifact_identifier" => "example.com/repository-name",
+            "tag" => "v1.0.0",
+            "version" => "v1.0.0",
+            "digest" => nil,
+            "custom" => "preserved"
+          }
+        }]
+      end
+
+      it "updates the tag and version without changing the key style" do
+        source = updated_requirements.source_hash
+
+        expect(source).to include(
+          "tag" => "v2.0.0",
+          "version" => "v2.0.0",
+          "custom" => "preserved"
+        )
+        expect(source).not_to have_key(:tag)
+        expect(source).not_to have_key(:version)
+      end
+
+      context "when pinned to a digest" do
+        before { requirements.first.fetch(:source)["digest"] = "sha256:abc123" }
+
+        it "leaves the source unchanged" do
+          expect(updated_requirements).to eq(requirements.first)
+        end
       end
     end
   end

--- a/opentofu/spec/dependabot/opentofu/update_checker_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/update_checker_spec.rb
@@ -361,6 +361,20 @@ RSpec.describe Dependabot::Opentofu::UpdateChecker do
       end
 
       it { is_expected.to be(false) }
+
+      context "with string-keyed source details" do
+        let(:source) do
+          {
+            "type" => "git",
+            "url" => "https://github.com/cloudposse/terraform-null-label.git",
+            "branch" => nil,
+            "ref" => "tags/0.3.7",
+            "proxy_url" => "https://my.example.com"
+          }
+        end
+
+        it { is_expected.to be(false) }
+      end
     end
   end
 end


### PR DESCRIPTION
Uses typed requirement and source readers across OpenTofu, including OCI, local variable, and provider lockfile hash paths. Reduces Object-generic blockers from 147 to 123 and `Sorbet/ForbidTUntyped` from 943 to 929. Promotes the file updater and metadata finder to `typed: strong`.