### PR TITLE
NuGet: don't fail the job when an unrelated submodule can't be cloned

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Clone/CloneWorkerTests.cs
@@ -137,6 +137,50 @@ public class CloneWorkerTests
     }
 
     [Fact]
+    public async Task SubmoduleCloneFailureDoesNotFailTheJob_CouldNotReadUsername()
+    {
+        // the repository under update was cloned successfully; only an unrelated submodule was inaccessible
+        await TestCloneAsync(
+            provider: "github",
+            repoMoniker: "test/repo",
+            testGitCommandHandler: new TestGitCommandHandlerWithOutputs("", """
+                Cloning into '/home/dependabot/dependabot-updater/repo'...
+                Submodule 'packages/private-sub' (https://github.com/test/private-sub.git) registered for path 'packages/private-sub'
+                Cloning into '/home/dependabot/dependabot-updater/repo/packages/private-sub'...
+                fatal: could not read Username for 'https://github.com': No such device or address
+                fatal: clone of 'https://github.com/test/private-sub.git' into submodule path '/home/dependabot/dependabot-updater/repo/packages/private-sub' failed
+                Failed to clone 'packages/private-sub'. Retry scheduled
+                Cloning into '/home/dependabot/dependabot-updater/repo/packages/private-sub'...
+                fatal: could not read Username for 'https://github.com': No such device or address
+                fatal: clone of 'https://github.com/test/private-sub.git' into submodule path '/home/dependabot/dependabot-updater/repo/packages/private-sub' failed
+                Failed to clone 'packages/private-sub' a second time, aborting
+                """),
+            expectedApiMessages: [],
+            expectedExitCode: 0
+        );
+    }
+
+    [Fact]
+    public async Task SubmoduleCloneFailureDoesNotFailTheJob_AuthenticationFailed()
+    {
+        await TestCloneAsync(
+            provider: "github",
+            repoMoniker: "test/repo",
+            testGitCommandHandler: new TestGitCommandHandlerWithOutputs("", """
+                Cloning into '/home/dependabot/dependabot-updater/repo'...
+                Submodule 'packages/private-sub' (https://github.com/test/private-sub.git) registered for path 'packages/private-sub'
+                Cloning into '/home/dependabot/dependabot-updater/repo/packages/private-sub'...
+                remote: Invalid username or token.
+                fatal: Authentication failed for 'https://github.com/test/private-sub.git/'
+                fatal: clone of 'https://github.com/test/private-sub.git' into submodule path '/home/dependabot/dependabot-updater/repo/packages/private-sub' failed
+                Failed to clone 'packages/private-sub' a second time, aborting
+                """),
+            expectedApiMessages: [],
+            expectedExitCode: 0
+        );
+    }
+
+    [Fact]
     public async Task JobFileParseErrorIsReported_InvalidJson()
     {
         // arrange

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/ShellGitCommandHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Clone/ShellGitCommandHandler.cs
@@ -1,9 +1,14 @@
 using System.Net;
+using System.Text.RegularExpressions;
 
 namespace NuGetUpdater.Core.Clone;
 
 public class ShellGitCommandHandler : IGitCommandHandler
 {
+    // Kept in sync with `GIT_SUBMODULE_CLONE_ERROR` in `common/lib/dependabot/file_fetchers/base.rb`.
+    private static readonly Regex SubmoduleCloneFailure =
+        new(@"^fatal: clone of '(?<url>.*)' into submodule path '.*' failed\r?$", RegexOptions.Multiline);
+
     private readonly ILogger _logger;
 
     public ShellGitCommandHandler(ILogger logger)
@@ -15,11 +20,23 @@ public class ShellGitCommandHandler : IGitCommandHandler
     {
         _logger.Info($"Running command: git {string.Join(" ", args)}{(workingDirectory is null ? "" : $" in directory {workingDirectory}")}");
         var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("git", args, workingDirectory);
-        HandleErrorsFromOutput(stdout, stderr);
+        HandleErrorsFromOutput(stdout, stderr, _logger);
     }
 
-    internal static void HandleErrorsFromOutput(string stdout, string stderr)
+    internal static void HandleErrorsFromOutput(string stdout, string stderr, ILogger? logger = null)
     {
+        // Submodules might be in the repo but unrelated to dependencies, and submodule paths are
+        // excluded from discovery, so a failed submodule clone need not fail the job.  git descends
+        // into submodules only after the containing repository is cloned, so this line also tells us
+        // the top-level clone succeeded.  stdout and stderr are matched together because git reports
+        // the authentication failure and the submodule path on separate lines.
+        var submoduleFailure = SubmoduleCloneFailure.Match($"{stdout}\n{stderr}");
+        if (submoduleFailure.Success)
+        {
+            logger?.Error($"Cloning of submodule failed: {submoduleFailure.Groups["url"].Value}");
+            return;
+        }
+
         foreach (var output in new[] { stdout, stderr })
         {
             ThrowOnUnauthenticated(output);


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #15857.

A NuGet job fails with `job_repo_not_found` when the repository contains a private git submodule that
Dependabot cannot read — even when that submodule has nothing to do with the .NET projects being
updated. Every other ecosystem in the same repository, at the same commit, hits the identical
submodule failure and completes normally.

`ShellGitCommandHandler` inspects the output of `git clone --recurse-submodules` for two strings and
maps either one to `HttpStatusCode.Unauthorized`, which `CloneWorker` turns into `JobRepoNotFound`:

```csharp
if (output.Contains("Authentication failed for") ||
    output.Contains("could not read Username for"))
```

Both strings are what git prints when *a submodule's* clone is unauthenticated. Nothing distinguishes
"the repository under update is inaccessible" from "an unrelated submodule is inaccessible", so the
latter aborts the job before discovery starts and the ecosystem produces no updates at all. The
resulting `job_repo_not_found` is also misleading: the repository under update was cloned
successfully.

The shared Ruby path handles this deliberately, and says so in
[`file_fetchers/base.rb`](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/file_fetchers/base.rb):

```ruby
# Submodules might be in the repo but unrelated to dependencies,
# so ignoring this error to try the update anyway since the base repo exists.
Dependabot.logger.error("Cloning of submodule failed: #{url} error: #{code || 'unknown'}")
```

NuGet has cloned in C# since #10864 and never received that behaviour. #15093 already excludes
submodule paths from discovery, so submodule contents are never read even when the checkout succeeds
— the clone step is the only place left that treats a failed submodule as fatal.

This change makes the NuGet clone step agree with the Ruby file fetcher: a submodule that can't be
cloned is logged and ignored.

### Anything you want to highlight for special attention from reviewers?

**Why match on the submodule line rather than track the top-level clone's success directly?** git
recurses into submodules only after the containing repository has been retrieved, so a
`fatal: clone of '<url>' into submodule path '<path>' failed` line implies the top-level clone
succeeded. That makes the line itself a sound discriminator, with no extra state to thread through:

```csharp
private static readonly Regex SubmoduleCloneFailure =
    new(@"^fatal: clone of '(?<url>.*)' into submodule path '.*' failed\r?$", RegexOptions.Multiline);
```

**Why only one of the two Ruby patterns?** `GIT_SUBMODULE_ERROR_REGEX` also covers
`fatal: unable to access '<url>': The requested URL returned error: <code>`. In C# that shape cannot
change the outcome — neither of the two strings that trigger the throw appears in it — so porting it
would be dead code. Happy to add it for symmetry if you'd prefer.

**Why match `stdout` and `stderr` joined?** git reports the authentication failure and the failing
submodule path on separate lines, and the existing code checks each stream independently.

**Why the optional `ILogger?` on `HandleErrorsFromOutput`?** So the suppressed failure stays visible
in the job log, using the same `Cloning of submodule failed: <url>` wording as the Ruby path so one
grep works across ecosystems. Keeping the check in this method rather than in `RunGitCommandAsync`
means the existing `TestGitCommandHandlerWithOutputs` seam exercises it, and the tests can go through
`CloneWorker.RunAsync` instead of poking at the static helper.

**What this does not change:** a repository under update that is itself inaccessible still fails. git
aborts before touching submodules, so no submodule line is emitted and the throw path is unchanged —
the existing `UnauthorizedClone*` tests cover this and still pass.

### How will you know you've accomplished your goal?

Two tests added to `CloneWorkerTests`, next to the existing
`UnauthorizedCloneGeneratesTheExpectedApiMessagesFromGitCommandOutput`. Both feed verbatim `git`
output through `TestGitCommandHandlerWithOutputs` and assert the job's observable outcome — exit code
`0` and no API messages:

- `SubmoduleCloneFailureDoesNotFailTheJob_CouldNotReadUsername` — output captured from a real failing
  run
- `SubmoduleCloneFailureDoesNotFailTheJob_AuthenticationFailed` — the other string that triggers the
  throw

Both fail on `main`:

```
Failed CloneWorkerTests.SubmoduleCloneFailureDoesNotFailTheJob_CouldNotReadUsername
  Assert.Equal() Failure: Values differ
  Expected: 0
  Actual:   1
Failed CloneWorkerTests.SubmoduleCloneFailureDoesNotFailTheJob_AuthenticationFailed
  Assert.Equal() Failure: Values differ
  Expected: 0
  Actual:   1

Failed! - Failed: 2, Passed: 11, Total: 13
```

and pass with the change, with the other 11 unaffected:

```
Passed! - Failed: 0, Passed: 13, Skipped: 0, Total: 13
```

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
  - I ran `CloneWorkerTests` with and without the change, as above, but not the full suite locally.
    `.github/copilot-instructions.md` asks that tests not be run on the host system, and CONTRIBUTING
    notes that CI will run them, so I'm relying on CI for the complete suite. Happy to iterate on
    anything it turns up.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
