### PR TITLE
Add artifact metadata permission

### DIFF
--- a/.github/workflows/images-updater-core.yml
+++ b/.github/workflows/images-updater-core.yml
@@ -19,6 +19,7 @@ jobs:
       id-token: write
       packages: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
The updater-core attestation succeeds, but `actions/attest-build-provenance` warns that it cannot create an artifact metadata storage record. Grant the job the required `artifact-metadata: write` permission.

This follows up on #12116 and addresses the warning in [run 31516329668](https://github.com/dependabot/dependabot-core/actions/runs/31516329668/job/93862269827#step:7:33).