### PR TITLE
Fix NuGet updated file line endings

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTestHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Cli.Test/EntryPointTestHelper.cs
@@ -41,6 +41,8 @@ internal static class EntryPointTestHelper
         // save packages
         await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(packages, tempDirectory.DirectoryPath);
 
+        await GitTestHelper.InitializeRepositoryAsync(tempDirectory.DirectoryPath, files.Select(file => file.Path));
+
         var actualUrls = new List<string>();
         using var http = TestHttpServer.CreateTestStringServer((method, url) =>
         {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/GitTestHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/GitTestHelper.cs
@@ -1,0 +1,23 @@
+using Xunit;
+
+namespace NuGetUpdater.Core.Test;
+
+public static class GitTestHelper
+{
+    public static async Task InitializeRepositoryAsync(string workingDirectory, IEnumerable<string> trackedPaths)
+    {
+        await RunAsync(workingDirectory, "init");
+
+        var paths = trackedPaths.ToArray();
+        if (paths.Length > 0)
+        {
+            await RunAsync(workingDirectory, ["add", "--", .. paths]);
+        }
+    }
+
+    private static async Task RunAsync(string workingDirectory, params string[] arguments)
+    {
+        var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("git", arguments, workingDirectory);
+        Assert.True(exitCode == 0, $"git {string.Join(' ', arguments)} failed.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
@@ -1309,6 +1309,14 @@ public class EndToEndTests
             MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.0.0", "net9.0"),
             MockNuGetPackage.CreateSimplePackage("Transitive.Package", "2.1.0", "net9.0"),
         ], repoContentsPath);
+        await GitTestHelper.InitializeRepositoryAsync(
+            repoContentsPath,
+            [
+                "src/client/client.csproj",
+                "src/client/packages.lock.json",
+                "src/library/library.csproj",
+                "src/library/packages.lock.json",
+            ]);
         var jobId = "TEST-JOB-ID";
         var experimentsManager = new ExperimentsManager();
         var logger = new TestLogger();
@@ -1632,6 +1640,7 @@ public class EndToEndTests
             Directory.CreateDirectory(directory);
             await File.WriteAllBytesAsync(fullPath, content);
         }
+        await GitTestHelper.InitializeRepositoryAsync(repoContentsPath, rawFiles.Select(file => file.Path));
 
         // act
         experimentsManager ??= new ExperimentsManager();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/GitEOLMetadataProviderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/GitEOLMetadataProviderTests.cs
@@ -1,0 +1,58 @@
+using NuGetUpdater.Core.Run;
+
+using Xunit;
+
+using static NuGetUpdater.Core.Utilities.EOLHandling;
+
+namespace NuGetUpdater.Core.Test.Run;
+
+public class GitEOLMetadataProviderTests
+{
+    [Fact]
+    public async Task ReadsNullDelimitedOutputFromGit()
+    {
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
+            (".gitattributes", "*.csproj text eol=crlf\n"),
+            ("project.csproj", "<Project>\r\n  <PropertyGroup />\r\n</Project>\r\n"),
+            ("src/other.csproj", "<Project>\r\n  <ItemGroup />\r\n</Project>\r\n"));
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+
+        await GitTestHelper.InitializeRepositoryAsync(
+            repoContentsPath.FullName,
+            [".gitattributes", "project.csproj", "src/other.csproj"]);
+
+        var provider = new GitEOLMetadataProvider();
+        var result = await provider.GetIndexEOLsAsync(repoContentsPath, ["project.csproj", "src/other.csproj"]);
+
+        Assert.Equal(
+            new Dictionary<string, EOLType>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["project.csproj"] = EOLType.LF,
+                ["src/other.csproj"] = EOLType.LF,
+            },
+            result);
+    }
+
+    [Fact]
+    public void ParseOutputReturnsSupportedIndexLineEndings()
+    {
+        var output = string.Join('\0',
+            "i/lf    w/crlf attr/text eol=crlf\tproject.csproj",
+            "i/crlf  w/crlf attr/\tsrc/project with spaces.csproj",
+            "i/lf    w/lf attr/\tsrc/Project with spaces.csproj",
+            "i/mixed w/mixed attr/\tmixed.props",
+            "i/-text w/-text attr/-text\tbinary.props",
+            "");
+
+        var result = GitEOLMetadataProvider.ParseOutput(output);
+
+        Assert.Equal(
+            new Dictionary<string, EOLType>(StringComparer.Ordinal)
+            {
+                ["project.csproj"] = EOLType.LF,
+                ["src/project with spaces.csproj"] = EOLType.CRLF,
+                ["src/Project with spaces.csproj"] = EOLType.LF,
+            },
+            result);
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ModifiedFilesTrackerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/ModifiedFilesTrackerTests.cs
@@ -2,8 +2,11 @@ using System.Collections.Immutable;
 
 using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Run;
+using NuGetUpdater.Core.Utilities;
 
 using Xunit;
+
+using static NuGetUpdater.Core.Utilities.EOLHandling;
 
 namespace NuGetUpdater.Core.Test.Run;
 
@@ -107,7 +110,7 @@ public class ModifiedFilesTrackerTests
         };
 
         // Create tracker with initial files
-        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger, new TestEOLMetadataProvider([]));
         await tracker.StartTrackingAsync(discoveryResult);
 
         // The lock file SHOULD be tracked
@@ -220,7 +223,7 @@ public class ModifiedFilesTrackerTests
         };
 
         // Create tracker with initial files
-        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger);
+        var tracker = new ModifiedFilesTracker(repoContentsPath, initialFiles, logger, new TestEOLMetadataProvider([]));
         await tracker.StartTrackingAsync(discoveryResult);
 
         // The props file SHOULD be tracked
@@ -431,6 +434,141 @@ public class ModifiedFilesTrackerTests
     }
 
     [Fact]
+    public async Task UpdatedFileUsesGitIndexLineEndings()
+    {
+        const string originalContent = "<Project>\r\n  <PropertyGroup />\r\n</Project>\r\n";
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(("project.csproj", originalContent));
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new StringLogger();
+        var tracker = CreateTracker(repoContentsPath, new()
+        {
+            ["project.csproj"] = EOLType.LF,
+        }, logger);
+        await tracker.StartTrackingAsync(CreateDiscoveryResult());
+
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, "<Project>\r\n  <PropertyGroup>\r\n    <Version>2.0.0</Version>\r\n  </PropertyGroup>\r\n</Project>\r\n", TestContext.Current.CancellationToken);
+
+        var updatedFiles = await tracker.StopTrackingAsync();
+
+        var updatedFile = Assert.Single(updatedFiles);
+        Assert.DoesNotContain("\r", updatedFile.Content);
+        Assert.DoesNotContain("\r", await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken));
+        Assert.Contains(
+            logger.Messages,
+            message => message.Contains("Updating line endings for [project.csproj] from CRLF to LF to match the Git index."));
+    }
+
+    [Fact]
+    public async Task UpdatedFileUsesCRLFGitIndexLineEndings()
+    {
+        const string originalContent = "<Project>\n  <PropertyGroup />\n</Project>\n";
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(("project.csproj", originalContent));
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var tracker = CreateTracker(repoContentsPath, new()
+        {
+            ["project.csproj"] = EOLType.CRLF,
+        });
+        await tracker.StartTrackingAsync(CreateDiscoveryResult());
+
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, "<Project>\n  <PropertyGroup>\n    <Version>2.0.0</Version>\n  </PropertyGroup>\n</Project>\n", TestContext.Current.CancellationToken);
+
+        var updatedFiles = await tracker.StopTrackingAsync();
+
+        var updatedFile = Assert.Single(updatedFiles);
+        Assert.DoesNotMatch("(?<!\r)\n", updatedFile.Content);
+        Assert.DoesNotMatch("(?<!\r)\n", await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task UpdatedFileLogsWhenLineEndingsMatchGitIndex()
+    {
+        const string originalContent = "<Project>\n  <PropertyGroup />\n</Project>\n";
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(("project.csproj", originalContent));
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var logger = new StringLogger();
+        var tracker = CreateTracker(repoContentsPath, new()
+        {
+            ["project.csproj"] = EOLType.LF,
+        }, logger);
+        await tracker.StartTrackingAsync(CreateDiscoveryResult());
+
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, "<Project>\n  <PropertyGroup>\n    <Version>2.0.0</Version>\n  </PropertyGroup>\n</Project>\n", TestContext.Current.CancellationToken);
+
+        await tracker.StopTrackingAsync();
+
+        Assert.Contains(
+            logger.Messages,
+            message => message.Contains("Line endings for [project.csproj] already match the Git index: LF."));
+    }
+
+    [Fact]
+    public async Task IndexLineEndingsDoNotCauseUnchangedFileToBeReported()
+    {
+        const string originalContent = "<Project>\r\n  <PropertyGroup />\r\n</Project>\r\n";
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(("project.csproj", originalContent));
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var tracker = CreateTracker(repoContentsPath, new()
+        {
+            ["project.csproj"] = EOLType.LF,
+        });
+        await tracker.StartTrackingAsync(CreateDiscoveryResult());
+
+        var updatedFiles = await tracker.StopTrackingAsync();
+
+        Assert.Empty(updatedFiles);
+    }
+
+    [Fact]
+    public async Task UpdatedFileUsesGitIndexLineEndingsWhileOriginalContentsAreRestored()
+    {
+        const string originalContent = "<Project>\r\n  <PropertyGroup />\r\n</Project>\r\n";
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(("project.csproj", originalContent));
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var tracker = CreateTracker(repoContentsPath, new()
+        {
+            ["project.csproj"] = EOLType.LF,
+        });
+        await tracker.StartTrackingAsync(CreateDiscoveryResult());
+
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllTextAsync(projectPath, "<Project>\r\n  <PropertyGroup>\r\n    <Version>2.0.0</Version>\r\n  </PropertyGroup>\r\n</Project>\r\n", TestContext.Current.CancellationToken);
+
+        var updatedFiles = await tracker.StopTrackingAsync(restoreOriginalContents: true);
+
+        var updatedFile = Assert.Single(updatedFiles);
+        Assert.DoesNotContain("\r", updatedFile.Content);
+        Assert.Equal(originalContent, await File.ReadAllTextAsync(projectPath, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task UpdatedFilePreservesBOMWhenUsingGitIndexLineEndings()
+    {
+        const string originalContent = "<Project>\r\n  <PropertyGroup />\r\n</Project>\r\n";
+        using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(("project.csproj", originalContent));
+        var projectPath = Path.Join(tempDirectory.DirectoryPath, "project.csproj");
+        await File.WriteAllBytesAsync(projectPath, originalContent.SetBOM(setBOM: true), TestContext.Current.CancellationToken);
+        var repoContentsPath = new DirectoryInfo(tempDirectory.DirectoryPath);
+        var tracker = CreateTracker(repoContentsPath, new()
+        {
+            ["project.csproj"] = EOLType.LF,
+        });
+        await tracker.StartTrackingAsync(CreateDiscoveryResult());
+
+        await File.WriteAllTextAsync(projectPath, "<Project>\r\n  <PropertyGroup>\r\n    <Version>2.0.0</Version>\r\n  </PropertyGroup>\r\n</Project>\r\n", TestContext.Current.CancellationToken);
+
+        var updatedFiles = await tracker.StopTrackingAsync();
+
+        var updatedFile = Assert.Single(updatedFiles);
+        Assert.Equal("base64", updatedFile.ContentEncoding);
+        var rawContent = Convert.FromBase64String(updatedFile.Content);
+        Assert.True(rawContent.HasBOM());
+        Assert.DoesNotContain((byte)'\r', rawContent);
+    }
+
+    [Fact]
     public async Task GetInitiallyExistingFiles_FindsAllEditableFileTypes()
     {
         using var tempDirectory = await TemporaryDirectory.CreateWithContentsAsync(
@@ -489,5 +627,47 @@ public class ModifiedFilesTrackerTests
     public void MatchesAllowedEditablePattern(string fileName, bool expected)
     {
         Assert.Equal(expected, ModifiedFilesTracker.MatchesAllowedEditablePattern(fileName));
+    }
+
+    private static ModifiedFilesTracker CreateTracker(
+        DirectoryInfo repoContentsPath,
+        Dictionary<string, EOLType> indexEOLs,
+        ILogger? logger = null)
+    {
+        var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
+        return new ModifiedFilesTracker(
+            repoContentsPath,
+            initialFiles,
+            logger ?? new TestLogger(),
+            new TestEOLMetadataProvider(indexEOLs));
+    }
+
+    private static WorkspaceDiscoveryResult CreateDiscoveryResult()
+    {
+        return new WorkspaceDiscoveryResult()
+        {
+            Path = "/",
+            Projects = [
+                new ProjectDiscoveryResult()
+                {
+                    FilePath = "project.csproj",
+                    Dependencies = [],
+                    TargetFrameworks = ["net9.0"],
+                    ReferencedProjectPaths = [],
+                    ImportedFiles = [],
+                    AdditionalFiles = [],
+                }
+            ],
+        };
+    }
+
+    private sealed class TestEOLMetadataProvider(Dictionary<string, EOLType> indexEOLs) : IEOLMetadataProvider
+    {
+        public Task<Dictionary<string, EOLType>> GetIndexEOLsAsync(
+            DirectoryInfo repoContentsPath,
+            IReadOnlyCollection<string> repoRelativePaths)
+        {
+            return Task.FromResult(indexEOLs);
+        }
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/GitEOLMetadataProvider.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/GitEOLMetadataProvider.cs
@@ -1,0 +1,64 @@
+using static NuGetUpdater.Core.Utilities.EOLHandling;
+
+namespace NuGetUpdater.Core.Run;
+
+internal sealed class GitEOLMetadataProvider : IEOLMetadataProvider
+{
+    public async Task<Dictionary<string, EOLType>> GetIndexEOLsAsync(
+        DirectoryInfo repoContentsPath,
+        IReadOnlyCollection<string> repoRelativePaths)
+    {
+        if (repoRelativePaths.Count == 0)
+        {
+            return new Dictionary<string, EOLType>(StringComparer.Ordinal);
+        }
+
+        var arguments = new List<string>
+        {
+            "--literal-pathspecs",
+            "ls-files",
+            "--eol",
+            "-z",
+            "--",
+        };
+        arguments.AddRange(repoRelativePaths);
+
+        var (exitCode, stdout, stderr) = await ProcessEx.RunAsync("git", arguments, repoContentsPath.FullName);
+        if (exitCode != 0)
+        {
+            throw new InvalidOperationException($"Unable to determine Git index line endings:\n{stderr}");
+        }
+
+        return ParseOutput(stdout);
+    }
+
+    internal static Dictionary<string, EOLType> ParseOutput(string output)
+    {
+        var result = new Dictionary<string, EOLType>(StringComparer.Ordinal);
+        foreach (var record in output.Split('\0', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separatorIndex = record.IndexOf('\t');
+            if (separatorIndex < 0)
+            {
+                continue;
+            }
+
+            var metadata = record[..separatorIndex];
+            var path = record[(separatorIndex + 1)..].NormalizePathToUnix();
+            var indexMetadata = metadata.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            var eol = indexMetadata switch
+            {
+                "i/lf" => EOLType.LF,
+                "i/crlf" => EOLType.CRLF,
+                _ => (EOLType?)null,
+            };
+
+            if (eol is not null)
+            {
+                result[path] = eol.Value;
+            }
+        }
+
+        return result;
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IEOLMetadataProvider.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IEOLMetadataProvider.cs
@@ -1,0 +1,10 @@
+using static NuGetUpdater.Core.Utilities.EOLHandling;
+
+namespace NuGetUpdater.Core.Run;
+
+internal interface IEOLMetadataProvider
+{
+    Task<Dictionary<string, EOLType>> GetIndexEOLsAsync(
+        DirectoryInfo repoContentsPath,
+        IReadOnlyCollection<string> repoRelativePaths);
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ModifiedFilesTracker.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Text;
 
 using NuGetUpdater.Core.Discover;
 using NuGetUpdater.Core.Run.ApiModel;
@@ -13,9 +14,10 @@ public class ModifiedFilesTracker
     public readonly DirectoryInfo RepoContentsPath;
     private WorkspaceDiscoveryResult? _currentDiscoveryResult = null;
     private readonly ILogger _logger;
+    private readonly IEOLMetadataProvider _eolMetadataProvider;
 
     private readonly Dictionary<string, string> _originalDependencyFileContents = [];
-    private readonly Dictionary<string, EOLType> _originalDependencyFileEOFs = [];
+    private readonly Dictionary<string, EOLType> _originalDependencyFileEOLs = [];
     private readonly Dictionary<string, bool> _originalDependencyFileBOMs = [];
     private string[] _nonProjectFiles = [];
     private readonly HashSet<string> _initiallyExistingFiles;
@@ -41,14 +43,23 @@ public class ModifiedFilesTracker
     ];
 
     public IReadOnlyDictionary<string, string> OriginalDependencyFileContents => _originalDependencyFileContents;
-    //public IReadOnlyDictionary<string, EOLType> OriginalDependencyFileEOFs => _originalDependencyFileEOFs;
     public IReadOnlyDictionary<string, bool> OriginalDependencyFileBOMs => _originalDependencyFileBOMs;
 
     public ModifiedFilesTracker(DirectoryInfo repoContentsPath, HashSet<string> initiallyExistingFiles, ILogger logger)
+        : this(repoContentsPath, initiallyExistingFiles, logger, new GitEOLMetadataProvider())
+    {
+    }
+
+    internal ModifiedFilesTracker(
+        DirectoryInfo repoContentsPath,
+        HashSet<string> initiallyExistingFiles,
+        ILogger logger,
+        IEOLMetadataProvider eolMetadataProvider)
     {
         RepoContentsPath = repoContentsPath;
         _initiallyExistingFiles = initiallyExistingFiles;
         _logger = logger;
+        _eolMetadataProvider = eolMetadataProvider;
     }
 
     /// <summary>
@@ -87,7 +98,7 @@ public class ModifiedFilesTracker
             var content = await File.ReadAllTextAsync(localFullPath);
             var rawContent = await File.ReadAllBytesAsync(localFullPath);
             _originalDependencyFileContents[repoFullPath] = content;
-            _originalDependencyFileEOFs[repoFullPath] = content.GetPredominantEOL();
+            _originalDependencyFileEOLs[repoFullPath] = content.GetPredominantEOL();
             _originalDependencyFileBOMs[repoFullPath] = rawContent.HasBOM();
         }
 
@@ -133,6 +144,7 @@ public class ModifiedFilesTracker
         }
 
         var updatedDependencyFiles = new Dictionary<string, DependencyFile>();
+        var updatedDependencyFileRepoPaths = new Dictionary<string, string>();
         async Task AddUpdatedFileIfDifferentAsync(string directory, string fileName)
         {
             var repoFullPath = CorrectRepoRelativePathCasing(directory, fileName);
@@ -140,7 +152,7 @@ public class ModifiedFilesTracker
             var originalContent = _originalDependencyFileContents[repoFullPath];
             var updatedContent = await File.ReadAllTextAsync(localFullPath);
 
-            updatedContent = updatedContent.SetEOL(_originalDependencyFileEOFs[repoFullPath]);
+            updatedContent = updatedContent.SetEOL(_originalDependencyFileEOLs[repoFullPath]);
             var updatedRawContent = updatedContent.SetBOM(_originalDependencyFileBOMs[repoFullPath]);
             await File.WriteAllBytesAsync(localFullPath, updatedRawContent);
 
@@ -161,11 +173,12 @@ public class ModifiedFilesTracker
                     Content = reportedContent,
                     ContentEncoding = encoding,
                 };
+                updatedDependencyFileRepoPaths[localFullPath] = repoFullPath;
 
                 if (restoreOriginalContents)
                 {
                     var originalRawContent = originalContent
-                        .SetEOL(_originalDependencyFileEOFs[repoFullPath])
+                        .SetEOL(_originalDependencyFileEOLs[repoFullPath])
                         .SetBOM(_originalDependencyFileBOMs[repoFullPath]);
                     await File.WriteAllBytesAsync(localFullPath, originalRawContent);
                 }
@@ -198,6 +211,46 @@ public class ModifiedFilesTracker
             await AddUpdatedFileIfDifferentAsync(_currentDiscoveryResult.Path, nonProjectFile);
         }
 
+        var updatedRepoRelativePaths = updatedDependencyFiles.Values
+            .Select(GetRepoRelativePath)
+            .ToArray();
+        var indexEOLs = await _eolMetadataProvider.GetIndexEOLsAsync(RepoContentsPath, updatedRepoRelativePaths);
+        foreach (var (localFullPath, dependencyFile) in updatedDependencyFiles.ToArray())
+        {
+            var repoRelativePath = GetRepoRelativePath(dependencyFile);
+            if (!indexEOLs.TryGetValue(repoRelativePath, out var indexEOL))
+            {
+                continue;
+            }
+
+            var content = dependencyFile.ContentEncoding == "base64"
+                ? GetBase64ContentWithoutBOM(dependencyFile.Content)
+                : dependencyFile.Content;
+            var trackedRepoPath = updatedDependencyFileRepoPaths[localFullPath];
+            var currentEOL = _originalDependencyFileEOLs[trackedRepoPath];
+            if (currentEOL != indexEOL)
+            {
+                _logger.Info($"Updating line endings for [{repoRelativePath}] from {currentEOL} to {indexEOL} to match the Git index.");
+            }
+            else
+            {
+                _logger.Info($"Line endings for [{repoRelativePath}] already match the Git index: {indexEOL}.");
+            }
+
+            var normalizedContent = content.SetEOL(indexEOL);
+            var hasBOM = _originalDependencyFileBOMs[trackedRepoPath];
+            var normalizedRawContent = normalizedContent.SetBOM(hasBOM);
+            updatedDependencyFiles[localFullPath] = dependencyFile with
+            {
+                Content = hasBOM ? Convert.ToBase64String(normalizedRawContent) : normalizedContent,
+            };
+
+            if (!restoreOriginalContents)
+            {
+                await File.WriteAllBytesAsync(localFullPath, normalizedRawContent);
+            }
+        }
+
         _currentDiscoveryResult = null;
 
         var updatedDependencyFileList = updatedDependencyFiles
@@ -205,6 +258,18 @@ public class ModifiedFilesTracker
             .Select(kvp => kvp.Value)
             .ToImmutableArray();
         return updatedDependencyFileList;
+    }
+
+    private static string GetRepoRelativePath(DependencyFile dependencyFile)
+    {
+        return Path.Join(dependencyFile.Directory, dependencyFile.Name).NormalizePathToUnix().TrimStart('/');
+    }
+
+    private static string GetBase64ContentWithoutBOM(string base64Content)
+    {
+        var rawContent = Convert.FromBase64String(base64Content);
+        var bomLength = rawContent.HasBOM() ? Encoding.UTF8.GetPreamble().Length : 0;
+        return Encoding.UTF8.GetString(rawContent.AsSpan(bomLength));
     }
 
     private string CorrectRepoRelativePathCasing(string directory, string fileName)


### PR DESCRIPTION
## Summary
- add an injectable Git index EOL metadata provider for the NuGet updater
- normalize updated dependency files to the EOL representation stored in the Git index
- preserve BOM and restore-original-content behavior, and log EOL conversions
- fix the `_originalDependencyFileEOLs` naming typo

## Tests
- `dotnet build .\nuget\helpers\lib\NuGetUpdater\NuGetUpdater.slnx --configuration Release --no-restore`
- `dotnet test .\nuget\helpers\lib\NuGetUpdater\NuGetUpdater.Core.Test\NuGetUpdater.Core.Test.csproj --configuration Release --no-restore --no-build --filter "FullyQualifiedName~ModifiedFilesTrackerTests|FullyQualifiedName~GitEOLMetadataProviderTests"`