### PR TITLE
Remove unused updater timeout field

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -55,8 +55,7 @@ public class SerializationTests : TestBase
                     "type": "git_source",
                     "replaces-base": false
                   }
-                ],
-                "max-updater-run-time": 0
+                                ]
               }
             }
             """);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -43,7 +43,6 @@ public sealed record Job
     public bool RepoPrivate { get; init; } = false;
     public CommitOptions? CommitMessageOptions { get; init; } = null;
     public ImmutableArray<Dictionary<string, object>>? CredentialsMetadata { get; init; } = null;
-    public int MaxUpdaterRunTime { get; init; } = 0;
     public Cooldown? Cooldown { get; init; } = null;
 
     public ImmutableArray<string> GetRawDirectories()

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_multi_dir_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_multi_dir_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
             "allowed-updates" => [{ "dependency-type" => "direct", "update-type" => "all" }],
             "credentials-metadata" => [{ "type" => "git_source", "host" => "github.com" }],
             "security-advisories" => [],
-            "max-updater-run-time" => 2700,
             "vendor-dependencies" => false,
             "experiments" => { "grouped-updates-prototype" => true },
             "reject-external-code" => false,

--- a/updater/spec/fixtures/job_definitions/bundler/security_updates/group_update_multi_dir.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/security_updates/group_update_multi_dir.yaml
@@ -23,7 +23,6 @@ job:
   grouped-update: false
   ignore-conditions: []
   lockfile-only: false
-  max-updater-run-time: 2700
   package-manager: bundler
   proxy-log-response-body-on-auth-failure: true
   requirements-update-strategy:

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/allow_update_types_minor_and_patch.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/allow_update_types_minor_and_patch.yaml
@@ -24,7 +24,6 @@ job:
     dependency-change-validation: true
   ignore-conditions: []
   lockfile-only: false
-  max-updater-run-time: 2700
   package-manager: bundler
   proxy-log-response-body-on-auth-failure: true
   requirements-update-strategy: bump_versions_if_necessary

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/allow_update_types_patch_only.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/allow_update_types_patch_only.yaml
@@ -23,7 +23,6 @@ job:
     dependency-change-validation: true
   ignore-conditions: []
   lockfile-only: false
-  max-updater-run-time: 2700
   package-manager: bundler
   proxy-log-response-body-on-auth-failure: true
   requirements-update-strategy: bump_versions_if_necessary

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh.yaml
@@ -28,7 +28,6 @@ job:
     - type: git_source
       host: github.com
   security-advisories: []
-  max-updater-run-time: 2700
   vendor-dependencies: false
   experiments:
     grouped-updates-prototype: true

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_dependencies_changed.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_dependencies_changed.yaml
@@ -30,7 +30,6 @@ job:
     - type: git_source
       host: github.com
   security-advisories: []
-  max-updater-run-time: 2700
   vendor-dependencies: false
   experiments:
     grouped-updates-prototype: true

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_empty_group.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_empty_group.yaml
@@ -27,7 +27,6 @@ job:
     - type: git_source
       host: github.com
   security-advisories: []
-  max-updater-run-time: 2700
   vendor-dependencies: false
   experiments:
     grouped-updates-prototype: true

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_missing_group.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_missing_group.yaml
@@ -27,7 +27,6 @@ job:
   - type: git_source
     host: github.com
   security-advisories: []
-  max-updater-run-time: 2700
   vendor-dependencies: false
   experiments:
     grouped-updates-prototype: true

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_multiple_groups_unchaged.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_multiple_groups_unchaged.yaml
@@ -35,7 +35,6 @@ job:
       host: github.com
   security-advisories: []
   security-updates-only: false
-  max-updater-run-time: 2700
   vendor-dependencies: false
   repo-private: false
   proxy-log-response-body-on-auth-failure: true

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_multiple_groups_unchaged_second_group.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_multiple_groups_unchaged_second_group.yaml
@@ -35,7 +35,6 @@ job:
       host: github.com
   security-advisories: []
   security-updates-only: false
-  max-updater-run-time: 2700
   vendor-dependencies: false
   repo-private: false
   proxy-log-response-body-on-auth-failure: true

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_similar_pr.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_similar_pr.yaml
@@ -37,7 +37,6 @@ job:
     - type: git_source
       host: github.com
   security-advisories: []
-  max-updater-run-time: 2700
   vendor-dependencies: false
   experiments:
     grouped-updates-prototype: true

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_versions_changed.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/group_update_refresh_versions_changed.yaml
@@ -27,7 +27,6 @@ job:
     - type: git_source
       host: github.com
   security-advisories: []
-  max-updater-run-time: 2700
   vendor-dependencies: false
   experiments:
     grouped-updates-prototype: true

--- a/updater/spec/fixtures/job_definitions/bundler/version_updates/pull_request_simple.yaml
+++ b/updater/spec/fixtures/job_definitions/bundler/version_updates/pull_request_simple.yaml
@@ -24,7 +24,6 @@ job:
     dependency-change-validation: true
   ignore-conditions: []
   lockfile-only: false
-  max-updater-run-time: 2700
   package-manager: bundler
   proxy-log-response-body-on-auth-failure: true
   requirements-update-strategy: bump_versions_if_necessary

--- a/updater/spec/fixtures/job_definitions/dummy/version_updates/group_update_peer_manifests.yaml
+++ b/updater/spec/fixtures/job_definitions/dummy/version_updates/group_update_peer_manifests.yaml
@@ -27,7 +27,6 @@ job:
     - type: git_source
       host: github.com
   security-advisories: []
-  max-updater-run-time: 2700
   vendor-dependencies: false
   experiments:
     grouped-updates-prototype: true


### PR DESCRIPTION
### What are you trying to accomplish?

Remove the unused `max-updater-run-time` job field from updater fixtures and the NuGet job model.

The Ruby updater already discards this field when constructing a job, and the NuGet property was optional and had no readers. Removing it keeps fixtures and models aligned with the job contract without changing updater behavior.

### Anything you want to highlight for special attention from reviewers?

The field is safe to remove independently: Ruby ignores it, and NuGet job deserialization accepts both a missing property and unknown properties.

### How will you know you've accomplished your goal?

Validated with:

- The focused updater operation spec: 2 examples, 0 failures
- NuGet serialization tests: 55 passed, 0 failed
- An exact repository search confirming no `max-updater-run-time`, `max_updater_run_time`, or `MaxUpdaterRunTime` references remain

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

Related:
* https://github.com/github/dependabot-action/pull/1756