### PR TITLE
Type Cargo requirement access

### DIFF
--- a/cargo/lib/dependabot/cargo/file_parser.rb
+++ b/cargo/lib/dependabot/cargo/file_parser.rb
@@ -42,7 +42,7 @@ module Dependabot
         # TODO: Currently, Dependabot can't handle dependencies that have
         # multiple sources. Fix that!
         dependencies.reject do |dep|
-          dep.requirements.map { |r| r.fetch(:source) }.uniq.count > 1
+          dep.requirements.map(&:source).uniq.count > 1
         end
       end
 

--- a/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/lockfile_updater.rb
@@ -255,8 +255,8 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def git_source_url
           dependency.previous_requirements
-                    &.find { |r| r.dig(:source, :type) == "git" }
-                    &.dig(:source, :url)
+                    &.find { |r| r.source_string("type") == "git" }
+                    &.source_string("url")
         end
 
         sig { returns(String) }
@@ -779,9 +779,9 @@ module Dependabot
         # only when no current git source exists.
         sig { params(key: Symbol).returns(T.nilable(String)) }
         def git_source_detail(key)
-          source = dependency.requirements.find { |r| r.dig(:source, :type) == "git" }&.dig(:source) ||
-                   dependency.previous_requirements&.find { |r| r.dig(:source, :type) == "git" }&.dig(:source)
-          source&.dig(key)
+          requirement = dependency.requirements.find { |r| r.source_string("type") == "git" } ||
+                        dependency.previous_requirements&.find { |r| r.source_string("type") == "git" }
+          requirement&.source_string(key.to_s)
         end
 
         sig do

--- a/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/manifest_updater.rb
@@ -65,7 +65,7 @@ module Dependabot
           changed_requirements =
             dependency.requirements - (dependency.previous_requirements || [])
 
-          changed_requirements.any? { |f| f[:file] == file.name }
+          changed_requirements.any? { |requirement| requirement.file == file.name }
         end
 
         sig { params(content: String, filename: String, dependency: Dependabot::Dependency).returns(String) }
@@ -82,16 +82,16 @@ module Dependabot
           reqs.each do |new_req, old_req|
             next if old_req.nil?
 
-            raise "Bad req match" unless new_req[:file] == old_req[:file]
-            next if new_req[:requirement] == old_req[:requirement]
-            next unless new_req[:file] == filename
+            raise "Bad req match" unless new_req.file == old_req.file
+            next if new_req.requirement == old_req.requirement
+            next unless new_req.file == filename
 
             updated_content =
               update_manifest_req(
                 content: updated_content,
                 dep: dependency,
-                old_req: old_req.fetch(:requirement),
-                new_req: new_req.fetch(:requirement)
+                old_req: T.must(old_req.requirement_string),
+                new_req: T.must(new_req.requirement_string)
               )
           end
 
@@ -102,13 +102,13 @@ module Dependabot
         def update_git_pin(content:, filename:, dependency:)
           updated_pin =
             dependency.requirements
-                      .find { |r| r[:file] == filename }
-                      &.dig(:source, :ref)
+                      .find { |r| r.file == filename }
+                      &.source_string("ref")
 
           old_pin =
             dependency.previous_requirements
-                      &.find { |r| r[:file] == filename }
-                      &.dig(:source, :ref)
+                      &.find { |r| r.file == filename }
+                      &.source_string("ref")
 
           return content unless old_pin
 
@@ -116,7 +116,7 @@ module Dependabot
             content: content,
             dep: dependency,
             old_pin: old_pin,
-            new_pin: updated_pin
+            new_pin: T.must(updated_pin)
           )
         end
 

--- a/cargo/lib/dependabot/cargo/file_updater/workspace_manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/workspace_manifest_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/cargo/lib/dependabot/cargo/file_updater/workspace_manifest_updater.rb
+++ b/cargo/lib/dependabot/cargo/file_updater/workspace_manifest_updater.rb
@@ -39,7 +39,7 @@ module Dependabot
 
         sig { params(dep: Dependabot::Dependency).returns(T::Boolean) }
         def workspace_dependency?(dep)
-          dep.requirements.any? { |r| r[:groups]&.include?("workspace.dependencies") }
+          dep.requirements.any? { |r| r.groups&.include?("workspace.dependencies") }
         end
 
         sig { params(content: String, dep: Dependabot::Dependency).returns(String) }
@@ -66,8 +66,8 @@ module Dependabot
 
         sig { params(requirements: T.nilable(T::Array[Dependabot::DependencyRequirement])).returns(T.nilable(String)) }
         def find_workspace_requirement(requirements)
-          requirements&.find { |r| r[:groups]&.include?("workspace.dependencies") }
-                      &.fetch(:requirement)
+          requirements&.find { |r| r.groups&.include?("workspace.dependencies") }
+                      &.requirement_string
         end
 
         sig { params(section: String, dep_name: String, old_req: String, new_req: String).returns(String) }

--- a/cargo/lib/dependabot/cargo/metadata_finder.rb
+++ b/cargo/lib/dependabot/cargo/metadata_finder.rb
@@ -54,26 +54,15 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_git_url
-        info = T.cast(
-          dependency.requirements.filter_map { |r| r[:source] }.first,
-          T.nilable(T::Hash[T.any(String, Symbol), T.anything])
-        )
-        return unless info
-
-        url = info[:url] || info["url"]
-        Source.from_url(T.cast(url, T.nilable(String)))
+        Source.from_url(dependency.source_string("url", allowed_types: ["git"]))
       end
 
       sig { returns(T.nilable(T::Hash[String, T.anything])) }
       def crates_listing
         return @crates_listing unless @crates_listing.nil?
 
-        info = T.cast(
-          dependency.requirements.filter_map { |r| r[:source] }.first,
-          T.nilable(T::Hash[T.any(String, Symbol), T.anything])
-        )
-        index = T.cast((info && (info[:index] || info["index"])) || CRATES_IO_API, String)
-        hdrs = build_headers(index, info)
+        index = dependency.source_string("index") || CRATES_IO_API
+        hdrs = build_headers(index, dependency.source_string("name"))
 
         url = metadata_fetch_url(dependency, index)
         response = fetch_metadata(url, hdrs)
@@ -82,16 +71,14 @@ module Dependabot
       end
 
       sig do
-        params(index: String, info: T.nilable(T::Hash[T.any(String, Symbol), T.anything]))
+        params(index: String, registry_name: T.nilable(String))
           .returns(T::Hash[String, String])
       end
-      def build_headers(index, info)
+      def build_headers(index, registry_name)
         hdrs = { "User-Agent" => "Dependabot (dependabot.com)" }
         return hdrs if index == CRATES_IO_API
+        return hdrs if registry_name.nil?
 
-        return hdrs if info.nil?
-
-        registry_name = T.cast(info["name"] || info[:name], T.nilable(String))
         credentials.find { |cred| cred["type"] == "cargo_registry" && cred["registry"] == registry_name }&.tap do |cred|
           hdrs["Authorization"] = "Token #{cred['token']}"
         end

--- a/cargo/lib/dependabot/cargo/package/package_details_fetcher.rb
+++ b/cargo/lib/dependabot/cargo/package/package_details_fetcher.rb
@@ -75,11 +75,10 @@ module Dependabot
         def crates_listing
           return @crates_listing unless @crates_listing.nil?
 
-          info = fetch_dependency_info
-          index = fetch_index(info)
+          index = fetch_index
 
           hdrs = default_headers
-          hdrs.merge!(auth_headers(info)) if index != CRATES_IO_API
+          hdrs.merge!(auth_headers) if index != CRATES_IO_API
 
           url = metadata_fetch_url(dependency, index)
 
@@ -95,17 +94,9 @@ module Dependabot
           T.must(@crates_listing)
         end
 
-        sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.anything])) }
-        def fetch_dependency_info
-          T.cast(
-            dependency.requirements.filter_map { |r| r[:source] }.first,
-            T.nilable(T::Hash[T.any(String, Symbol), T.anything])
-          )
-        end
-
-        sig { params(info: T.nilable(T::Hash[T.any(String, Symbol), T.anything])).returns(String) }
-        def fetch_index(info)
-          T.cast((info && (info[:index] || info["index"])) || CRATES_IO_API, String)
+        sig { returns(String) }
+        def fetch_index
+          dependency.source_string("index") || CRATES_IO_API
         end
 
         sig { returns(T::Hash[String, String]) }
@@ -113,9 +104,9 @@ module Dependabot
           { "User-Agent" => "Dependabot (dependabot.com)" }
         end
 
-        sig { params(info: T.nilable(T::Hash[T.any(String, Symbol), T.anything])).returns(T::Hash[String, String]) }
-        def auth_headers(info)
-          registry_name = T.cast(info && (info[:name] || info["name"]), T.nilable(String))
+        sig { returns(T::Hash[String, String]) }
+        def auth_headers
+          registry_name = dependency.source_string("name")
           registry_creds = credentials.find do |cred|
             cred["type"] == "cargo_registry" && cred["registry"] == registry_name
           end
@@ -178,7 +169,7 @@ module Dependabot
           return true if dependency.numeric_version&.prerelease?
 
           dependency.requirements.any? do |req|
-            reqs = (req.fetch(:requirement) || "").split(",").map(&:strip)
+            reqs = (req.requirement_string || "").split(",").map(&:strip)
             reqs.any? { |r| r.match?(/[A-Za-z]/) }
           end
         end

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -221,7 +221,8 @@ module Dependabot
         # of the latest tag that looks like a version.
         if git_commit_checker.pinned_ref_looks_like_version?
           latest_tag = git_commit_checker.local_tag_for_latest_version(update_cooldown)
-          return latest_tag&.fetch(:commit_sha) || dependency.version
+          commit_sha = T.cast(latest_tag&.fetch(:commit_sha), T.nilable(String))
+          return commit_sha || dependency.version
         end
 
         # If the dependency is pinned to a tag that doesn't look like a
@@ -241,7 +242,7 @@ module Dependabot
         if git_commit_checker.pinned_ref_looks_like_version? &&
            latest_git_tag_is_resolvable?
           new_tag = git_commit_checker.local_tag_for_latest_version(update_cooldown)
-          return T.must(new_tag).fetch(:commit_sha)
+          return T.cast(T.must(new_tag).fetch(:commit_sha), String)
         end
 
         # If the dependency is pinned then there's nothing we can do.
@@ -270,7 +271,7 @@ module Dependabot
           dependency_files: dependency_files,
           dependency: dependency,
           unlock_requirement: true,
-          replacement_git_pin: replacement_tag.fetch(:tag)
+          replacement_git_pin: T.cast(replacement_tag.fetch(:tag), String)
         ).prepared_dependency_files
 
         VersionResolver.new(
@@ -362,7 +363,7 @@ module Dependabot
         if git_commit_checker.pinned_ref_looks_like_version? &&
            latest_git_tag_is_resolvable?
           new_tag = T.must(git_commit_checker.local_tag_for_latest_version(update_cooldown))
-          return source_with_ref(T.must(dependency_source_details), new_tag.fetch(:tag))
+          return source_with_ref(T.must(dependency_source_details), T.cast(new_tag.fetch(:tag), String))
         end
 
         # Otherwise return the original source

--- a/cargo/lib/dependabot/cargo/update_checker.rb
+++ b/cargo/lib/dependabot/cargo/update_checker.rb
@@ -353,7 +353,7 @@ module Dependabot
         latest_resolvable_version
       end
 
-      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.anything])) }
+      sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
       def updated_source
         # Never need to update source, unless a git_dependency
         return dependency_source_details unless git_dependency?
@@ -362,16 +362,37 @@ module Dependabot
         if git_commit_checker.pinned_ref_looks_like_version? &&
            latest_git_tag_is_resolvable?
           new_tag = T.must(git_commit_checker.local_tag_for_latest_version(update_cooldown))
-          return T.must(dependency_source_details).merge(ref: new_tag.fetch(:tag))
+          return source_with_ref(T.must(dependency_source_details), new_tag.fetch(:tag))
         end
 
         # Otherwise return the original source
         dependency_source_details
       end
 
-      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.anything])) }
+      sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
       def dependency_source_details
         dependency.source_details
+      end
+
+      sig do
+        params(
+          source: Dependabot::DependencyRequirement::ObjectHash,
+          ref: String
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
+      end
+      def source_with_ref(source, ref)
+        updated_source = source.dup
+        key = if source.key?(:ref)
+                :ref
+              elsif source.key?("ref")
+                "ref"
+              elsif source.keys.any?(Symbol)
+                :ref
+              else
+                "ref"
+              end
+        updated_source[key] = ref
+        updated_source
       end
 
       sig { returns(T::Boolean) }

--- a/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/file_preparer.rb
@@ -238,8 +238,8 @@ module Dependabot
         sig { params(filename: String).returns(String) }
         def temporary_requirement_for_resolution(filename)
           original_req = dependency.requirements
-                                   .find { |r| r.fetch(:file) == filename }
-                                   &.fetch(:requirement)
+                                   .find { |r| r.file == filename }
+                                   &.requirement_string
 
           lower_bound_req =
             if original_req && !unlock_requirement?
@@ -268,11 +268,12 @@ module Dependabot
               dependency.version
             else
               version_from_requirement =
-                dependency.requirements.filter_map { |r| r.fetch(:requirement) }
-                                       .flat_map { |req_str| Cargo::Requirement.new(req_str) }
-                                       .flat_map(&:requirements)
-                                       .reject { |req_array| req_array.first.start_with?("<") }
-                                       .map(&:last)
+                dependency.requirements
+                          .filter_map(&:requirement_string)
+                          .flat_map { |req_str| Cargo::Requirement.new(req_str) }
+                          .flat_map(&:requirements)
+                          .reject { |req_array| req_array.first.start_with?("<") }
+                          .map(&:last)
                           .max&.to_s
 
               version_from_requirement || 0

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/latest_version_finder.rb
@@ -49,7 +49,7 @@ module Dependabot
           return true if dependency.numeric_version&.prerelease?
 
           dependency.requirements.any? do |req|
-            reqs = (req.fetch(:requirement) || "").split(",").map(&:strip)
+            reqs = (req.requirement_string || "").split(",").map(&:strip)
             reqs.any? { |r| r.match?(/[A-Za-z]/) }
           end
         end

--- a/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/requirements_updater.rb
@@ -36,7 +36,7 @@ module Dependabot
         sig do
           params(
             requirements: T::Array[Dependabot::DependencyRequirement],
-            updated_source: T.nilable(T::Hash[T.any(String, Symbol), T.anything]),
+            updated_source: T.nilable(Dependabot::DependencyRequirement::ObjectHash),
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             target_version: T.nilable(T.any(String, Gem::Version))
           ).void
@@ -71,7 +71,7 @@ module Dependabot
           requirements.map do |req|
             req = Dependabot::DependencyRequirement.create(req.merge(source: updated_source))
             next req unless target_version
-            next req if req[:requirement].nil?
+            next req if req.requirement.nil?
 
             # TODO: Add a RequirementsUpdateStrategy::WidenRanges options
             if update_strategy == Dependabot::RequirementsUpdateStrategy::BumpVersionsIfNecessary
@@ -87,7 +87,7 @@ module Dependabot
         sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
-        sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.anything])) }
+        sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
         attr_reader :updated_source
 
         sig { returns(Dependabot::RequirementsUpdateStrategy) }
@@ -105,7 +105,7 @@ module Dependabot
 
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement(req)
-          string_reqs = req[:requirement].split(",").map(&:strip)
+          string_reqs = T.must(req.requirement_string).split(",").map(&:strip)
 
           new_requirement =
             if (exact_req = exact_req(string_reqs))
@@ -128,7 +128,7 @@ module Dependabot
 
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_version_requirement_if_needed(req)
-          string_reqs = req[:requirement].split(",").map(&:strip)
+          string_reqs = T.must(req.requirement_string).split(",").map(&:strip)
           ruby_reqs = string_reqs.map { |r| Dependabot::Cargo::Requirement.new(r) }
 
           return req if ruby_reqs.all? { |r| r.satisfied_by?(target_version) }

--- a/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
+++ b/cargo/lib/dependabot/cargo/update_checker/version_resolver.rb
@@ -485,8 +485,8 @@ module Dependabot
             )
             next unless checker.git_dependency?
 
-            url = T.must(dep.requirements.find { |r| r.dig(:source, :type) == "git" })
-                   .fetch(:source).fetch(:url)
+            requirement = T.must(dep.requirements.find { |r| r.source_string("type") == "git" })
+            url = T.must(requirement.source_string("url"))
 
             if checker.git_repo_reachable?
               T.must(@reachable_git_urls) << url
@@ -616,8 +616,8 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         def git_source_url
           dependency.requirements
-                    .find { |r| r.dig(:source, :type) == "git" }
-                    &.dig(:source, :url)
+                    .find { |r| r.source_string("type") == "git" }
+                    &.source_string("url")
         end
 
         sig { returns(String) }

--- a/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/requirements_updater_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::RequirementsUpdater do
 
     specify { expect(updater.updated_requirements.count).to eq(1) }
 
+    context "with a malformed requirement" do
+      let(:requirements) do
+        [{ file: "Cargo.toml", requirement: 123, groups: [], source: nil }]
+      end
+
+      it "raises a type error" do
+        expect { updater.updated_requirements }
+          .to raise_error(TypeError, "requirement must be a string, :unfixable, or nil")
+      end
+    end
+
     context "when there is no latest version" do
       let(:target_version) { nil }
 

--- a/cargo/spec/dependabot/cargo/update_checker_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker_spec.rb
@@ -534,6 +534,43 @@ RSpec.describe Dependabot::Cargo::UpdateChecker do
           )
       end
     end
+
+    context "with string-keyed git source details" do
+      let(:requirements) do
+        [{
+          file: "Cargo.toml",
+          requirement: nil,
+          groups: [],
+          source: {
+            "type" => "git",
+            "url" => "https://github.com/BurntSushi/utf8-ranges",
+            "ref" => "v1.0.0",
+            "custom" => "preserved"
+          }
+        }]
+      end
+      let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+      before do
+        allow(checker).to receive_messages(
+          target_version: "v1.5.0",
+          git_dependency?: true,
+          latest_git_tag_is_resolvable?: true,
+          git_commit_checker: git_checker
+        )
+        allow(git_checker).to receive_messages(
+          pinned_ref_looks_like_version?: true,
+          local_tag_for_latest_version: { tag: "v1.5.0" }
+        )
+      end
+
+      it "preserves the source payload and key style" do
+        source = checker.updated_requirements.first.source_hash
+
+        expect(source).to include("ref" => "v1.5.0", "custom" => "preserved")
+        expect(source).not_to have_key(:ref)
+      end
+    end
   end
 
   describe "#requirements_unlocked_or_can_be?" do


### PR DESCRIPTION
Uses typed requirement and source readers across Cargo while preserving git, workspace, registry, and `:unfixable` behavior. Reduces Object-generic blockers from 135 to 112. Promotes four requirement consumers to `typed: strong`.