### PR TITLE
Type Hex requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 929
+# Offense count: 926
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"

--- a/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
@@ -139,7 +139,7 @@ module Dependabot
             .reduce(mixfile_content.dup) do |content, dep|
               # Run on the updated mixfile content, so we're updating from the
               # updated requirements
-              req_details = dep.requirements.find { |r| r[:file] == filename }
+              req_details = dep.requirements.find { |r| r.file == filename }
 
               next content unless req_details
               next content unless Hex::Version.correct?(dep.version)
@@ -147,7 +147,7 @@ module Dependabot
               MixfileRequirementUpdater.new(
                 dependency_name: dep.name,
                 mixfile_content: content,
-                previous_requirement: req_details.fetch(:requirement),
+                previous_requirement: req_details.requirement_string,
                 updated_requirement: dep.version,
                 insert_if_bare: true
               ).updated_content

--- a/hex/lib/dependabot/hex/file_updater/mixfile_requirement_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/mixfile_requirement_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/hex/lib/dependabot/hex/file_updater/mixfile_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/mixfile_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/hex/lib/dependabot/hex/file_updater/mixfile_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/mixfile_updater.rb
@@ -56,19 +56,19 @@ module Dependabot
           changed_requirements =
             dependency.requirements - (dependency.previous_requirements || [])
 
-          changed_requirements.any? { |f| f[:file] == file.name }
+          changed_requirements.any? { |requirement| requirement.file == file.name }
         end
 
         sig { params(content: String, filename: String, dependency: Dependabot::Dependency).returns(String) }
         def update_requirement(content:, filename:, dependency:)
           updated_req =
-            dependency.requirements.find { |r| r[:file] == filename }
-                                   &.fetch(:requirement)
+            dependency.requirements.find { |r| r.file == filename }
+                                   &.requirement_string
 
           old_req =
             dependency.previous_requirements
-                      &.find { |r| r[:file] == filename }
-                      &.fetch(:requirement)
+                      &.find { |r| r.file == filename }
+                      &.requirement_string
 
           return content unless old_req
 
@@ -83,13 +83,13 @@ module Dependabot
         sig { params(content: String, filename: String, dependency: Dependabot::Dependency).returns(String) }
         def update_git_pin(content:, filename:, dependency:)
           updated_pin =
-            dependency.requirements.find { |r| r[:file] == filename }
-                                   &.dig(:source, :ref)
+            dependency.requirements.find { |r| r.file == filename }
+                                   &.source_string("ref")
 
           old_pin =
             dependency.previous_requirements
-                      &.find { |r| r[:file] == filename }
-                      &.dig(:source, :ref)
+                      &.find { |r| r.file == filename }
+                      &.source_string("ref")
 
           return content unless old_pin
           return content if old_pin == updated_pin
@@ -98,7 +98,7 @@ module Dependabot
             dependency_name: dependency.name,
             mixfile_content: content,
             previous_pin: old_pin,
-            updated_pin: updated_pin
+            updated_pin: T.must(updated_pin)
           ).updated_content
         end
       end

--- a/hex/lib/dependabot/hex/metadata_finder.rb
+++ b/hex/lib/dependabot/hex/metadata_finder.rb
@@ -47,10 +47,7 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_git_url
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-
-        url = info[:url] || info.fetch("url")
-        Source.from_url(url)
+        Source.from_url(dependency.source_string("url", allowed_types: ["git"]))
       end
 
       sig { returns(T.nilable(T::Hash[String, T.untyped])) }

--- a/hex/lib/dependabot/hex/update_checker.rb
+++ b/hex/lib/dependabot/hex/update_checker.rb
@@ -167,7 +167,7 @@ module Dependabot
         false
       end
 
-      sig { returns(T.nilable(T::Hash[T.untyped, T.untyped])) }
+      sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
       def updated_source
         # Never need to update source, unless a git_dependency
         return dependency_source_details unless git_dependency?
@@ -176,16 +176,40 @@ module Dependabot
         if git_commit_checker.pinned_ref_looks_like_version? &&
            latest_git_tag_is_resolvable?
           new_tag = git_commit_checker.local_tag_for_latest_version(update_cooldown)
-          return T.must(dependency_source_details).merge(ref: T.must(new_tag).fetch(:tag))
+          return source_with_ref(
+            T.must(dependency_source_details),
+            T.cast(T.must(new_tag).fetch(:tag), String)
+          )
         end
 
         # Otherwise return the original source
         dependency_source_details
       end
 
-      sig { returns(T.nilable(T::Hash[T.any(String, Symbol), T.untyped])) }
+      sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
       def dependency_source_details
         dependency.source_details
+      end
+
+      sig do
+        params(
+          source: Dependabot::DependencyRequirement::ObjectHash,
+          ref: String
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
+      end
+      def source_with_ref(source, ref)
+        updated_source = source.dup
+        key = if source.key?(:ref)
+                :ref
+              elsif source.key?("ref")
+                "ref"
+              elsif source.keys.any?(Symbol)
+                :ref
+              else
+                "ref"
+              end
+        updated_source[key] = ref
+        updated_source
       end
 
       sig do

--- a/hex/lib/dependabot/hex/update_checker/file_preparer.rb
+++ b/hex/lib/dependabot/hex/update_checker/file_preparer.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/hex/lib/dependabot/hex/update_checker/file_preparer.rb
+++ b/hex/lib/dependabot/hex/update_checker/file_preparer.rb
@@ -95,8 +95,8 @@ module Dependabot
         sig { params(content: String, filename: String).returns(String) }
         def relax_version(content, filename:)
           old_requirement =
-            dependency.requirements.find { |r| r.fetch(:file) == filename }
-                                   &.fetch(:requirement)
+            dependency.requirements.find { |r| r.file == filename }
+                                   &.requirement_string
           updated_requirement = updated_version_requirement_string(filename)
 
           Hex::FileUpdater::MixfileRequirementUpdater.new(
@@ -124,20 +124,21 @@ module Dependabot
         sig { params(filename: String).returns(String) }
         def updated_version_req_lower_bound(filename)
           original_req = dependency.requirements
-                                   .find { |r| r.fetch(:file) == filename }
-                                   &.fetch(:requirement)
+                                   .find { |r| r.file == filename }
+                                   &.requirement_string
 
           if original_req && !unlock_requirement? then original_req
           elsif dependency.version&.match?(/^[0-9a-f]{40}$/) then ">= 0"
           elsif dependency.version then ">= #{dependency.version}"
           else
             version_for_requirement =
-              dependency.requirements.filter_map { |r| r[:requirement] }
-                                     .reject { |req_string| req_string.start_with?("<") }
-                                     .select { |req_string| req_string.match?(version_regex) }
-                                     .map { |req_string| req_string.match(version_regex) }
-                                     .select { |version| version_class.correct?(version.to_s) }
-                                     .max_by { |version| version_class.new(version.to_s) }
+              dependency.requirements
+                        .filter_map(&:requirement_string)
+                        .reject { |req_string| req_string.start_with?("<") }
+                        .select { |req_string| req_string.match?(version_regex) }
+                        .map { |req_string| req_string.match(version_regex) }
+                        .select { |version| version_class.correct?(version.to_s) }
+                        .max_by { |version| version_class.new(version.to_s) }
 
             return ">= 0" unless version_for_requirement
 
@@ -155,8 +156,8 @@ module Dependabot
         sig { params(content: String, filename: String).returns(String) }
         def replace_git_pin(content, filename:)
           old_pin =
-            dependency.requirements.find { |r| r.fetch(:file) == filename }
-                                   &.dig(:source, :ref)
+            dependency.requirements.find { |r| r.file == filename }
+                                   &.source_string("ref")
 
           return content unless old_pin
           return content if old_pin == replacement_git_pin
@@ -212,7 +213,7 @@ module Dependabot
           end
 
           dependency.requirements.any? do |req|
-            req[:requirement].match?(/\d-[A-Za-z0-9]/)
+            req.requirement_string&.match?(/\d-[A-Za-z0-9]/)
           end
         end
 
@@ -228,7 +229,7 @@ module Dependabot
 
         sig { params(file_name: String).returns(T::Boolean) }
         def dependency_appears_in_file?(file_name)
-          dependency.requirements.any? { |r| r[:file] == file_name }
+          dependency.requirements.any? { |r| r.file == file_name }
         end
       end
     end

--- a/hex/lib/dependabot/hex/update_checker/latest_version_finder.rb
+++ b/hex/lib/dependabot/hex/update_checker/latest_version_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/hex/lib/dependabot/hex/update_checker/latest_version_finder.rb
+++ b/hex/lib/dependabot/hex/update_checker/latest_version_finder.rb
@@ -105,7 +105,7 @@ module Dependabot
           return true if current_version&.prerelease?
 
           dependency.requirements.any? do |req|
-            req[:requirement]&.match?(/\d-[A-Za-z0-9]/)
+            req.requirement_string&.match?(/\d-[A-Za-z0-9]/)
           end
         end
 

--- a/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
+++ b/hex/lib/dependabot/hex/update_checker/requirements_updater.rb
@@ -23,7 +23,7 @@ module Dependabot
           params(
             requirements: T::Array[Dependabot::DependencyRequirement],
             latest_resolvable_version: T.nilable(String),
-            updated_source: T.nilable(T::Hash[Symbol, T.nilable(String)])
+            updated_source: T.nilable(Dependabot::DependencyRequirement::ObjectHash)
           ).void
         end
         def initialize(
@@ -57,7 +57,7 @@ module Dependabot
         sig { returns(T.nilable(Dependabot::Version)) }
         attr_reader :latest_resolvable_version
 
-        sig { returns(T.nilable(T::Hash[Symbol, T.nilable(String)])) }
+        sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
         attr_reader :updated_source
 
         # rubocop:disable Metrics/PerceivedComplexity
@@ -65,25 +65,27 @@ module Dependabot
         sig { params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def updated_mixfile_requirement(req)
           req = update_source(req)
-          return req unless latest_resolvable_version && req[:requirement]
-          return req if req_satisfied_by_latest_resolvable?(req[:requirement])
+          requirement_string = req.requirement_string
+          return req unless latest_resolvable_version && requirement_string
+          return req if req_satisfied_by_latest_resolvable?(requirement_string)
 
-          or_string_reqs = req[:requirement].split(OR_SEPARATOR)
-          last_string_reqs = or_string_reqs.last.split(AND_SEPARATOR)
-                                           .map(&:strip)
+          or_string_reqs = requirement_string.split(OR_SEPARATOR)
+          last_string_reqs = T.must(or_string_reqs.last)
+                              .split(AND_SEPARATOR)
+                              .map(&:strip)
 
           new_requirement =
             if last_string_reqs.any? { |r| r.match(/^(?:\d|=)/) }
               exact_req = last_string_reqs.find { |r| r.match(/^(?:\d|=)/) }
-              update_exact_version(exact_req, T.must(latest_resolvable_version)).to_s
+              update_exact_version(T.must(exact_req), T.must(latest_resolvable_version)).to_s
             elsif last_string_reqs.any? { |r| r.start_with?("~>") }
               tw_req = last_string_reqs.find { |r| r.start_with?("~>") }
-              update_twiddle_version(tw_req, T.must(latest_resolvable_version)).to_s
+              update_twiddle_version(T.must(tw_req), T.must(latest_resolvable_version)).to_s
             else
               update_mixfile_range(last_string_reqs).join(" and ")
             end
 
-          new_requirement = req[:requirement] + " or " + new_requirement if or_string_reqs.count > 1
+          new_requirement = requirement_string + " or " + new_requirement if or_string_reqs.count > 1
 
           Dependabot::DependencyRequirement.create(req.merge(requirement: new_requirement))
         end
@@ -96,7 +98,7 @@ module Dependabot
         def update_source(requirement_hash)
           # Only git sources ever need to be updated. Anything else should be
           # left alone.
-          return requirement_hash unless requirement_hash.dig(:source, :type) == "git"
+          return requirement_hash unless requirement_hash.source_string("type") == "git"
 
           Dependabot::DependencyRequirement.create(requirement_hash.merge(source: updated_source))
         end

--- a/hex/spec/dependabot/hex/update_checker/requirements_updater_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker/requirements_updater_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe Dependabot::Hex::UpdateChecker::RequirementsUpdater do
 
     specify { expect(updater.updated_requirements.count).to eq(1) }
 
+    context "with a malformed requirement" do
+      let(:mixfile_req) do
+        { file: "mix.exs", requirement: 123, groups: [], source: nil }
+      end
+
+      it "raises a type error" do
+        expect { updater.updated_requirements }
+          .to raise_error(TypeError, "requirement must be a string, :unfixable, or nil")
+      end
+    end
+
     context "when there is no resolvable version" do
       let(:latest_resolvable_version) { nil }
 

--- a/hex/spec/dependabot/hex/update_checker_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker_spec.rb
@@ -1142,6 +1142,30 @@ RSpec.describe Dependabot::Hex::UpdateChecker do
             }]
           )
       end
+
+      context "with string-keyed source details" do
+        let(:dependency_requirements) do
+          [{
+            requirement: nil,
+            file: "mix.exs",
+            groups: [],
+            source: {
+              "type" => "git",
+              "url" => "https://github.com/dependabot-fixtures/phoenix.git",
+              "branch" => "master",
+              "ref" => "v1.2.0",
+              "custom" => "preserved"
+            }
+          }]
+        end
+
+        it "preserves the source payload and key style" do
+          source = checker.updated_requirements.first.source_hash
+
+          expect(source).to include("ref" => "v1.3.2", "custom" => "preserved")
+          expect(source).not_to have_key(:ref)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Uses typed requirement and source readers across Hex while preserving bare dependencies, git pins, and source key style. Reduces Object-generic blockers from 112 to 93 and `Sorbet/ForbidTUntyped` from 929 to 926. Promotes four requirement consumers to `typed: strong`.