### PR TITLE
Type Composer requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 926
+# Offense count: 924
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -293,7 +293,6 @@ Sorbet/ForbidTUntyped:
     - "composer/lib/dependabot/composer/file_fetcher/path_dependency_builder.rb"
     - "composer/lib/dependabot/composer/file_parser.rb"
     - "composer/lib/dependabot/composer/file_updater/lockfile_updater.rb"
-    - "composer/lib/dependabot/composer/file_updater/manifest_updater.rb"
     - "composer/lib/dependabot/composer/helpers.rb"
     - "composer/lib/dependabot/composer/metadata_finder.rb"
     - "composer/lib/dependabot/composer/package/package_details_fetcher.rb"

--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -320,8 +320,8 @@ module Dependabot
             next content unless Composer::Version.correct?(updated_req)
 
             old_req =
-              dep.requirements.find { |r| r[:file] == PackageManager::MANIFEST_FILENAME }
-                              &.fetch(:requirement)
+              dep.requirements.find { |r| r.file == PackageManager::MANIFEST_FILENAME }
+                              &.requirement_string
 
             # When updating a subdep there won't be an old requirement
             next content unless old_req

--- a/composer/lib/dependabot/composer/file_updater/manifest_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/manifest_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/composer/lib/dependabot/composer/file_updater/manifest_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/manifest_updater.rb
@@ -23,8 +23,8 @@ module Dependabot
             dependencies.reduce(manifest.content.dup) do |content, dep|
               updated_content = content
               updated_requirements(dep).each do |new_req|
-                old_req = old_requirement(dep, new_req)&.fetch(:requirement)
-                updated_req = new_req.fetch(:requirement)
+                old_req = T.must(old_requirement(dep, new_req)&.requirement_string)
+                updated_req = T.must(new_req.requirement_string)
 
                 regex =
                   /
@@ -54,20 +54,20 @@ module Dependabot
 
         sig { params(dependency: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
         def new_requirements(dependency)
-          dependency.requirements.select { |r| r[:file] == manifest.name }
+          dependency.requirements.select { |r| r.file == manifest.name }
         end
 
         sig do
           params(
             dependency: Dependabot::Dependency,
-            new_requirement: T::Hash[Symbol, T.untyped]
+            new_requirement: Dependabot::DependencyRequirement
           )
-            .returns(T.nilable(T::Hash[Symbol, T.untyped]))
+            .returns(T.nilable(Dependabot::DependencyRequirement))
         end
         def old_requirement(dependency, new_requirement)
           T.must(dependency.previous_requirements)
-           .select { |r| r[:file] == manifest.name }
-           .find { |r| r[:groups] == new_requirement[:groups] }
+           .select { |r| r.file == manifest.name }
+           .find { |r| r.groups == new_requirement.groups }
         end
 
         sig { params(dependency: Dependabot::Dependency).returns(T::Array[Dependabot::DependencyRequirement]) }
@@ -81,7 +81,7 @@ module Dependabot
           changed_requirements =
             dependency.requirements - T.must(dependency.previous_requirements)
 
-          changed_requirements.any? { |f| f[:file] == file.name }
+          changed_requirements.any? { |requirement| requirement.file == file.name }
         end
       end
     end

--- a/composer/lib/dependabot/composer/metadata_finder.rb
+++ b/composer/lib/dependabot/composer/metadata_finder.rb
@@ -36,12 +36,7 @@ module Dependabot
 
       sig { returns(T.nilable(Source)) }
       def source_from_dependency
-        source_url =
-          dependency.requirements
-                    .filter_map { |r| r.fetch(:source) }
-                    .first&.fetch(:url, nil)
-
-        Source.from_url(source_url)
+        Source.from_url(dependency.source_string("url"))
       end
 
       sig { returns(T.nilable(Source)) }

--- a/composer/lib/dependabot/composer/update_checker.rb
+++ b/composer/lib/dependabot/composer/update_checker.rb
@@ -156,13 +156,13 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def path_dependency?
-        dependency.requirements.any? { |r| r.dig(:source, :type) == "path" }
+        dependency.requirements.any? { |r| r.source_string("type") == "path" }
       end
 
       # To be a true git dependency, it must have a branch.
       sig { returns(T::Boolean) }
       def git_dependency?
-        dependency.requirements.any? { |r| r.dig(:source, :branch) }
+        dependency.requirements.any? { |r| r.source_string("branch") }
       end
 
       sig { returns(Dependabot::DependencyFile) }

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
+++ b/composer/lib/dependabot/composer/update_checker/latest_version_finder.rb
@@ -74,7 +74,7 @@ module Dependabot
           return true if current_version&.prerelease?
 
           dependency.requirements.any? do |req|
-            req[:requirement].match?(/\d-[A-Za-z]/)
+            req.requirement_string&.match?(/\d-[A-Za-z]/)
           end
         end
 

--- a/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
+++ b/composer/lib/dependabot/composer/update_checker/requirements_updater.rb
@@ -11,6 +11,7 @@ require "sorbet-runtime"
 require "dependabot/composer/requirement"
 require "dependabot/composer/update_checker"
 require "dependabot/composer/version"
+require "dependabot/dependency_requirement"
 require "dependabot/requirements_update_strategy"
 
 module Dependabot
@@ -36,7 +37,7 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, String]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             update_strategy: Dependabot::RequirementsUpdateStrategy,
             latest_resolvable_version: T.nilable(T.any(String, Composer::Version))
           ).void
@@ -46,7 +47,10 @@ module Dependabot
           update_strategy:,
           latest_resolvable_version:
         )
-          @requirements = requirements
+          @requirements = T.let(
+            requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @update_strategy = update_strategy
 
           check_update_strategy
@@ -59,7 +63,7 @@ module Dependabot
           )
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, String]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements if update_strategy.lockfile_only?
           return requirements unless latest_resolvable_version
@@ -69,7 +73,7 @@ module Dependabot
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, String]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(Dependabot::RequirementsUpdateStrategy) }
@@ -85,9 +89,12 @@ module Dependabot
           raise "Unknown update strategy: #{update_strategy}"
         end
 
-        sig { params(req: T::Hash[Symbol, String]).returns(T::Hash[Symbol, String]) }
+        sig do
+          params(req: Dependabot::DependencyRequirement)
+            .returns(Dependabot::DependencyRequirement)
+        end
         def updated_requirement(req)
-          req_string = T.must(req[:requirement]).strip
+          req_string = T.must(req.requirement_string).strip
           or_string_reqs = req_string.split(OR_SEPARATOR)
           or_separator = req_string.match(OR_SEPARATOR)&.to_s || " || "
           branch_or_string_reqs, numeric_or_string_reqs = or_string_reqs
@@ -110,12 +117,16 @@ module Dependabot
           # Add a T.must for new_req as it's defined in the case statement with multiple options
           new_req = T.must(new_req)
           new_req_string =
-            [new_req[:requirement], *branch_or_string_reqs].join(or_separator)
-          new_req.merge(requirement: new_req_string)
+            [T.must(new_req.requirement_string), *branch_or_string_reqs].join(or_separator)
+          Dependabot::DependencyRequirement.create(new_req.merge(requirement: new_req_string))
         end
-        sig { params(req: T::Hash[Symbol, String]).returns(T::Hash[Symbol, String]) }
+
+        sig do
+          params(req: Dependabot::DependencyRequirement)
+            .returns(Dependabot::DependencyRequirement)
+        end
         def updated_alias(req)
-          req_string = T.must(req[:requirement])
+          req_string = T.must(req.requirement_string)
           parts = req_string.split(/\sas\s/)
           real_version = T.must(parts.first).strip
 
@@ -125,13 +136,16 @@ module Dependabot
 
           new_version_string = T.must(latest_resolvable_version).to_s
           new_req = req_string.sub(real_version, new_version_string)
-          req.merge(requirement: new_req)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: new_req))
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
-        sig { params(req: T::Hash[Symbol, String], or_separator: String).returns(T::Hash[Symbol, String]) }
+        sig do
+          params(req: Dependabot::DependencyRequirement, or_separator: String)
+            .returns(Dependabot::DependencyRequirement)
+        end
         def widen_requirement(req, or_separator)
-          current_requirement = T.must(req[:requirement])
+          current_requirement = T.must(req.requirement_string)
           reqs = current_requirement.strip.split(SEPARATOR).map(&:strip)
 
           updated_requirement =
@@ -147,13 +161,16 @@ module Dependabot
               update_version_string(current_requirement)
             end
 
-          req.merge(requirement: updated_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: updated_requirement))
         end
         # rubocop:enable Metrics/PerceivedComplexity
 
-        sig { params(req: T::Hash[Symbol, String], or_separator: String).returns(T::Hash[Symbol, String]) }
+        sig do
+          params(req: Dependabot::DependencyRequirement, or_separator: String)
+            .returns(Dependabot::DependencyRequirement)
+        end
         def update_requirement_version(req, or_separator)
-          current_requirement = T.must(req[:requirement])
+          current_requirement = T.must(req.requirement_string)
           reqs = current_requirement.strip.split(SEPARATOR).map(&:strip)
 
           updated_requirement =
@@ -167,7 +184,7 @@ module Dependabot
               update_version_string(current_requirement)
             end
 
-          req.merge(requirement: updated_requirement)
+          Dependabot::DependencyRequirement.create(req.merge(requirement: updated_requirement))
         end
 
         sig { params(requirement_string: String).returns(T::Boolean) }

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -265,22 +265,22 @@ module Dependabot
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
-        # rubocop:disable Metrics/AbcSize
         sig { returns(String) }
         def updated_version_requirement_string
           lower_bound =
             if requirements_to_unlock == :none
-              dependency.requirements.first&.fetch(:requirement) || ">= 0"
+              dependency.requirements.first&.requirement_string || ">= 0"
             elsif dependency.version
               ">= #{dependency.version}"
             else
               version_for_requirement =
-                dependency.requirements.filter_map { |r| r[:requirement] }
-                                       .reject { |req_string| req_string.start_with?("<") }
-                                       .select { |req_string| req_string.match?(VERSION_REGEX) }
-                                       .map { |req_string| req_string.match(VERSION_REGEX) }
-                                       .select { |version| requirement_valid?(">= #{version}") }
-                                       .max_by { |version| Composer::Version.new(version.to_s) }
+                dependency.requirements
+                          .filter_map(&:requirement_string)
+                          .reject { |req_string| req_string.start_with?("<") }
+                          .select { |req_string| req_string.match?(VERSION_REGEX) }
+                          .map { |req_string| req_string.match(VERSION_REGEX) }
+                          .select { |version| requirement_valid?(">= #{version}") }
+                          .max_by { |version| Composer::Version.new(version.to_s) }
 
               ">= #{version_for_requirement || 0}"
             end
@@ -301,7 +301,6 @@ module Dependabot
           lower_bound + ", == #{latest_allowable_version}"
         end
         # rubocop:enable Metrics/PerceivedComplexity
-        # rubocop:enable Metrics/AbcSize
 
         # TODO: Extract error handling and share between the lockfile updater
         #

--- a/composer/spec/dependabot/composer/metadata_finder_spec.rb
+++ b/composer/spec/dependabot/composer/metadata_finder_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe Dependabot::Composer::MetadataFinder do
             requirement: "1.*",
             groups: [],
             source: {
-              type: "git",
-              url: "https://github.com/Seldaek/monolog.git"
+              "type" => "git",
+              "url" => "https://github.com/Seldaek/monolog.git"
             }
           }]
         end

--- a/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/requirements_updater_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe Dependabot::Composer::UpdateChecker::RequirementsUpdater do
 
     specify { expect(updater.updated_requirements.count).to eq(1) }
 
+    context "with a malformed requirement" do
+      let(:latest_resolvable_version) { "1.5.0" }
+      let(:composer_json_req) do
+        { file: "composer.json", requirement: 123, groups: [], source: nil }
+      end
+
+      it "raises a type error" do
+        expect { updater.updated_requirements }
+          .to raise_error(TypeError, "requirement must be a string, :unfixable, or nil")
+      end
+    end
+
     context "when there is no resolvable version" do
       let(:latest_resolvable_version) { nil }
 


### PR DESCRIPTION
Uses `DependencyRequirement` throughout Composer requirement updates, metadata, manifests, lockfiles, and resolution. Reduces Object-generic blockers from 93 to 80 and `Sorbet/ForbidTUntyped` from 926 to 924. Promotes two requirement consumers to `typed: strong`.