### PR TITLE
Type Swift requirement access

### DIFF
--- a/swift/lib/dependabot/swift/file_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/dependency"

--- a/swift/lib/dependabot/swift/file_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser.rb
@@ -52,9 +52,12 @@ module Dependabot
 
         dependency_parser.parse.map do |dep|
           if dep.top_level?
-            source = T.must(dep.requirements.first)[:source]
+            requirement = T.must(dep.requirements.first)
 
-            requirements = ManifestParser.new(T.must(package_manifest_file), source: source).requirements
+            requirements = ManifestParser.new(
+              T.must(package_manifest_file),
+              requirement: requirement
+            ).requirements
 
             dependency_set << Dependency.new(
               name: dep.name,

--- a/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependabot/file_parsers/base"
+require "dependabot/dependency_requirement"
 require "dependabot/swift/native_requirement"
 
 module Dependabot
@@ -19,18 +20,18 @@ module Dependabot
         sig do
           params(
             manifest: Dependabot::DependencyFile,
-            source: T::Hash[Symbol, String]
+            requirement: Dependabot::DependencyRequirement
           ).void
         end
-        def initialize(manifest, source:)
+        def initialize(manifest, requirement:)
           @manifest = manifest
-          @source = source
+          @requirement = requirement
         end
 
         sig { returns(T::Array[T::Hash[Symbol, Object]]) }
         def requirements
           found = manifest.content&.scan(DEPENDENCY)&.find do |_declaration, url, _requirement|
-            SharedHelpers.scp_to_standard(url.to_s) == source[:url]
+            SharedHelpers.scp_to_standard(url.to_s) == requirement.source_string("url")
           end
 
           return [] unless found
@@ -43,7 +44,7 @@ module Dependabot
               requirement: requirement.to_s,
               groups: ["dependencies"],
               file: manifest.name,
-              source: source,
+              source: T.must(self.requirement.source_hash),
               metadata: { declaration_string: declaration, requirement_string: requirement.declaration }
             }
           ]
@@ -54,8 +55,8 @@ module Dependabot
         sig { returns(Dependabot::DependencyFile) }
         attr_reader :manifest
 
-        sig { returns(T::Hash[Symbol, String]) }
-        attr_reader :source
+        sig { returns(Dependabot::DependencyRequirement) }
+        attr_reader :requirement
       end
     end
   end

--- a/swift/lib/dependabot/swift/file_parser/xcode_spm_resolver.rb
+++ b/swift/lib/dependabot/swift/file_parser/xcode_spm_resolver.rb
@@ -142,16 +142,18 @@ module Dependabot
           kind = req_info[:kind]
 
           new_requirements = dep.requirements.map do |req|
-            req.merge(
-              requirement: requirement_str || req[:requirement],
-              file: pbxproj_file,
-              metadata: {
-                # declaration_string is not applicable for Xcode-managed SPM
-                # (no Package.swift manifest to extract it from)
-                declaration_string: nil,
-                requirement_string: requirement_string,
-                kind: kind
-              }.compact
+            Dependabot::DependencyRequirement.create(
+              req.merge(
+                requirement: requirement_str || req.requirement,
+                file: pbxproj_file,
+                metadata: {
+                  # declaration_string is not applicable for Xcode-managed SPM
+                  # (no Package.swift manifest to extract it from)
+                  declaration_string: nil,
+                  requirement_string: requirement_string,
+                  kind: kind
+                }.compact
+              )
             )
           end
 

--- a/swift/lib/dependabot/swift/file_updater.rb
+++ b/swift/lib/dependabot/swift/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/file_updaters"

--- a/swift/lib/dependabot/swift/file_updater.rb
+++ b/swift/lib/dependabot/swift/file_updater.rb
@@ -141,7 +141,7 @@ module Dependabot
 
       sig { params(dep: Dependabot::Dependency).returns(T::Set[String]) }
       def requirement_files_for(dep)
-        files = dep.requirements.map { |req| req[:file] } + (dep.previous_requirements || []).map { |req| req[:file] }
+        files = dep.requirements.map(&:file) + (dep.previous_requirements || []).map(&:file)
         files.compact.to_set
       end
 

--- a/swift/lib/dependabot/swift/file_updater/manifest_updater.rb
+++ b/swift/lib/dependabot/swift/file_updater/manifest_updater.rb
@@ -14,8 +14,8 @@ module Dependabot
         sig do
           params(
             content: String,
-            old_requirements: T::Array[T::Hash[Symbol, Object]],
-            new_requirements: T::Array[T::Hash[Symbol, Object]]
+            old_requirements: T::Array[Dependabot::DependencyRequirement],
+            new_requirements: T::Array[Dependabot::DependencyRequirement]
           )
             .void
         end
@@ -30,13 +30,12 @@ module Dependabot
           updated_content = content
 
           old_requirements.zip(new_requirements).each do |old, new|
-            old_metadata = metadata(old)
-            new_metadata = metadata(T.must(new))
+            new_requirement = T.must(new)
             updated_content = RequirementReplacer.new(
               content: updated_content,
-              declaration: string_value(old_metadata, :declaration_string),
-              old_requirement: string_value(old_metadata, :requirement_string),
-              new_requirement: string_value(new_metadata, :requirement_string)
+              declaration: T.must(old.metadata_string("declaration_string")),
+              old_requirement: T.must(old.metadata_string("requirement_string")),
+              new_requirement: T.must(new_requirement.metadata_string("requirement_string"))
             ).updated_content
           end
 
@@ -48,27 +47,11 @@ module Dependabot
         sig { returns(String) }
         attr_reader :content
 
-        sig { returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :old_requirements
 
-        sig { returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :new_requirements
-
-        sig { params(requirement: T::Hash[Symbol, Object]).returns(T::Hash[Symbol, Object]) }
-        def metadata(requirement)
-          value = requirement[:metadata]
-          raise TypeError, "Expected metadata to be a Hash" unless value.is_a?(Hash)
-
-          value
-        end
-
-        sig { params(hash: T::Hash[Symbol, Object], key: Symbol).returns(String) }
-        def string_value(hash, key)
-          value = hash.fetch(key)
-          raise TypeError, "Expected #{key} to be a String" unless value.is_a?(String)
-
-          value
-        end
       end
     end
   end

--- a/swift/lib/dependabot/swift/file_updater/xcode_lockfile_updater.rb
+++ b/swift/lib/dependabot/swift/file_updater/xcode_lockfile_updater.rb
@@ -169,9 +169,8 @@ module Dependabot
           state = pin["state"]
           return unless state.is_a?(Hash)
 
-          source = dependency.requirements.first&.dig(:source)
           new_version = dependency.version
-          new_ref = source&.dig(:ref)
+          new_ref = dependency.requirements.first&.source_string("ref")
 
           if new_version
             state["version"] = new_version
@@ -228,7 +227,7 @@ module Dependabot
           @dependencies_for_file ||= T.let(
             dependencies.select do |dep|
               dep.requirements.any? do |req|
-                req_file_matches_resolved_scope?(req[:file])
+                req_file_matches_resolved_scope?(req.file)
               end
             end,
             T.nilable(T::Array[Dependabot::Dependency])

--- a/swift/lib/dependabot/swift/native_requirement.rb
+++ b/swift/lib/dependabot/swift/native_requirement.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependabot/utils"
+require "dependabot/dependency_requirement"
 require "dependabot/swift/requirement"
 require "sorbet-runtime"
 
@@ -17,32 +18,56 @@ module Dependabot
       attr_reader :declaration
 
       sig do
-        type_parameters(:T)
-          .params(
-            requirements: T::Array[T::Hash[Symbol, Object]],
-            _blk: T.proc.params(declaration: NativeRequirement).returns(String)
-          )
-          .returns(T::Array[T::Hash[Symbol, Object]])
+        params(
+          requirements: T::Array[Dependabot::DependencyRequirement],
+          _blk: T.proc.params(declaration: NativeRequirement).returns(String)
+        )
+          .returns(T::Array[Dependabot::DependencyRequirement])
       end
       def self.map_requirements(requirements, &_blk)
         requirements.map do |requirement|
-          metadata = requirement[:metadata]
-          next requirement unless metadata.is_a?(Hash)
+          metadata = requirement.metadata
+          next requirement unless metadata
 
-          requirement_string = metadata[:requirement_string]
-          next requirement unless requirement_string.is_a?(String)
+          requirement_string = requirement.metadata_string("requirement_string")
+          next requirement unless requirement_string
 
           declaration = new(requirement_string)
 
           new_declaration = yield(declaration)
           new_requirement = new(new_declaration)
 
-          requirement.merge(
-            requirement: new_requirement.to_s,
-            metadata: { requirement_string: new_declaration }
+          Dependabot::DependencyRequirement.create(
+            requirement.merge(
+              requirement: new_requirement.to_s,
+              metadata: hash_with_value(metadata, "requirement_string", new_declaration)
+            )
           )
         end
       end
+
+      sig do
+        params(
+          hash: Dependabot::DependencyRequirement::ObjectHash,
+          key: String,
+          value: Object
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
+      end
+      def self.hash_with_value(hash, key, value)
+        updated = hash.dup
+        actual_key = if hash.key?(key.to_sym)
+                       key.to_sym
+                     elsif hash.key?(key)
+                       key
+                     elsif hash.keys.any?(Symbol)
+                       key.to_sym
+                     else
+                       key
+                     end
+        updated[actual_key] = value
+        updated
+      end
+      private_class_method :hash_with_value
 
       sig { params(declaration: String).void }
       def initialize(declaration)

--- a/swift/lib/dependabot/swift/native_requirement.rb
+++ b/swift/lib/dependabot/swift/native_requirement.rb
@@ -40,7 +40,7 @@ module Dependabot
           Dependabot::DependencyRequirement.create(
             requirement.merge(
               requirement: new_requirement.to_s,
-              metadata: hash_with_value(metadata, "requirement_string", new_declaration)
+              metadata: requirement_string_metadata(metadata, new_declaration)
             )
           )
         end
@@ -48,26 +48,15 @@ module Dependabot
 
       sig do
         params(
-          hash: Dependabot::DependencyRequirement::ObjectHash,
-          key: String,
-          value: Object
+          metadata: Dependabot::DependencyRequirement::ObjectHash,
+          requirement_string: String
         ).returns(Dependabot::DependencyRequirement::ObjectHash)
       end
-      def self.hash_with_value(hash, key, value)
-        updated = hash.dup
-        actual_key = if hash.key?(key.to_sym)
-                       key.to_sym
-                     elsif hash.key?(key)
-                       key
-                     elsif hash.keys.any?(Symbol)
-                       key.to_sym
-                     else
-                       key
-                     end
-        updated[actual_key] = value
-        updated
+      def self.requirement_string_metadata(metadata, requirement_string)
+        key = metadata.key?("requirement_string") ? "requirement_string" : :requirement_string
+        { key => requirement_string }
       end
-      private_class_method :hash_with_value
+      private_class_method :requirement_string_metadata
 
       sig { params(declaration: String).void }
       def initialize(declaration)

--- a/swift/lib/dependabot/swift/update_checker.rb
+++ b/swift/lib/dependabot/swift/update_checker.rb
@@ -171,7 +171,10 @@ module Dependabot
         Version.new(lowest_resolvable_security_fix_version)
       end
 
-      sig { params(requirements: T::Array[T::Hash[Symbol, Object]]).returns(VersionResolver) }
+      sig do
+        params(requirements: T::Array[Dependabot::DependencyRequirement])
+          .returns(VersionResolver)
+      end
       def version_resolver_for(requirements)
         VersionResolver.new(
           dependency: dependency,
@@ -187,21 +190,24 @@ module Dependabot
         git_commit_checker.local_tag_for_latest_version(update_cooldown)
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, Object]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def unlocked_requirements
         NativeRequirement.map_requirements(old_requirements) do |_old_requirement|
           "\"#{dependency.version}\"...\"#{latest_version}\""
         end
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, Object]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def force_lowest_security_fix_requirements
         NativeRequirement.map_requirements(old_requirements) do |_old_requirement|
           "\"#{lowest_security_fix_version}\"...\"#{lowest_security_fix_version}\""
         end
       end
 
-      sig { params(new_requirements: T::Array[T::Hash[Symbol, Object]]).returns(Dependabot::DependencyFile) }
+      sig do
+        params(new_requirements: T::Array[Dependabot::DependencyRequirement])
+          .returns(Dependabot::DependencyFile)
+      end
       def prepare_manifest_for(new_requirements)
         manifest_file = T.must(manifest)
 

--- a/swift/lib/dependabot/swift/update_checker/requirements_updater.rb
+++ b/swift/lib/dependabot/swift/update_checker/requirements_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/dependency_requirement"

--- a/swift/lib/dependabot/swift/update_checker/requirements_updater.rb
+++ b/swift/lib/dependabot/swift/update_checker/requirements_updater.rb
@@ -70,23 +70,22 @@ module Dependabot
 
         sig { params(requirement: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement) }
         def update_xcode_requirement(requirement)
-          metadata = requirement[:metadata] || {}
-          requirement_string = metadata[:requirement_string]
-          kind = metadata[:kind]
+          metadata = requirement.metadata || {}
+          requirement_string = requirement.metadata_string("requirement_string")
+          kind = requirement.metadata_string("kind")
 
           new_requirement_string = build_xcode_requirement_string(requirement_string, kind)
           new_requirement = build_xcode_requirement(requirement_string, kind)
 
           # Update source ref to target version
-          updated_source = update_source_ref(requirement[:source])
+          updated_source = update_source_ref(requirement.source_hash)
+          updated_metadata = hash_with_value(metadata, "requirement_string", new_requirement_string)
 
           Dependabot::DependencyRequirement.create(
             requirement.merge(
               requirement: new_requirement,
               source: updated_source,
-              metadata: metadata.merge(
-                requirement_string: new_requirement_string
-              ).compact
+              metadata: updated_metadata
             )
           )
         end
@@ -103,10 +102,33 @@ module Dependabot
           # otherwise fall back to version string
           ref = target_commit_sha || target_version.to_s
 
-          updated_source = source.dup
-          updated_source[:ref] = ref
-          updated_source["ref"] = ref
-          updated_source
+          hash_with_value(source, "ref", ref)
+        end
+
+        sig do
+          params(
+            hash: Dependabot::DependencyRequirement::ObjectHash,
+            key: String,
+            value: T.nilable(Object)
+          ).returns(Dependabot::DependencyRequirement::ObjectHash)
+        end
+        def hash_with_value(hash, key, value)
+          updated = hash.dup
+          actual_key = if hash.key?(key.to_sym)
+                         key.to_sym
+                       elsif hash.key?(key)
+                         key
+                       elsif hash.keys.any?(Symbol)
+                         key.to_sym
+                       else
+                         key
+                       end
+          if value.nil?
+            updated.delete(actual_key)
+          else
+            updated[actual_key] = value
+          end
+          updated
         end
 
         sig do

--- a/swift/lib/dependabot/swift/update_checker/xcode_version_resolver.rb
+++ b/swift/lib/dependabot/swift/update_checker/xcode_version_resolver.rb
@@ -123,7 +123,7 @@ module Dependabot
 
         sig { returns(T.nilable(Dependabot::Swift::Requirement)) }
         def dependency_requirement
-          req_string = dependency.requirements.first&.dig(:requirement)
+          req_string = dependency.requirements.first&.requirement_string
           return nil unless req_string
 
           Dependabot::Swift::Requirement.new(req_string)
@@ -133,7 +133,7 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def requirement_kind
-          dependency.requirements.first&.dig(:metadata, :kind)
+          dependency.requirements.first&.metadata_string("kind")
         end
 
         sig { params(version: Object).returns(T::Boolean) }
@@ -171,8 +171,8 @@ module Dependabot
         sig { returns(T::Boolean) }
         def package_resolved_requirement?
           dependency.requirements.any? do |req|
-            file = req[:file]
-            file.is_a?(String) && XcodeFileHelpers.xcode_resolved_path?(file)
+            file = req.file
+            file && XcodeFileHelpers.xcode_resolved_path?(file)
           end
         end
 

--- a/swift/spec/dependabot/swift/update_checker/requirements_updater_spec.rb
+++ b/swift/spec/dependabot/swift/update_checker/requirements_updater_spec.rb
@@ -58,6 +58,50 @@ RSpec.describe Dependabot::Swift::UpdateChecker::RequirementsUpdater do
         updated = updater.updated_requirements
         expect(updated.first[:metadata][:requirement_string]).to eq("from: \"7.0.2\"")
       end
+
+      context "with string-keyed source and metadata" do
+        let(:requirements) do
+          [{
+            file: "MyApp.xcodeproj/project.pbxproj",
+            requirement: ">= 7.0.0, < 8.0.0",
+            groups: [],
+            source: {
+              "type" => "git",
+              "url" => "https://github.com/Quick/Quick.git",
+              "ref" => "7.0.0",
+              "custom" => "source"
+            },
+            metadata: {
+              "kind" => "upToNextMajorVersion",
+              "requirement_string" => "from: \"7.0.0\"",
+              "custom" => "metadata"
+            }
+          }]
+        end
+
+        it "preserves payloads and nested key styles" do
+          requirement = updater.updated_requirements.first
+          source = requirement.source_hash
+          metadata = requirement.metadata
+
+          expect(source).to include("ref" => "7.0.2", "custom" => "source")
+          expect(source).not_to have_key(:ref)
+          expect(metadata).to include(
+            "requirement_string" => "from: \"7.0.2\"",
+            "custom" => "metadata"
+          )
+          expect(metadata).not_to have_key(:requirement_string)
+        end
+      end
+
+      context "with a malformed requirement kind" do
+        before { requirements.first.fetch(:metadata)[:kind] = 123 }
+
+        it "raises a type error" do
+          expect { updater.updated_requirements }
+            .to raise_error(TypeError, "metadata kind must be a string or nil")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Uses typed requirement readers across classic SwiftPM and Xcode flows while preserving source and metadata key style. Reduces Object-generic blockers from 80 to 70. Promotes three requirement consumers to `typed: strong`.