### PR TITLE
Handle refresh operation assertion error for individual pull requests with multiple directories gracefully

### DIFF
--- a/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_version_update_pull_request.rb
@@ -58,6 +58,9 @@ module Dependabot
         def perform
           Dependabot.logger.info("Starting update job for #{job.source.repo}")
           Dependabot.logger.info("Checking and updating versions pull requests...")
+
+          return if abort_multi_directory_refresh?
+
           dependency = dependencies.last
 
           # Retrieve the list of initial notices from dependency snapshot
@@ -73,6 +76,30 @@ module Dependabot
         end
 
         private
+
+        # A multi-directory pull request should be refreshed through the group
+        # operation, which carries a dependency-group-to-refresh. When such a
+        # payload reaches this individual strategy we end the job cleanly and
+        # report a non-fatal exception instead of raising an unknown error.
+        sig { returns(T::Boolean) }
+        def abort_multi_directory_refresh?
+          directories = job.source.directories
+          return false unless directories && directories.count > 1
+
+          Dependabot.logger.warn(
+            "Skipping refresh for #{T.must(job.dependencies).join(', ')}: an individual pull request " \
+            "refresh cannot span multiple directories (#{directories.join(', ')})."
+          )
+
+          service.capture_exception(
+            error: Dependabot::DependabotError.new(
+              "Individual pull request refresh received multiple directories without a group to refresh."
+            ),
+            job: job
+          )
+
+          true
+        end
 
         sig { returns(Dependabot::Job) }
         attr_reader :job

--- a/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
@@ -184,6 +184,39 @@ RSpec.describe Dependabot::Updater::Operations::RefreshVersionUpdatePullRequest 
         perform
       end
     end
+
+    context "when the refresh job carries more than one directory" do
+      let(:job_definition) do
+        job_definition_fixture("bundler/version_updates/pull_request_multidir_refresh")
+      end
+
+      let(:dependency_files) do
+        %w(/foo /bar).flat_map do |dir|
+          [
+            Dependabot::DependencyFile.new(
+              name: "Gemfile",
+              content: fixture("bundler/original/Gemfile"),
+              directory: dir
+            ),
+            Dependabot::DependencyFile.new(
+              name: "Gemfile.lock",
+              content: fixture("bundler/original/Gemfile.lock"),
+              directory: dir
+            )
+          ]
+        end
+      end
+
+      it "ends the job gracefully without raising or touching pull requests" do
+        expect(mock_service).to receive(:capture_exception)
+        expect(mock_service).not_to receive(:create_pull_request)
+        expect(mock_service).not_to receive(:update_pull_request)
+        expect(mock_service).not_to receive(:close_pull_request)
+        expect(mock_error_handler).not_to receive(:handle_dependency_error)
+
+        expect { perform }.not_to raise_error
+      end
+    end
   end
 
   describe "#check_and_update_pull_request" do

--- a/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_version_update_pull_request_spec.rb
@@ -187,7 +187,12 @@ RSpec.describe Dependabot::Updater::Operations::RefreshVersionUpdatePullRequest 
 
     context "when the refresh job carries more than one directory" do
       let(:job_definition) do
-        job_definition_fixture("bundler/version_updates/pull_request_multidir_refresh")
+        definition = job_definition_fixture("bundler/version_updates/pull_request_simple")
+        definition["job"]["dependencies"] = ["dummy-pkg-a"]
+        definition["job"]["updating-a-pull-request"] = true
+        definition["job"]["source"].delete("directory")
+        definition["job"]["source"]["directories"] = %w(/foo /bar)
+        definition
       end
 
       let(:dependency_files) do


### PR DESCRIPTION
### What are you trying to accomplish?
Fixes #15698.

Refreshing an **individual** (non-group) PR whose payload carries more than one directory raised `Assertion failed: Current directory not set` and failed the job as an unknown error.

`RefreshVersionUpdatePullRequest` is built around a single `job.source.directory`. When a refresh job has multiple directories and no `dependency-group-to-refresh` (so it routes here instead of the group strategy), the `DependencySnapshot` current directory is never set, and the first read of `dependencies` trips `assert_current_directory_set!`.

This makes the strategy handle that payload gracefully: it logs a warning, reports a **non-fatal** exception via `service.capture_exception`, and ends the job cleanly. Single-directory refreshes are unaffected.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
- A multi-directory PR is meant to be refreshed through the group path; receiving it here indicates a malformed payload, so it should fail explicitly rather than build a PR. Mirrors the existing "missing group" guard in `RefreshGroupUpdatePullRequest`.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- Tested this in cli and the error reports correctly
- Added a unit regression test in `refresh_version_update_pull_request_spec.rb` (multi-directory bundler fixture) asserting `perform` doesn't raise, reports a non-fatal exception, and never creates/updates/closes a PR.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.