### PR TITLE
github_actions: fix regression on allowing less precise semver updates

### DIFF
--- a/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/package/package_details_fetcher.rb
@@ -129,7 +129,9 @@ module Dependabot
               return ref if ref&.version && T.must(ref.version) > current_version
 
               lower_precision_ref = git_commit_checker.local_ref_for_latest_version_lower_precision
-              return ref if ref&.version == current_version
+              # Keep the matching-precision ref when no newer lower-precision tag exists
+              return ref if ref&.version == current_version &&
+                            (lower_precision_ref.nil? || T.must(lower_precision_ref.version) <= current_version)
 
               lower_precision_ref
             end,

--- a/github_actions/spec/dependabot/github_actions/package/package_details_fetcher_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/package/package_details_fetcher_spec.rb
@@ -156,6 +156,30 @@ RSpec.describe Dependabot::GithubActions::Package::PackageDetailsFetcher do
             expect(fetcher.latest_version_tag.fetch(:tag)).to eq("v1.1")
           end
         end
+
+        context "when a higher lower-precision ref is available" do
+          let(:reference) { "v1.1.2" }
+          let(:dependency_version) { "1.1.2" }
+
+          before do
+            checker = instance_double(
+              Dependabot::GitCommitChecker,
+              local_ref_for_latest_version_matching_existing_precision: Dependabot::GitTagDetails.new(
+                tag: "v1.1.2",
+                version: Dependabot::GithubActions::Version.new("1.1.2")
+              ),
+              local_ref_for_latest_version_lower_precision: Dependabot::GitTagDetails.new(
+                tag: "v1.2",
+                version: Dependabot::GithubActions::Version.new("1.2")
+              )
+            )
+            allow(fetcher).to receive(:git_commit_checker).and_return(checker)
+          end
+
+          it "prefers the higher lower-precision ref over the unchanged matching-precision ref" do
+            expect(fetcher.latest_version_tag.fetch(:tag)).to eq("v1.2")
+          end
+        end
       end
 
       context "when the latest version is being ignored" do


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- What issues does this affect or fix? -->
~~Fix #15828.~~

<!-- Provide both a what and a _why_ for the change. -->

This PR fixes a regression introduced in #15267. `latest_version_tag` was changed to keep the matching-precision ref whenever it equals the current version, discarding the lower-precision ref even when that ref is a genuine (higher) update. This broke the behavior originally implemented in #9474 ("Actions: allow less precise semver updates").

Example: a dependency pinned to v1.2.3 (3-segment precision) would report "no update" after a new major tag v2 was published while v1.2.3 remained the newest 3-segment tag - the v2 ref was silently dropped. Upgrades only worked if the exact tag had been deleted, so whether a major update was offered depended on the old tag's existence rather than on version comparison.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

Edit: This doesn't completely fix the regression on allowing less precise semver updates. Dependabot's default cooldown filter also filters out low-precision refs (#15760), so a follow-up PR may still be needed to fully address the regression introduced in #15760. If you'd prefer the maintainers to handle all the necessary fix in a single PR, feel free to close this one.

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

- `bundle exec rspec github_actions/spec/dependabot/github_actions/package/package_details_fetcher_spec.rb` - 26 examples, 0 failures.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
