### PR TITLE
Type Bazel requirement access

### DIFF
--- a/bazel/lib/dependabot/bazel/file_updater.rb
+++ b/bazel/lib/dependabot/bazel/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/file_updaters"

--- a/bazel/lib/dependabot/bazel/file_updater.rb
+++ b/bazel/lib/dependabot/bazel/file_updater.rb
@@ -87,13 +87,13 @@ module Dependabot
 
       sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
       def bzlmod_dependency?(dependency)
-        dependency.requirements.any? { |req| req[:file]&.end_with?("MODULE.bazel") }
+        dependency.requirements.any? { |req| req.file&.end_with?("MODULE.bazel") }
       end
 
       sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
       def workspace_dependency?(dependency)
         dependency.requirements.any? do |req|
-          req[:file] == "WORKSPACE" || req[:file]&.end_with?("WORKSPACE.bazel")
+          req.file == "WORKSPACE" || req.file&.end_with?("WORKSPACE.bazel")
         end
       end
 
@@ -121,7 +121,7 @@ module Dependabot
       def relevant_dependencies_for_file(file)
         dependencies.select do |dependency|
           dependency.package_manager == "bazel" &&
-            dependency.requirements.any? { |req| req[:file] == file.name }
+            dependency.requirements.any? { |req| req.file == file.name }
         end
       end
     end

--- a/bazel/lib/dependabot/bazel/file_updater/lockfile_updater.rb
+++ b/bazel/lib/dependabot/bazel/file_updater/lockfile_updater.rb
@@ -104,7 +104,7 @@ module Dependabot
 
         sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
         def bzlmod_dependency?(dependency)
-          dependency.requirements.any? { |req| req[:file]&.end_with?("MODULE.bazel") }
+          dependency.requirements.any? { |req| req.file&.end_with?("MODULE.bazel") }
         end
 
         sig { returns(String) }

--- a/bazel/lib/dependabot/bazel/file_updater/workspace_file_updater.rb
+++ b/bazel/lib/dependabot/bazel/file_updater/workspace_file_updater.rb
@@ -80,8 +80,8 @@ module Dependabot
 
         sig { params(dependency: Dependabot::Dependency).returns(Symbol) }
         def dependency_type(dependency)
-          return :http_archive if dependency.requirements.any? { |req| req.dig(:source, :type) == "http_archive" }
-          return :git_repository if dependency.requirements.any? { |req| req.dig(:source, :type) == "git_repository" }
+          return :http_archive if dependency.requirements.any? { |req| req.source_string("type") == "http_archive" }
+          return :git_repository if dependency.requirements.any? { |req| req.source_string("type") == "git_repository" }
 
           :unknown
         end

--- a/bazel/lib/dependabot/bazel/metadata_finder.rb
+++ b/bazel/lib/dependabot/bazel/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/metadata_finders"

--- a/bazel/lib/dependabot/bazel/metadata_finder.rb
+++ b/bazel/lib/dependabot/bazel/metadata_finder.rb
@@ -39,12 +39,12 @@ module Dependabot
       sig { returns(Symbol) }
       def source_type
         return :bazel_dep if dependency.requirements.empty?
-        return :bazel_dep if dependency.requirements.any? { |r| r[:source].nil? }
+        return :bazel_dep if dependency.requirements.any? { |requirement| requirement.source.nil? }
 
-        source_details = dependency.requirements.first&.dig(:source)
-        return :bazel_dep unless source_details
+        requirement = dependency.requirements.first
+        return :bazel_dep unless requirement
 
-        case source_details[:type]
+        case requirement.source_string("type")
         when "http_archive" then :http_archive
         when "git_repository" then :git_repository
         else :unknown
@@ -65,7 +65,7 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_http_archive
-        url = dependency.requirements.first&.dig(:source, :url)
+        url = dependency.requirements.first&.source_string("url")
         return nil unless url
 
         source_from_url(url)
@@ -73,7 +73,7 @@ module Dependabot
 
       sig { returns(T.nilable(Dependabot::Source)) }
       def find_source_from_git_repository
-        remote_url = dependency.requirements.first&.dig(:source, :remote)
+        remote_url = dependency.requirements.first&.source_string("remote")
         return nil unless remote_url
 
         Dependabot::Source.from_url(remote_url)

--- a/bazel/lib/dependabot/bazel/update_checker/requirements_updater.rb
+++ b/bazel/lib/dependabot/bazel/update_checker/requirements_updater.rb
@@ -21,10 +21,10 @@ module Dependabot
 
         sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
-          @requirements.map do |requirement|
-            updated_requirement = requirement.dup
-            updated_requirement[:requirement] = @latest_version
-            updated_requirement
+          requirements.map do |requirement|
+            Dependabot::DependencyRequirement.create(
+              requirement.merge(requirement: latest_version)
+            )
           end
         end
 

--- a/bazel/spec/dependabot/bazel/metadata_finder_spec.rb
+++ b/bazel/spec/dependabot/bazel/metadata_finder_spec.rb
@@ -159,6 +159,42 @@ RSpec.describe Dependabot::Bazel::MetadataFinder do
         expect(source_url).to eq("https://github.com/bazelbuild/rules_cc")
       end
 
+      context "with string-keyed source details" do
+        let(:requirements) do
+          [{
+            file: "WORKSPACE",
+            requirement: "0.2.0",
+            groups: [],
+            source: {
+              "type" => "http_archive",
+              "url" => "https://github.com/bazelbuild/rules_cc/archive/v0.2.0.tar.gz"
+            }
+          }]
+        end
+
+        it "extracts the GitHub repository URL" do
+          expect(source_url).to eq("https://github.com/bazelbuild/rules_cc")
+        end
+      end
+
+      context "with a malformed source type" do
+        let(:requirements) do
+          [{
+            file: "WORKSPACE",
+            requirement: "0.2.0",
+            groups: [],
+            source: {
+              type: 123,
+              url: "https://github.com/bazelbuild/rules_cc/archive/v0.2.0.tar.gz"
+            }
+          }]
+        end
+
+        it "raises a type error" do
+          expect { source_url }.to raise_error(TypeError, "source type must be a string or nil")
+        end
+      end
+
       context "with a GitHub releases URL" do
         let(:requirements) do
           [{

--- a/bazel/spec/dependabot/bazel/update_checker/requirements_updater_spec.rb
+++ b/bazel/spec/dependabot/bazel/update_checker/requirements_updater_spec.rb
@@ -145,6 +145,32 @@ RSpec.describe Dependabot::Bazel::UpdateChecker::RequirementsUpdater do
           }]
         )
       end
+
+      context "with string-keyed nested attributes" do
+        let(:requirements) do
+          [{
+            file: "MODULE.bazel",
+            requirement: "0.33.0",
+            groups: %w(main test),
+            source: {
+              "type" => "registry",
+              "url" => "https://registry.bazel.build",
+              "custom" => "preserved"
+            }
+          }]
+        end
+
+        it "preserves the nested source payload and key style" do
+          source = updater.updated_requirements.first.source_hash
+
+          expect(source).to include(
+            "type" => "registry",
+            "url" => "https://registry.bazel.build",
+            "custom" => "preserved"
+          )
+          expect(source).not_to have_key(:type)
+        end
+      end
     end
 
     context "when requirements are modified after creation" do


### PR DESCRIPTION
Uses typed requirement and source readers across Bazel file updates and metadata. Reduces Object-generic blockers from 70 to 62. Promotes the file updater and metadata finder to `typed: strong`.