### PR TITLE
Type pre-commit requirement access

### DIFF
--- a/pre_commit/lib/dependabot/pre_commit.rb
+++ b/pre_commit/lib/dependabot/pre_commit.rb
@@ -29,7 +29,7 @@ Dependabot::Dependency.register_humanized_previous_version_builder(
     return nil unless previous_reqs
 
     comment = previous_reqs
-              .filter_map { |r| r.dig(:metadata, :comment) }
+              .filter_map { |requirement| requirement.metadata_string("comment") }
               .first
     return nil unless comment
 

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/base.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/base.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/dependency_requirement"
 require "dependabot/package/release_cooldown_options"
 
 module Dependabot
@@ -41,9 +42,9 @@ module Dependabot
 
         sig do
           params(
-            source: T::Hash[Symbol, Object],
+            source: Dependabot::DependencyRequirement::ObjectHash,
             credentials: T::Array[Dependabot::Credential],
-            requirements: T::Array[T::Hash[Symbol, Object]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             current_version: T.nilable(String),
             cooldown_options: T.nilable(Dependabot::Package::ReleaseCooldownOptions)
           ).void
@@ -51,7 +52,10 @@ module Dependabot
         def initialize(source:, credentials:, requirements:, current_version:, cooldown_options: nil)
           @source = source
           @credentials = credentials
-          @requirements = requirements
+          @requirements = T.let(
+            requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
           @current_version = current_version
           @cooldown_options = cooldown_options
         end
@@ -65,18 +69,21 @@ module Dependabot
         # Generate updated requirements for the new version
         # Should preserve the original version constraint operator (>=, ~=, etc.)
         # and update the source hash with the new original_string
-        sig { abstract.params(latest_version: String).returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig do
+          abstract.params(latest_version: String)
+                  .returns(T::Array[Dependabot::DependencyRequirement])
+        end
         def updated_requirements(latest_version); end
 
         private
 
-        sig { returns(T::Hash[Symbol, Object]) }
+        sig { returns(Dependabot::DependencyRequirement::ObjectHash) }
         attr_reader :source
 
         sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
 
-        sig { returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(String)) }
@@ -87,13 +94,80 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def package_name
-          source[:package_name]&.to_s
+          source_string(source, "package_name")
         end
 
-        sig { params(requirement: T.nilable(T::Hash[Symbol, Object])).returns(T.nilable(String)) }
+        sig do
+          params(requirement: T.nilable(Dependabot::DependencyRequirement))
+            .returns(T.nilable(String))
+        end
         def requirement_string(requirement)
-          value = requirement&.dig(:requirement)
-          value if value.is_a?(String)
+          requirement&.requirement_string
+        end
+
+        sig do
+          params(
+            requirement: Dependabot::DependencyRequirement
+          ).returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash))
+        end
+        def additional_dependency_source(requirement)
+          details = requirement.source_hash
+          return unless details
+          return unless source_string(details, "type") == "additional_dependency"
+
+          details
+        end
+
+        sig do
+          params(
+            requirement: Dependabot::DependencyRequirement,
+            new_requirement: T.nilable(String),
+            original_string: String
+          ).returns(Dependabot::DependencyRequirement)
+        end
+        def build_requirement_entry(requirement, new_requirement:, original_string:)
+          original_source = T.must(additional_dependency_source(requirement))
+          new_source = source_with_value(original_source, "original_string", original_string)
+
+          Dependabot::DependencyRequirement.create(
+            requirement.merge(requirement: new_requirement, source: new_source)
+          )
+        end
+
+        sig do
+          params(
+            details: Dependabot::DependencyRequirement::ObjectHash,
+            key: String
+          ).returns(T.nilable(String))
+        end
+        def source_string(details, key)
+          value = details.key?(key.to_sym) ? details[key.to_sym] : details[key]
+          return if value.nil?
+          return value if value.is_a?(String)
+
+          raise TypeError, "source #{key} must be a string or nil"
+        end
+
+        sig do
+          params(
+            details: Dependabot::DependencyRequirement::ObjectHash,
+            key: String,
+            value: Object
+          ).returns(Dependabot::DependencyRequirement::ObjectHash)
+        end
+        def source_with_value(details, key, value)
+          updated = details.dup
+          actual_key = if details.key?(key.to_sym)
+                         key.to_sym
+                       elsif details.key?(key)
+                         key
+                       elsif details.keys.any?(Symbol)
+                         key.to_sym
+                       else
+                         key
+                       end
+          updated[actual_key] = value
+          updated
         end
       end
     end

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/dart.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/dart.rb
@@ -24,26 +24,28 @@ module Dependabot
           )
         end
 
-        sig { override.params(latest_version: String).returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig do
+          override.params(latest_version: String)
+                  .returns(T::Array[Dependabot::DependencyRequirement])
+        end
         def updated_requirements(latest_version)
           requirements.map do |original_req|
-            original_source = original_req[:source]
-            next original_req unless original_source.is_a?(Hash)
-            next original_req unless original_source[:type] == "additional_dependency"
+            original_source = additional_dependency_source(original_req)
+            next original_req unless original_source
 
             original_requirement = requirement_string(original_req)
             new_requirement = build_updated_requirement(original_requirement, latest_version)
 
             new_original_string = build_original_string(
-              package_name: original_source[:original_name] || original_source[:package_name],
+              package_name: source_string(original_source, "original_name") ||
+                            source_string(original_source, "package_name"),
               requirement: new_requirement
             )
 
-            new_source = original_source.merge(original_string: new_original_string)
-
-            original_req.merge(
-              requirement: new_requirement,
-              source: new_source
+            build_requirement_entry(
+              original_req,
+              new_requirement: new_requirement,
+              original_string: new_original_string
             )
           end
         end

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/go.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/go.rb
@@ -24,25 +24,27 @@ module Dependabot
           )
         end
 
-        sig { override.params(latest_version: String).returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig do
+          override.params(latest_version: String)
+                  .returns(T::Array[Dependabot::DependencyRequirement])
+        end
         def updated_requirements(latest_version)
           requirements.map do |original_req|
-            original_source = original_req[:source]
-            next original_req unless original_source.is_a?(Hash)
-            next original_req unless original_source[:type] == "additional_dependency"
+            original_source = additional_dependency_source(original_req)
+            next original_req unless original_source
 
             new_requirement = "v#{latest_version}"
 
             new_original_string = build_original_string(
-              original_name: original_source[:original_name] || original_source[:package_name],
+              original_name: source_string(original_source, "original_name") ||
+                             source_string(original_source, "package_name"),
               requirement: new_requirement
             )
 
-            new_source = original_source.merge(original_string: new_original_string)
-
-            original_req.merge(
-              requirement: new_requirement,
-              source: new_source
+            build_requirement_entry(
+              original_req,
+              new_requirement: new_requirement,
+              original_string: new_original_string
             )
           end
         end

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/node.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/node.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/node.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/node.rb
@@ -25,26 +25,28 @@ module Dependabot
           )
         end
 
-        sig { override.params(latest_version: String).returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig do
+          override.params(latest_version: String)
+                  .returns(T::Array[Dependabot::DependencyRequirement])
+        end
         def updated_requirements(latest_version)
           requirements.map do |original_req|
-            original_source = original_req[:source]
-            next original_req unless original_source.is_a?(Hash)
-            next original_req unless original_source[:type] == "additional_dependency"
+            original_source = additional_dependency_source(original_req)
+            next original_req unless original_source
 
             original_requirement = requirement_string(original_req)
             new_requirement = build_updated_requirement(original_requirement, latest_version)
 
             new_original_string = build_original_string(
-              package_name: original_source[:original_name] || original_source[:package_name],
+              package_name: source_string(original_source, "original_name") ||
+                            source_string(original_source, "package_name"),
               requirement: new_requirement
             )
 
-            new_source = original_source.merge(original_string: new_original_string)
-
-            original_req.merge(
-              requirement: new_requirement,
-              source: new_source
+            build_requirement_entry(
+              original_req,
+              new_requirement: new_requirement,
+              original_string: new_original_string
             )
           end
         end

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/python.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/python.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/python.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/python.rb
@@ -26,27 +26,29 @@ module Dependabot
           )
         end
 
-        sig { override.params(latest_version: String).returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig do
+          override.params(latest_version: String)
+                  .returns(T::Array[Dependabot::DependencyRequirement])
+        end
         def updated_requirements(latest_version)
           requirements.map do |original_req|
-            original_source = original_req[:source]
-            next original_req unless original_source.is_a?(Hash)
-            next original_req unless original_source[:type] == "additional_dependency"
+            original_source = additional_dependency_source(original_req)
+            next original_req unless original_source
 
             original_requirement = requirement_string(original_req)
             new_requirement = build_updated_requirement(original_requirement, latest_version)
 
             new_original_string = build_original_string(
-              original_name: original_source[:original_name] || original_source[:package_name],
-              extras: original_source[:extras],
+              original_name: source_string(original_source, "original_name") ||
+                             source_string(original_source, "package_name"),
+              extras: source_string(original_source, "extras"),
               requirement: new_requirement
             )
 
-            new_source = original_source.merge(original_string: new_original_string)
-
-            original_req.merge(
-              requirement: new_requirement,
-              source: new_source
+            build_requirement_entry(
+              original_req,
+              new_requirement: new_requirement,
+              original_string: new_original_string
             )
           end
         end
@@ -180,14 +182,15 @@ module Dependabot
           )
 
           updated_reqs = updater.updated_requirements
-          updated_req = updated_reqs.first&.fetch(:requirement, nil)
+          updated_req = updated_reqs.first&.requirement
 
           return ">=#{new_version}" if updated_req == :unfixable
 
-          if updated_req == original_requirement
+          updated_req_string = T.cast(updated_req, T.nilable(String))
+          if updated_req_string == original_requirement
             force_bump_lower_bounds(original_requirement, new_version)
           else
-            updated_req || ">=#{new_version}"
+            updated_req_string || ">=#{new_version}"
           end
         end
 

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/ruby.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/ruby.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/ruby.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/ruby.rb
@@ -25,26 +25,28 @@ module Dependabot
           )
         end
 
-        sig { override.params(latest_version: String).returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig do
+          override.params(latest_version: String)
+                  .returns(T::Array[Dependabot::DependencyRequirement])
+        end
         def updated_requirements(latest_version)
           requirements.map do |original_req|
-            original_source = original_req[:source]
-            next original_req unless original_source.is_a?(Hash)
-            next original_req unless original_source[:type] == "additional_dependency"
+            original_source = additional_dependency_source(original_req)
+            next original_req unless original_source
 
             original_requirement = requirement_string(original_req)
             new_requirement = build_updated_requirement(original_requirement, latest_version)
 
             new_original_string = build_original_string(
-              package_name: original_source[:original_name] || original_source[:package_name],
+              package_name: source_string(original_source, "original_name") ||
+                            source_string(original_source, "package_name"),
               requirement: new_requirement
             )
 
-            new_source = original_source.merge(original_string: new_original_string)
-
-            original_req.merge(
-              requirement: new_requirement,
-              source: new_source
+            build_requirement_entry(
+              original_req,
+              new_requirement: new_requirement,
+              original_string: new_original_string
             )
           end
         end

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/rust.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/rust.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/rust.rb
+++ b/pre_commit/lib/dependabot/pre_commit/additional_dependency_checkers/rust.rb
@@ -25,27 +25,29 @@ module Dependabot
           )
         end
 
-        sig { override.params(latest_version: String).returns(T::Array[T::Hash[Symbol, Object]]) }
+        sig do
+          override.params(latest_version: String)
+                  .returns(T::Array[Dependabot::DependencyRequirement])
+        end
         def updated_requirements(latest_version)
           requirements.map do |original_req|
-            original_source = original_req[:source]
-            next original_req unless original_source.is_a?(Hash)
-            next original_req unless original_source[:type] == "additional_dependency"
+            original_source = additional_dependency_source(original_req)
+            next original_req unless original_source
 
             original_requirement = requirement_string(original_req)
             new_requirement = build_updated_requirement(original_requirement, latest_version)
 
             new_original_string = build_original_string(
-              package_name: original_source[:original_name] || original_source[:package_name],
+              package_name: source_string(original_source, "original_name") ||
+                            source_string(original_source, "package_name"),
               requirement: new_requirement,
-              cli: original_source[:extras] == "cli"
+              cli: source_string(original_source, "extras") == "cli"
             )
 
-            new_source = original_source.merge(original_string: new_original_string)
-
-            original_req.merge(
-              requirement: new_requirement,
-              source: new_source
+            build_requirement_entry(
+              original_req,
+              new_requirement: new_requirement,
+              original_string: new_original_string
             )
           end
         end

--- a/pre_commit/lib/dependabot/pre_commit/file_updater.rb
+++ b/pre_commit/lib/dependabot/pre_commit/file_updater.rb
@@ -60,19 +60,21 @@ module Dependabot
 
       sig do
         params(file: Dependabot::DependencyFile)
-          .returns(T::Array[[T::Hash[Symbol, Object], T::Hash[Symbol, Object]]])
+          .returns(
+            T::Array[
+              [Dependabot::DependencyRequirement, Dependabot::DependencyRequirement]
+            ]
+          )
       end
       def requirement_pairs_for_file(file)
         pairs = dependency.requirements.zip(T.must(dependency.previous_requirements))
         filtered_pairs = pairs.reject do |new_req, old_req|
           next true unless old_req
 
-          file_name = T.cast(new_req[:file], T.nilable(String))
+          file_name = new_req.file
           next true if file_name != file.name
 
-          new_source = T.cast(new_req[:source], T.nilable(T::Hash[Symbol, Object]))
-          old_source = T.cast(old_req[:source], T.nilable(T::Hash[Symbol, Object]))
-          new_source == old_source
+          new_req.source == old_req.source
         end
 
         filtered_pairs.map { |new_req, old_req| [new_req, T.must(old_req)] }
@@ -81,15 +83,12 @@ module Dependabot
       sig do
         params(
           content: String,
-          new_req: T::Hash[Symbol, Object],
-          old_req: T::Hash[Symbol, Object]
+          new_req: Dependabot::DependencyRequirement,
+          old_req: Dependabot::DependencyRequirement
         ).returns(String)
       end
       def apply_requirement_update(content, new_req, old_req)
-        new_source = T.cast(new_req.fetch(:source), T::Hash[Symbol, Object])
-        source_type = T.cast(new_source.fetch(:type), String)
-
-        case source_type
+        case new_req.source_string("type")
         when "git"
           apply_git_requirement_update(content, new_req, old_req)
         when "additional_dependency"
@@ -102,20 +101,16 @@ module Dependabot
       sig do
         params(
           content: String,
-          new_req: T::Hash[Symbol, Object],
-          old_req: T::Hash[Symbol, Object]
+          new_req: Dependabot::DependencyRequirement,
+          old_req: Dependabot::DependencyRequirement
         ).returns(String)
       end
       def apply_git_requirement_update(content, new_req, old_req)
-        new_source = T.cast(new_req.fetch(:source), T::Hash[Symbol, Object])
-        old_source = T.cast(old_req.fetch(:source), T::Hash[Symbol, Object])
-        repo_url = T.cast(old_source.fetch(:url), String)
-        old_ref = T.cast(old_source.fetch(:ref), String)
-        new_ref = T.cast(new_source.fetch(:ref), String)
-
-        new_metadata = T.cast(new_req.fetch(:metadata, {}), T::Hash[Symbol, Object])
-        old_version = T.cast(new_metadata[:comment_version], T.nilable(String))
-        new_version = T.cast(new_metadata[:new_comment_version], T.nilable(String))
+        repo_url = T.must(old_req.source_string("url"))
+        old_ref = T.must(old_req.source_string("ref"))
+        new_ref = T.must(new_req.source_string("ref"))
+        old_version = new_req.metadata_string("comment_version")
+        new_version = new_req.metadata_string("new_comment_version")
 
         replace_ref_in_content(
           content,
@@ -130,16 +125,13 @@ module Dependabot
       sig do
         params(
           content: String,
-          new_req: T::Hash[Symbol, Object],
-          old_req: T::Hash[Symbol, Object]
+          new_req: Dependabot::DependencyRequirement,
+          old_req: Dependabot::DependencyRequirement
         ).returns(String)
       end
       def apply_additional_dependency_update(content, new_req, old_req)
-        old_source = T.cast(old_req.fetch(:source), T::Hash[Symbol, Object])
-        new_source = T.cast(new_req.fetch(:source), T::Hash[Symbol, Object])
-
-        old_string = T.cast(old_source.fetch(:original_string), String)
-        new_string = T.cast(new_source.fetch(:original_string), String)
+        old_string = T.must(old_req.source_string("original_string"))
+        new_string = T.must(new_req.source_string("original_string"))
 
         replace_additional_dependency_in_content(content, old_string, new_string)
       end

--- a/pre_commit/lib/dependabot/pre_commit/helpers.rb
+++ b/pre_commit/lib/dependabot/pre_commit/helpers.rb
@@ -60,11 +60,19 @@ module Dependabot
           )
         end
 
-        sig { params(source: T.nilable(T::Hash[Symbol, Object])).returns(Dependabot::GitCommitChecker) }
+        sig do
+          params(source: T.nilable(Dependabot::DependencyRequirement::ObjectHash))
+            .returns(Dependabot::GitCommitChecker)
+        end
         def git_commit_checker_for(source)
           @git_commit_checkers ||= T.let(
             {},
-            T.nilable(T::Hash[T.nilable(T::Hash[Symbol, Object]), Dependabot::GitCommitChecker])
+            T.nilable(
+              T::Hash[
+                T.nilable(Dependabot::DependencyRequirement::ObjectHash),
+                Dependabot::GitCommitChecker
+              ]
+            )
           )
 
           @git_commit_checkers[source] ||= Dependabot::GitCommitChecker.new(
@@ -73,8 +81,16 @@ module Dependabot
             ignored_versions: ignored_versions,
             raise_on_ignored: raise_on_ignored,
             consider_version_branches_pinned: @consider_version_branches_pinned,
-            dependency_source_details: source || @dependency_source_details
+            dependency_source_details: source ? symbolize_source(source) : @dependency_source_details
           )
+        end
+
+        sig do
+          params(source: Dependabot::DependencyRequirement::ObjectHash)
+            .returns(T::Hash[Symbol, Object])
+        end
+        def symbolize_source(source)
+          source.to_h { |key, value| [key.to_sym, value] }
         end
       end
     end

--- a/pre_commit/lib/dependabot/pre_commit/metadata_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/pre_commit/lib/dependabot/pre_commit/metadata_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/metadata_finder.rb
@@ -14,7 +14,7 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        requirement = dependency.requirements.first
+        requirement = dependency.requirements.find(&:source_hash)
         url = requirement&.source_string("url") ||
               requirement&.source_string("repo_url") ||
               dependency.name

--- a/pre_commit/lib/dependabot/pre_commit/metadata_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/metadata_finder.rb
@@ -14,14 +14,10 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-
-        url =
-          if info.nil?
-            dependency.name
-          else
-            info[:url] || info[:repo_url] || info["url"] || dependency.name
-          end
+        requirement = dependency.requirements.first
+        url = requirement&.source_string("url") ||
+              requirement&.source_string("repo_url") ||
+              dependency.name
         Source.from_url(url)
       end
     end

--- a/pre_commit/lib/dependabot/pre_commit/package/package_details_fetcher.rb
+++ b/pre_commit/lib/dependabot/pre_commit/package/package_details_fetcher.rb
@@ -159,7 +159,7 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def frozen_comment_ref
-          comment = dependency.requirements.first&.dig(:metadata, :comment)
+          comment = dependency.requirements.first&.metadata_string("comment")
           return nil unless comment
 
           match = comment.match(CommentVersionHelper::FROZEN_COMMENT_REF_PATTERN)
@@ -173,7 +173,7 @@ module Dependabot
 
         sig { returns(T::Boolean) }
         def version_comment?
-          comment = dependency.requirements.first&.dig(:metadata, :comment)
+          comment = dependency.requirements.first&.metadata_string("comment")
           return false unless comment
 
           comment.match?(CommentVersionHelper::COMMENT_VERSION_PATTERN)

--- a/pre_commit/lib/dependabot/pre_commit/update_checker.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker.rb
@@ -51,10 +51,12 @@ module Dependabot
 
         updated_reqs = dependency.requirements.map do |req|
           source = req.source_hash
+          next req unless source
+
           updated = updated_ref(source)
           next req unless updated
 
-          new_source = hash_with_value(T.must(source), "ref", updated)
+          new_source = hash_with_value(source, "ref", updated)
           new_metadata = updated_comment_version_metadata(req, updated)
           Dependabot::DependencyRequirement.create(
             req.merge(source: new_source, metadata: new_metadata)

--- a/pre_commit/lib/dependabot/pre_commit/update_checker.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker.rb
@@ -50,23 +50,25 @@ module Dependabot
         return wrap_requirements(additional_dependency_updated_requirements) if additional_dependency?
 
         updated_reqs = dependency.requirements.map do |req|
-          source = T.cast(req[:source], T.nilable(T::Hash[Symbol, Object]))
+          source = req.source_hash
           updated = updated_ref(source)
           next req unless updated
 
-          current = T.cast(source&.[](:ref), T.nilable(String))
+          current = req.source_string("ref")
 
           # Maintain short git hash when the updated SHA starts with the current SHA
-          if T.cast(req[:type], T.nilable(String)) == "git" &&
+          if req.source_string("type") == "git" &&
              git_commit_checker.ref_looks_like_commit_sha?(updated) &&
              current && git_commit_checker.ref_looks_like_commit_sha?(current) &&
              updated.start_with?(current)
             next req
           end
 
-          new_source = T.must(source).merge(ref: updated)
+          new_source = hash_with_value(T.must(source), "ref", updated)
           new_metadata = updated_comment_version_metadata(req, updated)
-          req.merge(source: new_source, metadata: new_metadata)
+          Dependabot::DependencyRequirement.create(
+            req.merge(source: new_source, metadata: new_metadata)
+          )
         end
         wrap_requirements(updated_reqs)
       end
@@ -166,7 +168,10 @@ module Dependabot
         )
       end
 
-      sig { params(source: T.nilable(T::Hash[Symbol, Object])).returns(T.nilable(String)) }
+      sig do
+        params(source: T.nilable(Dependabot::DependencyRequirement::ObjectHash))
+          .returns(T.nilable(String))
+      end
       def updated_ref(source)
         return unless git_commit_checker.git_dependency?
 
@@ -213,13 +218,13 @@ module Dependabot
 
       sig do
         params(
-          req: T::Hash[Symbol, Object],
+          req: Dependabot::DependencyRequirement,
           new_ref: String
-        ).returns(T::Hash[Symbol, Object])
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
       end
       def updated_comment_version_metadata(req, new_ref)
-        existing_metadata = T.cast(req.fetch(:metadata, {}), T::Hash[Symbol, Object])
-        comment = T.cast(existing_metadata[:comment], T.nilable(String))
+        existing_metadata = req.metadata || {}
+        comment = req.metadata_string("comment")
         return existing_metadata unless comment
 
         old_version = extract_version_from_comment(comment)
@@ -228,7 +233,8 @@ module Dependabot
         new_version = resolve_new_comment_version(new_ref)
         return existing_metadata unless new_version
 
-        existing_metadata.merge(comment_version: old_version, new_comment_version: new_version)
+        updated = hash_with_value(existing_metadata, "comment_version", old_version)
+        hash_with_value(updated, "new_comment_version", new_version)
       end
 
       sig { params(comment: String).returns(T.nilable(String)) }
@@ -243,10 +249,7 @@ module Dependabot
           begin
             comment = T.let(
               @dependency.requirements
-                .filter_map do |req|
-                  val = T.cast(req.fetch(:metadata, {}), T::Hash[Symbol, Object])[:comment]
-                  T.cast(val, T.nilable(String))
-                end
+                .filter_map { |req| req.metadata_string("comment") }
                 .first,
               T.nilable(String)
             )
@@ -310,16 +313,14 @@ module Dependabot
         requirement = dependency.requirements.first
         return false unless requirement
 
-        source = T.cast(requirement[:source], T.nilable(T::Hash[Symbol, Object]))
-        return false unless source
-
-        T.cast(source[:type], T.nilable(String)) == "additional_dependency"
+        requirement.source_string("type") == "additional_dependency"
       end
 
       sig { returns(T.nilable(T.any(String, Gem::Version))) }
       def additional_dependency_latest_version
-        source = T.cast(dependency.requirements.first&.dig(:source), T::Hash[Symbol, Object])
-        language = T.cast(source[:language], T.nilable(String))
+        requirement = T.must(dependency.requirements.first)
+        source = T.must(requirement.source_hash)
+        language = requirement.source_string("language")
         return nil unless language && AdditionalDependencyCheckers.supported?(language)
 
         checker = additional_dependency_checker(language, source)
@@ -331,10 +332,11 @@ module Dependabot
         latest
       end
 
-      sig { returns(T::Array[T::Hash[Symbol, Object]]) }
+      sig { returns(T::Array[Dependabot::DependencyRequirement]) }
       def additional_dependency_updated_requirements
-        source = T.cast(dependency.requirements.first&.dig(:source), T::Hash[Symbol, Object])
-        language = T.cast(source[:language], T.nilable(String))
+        requirement = T.must(dependency.requirements.first)
+        source = T.must(requirement.source_hash)
+        language = requirement.source_string("language")
         return dependency.requirements unless language && AdditionalDependencyCheckers.supported?(language)
 
         checker = additional_dependency_checker(language, source)
@@ -349,7 +351,7 @@ module Dependabot
       sig do
         params(
           language: String,
-          source: T::Hash[Symbol, Object]
+          source: Dependabot::DependencyRequirement::ObjectHash
         ).returns(T.nilable(Dependabot::PreCommit::AdditionalDependencyCheckers::Base))
       end
       def additional_dependency_checker(language, source)
@@ -364,6 +366,28 @@ module Dependabot
       rescue StandardError => e
         Dependabot.logger.error("Error creating checker for #{language}: #{e.message}")
         nil
+      end
+
+      sig do
+        params(
+          hash: Dependabot::DependencyRequirement::ObjectHash,
+          key: String,
+          value: Object
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
+      end
+      def hash_with_value(hash, key, value)
+        updated = hash.dup
+        actual_key = if hash.key?(key.to_sym)
+                       key.to_sym
+                     elsif hash.key?(key)
+                       key
+                     elsif hash.keys.any?(Symbol)
+                       key.to_sym
+                     else
+                       key
+                     end
+        updated[actual_key] = value
+        updated
       end
     end
   end

--- a/pre_commit/lib/dependabot/pre_commit/update_checker.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker.rb
@@ -54,16 +54,6 @@ module Dependabot
           updated = updated_ref(source)
           next req unless updated
 
-          current = req.source_string("ref")
-
-          # Maintain short git hash when the updated SHA starts with the current SHA
-          if req.source_string("type") == "git" &&
-             git_commit_checker.ref_looks_like_commit_sha?(updated) &&
-             current && git_commit_checker.ref_looks_like_commit_sha?(current) &&
-             updated.start_with?(current)
-            next req
-          end
-
           new_source = hash_with_value(T.must(source), "ref", updated)
           new_metadata = updated_comment_version_metadata(req, updated)
           Dependabot::DependencyRequirement.create(

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -384,13 +384,13 @@ module Dependabot
         # when the dependency's stored version is a commit SHA.
         sig { returns(T.nilable(Dependabot::Version)) }
         def version_from_frozen_comment
-          comment = dependency.requirements.first&.dig(:metadata, :comment)
+          comment = dependency.requirements.first&.metadata_string("comment")
           return nil unless comment
 
           match = comment.match(CommentVersionHelper::FROZEN_COMMENT_REF_PATTERN)
           return nil unless match
 
-          version_str = match[1].sub(/\Av/i, "")
+          version_str = T.must(match[1]).sub(/\Av/i, "")
           return nil unless Dependabot::PreCommit::Version.correct?(version_str)
 
           Dependabot::PreCommit::Version.new(version_str)

--- a/pre_commit/spec/dependabot/pre_commit/additional_dependency_checkers/python_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/additional_dependency_checkers/python_spec.rb
@@ -136,6 +136,31 @@ RSpec.describe Dependabot::PreCommit::AdditionalDependencyCheckers::Python do
         expect(updated.first[:requirement]).to eq("==2.31.0.10")
         expect(updated.first[:source][:original_string]).to eq("types-requests==2.31.0.10")
       end
+
+      context "with string-keyed source details" do
+        let(:source) do
+          {
+            "type" => "additional_dependency",
+            "language" => "python",
+            "hook_id" => "mypy",
+            "repo_url" => "https://github.com/pre-commit/mirrors-mypy",
+            "package_name" => "types-requests",
+            "original_name" => "types-requests",
+            "original_string" => "types-requests==2.31.0.1",
+            "custom" => "preserved"
+          }
+        end
+
+        it "preserves the source payload and key style" do
+          updated_source = checker.updated_requirements(latest_version).first.source_hash
+
+          expect(updated_source).to include(
+            "original_string" => "types-requests==2.31.0.10",
+            "custom" => "preserved"
+          )
+          expect(updated_source).not_to have_key(:original_string)
+        end
+      end
     end
 
     context "with minimum version constraint (>=)" do

--- a/pre_commit/spec/dependabot/pre_commit/metadata_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/metadata_finder_spec.rb
@@ -57,6 +57,32 @@ RSpec.describe Dependabot::PreCommit::MetadataFinder do
       end
 
       it { is_expected.to eq("https://github.com/pre-commit/pre-commit-hooks") }
+
+      context "when an earlier requirement has no source" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: "v4.4.0",
+            requirements: [
+              {
+                requirement: nil,
+                groups: [],
+                file: ".pre-commit-config.yaml",
+                source: nil
+              },
+              {
+                requirement: nil,
+                groups: [],
+                file: ".pre-commit-config.yaml",
+                source: dependency_source
+              }
+            ],
+            package_manager: "pre_commit"
+          )
+        end
+
+        it { is_expected.to eq("https://github.com/pre-commit/pre-commit-hooks") }
+      end
     end
 
     context "when dealing with a subdependency (no requirements)" do

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -254,6 +254,35 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
         expect(updated_requirements.first[:source][:ref]).not_to eq(reference)
       end
 
+      context "when an earlier requirement has no source" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "https://github.com/#{dependency_name}",
+            version: dependency_version,
+            requirements: [
+              {
+                requirement: nil,
+                groups: [],
+                file: ".pre-commit-config.yaml",
+                source: nil
+              },
+              {
+                requirement: nil,
+                groups: [],
+                file: ".pre-commit-config.yaml",
+                source: dependency_source
+              }
+            ],
+            package_manager: "pre_commit"
+          )
+        end
+
+        it "leaves the source-less requirement unchanged" do
+          expect(updated_requirements.first).to eq(dependency.requirements.first)
+          expect(updated_requirements.last.source_string("ref")).not_to eq(reference)
+        end
+      end
+
       context "with string-keyed source details" do
         let(:dependency_source) do
           {

--- a/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker_spec.rb
@@ -253,6 +253,26 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker do
       it "updates the ref in the source" do
         expect(updated_requirements.first[:source][:ref]).not_to eq(reference)
       end
+
+      context "with string-keyed source details" do
+        let(:dependency_source) do
+          {
+            "type" => "git",
+            "url" => "https://github.com/#{dependency_name}",
+            "ref" => reference,
+            "branch" => nil,
+            "custom" => "preserved"
+          }
+        end
+
+        it "preserves the source payload and key style" do
+          source = updated_requirements.first.source_hash
+
+          expect(source).to include("custom" => "preserved")
+          expect(source).to have_key("ref")
+          expect(source).not_to have_key(:ref)
+        end
+      end
     end
 
     context "when dependency is pinned to commit SHA without version tags" do


### PR DESCRIPTION
Uses typed requirement, source, and comment readers across git hooks and additional dependencies. Reduces Object-generic blockers from 62 to 55. Promotes six consumers to `typed: strong`.