### PR TITLE
Type Nix requirement access

### DIFF
--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -84,12 +84,12 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def new_source_ref
-        dependency.requirements.first&.dig(:source, :ref)
+        dependency.requirements.first&.source_string("ref")
       end
 
       sig { returns(T.nilable(String)) }
       def old_source_ref
-        dependency.previous_requirements&.first&.dig(:source, :ref)
+        dependency.previous_requirements&.first&.source_string("ref")
       end
 
       sig { override.void }

--- a/nix/lib/dependabot/nix/metadata_finder.rb
+++ b/nix/lib/dependabot/nix/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/nix/lib/dependabot/nix/metadata_finder.rb
+++ b/nix/lib/dependabot/nix/metadata_finder.rb
@@ -19,8 +19,7 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        source = dependency.requirements.first&.fetch(:source, nil)
-        url = source && (source[:url] || source["url"])
+        url = dependency.requirements.first&.source_string("url")
 
         return Source.from_url(NIXPKGS_SOURCE_URL) if Channel.channel_url?(url)
 

--- a/nix/lib/dependabot/nix/update_checker.rb
+++ b/nix/lib/dependabot/nix/update_checker.rb
@@ -97,11 +97,16 @@ module Dependabot
         return dependency.requirements unless result
 
         dependency.requirements.map do |req|
-          source = req[:source]
-          next req unless source
+          next req unless req.source_hash
 
           Dependabot::DependencyRequirement.create(
-            req.merge(source: source.merge(ref: result[:channel], url: result[:url]))
+            req.merge(
+              source: source_with_values(
+                req,
+                "ref" => result[:channel],
+                "url" => result[:url]
+              )
+            )
           )
         end
       end
@@ -151,10 +156,17 @@ module Dependabot
         return dependency.requirements unless new_tag
 
         dependency.requirements.map do |req|
-          source = req[:source]
-          next req unless source
+          next req unless req.source_hash
 
-          Dependabot::DependencyRequirement.create(req.merge(source: source.merge(ref: new_tag[:tag], branch: nil)))
+          Dependabot::DependencyRequirement.create(
+            req.merge(
+              source: source_with_values(
+                req,
+                "ref" => T.cast(new_tag[:tag], String),
+                "branch" => nil
+              )
+            )
+          )
         end
       end
 
@@ -180,10 +192,17 @@ module Dependabot
         return dependency.requirements unless result
 
         dependency.requirements.map do |req|
-          source = req[:source]
-          next req unless source
+          next req unless req.source_hash
 
-          Dependabot::DependencyRequirement.create(req.merge(source: source.merge(ref: result[:branch], branch: nil)))
+          Dependabot::DependencyRequirement.create(
+            req.merge(
+              source: source_with_values(
+                req,
+                "ref" => result[:branch],
+                "branch" => nil
+              )
+            )
+          )
         end
       end
 
@@ -199,6 +218,29 @@ module Dependabot
           versioned_branch_finder&.latest_versioned_branch,
           T.nilable(T::Hash[Symbol, String])
         )
+      end
+
+      sig do
+        params(
+          requirement: Dependabot::DependencyRequirement,
+          values: T::Hash[String, T.nilable(String)]
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
+      end
+      def source_with_values(requirement, values)
+        source = T.must(requirement.source_hash).dup
+        values.each do |key, value|
+          actual_key = if source.key?(key.to_sym)
+                         key.to_sym
+                       elsif source.key?(key)
+                         key
+                       elsif source.keys.any?(Symbol)
+                         key.to_sym
+                       else
+                         key
+                       end
+          source[actual_key] = value
+        end
+        source
       end
 
       # --- Commit-tracking (existing behavior) ---

--- a/nix/spec/dependabot/nix/update_checker_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker_spec.rb
@@ -539,6 +539,36 @@ RSpec.describe Dependabot::Nix::UpdateChecker do
         expect(updated.first[:source][:ref]).to eq("v0.6.2")
         expect(updated.first[:source][:branch]).to be_nil
       end
+
+      context "with string-keyed source details" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "devenv",
+            version: "abc123",
+            requirements: [{
+              file: "flake.lock",
+              requirement: nil,
+              groups: [],
+              source: {
+                "type" => "git",
+                "url" => "https://github.com/cachix/devenv",
+                "branch" => nil,
+                "ref" => "v0.5",
+                "custom" => "preserved"
+              }
+            }],
+            package_manager: "nix"
+          )
+        end
+
+        it "preserves the source payload and key style" do
+          source = checker.updated_requirements.first.source_hash
+
+          expect(source).to include("ref" => "v0.6.2", "custom" => "preserved")
+          expect(source).not_to have_key(:ref)
+          expect(source).not_to have_key(:branch)
+        end
+      end
     end
 
     context "with a versioned branch input" do


### PR DESCRIPTION
Uses typed source readers across Nix metadata, flake updates, channels, tags, and versioned branches. Reduces Object-generic blockers from 55 to 48. Promotes the file updater and metadata finder to `typed: strong`.