### PR TITLE
Type Pub requirement sources

### DIFF
--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -9,6 +9,7 @@ require "sorbet-runtime"
 require "dependabot/errors"
 require "dependabot/logger"
 require "dependabot/pub/requirement"
+require "dependabot/pub/requirement_source"
 require "dependabot/requirements_update_strategy"
 require "dependabot/shared_helpers"
 
@@ -62,8 +63,8 @@ module Dependabot
 
       sig { params(dependency: Dependabot::Dependency).returns(String) }
       def repository_url(dependency)
-        source = dependency.requirements.first&.dig(:source)
-        source&.dig("description", "url") || options[:pub_hosted_url] || "https://pub.dev"
+        RequirementSource.new(dependency.requirements.first).description_string("url") || options[:pub_hosted_url] ||
+          "https://pub.dev"
       end
 
       sig { params(dependency: Dependabot::Dependency).returns(T::Hash[String, T.untyped]) }

--- a/pub/lib/dependabot/pub/metadata_finder.rb
+++ b/pub/lib/dependabot/pub/metadata_finder.rb
@@ -5,6 +5,7 @@ require "excon"
 require "sorbet-runtime"
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
+require "dependabot/pub/requirement_source"
 require "dependabot/registry_client"
 
 module Dependabot
@@ -16,14 +17,14 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        source = dependency.requirements.first&.dig(:source)
-        if source&.dig("type") == "git"
-          result = T.must(Source.from_url(source.dig("description", "url")))
-          result.directory = source.dig("description", "path")
-          result.commit = source.dig("description", "resolved-ref")
+        source = RequirementSource.new(dependency.requirements.first)
+        if source.type == "git"
+          result = T.must(Source.from_url(source.description_string("url")))
+          result.directory = source.description_string("path")
+          result.commit = source.description_string("resolved-ref")
           return result
         end
-        repository_url = source&.dig("description", "url") || "https://pub.dev"
+        repository_url = source.description_string("url") || "https://pub.dev"
 
         listing = repository_listing(repository_url)
         repo = listing.dig("latest", "pubspec", "repository")

--- a/pub/lib/dependabot/pub/requirement_source.rb
+++ b/pub/lib/dependabot/pub/requirement_source.rb
@@ -1,0 +1,53 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/dependency_requirement"
+
+module Dependabot
+  module Pub
+    class RequirementSource
+      extend T::Sig
+
+      sig { params(requirement: T.nilable(Dependabot::DependencyRequirement)).void }
+      def initialize(requirement)
+        @requirement = requirement
+      end
+
+      sig { returns(T.nilable(String)) }
+      def type
+        requirement&.source_string("type")
+      end
+
+      sig { params(key: String).returns(T.nilable(String)) }
+      def description_string(key)
+        description = description_hash
+        return unless description
+
+        value = description.key?(key.to_sym) ? description[key.to_sym] : description[key]
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise TypeError, "source description #{key} must be a string or nil"
+      end
+
+      private
+
+      sig { returns(T.nilable(Dependabot::DependencyRequirement)) }
+      attr_reader :requirement
+
+      sig { returns(T.nilable(Dependabot::DependencyRequirement::ObjectHash)) }
+      def description_hash
+        source = requirement&.source_hash
+        return unless source
+
+        value = source.key?(:description) ? source[:description] : source["description"]
+        return if value.nil?
+        unless value.is_a?(Hash) && value.keys.all? { |key| key.is_a?(String) || key.is_a?(Symbol) }
+          raise TypeError, "source description must be a hash with string or symbol keys"
+        end
+
+        value
+      end
+    end
+  end
+end

--- a/pub/spec/dependabot/pub/metadata_finder_spec.rb
+++ b/pub/spec/dependabot/pub/metadata_finder_spec.rb
@@ -122,5 +122,16 @@ RSpec.describe Dependabot::Pub::MetadataFinder do
     it "works for git dependencies" do
       expect(finder.source_url).to eq "https://github.com/google/dart-neats/tree/HEAD/retry"
     end
+
+    context "with a malformed source description" do
+      before do
+        dependency.requirements.first[:source]["description"] = "invalid"
+      end
+
+      it "raises a type error" do
+        expect { finder.source_url }
+          .to raise_error(TypeError, "source description must be a hash with string or symbol keys")
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds a typed Pub-local reader for nested hosted and git source descriptions. Reduces Object-generic blockers from 48 to 42 while leaving helper and registry JSON dynamic.