### PR TITLE
Type GitHub Actions requirement access

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -144,21 +144,21 @@ module Dependabot
         updated_requirement_pairs =
           dependency.requirements.zip(T.must(dependency.previous_requirements))
                     .reject do |new_req, old_req|
-            next true if new_req[:file] != file.name
+            next true if new_req.file != file.name
 
-            new_req[:source] == T.must(old_req)[:source]
+            new_req.source == T.must(old_req).source
           end
 
         updated_content = T.must(file.content)
 
         updated_requirement_pairs.each do |new_req, old_req|
           # TODO: Support updating Docker sources
-          next unless new_req.fetch(:source).fetch(:type) == "git"
+          next unless new_req.source_string("type") == "git"
 
-          old_ref = T.must(old_req).fetch(:source).fetch(:ref)
-          new_ref = new_req.fetch(:source).fetch(:ref)
+          old_ref = T.must(T.must(old_req).source_string("ref"))
+          new_ref = T.must(new_req.source_string("ref"))
 
-          old_declaration = T.must(old_req).fetch(:metadata).fetch(:declaration_string)
+          old_declaration = T.must(T.must(old_req).metadata_string("declaration_string"))
           new_declaration =
             old_declaration
             .gsub(/@.*+/, "@#{new_ref}")

--- a/github_actions/lib/dependabot/github_actions/metadata_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/metadata_finder.rb
@@ -15,7 +15,8 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        url = dependency.requirements.first&.source_string("url") ||
+        requirement = dependency.requirements.find(&:source_hash)
+        url = requirement&.source_string("url") ||
               "https://#{source_hostname}/#{dependency.name}"
         Source.from_url(url)
       end

--- a/github_actions/lib/dependabot/github_actions/metadata_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/metadata_finder.rb
@@ -15,14 +15,8 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-
-        url =
-          if info.nil?
-            "https://#{source_hostname}/#{dependency.name}"
-          else
-            info[:url] || info.fetch("url")
-          end
+        url = dependency.requirements.first&.source_string("url") ||
+              "https://#{source_hostname}/#{dependency.name}"
         Source.from_url(url)
       end
 

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -69,16 +69,6 @@ module Dependabot
           updated = updated_ref(source, onboarded: onboarded_requirement?(req))
           next req unless updated
 
-          current = req.source_string("ref")
-
-          # Maintain a short git hash only if it matches the latest
-          if req.source_string("type") == "git" &&
-             git_commit_checker.ref_looks_like_commit_sha?(updated) &&
-             git_commit_checker.ref_looks_like_commit_sha?(T.must(current)) &&
-             updated.start_with?(T.must(current))
-            next req
-          end
-
           new_source = source_with_ref(T.must(source), updated)
           Dependabot::DependencyRequirement.create(req.merge(source: new_source))
         end

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -65,24 +65,24 @@ module Dependabot
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         updated_reqs = dependency.requirements.map do |req|
-          source = T.cast(req.source, GitSource)
+          source = req.source_hash
           updated = updated_ref(source, onboarded: onboarded_requirement?(req))
           next req unless updated
 
-          current = source[:ref]
+          current = req.source_string("ref")
 
           # Maintain a short git hash only if it matches the latest
-          if req[:type] == "git" &&
+          if req.source_string("type") == "git" &&
              git_commit_checker.ref_looks_like_commit_sha?(updated) &&
              git_commit_checker.ref_looks_like_commit_sha?(T.must(current)) &&
              updated.start_with?(T.must(current))
             next req
           end
 
-          new_source = source.merge(ref: updated)
-          req.merge(source: new_source)
+          new_source = source_with_ref(T.must(source), updated)
+          Dependabot::DependencyRequirement.create(req.merge(source: new_source))
         end
-        wrap_requirements(updated_reqs)
+        updated_reqs
       end
 
       private
@@ -171,9 +171,7 @@ module Dependabot
         @git_metadata_fetcher ||= T.let(
           Dependabot::GitMetadataFetcher.new(
             url: T.must(
-              dependency.requirements.filter_map do |requirement|
-                T.cast(requirement.source, T.nilable(GitSource))&.fetch(:url, nil)
-              end.first
+              dependency.requirements.filter_map { |requirement| requirement.source_string("url") }.first
             ),
             credentials: credentials
           ),
@@ -248,20 +246,24 @@ module Dependabot
       end
 
       sig do
-        params(source: T.nilable(GitSource), onboarded: T::Boolean)
+        params(
+          source: T.nilable(Dependabot::DependencyRequirement::ObjectHash),
+          onboarded: T::Boolean
+        )
           .returns(T.nilable(String))
       end
       def updated_ref(source, onboarded: false)
         # TODO: Support Docker sources
         return unless git_commit_checker.git_dependency?
 
-        finder = onboarded ? latest_version_finder_for(source) : T.must(latest_version_finder)
+        git_source = source && symbolize_source(source)
+        finder = onboarded ? latest_version_finder_for(git_source) : T.must(latest_version_finder)
 
         if vulnerable? && (new_tag = finder.lowest_security_fix_release)
           return new_tag.fetch(:tag)
         end
 
-        source_git_commit_checker = git_helper.git_commit_checker_for(source)
+        source_git_commit_checker = git_helper.git_commit_checker_for(git_source)
 
         # Return the git tag if updating a pinned version
         if source_git_commit_checker.pinned_ref_looks_like_version? &&
@@ -277,6 +279,35 @@ module Dependabot
 
         # Otherwise we can't update the ref
         nil
+      end
+
+      sig do
+        params(source: Dependabot::DependencyRequirement::ObjectHash)
+          .returns(GitSource)
+      end
+      def symbolize_source(source)
+        T.cast(source.to_h { |key, value| [key.to_sym, value] }, GitSource)
+      end
+
+      sig do
+        params(
+          source: Dependabot::DependencyRequirement::ObjectHash,
+          ref: String
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
+      end
+      def source_with_ref(source, ref)
+        updated = source.dup
+        key = if source.key?(:ref)
+                :ref
+              elsif source.key?("ref")
+                "ref"
+              elsif source.keys.any?(Symbol)
+                :ref
+              else
+                "ref"
+              end
+        updated[key] = ref
+        updated
       end
 
       sig do

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -20,24 +20,24 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
         groups: [],
         file: ".github/workflows/workflow.yml",
         source: {
-          type: "git",
-          url: "https://github.com/actions/setup-node",
-          ref: "v1.1.0",
-          branch: nil
+          "type" => "git",
+          "url" => "https://github.com/actions/setup-node",
+          "ref" => "v1.1.0",
+          "branch" => nil
         },
-        metadata: { declaration_string: "actions/setup-node@master" }
+        metadata: { "declaration_string" => "actions/setup-node@master" }
       }],
       previous_requirements: [{
         requirement: nil,
         groups: [],
         file: ".github/workflows/workflow.yml",
         source: {
-          type: "git",
-          url: "https://github.com/actions/setup-node",
-          ref: "master",
-          branch: nil
+          "type" => "git",
+          "url" => "https://github.com/actions/setup-node",
+          "ref" => "master",
+          "branch" => nil
         },
-        metadata: { declaration_string: "actions/setup-node@master" }
+        metadata: { "declaration_string" => "actions/setup-node@master" }
       }],
       package_manager: "github_actions"
     )

--- a/github_actions/spec/dependabot/github_actions/metadata_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/metadata_finder_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe Dependabot::GithubActions::MetadataFinder do
       end
 
       it { is_expected.to eq("https://github.com/actions/checkout") }
+
+      context "with string-keyed source details" do
+        let(:dependency_source) do
+          {
+            "type" => "git",
+            "url" => "https://github.com/actions/checkout",
+            "ref" => "master",
+            "branch" => nil
+          }
+        end
+
+        it { is_expected.to eq("https://github.com/actions/checkout") }
+      end
     end
 
     context "when dealing with a subdependency" do

--- a/github_actions/spec/dependabot/github_actions/metadata_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/metadata_finder_spec.rb
@@ -70,6 +70,32 @@ RSpec.describe Dependabot::GithubActions::MetadataFinder do
 
         it { is_expected.to eq("https://github.com/actions/checkout") }
       end
+
+      context "when an earlier requirement has no source" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: nil,
+            requirements: [
+              {
+                requirement: nil,
+                groups: [],
+                file: ".github/workflows/workflow.yml",
+                source: nil
+              },
+              {
+                requirement: nil,
+                groups: [],
+                file: ".github/workflows/workflow.yml",
+                source: dependency_source
+              }
+            ],
+            package_manager: "github_actions"
+          )
+        end
+
+        it { is_expected.to eq("https://github.com/actions/checkout") }
+      end
     end
 
     context "when dealing with a subdependency" do

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -820,6 +820,26 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       it { is_expected.to eq(dependency.requirements) }
     end
 
+    context "with string-keyed source details" do
+      let(:reference) { "v1.0.1" }
+      let(:dependency_source) do
+        {
+          "type" => "git",
+          "url" => "https://github.com/#{dependency_name}",
+          "ref" => reference,
+          "branch" => nil,
+          "custom" => "preserved"
+        }
+      end
+
+      it "preserves the source payload and key style" do
+        source = updated_requirements.first.source_hash
+
+        expect(source).to include("ref" => "v1.1.0", "custom" => "preserved")
+        expect(source).not_to have_key(:ref)
+      end
+    end
+
     context "when a root composite action is fetched with an invalid workflow lockfile" do
       let(:dependency_files) do
         [


### PR DESCRIPTION
Uses typed source and declaration readers across GitHub Actions updates and metadata. Reduces Object-generic blockers from 42 to 36. Promotes the file updater to `typed: strong`.