### PR TITLE
Type Deno requirement access

### DIFF
--- a/deno/lib/dependabot/deno/file_parser.rb
+++ b/deno/lib/dependabot/deno/file_parser.rb
@@ -38,7 +38,7 @@ module Dependabot
             dep = parse_specifier(specifier.to_s, file)
             next unless dep
 
-            key = [dep.name, T.must(dep.requirements.first)[:source][:type]]
+            key = [dep.name, T.must(T.must(dep.requirements.first).source_string("type"))]
             existing = deps_by_key[key]
             deps_by_key[key] = if existing
                                  Dependabot::Dependency.new(

--- a/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
+++ b/deno/lib/dependabot/deno/file_updater/manifest_updater.rb
@@ -29,8 +29,8 @@ module Dependabot
           content = T.must(manifest.content).dup
 
           dependencies.each do |dep|
-            prev_reqs = (dep.previous_requirements || []).select { |r| r[:file] == manifest.name }
-            new_reqs = dep.requirements.select { |r| r[:file] == manifest.name }
+            prev_reqs = (dep.previous_requirements || []).select { |r| r.file == manifest.name }
+            new_reqs = dep.requirements.select { |r| r.file == manifest.name }
 
             prev_reqs.zip(new_reqs).each do |prev_req, new_req|
               content = apply_substitution(content, dep, prev_req, T.must(new_req))
@@ -52,15 +52,14 @@ module Dependabot
           params(
             content: String,
             dep: Dependabot::Dependency,
-            prev_req: T::Hash[Symbol, T.anything],
-            new_req: T::Hash[Symbol, T.anything]
+            prev_req: Dependabot::DependencyRequirement,
+            new_req: Dependabot::DependencyRequirement
           ).returns(String)
         end
         def apply_substitution(content, dep, prev_req, new_req)
-          source = T.cast(prev_req[:source], T::Hash[Symbol, T.anything])
-          source_type = T.cast(source[:type], String)
-          prev_req_str = T.cast(prev_req[:requirement], T.nilable(String))
-          new_req_str = T.cast(new_req[:requirement], T.nilable(String))
+          source_type = T.must(prev_req.source_string("type"))
+          prev_req_str = prev_req.requirement_string
+          new_req_str = new_req.requirement_string
 
           base = "#{source_type}:#{dep.name}"
           old_specifier = prev_req_str ? "#{base}@#{prev_req_str}" : base

--- a/deno/lib/dependabot/deno/metadata_finder.rb
+++ b/deno/lib/dependabot/deno/metadata_finder.rb
@@ -15,7 +15,7 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        source_type = dependency.requirements.first&.dig(:source, :type)
+        source_type = dependency.requirements.first&.source_string("type")
 
         case source_type
         when "npm"

--- a/deno/lib/dependabot/deno/package/package_details_fetcher.rb
+++ b/deno/lib/dependabot/deno/package/package_details_fetcher.rb
@@ -25,7 +25,7 @@ module Dependabot
 
         sig { returns(T::Array[Dependabot::Package::PackageRelease]) }
         def available_versions
-          source_type = dependency.requirements.first&.dig(:source, :type)
+          source_type = dependency.requirements.first&.source_string("type")
 
           case source_type
           when "jsr"

--- a/deno/lib/dependabot/deno/update_checker.rb
+++ b/deno/lib/dependabot/deno/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/update_checkers"

--- a/deno/lib/dependabot/deno/update_checker.rb
+++ b/deno/lib/dependabot/deno/update_checker.rb
@@ -33,9 +33,11 @@ module Dependabot
         return dependency.requirements unless latest_version
 
         updated = dependency.requirements.map do |req|
-          req.merge(requirement: updated_constraint(req[:requirement]))
+          Dependabot::DependencyRequirement.create(
+            req.merge(requirement: updated_constraint(req.requirement_string))
+          )
         end
-        wrap_requirements(updated)
+        updated
       end
 
       private

--- a/deno/spec/dependabot/deno/metadata_finder_spec.rb
+++ b/deno/spec/dependabot/deno/metadata_finder_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Dependabot::Deno::MetadataFinder do
           requirement: "^5.3.0",
           file: "deno.json",
           groups: ["imports"],
-          source: { type: "npm" }
+          source: { "type" => "npm" }
         }],
         package_manager: "deno"
       )

--- a/deno/spec/dependabot/deno/update_checker_spec.rb
+++ b/deno/spec/dependabot/deno/update_checker_spec.rb
@@ -80,6 +80,25 @@ RSpec.describe Dependabot::Deno::UpdateChecker do
       updated = checker.updated_requirements
       expect(updated.first[:requirement]).to eq("^1.1.4")
     end
+
+    context "with a malformed requirement" do
+      before { dependency.requirements.first[:requirement] = 123 }
+
+      it "raises a type error" do
+        expect { checker.updated_requirements }
+          .to raise_error(TypeError, "requirement must be a string, :unfixable, or nil")
+      end
+    end
+
+    context "with string-keyed source details" do
+      before do
+        dependency.requirements.first[:source] = { "type" => "jsr" }
+      end
+
+      it "updates requirements" do
+        expect(checker.updated_requirements.first[:requirement]).to eq("^1.1.4")
+      end
+    end
   end
 
   context "with cooldown enabled" do


### PR DESCRIPTION
Uses typed requirement and source readers across Deno npm and JSR parsing, updates, metadata, and manifests. Reduces Object-generic blockers from 36 to 32. Promotes two consumers to `typed: strong`.