### PR TITLE
Type Elm requirement access

### DIFF
--- a/elm/lib/dependabot/elm/file_updater/elm_json_updater.rb
+++ b/elm/lib/dependabot/elm/file_updater/elm_json_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/elm/file_updater"

--- a/elm/lib/dependabot/elm/file_updater/elm_json_updater.rb
+++ b/elm/lib/dependabot/elm/file_updater/elm_json_updater.rb
@@ -46,16 +46,16 @@ module Dependabot
         def requirement_changed?(file, dependency)
           changed_requirements = dependency.requirements - T.must(dependency.previous_requirements)
 
-          changed_requirements.any? { |f| f[:file] == file.name }
+          changed_requirements.any? { |requirement| requirement.file == file.name }
         end
 
         sig { params(content: T.nilable(String), filename: String, dependency: Dependabot::Dependency).returns(String) }
         def update_requirement(content:, filename:, dependency:)
-          updated_req = dependency.requirements.find { |r| r.fetch(:file) == filename }
-                                               &.fetch(:requirement)
+          updated_req = dependency.requirements.find { |r| r.file == filename }
+                                               &.requirement_string
 
-          old_req = dependency.previous_requirements&.find { |r| r.fetch(:file) == filename }
-                                                    &.fetch(:requirement)
+          old_req = dependency.previous_requirements&.find { |r| r.file == filename }
+                                                    &.requirement_string
 
           return T.must(content) unless old_req
 

--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -120,7 +120,7 @@ module Dependabot
         return false unless latest_version
 
         dependency.requirements
-                  .filter_map(&:requirement_string)
+                  .map(&:requirement_string)
                   .map { |r| requirement_class.new(r) }
                   .all? { |r| r.satisfied_by?(latest_version) }
       end

--- a/elm/lib/dependabot/elm/update_checker.rb
+++ b/elm/lib/dependabot/elm/update_checker.rb
@@ -70,7 +70,7 @@ module Dependabot
       def latest_version_finder_elm19
         @latest_version_finder_elm19 ||= T.let(
           begin
-            unless dependency.requirements.any? { |r| r.fetch(:file) == MANIFEST_FILE }
+            unless dependency.requirements.any? { |r| r.file == MANIFEST_FILE }
               raise Dependabot::DependencyFileNotResolvable, "No #{MANIFEST_FILE} found"
             end
 
@@ -120,7 +120,7 @@ module Dependabot
         return false unless latest_version
 
         dependency.requirements
-                  .map { |r| r.fetch(:requirement) }
+                  .filter_map(&:requirement_string)
                   .map { |r| requirement_class.new(r) }
                   .all? { |r| r.satisfied_by?(latest_version) }
       end

--- a/elm/lib/dependabot/elm/update_checker/latest_version_finder.rb
+++ b/elm/lib/dependabot/elm/update_checker/latest_version_finder.rb
@@ -161,7 +161,7 @@ module Dependabot
             next unless new_version
 
             old_reqs = original_dep.requirements.map do |req|
-              requirement_class.new(req[:requirement])
+              requirement_class.new(req.requirement_string)
             end
 
             next if old_reqs.all? { |req| req.satisfied_by?(new_version) }

--- a/elm/lib/dependabot/elm/update_checker/requirements_updater.rb
+++ b/elm/lib/dependabot/elm/update_checker/requirements_updater.rb
@@ -4,6 +4,7 @@
 require "dependabot/elm/version"
 require "dependabot/elm/requirement"
 require "dependabot/elm/update_checker"
+require "dependabot/dependency_requirement"
 
 module Dependabot
   module Elm
@@ -17,12 +18,15 @@ module Dependabot
 
         sig do
           params(
-            requirements: T::Array[T::Hash[Symbol, T.nilable(String)]],
+            requirements: T::Array[Dependabot::DependencyRequirement],
             latest_resolvable_version: T.nilable(T.any(String, Integer, Dependabot::Version))
           ).void
         end
         def initialize(requirements:, latest_resolvable_version:)
-          @requirements = requirements
+          @requirements = T.let(
+            requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) },
+            T::Array[Dependabot::DependencyRequirement]
+          )
 
           return unless latest_resolvable_version
           return unless version_class.correct?(latest_resolvable_version)
@@ -33,23 +37,25 @@ module Dependabot
           )
         end
 
-        sig { returns(T::Array[T::Hash[Symbol, T.nilable(String)]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         def updated_requirements
           return requirements unless latest_resolvable_version
 
           requirements.map do |req|
             updated_req_string = update_requirement(
-              req[:requirement],
+              req.requirement_string,
               T.must(latest_resolvable_version)
             )
 
-            req.merge(requirement: updated_req_string)
+            Dependabot::DependencyRequirement.create(
+              req.merge(requirement: updated_req_string)
+            )
           end
         end
 
         private
 
-        sig { returns(T::Array[T::Hash[Symbol, T.nilable(String)]]) }
+        sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
         sig { returns(T.nilable(Dependabot::Version)) }

--- a/elm/spec/dependabot/elm/update_checker/requirements_updater_spec.rb
+++ b/elm/spec/dependabot/elm/update_checker/requirements_updater_spec.rb
@@ -34,6 +34,40 @@ RSpec.describe Dependabot::Elm::UpdateChecker::RequirementsUpdater do
 
     specify { expect(updater.updated_requirements.count).to eq(1) }
 
+    context "with a malformed requirement" do
+      let(:elm_package_req) do
+        {
+          file: "elm-package.json",
+          requirement: 123,
+          groups: [],
+          source: nil
+        }
+      end
+
+      it "raises a type error" do
+        expect { updater.updated_requirements }
+          .to raise_error(TypeError, "requirement must be a string, :unfixable, or nil")
+      end
+    end
+
+    context "with string-keyed nested source details" do
+      let(:elm_package_req) do
+        {
+          file: "elm-package.json",
+          requirement: requirement_string,
+          groups: [],
+          source: { "type" => "registry", "custom" => "preserved" }
+        }
+      end
+
+      it "preserves the source payload and key style" do
+        source = updater.updated_requirements.first.source_hash
+
+        expect(source).to include("type" => "registry", "custom" => "preserved")
+        expect(source).not_to have_key(:type)
+      end
+    end
+
     context "when there is no resolvable version" do
       let(:latest_resolvable_version) { nil }
 

--- a/elm/spec/dependabot/elm/update_checker_spec.rb
+++ b/elm/spec/dependabot/elm/update_checker_spec.rb
@@ -78,6 +78,27 @@ RSpec.describe Dependabot::Elm::UpdateChecker do
 
       it { is_expected.to be(false) }
     end
+
+    context "with a nil requirement" do
+      let(:dependency_version) { nil }
+      let(:string_req) { nil }
+      let(:elm_package_url) do
+        "https://package.elm-lang.org/packages/realWorld/ElmPackage/releases.json"
+      end
+      let(:elm_package_response) do
+        fixture("elm_package_responses", "elm-lang-core.json")
+      end
+
+      before do
+        stub_request(:get, elm_package_url)
+          .to_return(status: 200, body: elm_package_response)
+      end
+
+      it "raises the requirement error" do
+        expect { checker.up_to_date? }
+          .to raise_error(Gem::Requirement::BadRequirementError, "Nil requirement not supported in Elm")
+      end
+    end
   end
 
   describe "can_update?" do


### PR DESCRIPTION
Uses `DependencyRequirement` throughout Elm range checking and manifest updates. Reduces Object-generic blockers from 32 to 29. Promotes two consumers to `typed: strong`.