### PR TITLE
Type Silent requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 924
+# Offense count: 923
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -383,7 +383,6 @@ Sorbet/ForbidTUntyped:
     - "sbt/lib/dependabot/sbt/file_fetcher.rb"
     - "sbt/lib/dependabot/sbt/package/package_details_fetcher.rb"
     - "sbt/lib/dependabot/sbt/update_checker.rb"
-    - "silent/lib/dependabot/silent/file_updater.rb"
     - "silent/lib/dependabot/silent/update_checker.rb"
     - "terraform/lib/dependabot/terraform/file_parser.rb"
     - "terraform/lib/dependabot/terraform/file_updater/provider_cli_config_builder.rb"

--- a/silent/lib/dependabot/silent/file_updater.rb
+++ b/silent/lib/dependabot/silent/file_updater.rb
@@ -51,10 +51,10 @@ module SilentPackageManager
         # If this was a multi-version update, assume we've updated all versions to be the same.
         info.delete("versions") if info["versions"]
 
-        info["version"] = requirements(file).first&.fetch(:requirement)
+        info["version"] = requirements(file).first&.requirement_string
         if info["depends-on"]
           # also bump dependants to the same version
-          original_content[info["depends-on"]]["version"] = requirements(file).first&.fetch(:requirement)
+          original_content[info["depends-on"]]["version"] = requirements(file).first&.requirement_string
         end
       end
       c = JSON.pretty_generate(original_content)
@@ -62,14 +62,20 @@ module SilentPackageManager
       c
     end
 
-    sig { params(file: Dependabot::DependencyFile).returns(T::Array[T::Hash[Symbol, String]]) }
+    sig do
+      params(file: Dependabot::DependencyFile)
+        .returns(T::Array[Dependabot::DependencyRequirement])
+    end
     def requirements(file)
-      dependency&.requirements&.filter { |r| r[:file] == file.name } || []
+      dependency&.requirements&.filter { |requirement| requirement.file == file.name } || []
     end
 
-    sig { params(file: T.untyped).returns(T::Array[T::Hash[Symbol, String]]) }
+    sig do
+      params(file: Dependabot::DependencyFile)
+        .returns(T::Array[Dependabot::DependencyRequirement])
+    end
     def previous_requirements(file)
-      dependency&.previous_requirements&.filter { |r| r[:file] == file.name } || []
+      dependency&.previous_requirements&.filter { |requirement| requirement.file == file.name } || []
     end
   end
 end


### PR DESCRIPTION
Uses typed requirement readers in the Silent file updater. Reduces Object-generic blockers from 29 to 27 and `Sorbet/ForbidTUntyped` from 924 to 923, removing one exclusion.