### PR TITLE
Type Julia requirement access

### DIFF
--- a/julia/lib/dependabot/julia/file_updater.rb
+++ b/julia/lib/dependabot/julia/file_updater.rb
@@ -97,8 +97,8 @@ module Dependabot
         dependencies.each do |dependency|
           # Find the new requirement for this dependency in this file
           new_requirement = dependency.requirements
-                                      .find { |req| T.cast(req[:file], String) == proj_file.name }
-                                      &.fetch(:requirement)
+                                      .find { |req| req.file == proj_file.name }
+                                      &.requirement_string
 
           next unless new_requirement
 

--- a/julia/lib/dependabot/julia/update_checker.rb
+++ b/julia/lib/dependabot/julia/update_checker.rb
@@ -84,7 +84,7 @@ module Dependabot
         candidates = latest_version_finder.available_versions
         return nil if candidates.empty?
 
-        current_requirement = T.cast(dependency.requirements.first&.fetch(:requirement, nil), T.nilable(String))
+        current_requirement = dependency.requirements.first&.requirement_string
 
         best = if current_requirement.nil? || current_requirement.strip == "*"
                  candidates.max

--- a/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
+++ b/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/dependency_requirement"

--- a/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
+++ b/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
@@ -58,7 +58,7 @@ module Dependabot
         ).returns(Dependabot::DependencyRequirement)
       end
       def update_requirement(requirement, target_version)
-        current_requirement = requirement[:requirement]
+        current_requirement = requirement.requirement_string
 
         # If requirement is nil (no compat entry), use target version
         new_requirement = if current_requirement.nil?

--- a/julia/spec/dependabot/julia/requirements_updater_spec.rb
+++ b/julia/spec/dependabot/julia/requirements_updater_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe Dependabot::Julia::RequirementsUpdater do
     end
 
     context "with special cases" do
+      context "with a malformed requirement" do
+        let(:requirements) do
+          [{ requirement: 123, file: "Project.toml", groups: ["dependencies"], source: nil }]
+        end
+        let(:target_version) { "0.35.0" }
+
+        it "raises a type error" do
+          expect { updater.updated_requirements }
+            .to raise_error(TypeError, "requirement must be a string, :unfixable, or nil")
+        end
+      end
+
       context "with nil requirement (no compat entry)" do
         let(:requirements) { [{ requirement: nil, file: "Project.toml", groups: ["dependencies"], source: nil }] }
         let(:target_version) { "0.35.0" }


### PR DESCRIPTION
Uses typed requirement strings across Julia compat updates, checking, and project-file matching. Reduces Object-generic blockers from 27 to 25. Promotes the requirements updater to `typed: strong`.