### PR TITLE
Type git-submodule requirement source

### DIFF
--- a/git_submodules/lib/dependabot/git_submodules/metadata_finder.rb
+++ b/git_submodules/lib/dependabot/git_submodules/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/git_submodules/lib/dependabot/git_submodules/metadata_finder.rb
+++ b/git_submodules/lib/dependabot/git_submodules/metadata_finder.rb
@@ -15,10 +15,7 @@ module Dependabot
 
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
-        url = dependency.requirements.first&.fetch(:source)&.fetch(:url) ||
-              dependency.requirements.first&.fetch(:source)&.fetch("url")
-
-        Source.from_url(url)
+        Source.from_url(dependency.requirements.first&.source_string("url"))
       end
     end
   end

--- a/git_submodules/spec/dependabot/git_submodules/metadata_finder_spec.rb
+++ b/git_submodules/spec/dependabot/git_submodules/metadata_finder_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe Dependabot::GitSubmodules::MetadataFinder do
         file: ".gitmodules",
         requirement: nil,
         groups: [],
-        source: { type: "git", url: url, branch: "master", ref: "master" }
+        source: { "type" => "git", "url" => url, "branch" => "master", "ref" => "master" }
       }],
       previous_requirements: [{
         file: ".gitmodules",
         requirement: nil,
         groups: [],
-        source: { type: "git", url: url, branch: "master", ref: "master" }
+        source: { "type" => "git", "url" => url, "branch" => "master", "ref" => "master" }
       }],
       package_manager: "submodules"
     )


### PR DESCRIPTION
Uses the typed source URL reader for git-submodule metadata. Reduces Object-generic blockers from 25 to 23 and promotes the metadata finder to `typed: strong`.