### PR TITLE
Type devcontainer requirement access

### DIFF
--- a/devcontainers/lib/dependabot/devcontainers/file_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/devcontainers/lib/dependabot/devcontainers/file_updater.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_updater.rb
@@ -17,7 +17,7 @@ module Dependabot
         updated_files = []
 
         manifests.each do |manifest|
-          requirement = dependency.requirements.find { |req| req[:file] == manifest.name }
+          requirement = dependency.requirements.find { |req| req.file == manifest.name }
           next unless requirement
 
           config_contents, lockfile_contents = update(manifest, requirement)
@@ -77,14 +77,14 @@ module Dependabot
       sig do
         params(
           manifest: Dependabot::DependencyFile,
-          requirement: T::Hash[Symbol, T.anything]
+          requirement: Dependabot::DependencyRequirement
         )
           .returns(T::Array[String])
       end
       def update(manifest, requirement)
         ConfigUpdater.new(
           feature: dependency.name,
-          requirement: T.cast(requirement[:requirement], T.nilable(String)),
+          requirement: requirement.requirement_string,
           version: T.must(dependency.version),
           manifest: manifest,
           repo_contents_path: T.must(repo_contents_path),

--- a/devcontainers/lib/dependabot/devcontainers/update_checker.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/devcontainers/lib/dependabot/devcontainers/update_checker.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker.rb
@@ -33,8 +33,9 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
-        updated_reqs = dependency.requirements.map do |requirement|
-          required_version = T.cast(version_class.new(requirement[:requirement]), Dependabot::Devcontainers::Version)
+        dependency.requirements.map do |requirement|
+          original_requirement = T.must(requirement.requirement_string)
+          required_version = T.cast(version_class.new(original_requirement), Dependabot::Devcontainers::Version)
           versions = T.cast(release_versions, T::Array[Dependabot::Devcontainers::Version])
           precision_matches = remove_precision_changes(versions, required_version)
           # When the published tags don't include a precision-matching tag (e.g. a feature
@@ -47,14 +48,10 @@ module Dependabot
             else
               versions.last&.truncate_to_precision_of(required_version)
             end
-          {
-            file: requirement[:file],
-            requirement: updated_requirement&.to_s || requirement[:requirement],
-            groups: requirement[:groups],
-            source: requirement[:source]
-          }
+          Dependabot::DependencyRequirement.create(
+            requirement.merge(requirement: updated_requirement&.to_s || original_requirement)
+          )
         end
-        wrap_requirements(updated_reqs)
       end
 
       private

--- a/devcontainers/spec/dependabot/devcontainers/update_checker_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/update_checker_spec.rb
@@ -195,6 +195,31 @@ RSpec.describe Dependabot::Devcontainers::UpdateChecker do
         expect(updated_requirements.first[:requirement]).to eq("2")
         expect(checker.latest_version.to_s).to eq("2.0.0")
       end
+
+      context "with additional requirement payload" do
+        before do
+          dependency.requirements.first[:source] = { "type" => "feature", "custom" => "source" }
+          dependency.requirements.first[:metadata] = { "custom" => "metadata" }
+          dependency.requirements.first[:custom] = "top-level"
+        end
+
+        it "preserves the full requirement payload and nested key style" do
+          requirement = updated_requirements.first
+
+          expect(requirement[:custom]).to eq("top-level")
+          expect(requirement.metadata).to eq({ "custom" => "metadata" })
+          expect(requirement.source_hash).to eq({ "type" => "feature", "custom" => "source" })
+        end
+      end
+
+      context "with a malformed requirement" do
+        before { dependency.requirements.first[:requirement] = 123 }
+
+        it "raises a type error" do
+          expect { updated_requirements }
+            .to raise_error(TypeError, "requirement must be a string, :unfixable, or nil")
+        end
+      end
     end
 
     context "when published tags only include full semver without precision-matching tags (minor update)" do


### PR DESCRIPTION
Uses typed requirement readers while preserving version precision and the full requirement payload. Reduces Object-generic blockers from 23 to 22. Promotes the file updater and update checker to `typed: strong`.