### PR TITLE
fix: merge cross-directory group changes through GroupDependencySelector

### DIFF
--- a/updater/lib/dependabot/updater/group_dependency_selector.rb
+++ b/updater/lib/dependabot/updater/group_dependency_selector.rb
@@ -84,11 +84,23 @@ module Dependabot
       end
       def create_merged_change(changes_by_dir, merged_dependencies, all_updated_files)
         base_change = T.must(changes_by_dir.first)
-        DependencyChange.new(
+
+        # DependencyChange's constructor stamps every dependency with the directory of the
+        # first updated file. A merged change spans directories, so record what each
+        # dependency was resolved in and restore it afterwards.
+        directories = merged_dependencies.map(&:directory)
+
+        merged_change = DependencyChange.new(
           job: base_change.job,
           updated_dependencies: merged_dependencies,
-          updated_dependency_files: all_updated_files
+          updated_dependency_files: all_updated_files,
+          dependency_group: base_change.dependency_group,
+          notices: changes_by_dir.flat_map(&:notices)
         )
+
+        merged_dependencies.each_with_index { |dep, i| dep.directory = directories[i] }
+
+        merged_change
       end
 
       sig { params(dependency_change: Dependabot::DependencyChange).void }
@@ -147,10 +159,15 @@ module Dependabot
       def deduplicate_by_name_only(changes_by_dir)
         directories_by_name = T.let({}, T::Hash[String, T::Array[String]])
 
-        # Collect all directories per dependency name before deduplication
+        # Collect all directories per dependency name before deduplication.
+        #
+        # Every change shares one Job, and the caller reassigns job.source.directory as it
+        # walks the directories, so by the time the changes are merged that field holds only
+        # the last one. Each dependency carries the directory it was resolved in, stamped by
+        # DependencyChange's constructor, so read it from there instead.
         changes_by_dir.each do |change|
-          directory = change.job.source.directory || "."
           Array(change.updated_dependencies).each do |dep|
+            directory = dep.directory || change.job.source.directory || "."
             directories_by_name[dep.name] ||= []
             T.must(directories_by_name[dep.name]) << directory
           end
@@ -181,9 +198,11 @@ module Dependabot
         merged_dependencies = T.let([], T::Array[Dependabot::Dependency])
 
         changes_by_dir.each do |change|
-          directory = change.job.source.directory || "."
-
           Array(change.updated_dependencies).each do |dep|
+            # Read the directory off the dependency rather than job.source, which the caller
+            # has already advanced past this change — see deduplicate_by_name_only.
+            directory = dep.directory || change.job.source.directory || "."
+
             key = yield(directory, dep)
             next if seen_keys.include?(key)
 

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -110,6 +110,11 @@ module Dependabot
         def dependency_change
           return @dependency_change if defined?(@dependency_change)
 
+          selector = Dependabot::Updater::GroupDependencySelector.new(
+            group: group,
+            dependency_snapshot: dependency_snapshot
+          )
+
           if job.source.directories.nil?
             @dependency_change = compile_all_dependency_changes_for(group)
           else
@@ -119,20 +124,16 @@ module Dependabot
               compile_all_dependency_changes_for(group)
             end
 
-            # merge the changes together into one
-            dependency_change = T.let(T.must(dependency_changes.first), Dependabot::DependencyChange)
-            dependency_change.merge_changes!(T.must(dependency_changes[1..-1])) if dependency_changes.count > 1
-            @dependency_change = T.let(dependency_change, T.nilable(Dependabot::DependencyChange))
+            # Merge the per-directory changes into one, deduplicating the dependencies that
+            # appear in more than one directory.
+            @dependency_change = T.let(
+              selector.merge_per_directory!(dependency_changes),
+              T.nilable(Dependabot::DependencyChange)
+            )
           end
 
           # Apply GroupDependencySelector filtering to ensure only group-eligible dependencies
-          if @dependency_change
-            selector = Dependabot::Updater::GroupDependencySelector.new(
-              group: group,
-              dependency_snapshot: dependency_snapshot
-            )
-            selector.filter_to_group!(@dependency_change)
-          end
+          selector.filter_to_group!(@dependency_change) if @dependency_change
 
           @dependency_change
         end

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -163,6 +163,11 @@ module Dependabot
 
           job_group = T.must(dependency_snapshot.job_group)
 
+          selector = Dependabot::Updater::GroupDependencySelector.new(
+            group: job_group,
+            dependency_snapshot: dependency_snapshot
+          )
+
           if job.source.directories.nil?
             @dependency_change = compile_all_dependency_changes_for(job_group)
           else
@@ -175,20 +180,16 @@ module Dependabot
               T::Array[Dependabot::DependencyChange]
             )
 
-            # merge the changes together into one
-            dependency_change = T.let(T.must(dependency_changes.first), Dependabot::DependencyChange)
-            dependency_change.merge_changes!(T.must(dependency_changes[1..-1])) if dependency_changes.count > 1
-            @dependency_change = T.let(dependency_change, T.nilable(Dependabot::DependencyChange))
+            # Merge the per-directory changes into one, deduplicating the dependencies that
+            # appear in more than one directory.
+            @dependency_change = T.let(
+              selector.merge_per_directory!(dependency_changes),
+              T.nilable(Dependabot::DependencyChange)
+            )
           end
 
           # Apply GroupDependencySelector filtering to ensure only group-eligible dependencies
-          if @dependency_change
-            selector = Dependabot::Updater::GroupDependencySelector.new(
-              group: job_group,
-              dependency_snapshot: dependency_snapshot
-            )
-            selector.filter_to_group!(@dependency_change)
-          end
+          selector.filter_to_group!(@dependency_change) if @dependency_change
 
           @dependency_change
         end

--- a/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
+++ b/updater/spec/dependabot/updater/group_dependency_selector_spec.rb
@@ -75,16 +75,19 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
   end
 
   describe "#merge_per_directory!" do
-    let(:rails_dep) { create_dependency("rails", "7.0.0") }
-    let(:pg_dep) { create_dependency("pg", "1.4.0") }
-    let(:redis_dep) { create_dependency("redis", "4.8.0") }
-    let(:duplicate_rails_dep) { create_dependency("rails", "7.0.1") }
+    # Each dependency carries the directory it was resolved in, as DependencyChange's
+    # constructor stamps it per per-directory change.
+    let(:rails_dep) { create_dependency("rails", "7.0.0", directory: "/api") }
+    let(:pg_dep) { create_dependency("pg", "1.4.0", directory: "/api") }
+    let(:redis_dep) { create_dependency("redis", "4.8.0", directory: "/web") }
+    let(:duplicate_rails_dep) { create_dependency("rails", "7.0.1", directory: "/web") }
 
     let(:change1) do
       create_dependency_change(
         job: job,
         dependencies: [rails_dep, pg_dep],
-        files: [create_dependency_file("Gemfile", "/api")]
+        files: [create_dependency_file("Gemfile", "/api")],
+        dependency_group: dependency_group
       )
     end
 
@@ -92,7 +95,8 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       create_dependency_change(
         job: create_job("/web"),
         dependencies: [redis_dep, duplicate_rails_dep],
-        files: [create_dependency_file("Gemfile", "/web")]
+        files: [create_dependency_file("Gemfile", "/web")],
+        dependency_group: dependency_group
       )
     end
 
@@ -106,13 +110,52 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
     context "with multiple changes" do
       before do
         allow(Dependabot::DependencyChange).to receive(:new) do |args|
+          # Mirror the real constructor, which stamps every dependency with the directory
+          # of the first updated file.
+          first_directory = args[:updated_dependency_files].first&.directory
+          args[:updated_dependencies].each { |dep| dep.directory = first_directory }
+
           instance_double(
             Dependabot::DependencyChange,
             job: args[:job],
             updated_dependencies: args[:updated_dependencies],
-            updated_dependency_files: args[:updated_dependency_files]
+            updated_dependency_files: args[:updated_dependency_files],
+            dependency_group: args[:dependency_group],
+            notices: args[:notices] || []
           )
         end
+      end
+
+      it "carries the dependency group onto the merged change" do
+        result = selector.merge_per_directory!([change1, change2])
+
+        # Without this, DependencyChange#grouped_update? is false on the merged change and
+        # the group PR is reported to the service as an ungrouped one.
+        expect(result.dependency_group).to eq(dependency_group)
+      end
+
+      it "carries the notices from every merged change" do
+        notice = Dependabot::Notice.new(mode: "WARN", type: "test", package_manager_name: "bundler")
+        change_with_notice = create_dependency_change(
+          job: create_job("/web"),
+          dependencies: [redis_dep],
+          files: [create_dependency_file("Gemfile", "/web")],
+          dependency_group: dependency_group,
+          notices: [notice]
+        )
+
+        result = selector.merge_per_directory!([change1, change_with_notice])
+
+        expect(result.notices).to eq([notice])
+      end
+
+      it "leaves each dependency in the directory it was resolved in" do
+        result = selector.merge_per_directory!([change1, change2])
+
+        directories = result.updated_dependencies.map { |d| [d.name, d.directory] }
+        expect(directories).to contain_exactly(
+          ["rails", "/api"], ["pg", "/api"], ["redis", "/web"], ["rails", "/web"]
+        )
       end
 
       it "merges dependencies with directory-aware deduplication" do
@@ -182,6 +225,56 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
           )
 
           selector.merge_per_directory!([change1, change2])
+        end
+      end
+
+      # In production every per-directory change shares one Job, and the caller assigns
+      # job.source.directory as it walks the directories — so by merge time that field
+      # holds only the LAST directory. Deriving directories from it collapses them all
+      # onto that one value, which is why these fixtures share a single job double.
+      context "when every change shares one job whose source has advanced to the last directory" do
+        let(:shared_job) { create_job("/web") }
+
+        let(:change1) do
+          create_dependency_change(
+            job: shared_job,
+            dependencies: [rails_dep, pg_dep],
+            files: [create_dependency_file("Gemfile", "/api")],
+            dependency_group: dependency_group
+          )
+        end
+
+        let(:change2) do
+          create_dependency_change(
+            job: shared_job,
+            dependencies: [redis_dep, duplicate_rails_dep],
+            files: [create_dependency_file("Gemfile", "/web")],
+            dependency_group: dependency_group
+          )
+        end
+
+        context "when group_by_dependency_name? is true" do
+          before do
+            allow(dependency_group).to receive(:group_by_dependency_name?).and_return(true)
+          end
+
+          it "records every directory the dependency was updated in" do
+            result = selector.merge_per_directory!([change1, change2])
+
+            rails = result.updated_dependencies.find { |d| d.name == "rails" }
+            expect(rails.metadata[:updated_directories]).to contain_exactly("/api", "/web")
+          end
+        end
+
+        it "keeps a dependency that appears in more than one directory" do
+          result = selector.merge_per_directory!([change1, change2])
+
+          # Both rails entries must survive: collapsing the directory makes their
+          # [directory, name] dedup keys identical and silently drops one update.
+          directories = result.updated_dependencies.map { |d| [d.name, d.directory] }
+          expect(directories).to contain_exactly(
+            ["rails", "/api"], ["pg", "/api"], ["redis", "/web"], ["rails", "/web"]
+          )
         end
       end
 
@@ -1408,9 +1501,18 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
       requirements: requirements,
       directory: directory
     ).tap do |dep|
+      stub_directory_accessor(dep, directory)
       stub_production_check(dep, requirements)
       stub_attribution_methods(dep)
     end
+  end
+
+  # Dependabot::Dependency#directory is an attr_accessor, and DependencyChange's
+  # constructor writes to it, so the double needs to round-trip rather than only read.
+  def stub_directory_accessor(dep, directory)
+    current = directory
+    allow(dep).to receive(:directory) { current }
+    allow(dep).to receive(:directory=) { |value| current = value }
   end
 
   def stub_production_check(dep, requirements)
@@ -1439,12 +1541,14 @@ RSpec.describe Dependabot::Updater::GroupDependencySelector do
     allow(dep).to receive(:attribution_timestamp) { timestamp }
   end
 
-  def create_dependency_change(job:, dependencies:, files:)
+  def create_dependency_change(job:, dependencies:, files:, dependency_group: nil, notices: [])
     instance_double(
       Dependabot::DependencyChange,
       job: job,
       updated_dependencies: dependencies,
-      updated_dependency_files: files
+      updated_dependency_files: files,
+      dependency_group: dependency_group,
+      notices: notices
     ).tap do |change|
       allow(change.updated_dependencies).to receive(:clear)
       allow(change.updated_dependencies).to receive(:concat)

--- a/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
@@ -236,6 +236,59 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
           expect(result.updated_dependencies).to be_empty
         end
 
+        context "when the job spans multiple directories" do
+          let(:dependency_group) do
+            Dependabot::DependencyGroup.new(
+              name: "dummy-group",
+              rules: { "patterns" => ["dummy-pkg-a"], "group-by" => "dependency-name" }
+            )
+          end
+
+          def change_for(directory)
+            Dependabot::DependencyChange.new(
+              job: job,
+              updated_dependencies: [
+                Dependabot::Dependency.new(
+                  name: "dummy-pkg-a",
+                  version: "4.1.0",
+                  previous_version: "4.0.0",
+                  requirements: [{
+                    file: "Gemfile", requirement: "~> 4.1.0", groups: ["default"], source: nil
+                  }],
+                  previous_requirements: [{
+                    file: "Gemfile", requirement: "~> 4.0.0", groups: ["default"], source: nil
+                  }],
+                  package_manager: "bundler",
+                  metadata: { all_versions: ["4.1.0"] }
+                )
+              ],
+              updated_dependency_files: [
+                Dependabot::DependencyFile.new(name: "Gemfile", content: "", directory: directory)
+              ],
+              dependency_group: dependency_group
+            )
+          end
+
+          before do
+            allow(job.source).to receive(:directories).and_return(["/api", "/web"])
+            allow(job.source).to receive(:directory=)
+            allow(create_group_update_pull_request)
+              .to receive(:compile_all_dependency_changes_for)
+              .and_return(change_for("/api"), change_for("/web"))
+          end
+
+          it "merges the per-directory changes into one deduplicated grouped change" do
+            result = create_group_update_pull_request.send(:dependency_change)
+
+            expect(result.updated_dependencies.map(&:name)).to eq(["dummy-pkg-a"])
+            expect(result.updated_dependency_files.map(&:directory)).to contain_exactly("/api", "/web")
+            # The group must survive the merge, or the PR is reported as an ungrouped one.
+            expect(result.dependency_group).to eq(dependency_group)
+            expect(result.updated_dependencies.first.metadata[:updated_directories])
+              .to contain_exactly("/api", "/web")
+          end
+        end
+
         it "preserves dependency files during filtering" do
           dependency_file = instance_double(
             Dependabot::DependencyFile,


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #15892.

`GroupDependencySelector#merge_per_directory!` has no production caller. Both group update operations merge their per-directory `DependencyChange`s with the plain concatenating `DependencyChange#merge_changes!` instead:

- `updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb:124`
- `updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb:180`

Each then builds a `GroupDependencySelector` a few lines later, but only to call `filter_to_group!`.

For a group using `group-by: dependency-name`, that means the same dependency is reported once per directory rather than once in total. And because `merge_per_directory!` is what populates `dep.metadata[:updated_directories]`, that metadata is never set outside its own spec, which leaves the `directories.count > 1` branch of `MessageBuilder#dependency_name_group_pr_name` (`:279-291`) and `#dependency_name_group_intro` (`:570-595`) unreachable in production. So a four-directory bump is titled `in <first directory>` and repeats the same dependency four times in its body and commit metadata.

`merge_per_directory!` was added in #12911 without being wired in, and `deduplicate_by_name_only` was later added to it by #14046, so the cross-directory half of `group-by: dependency-name` has never run.

### Anything you want to highlight for special attention from reviewers?

**Wiring the method in is not sufficient on its own.** Because it has never run, it carries three defects, all fixed here. I found each by running the patched updater, not by reading it:

1. **`create_merged_change` dropped `dependency_group`.** `DependencyChange#grouped_update?` is `!!dependency_group`, so the naive wiring reports every grouped PR to the service as an *ungrouped* one — worse than the bug being fixed. It also dropped `notices`, which `merge_changes!` concatenated.

2. **`create_merged_change` let the constructor clobber the directories.** `ensure_dependencies_have_directories` stamps *every* dependency with the first updated file's directory. `merge_changes!` never re-ran the constructor, so this is new exposure — a dependency resolved in `/dirB` came out as `/dirA`. Each dependency's directory is restored after construction.

3. **Both dedup helpers derived the directory from `change.job.source.directory`.** Every per-directory change shares one `Job`, and the caller assigns `job.source.directory` as it walks the directories, so by merge time that field holds only the last one. `deduplicate_by_name_only` therefore recorded `["/dirB"]` rather than `["/dirA", "/dirB"]` — the PR title stayed single-directory even with the wiring in place. For `deduplicate_by_directory_and_name` it is worse than cosmetic: a collapsed directory makes the `[directory, name]` keys of one dependency in two directories identical, silently dropping one update. Directories now come from the dependency.

**On the spec changes.** The existing `merge_per_directory!` specs gave each change its **own** `Job` double, so their fixtures satisfy the collapsed-directory code and the correct code equally — they cannot tell them apart, which is why none of this was caught. They now share a single `Job`, as production does. `create_dependency` also hardcoded `directory: "/api"` for dependencies handed to the `/web` change; those fixtures now carry the directory of their own change.

I deliberately did **not** touch the group *name* that `merge_per_directory!`'s callers report to the service. That is the separate defect in #14780, and this change leaves it exactly as it was.

### How will you know you've accomplished your goal?

Reproduced and verified end-to-end with `dependabot-cli` v1.92.0, by overlaying the patch onto `ghcr.io/dependabot/dependabot-updater-github-actions:latest`. The three touched files in that image are byte-identical to `main` at `55b3adf19172f02aecf7f711d3789e639e7a12e8`, so this exercises the real code path.

Two directories, each with an `action.yml` pinning `actions/checkout@v4.1.0`, and a group with `patterns: ["*"]` + `group-by: dependency-name`. The `create_pull_request` payload:

**Before**
```json
{
  "pr-title": "Bump actions/checkout in /dirA",
  "dependencies": [
    {"name": "actions/checkout", "version": "7.0.1", "directory": "/dirA"},
    {"name": "actions/checkout", "version": "7.0.1", "directory": "/dirB"}
  ]
}
```

**After**
```json
{
  "pr-title": "Bump actions/checkout across 2 directories",
  "dependencies": [
    {"name": "actions/checkout", "version": "7.0.1", "directory": "/dirA"}
  ]
}
```

with the body now listing each directory:

```
Bumps [actions/checkout](https://github.com/actions/checkout) across 2 directories:

- `/dirA`: 4.1.0 → 7.0.1
- `/dirB`: 4.1.0 → 7.0.1
```

**Control for the non-`group-by` path**, which this change also newly routes through the selector: two directories, one sharing a dependency with the other, group `patterns: ["*"]` and no `group-by`. The payload matches before and after — 3 dependencies, `actions/checkout` in `/dirA`, `actions/setup-node` in `/dirA`, `actions/checkout` in `/dirB`, and the same `the actions group across 2 directories with 2 updates` title. (Only the title's leading capital varies between runs, patched or not: `MessageBuilder` derives it from an unauthenticated `api.github.com/…/commits` lookup that gets rate-limited. Two *unpatched* runs disagree on it too.)

**Each new spec fails without the change.** Against unmodified `lib/`, the affected suites give 145 examples / 6 failures, and those 6 are exactly the new examples; with the change, 0 failures.

- Full updater suite: **973 examples, 0 failures**
- `bundle exec rubocop` on all 5 changed files: no offenses
- `bundle exec srb tc`: no errors

I also confirmed the directory restore in (2) is load-bearing rather than incidental, by disabling just that line and re-running the control: `/dirB` becomes `/dirA`.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
