### PR TITLE
bun: reject bun.lock lockfileVersion the bundled bun can't parse

### DIFF
--- a/bun/Dockerfile
+++ b/bun/Dockerfile
@@ -2,7 +2,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/oven-sh/bun/releases
-ARG BUN_VERSION=1.3.5
+ARG BUN_VERSION=1.3.14
 
 # See https://github.com/nodesource/distributions#installation-instructions
 ARG NODEJS_VERSION=24

--- a/bun/lib/dependabot/bun/bun_package_manager.rb
+++ b/bun/lib/dependabot/bun/bun_package_manager.rb
@@ -13,6 +13,11 @@ module Dependabot
       # In Bun 1.1.39, the lockfile format was changed from a binary bun.lockb to a text-based bun.lock.
       # https://bun.sh/blog/bun-lock-text-lockfile
       MIN_SUPPORTED_VERSION = Version.new("1.1.39")
+
+      # The highest bun.lock `lockfileVersion` the bun binary bundled in `bun/Dockerfile` can parse.
+      # Bun 1.4 raised the default to 2 (https://github.com/oven-sh/bun/pull/31539), which the bundled
+      # bun rejects at parse time. Bump this in lockstep with `ARG BUN_VERSION` in `bun/Dockerfile`.
+      MAX_SUPPORTED_LOCKFILE_VERSION = 1
       SUPPORTED_VERSIONS = T.let([MIN_SUPPORTED_VERSION].freeze, T::Array[Dependabot::Version])
       DEPRECATED_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
 

--- a/bun/lib/dependabot/bun/file_parser/bun_lock.rb
+++ b/bun/lib/dependabot/bun/file_parser/bun_lock.rb
@@ -3,6 +3,7 @@
 
 require "yaml"
 require "dependabot/errors"
+require "dependabot/bun/bun_package_manager"
 require "dependabot/bun/helpers"
 require "sorbet-runtime"
 
@@ -31,6 +32,8 @@ module Dependabot
             version = content["lockfileVersion"]
             raise_invalid!("expected 'lockfileVersion' to be an integer") unless version.is_a?(Integer)
             raise_invalid!("expected 'lockfileVersion' to be >= 0") unless version >= 0
+            raise_unsupported_lockfile_version!(version) if
+              version > BunPackageManager::MAX_SUPPORTED_LOCKFILE_VERSION
 
             # configVersion was introduced in Bun v1.3.2 to control install behavior.
             # When present, it must be preserved or Bun will use different install defaults.
@@ -109,6 +112,17 @@ module Dependabot
         sig { params(message: String).void }
         def raise_invalid!(message)
           raise Dependabot::DependencyFileNotParseable.new(@dependency_file.path, "Invalid bun.lock file: #{message}")
+        end
+
+        # The lockfile is well-formed and we can read it, but the bun binary we shell out to cannot.
+        # Without this, bun discards the lockfile it failed to parse, re-resolves from scratch and
+        # writes a downgraded lockfile back, all while exiting successfully.
+        sig { params(version: Integer).returns(T.noreturn) }
+        def raise_unsupported_lockfile_version!(version)
+          raise Dependabot::DependencyFileNotSupported,
+                "Unsupported bun.lock 'lockfileVersion' #{version} in #{@dependency_file.path}. " \
+                "The bun version Dependabot runs supports up to " \
+                "#{BunPackageManager::MAX_SUPPORTED_LOCKFILE_VERSION}."
         end
 
         sig do

--- a/bun/spec/dependabot/bun/file_parser/lockfile_parser_spec.rb
+++ b/bun/spec/dependabot/bun/file_parser/lockfile_parser_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe Dependabot::Bun::FileParser::LockfileParser do
         end
       end
 
+      context "when the lockfile version is newer than the bundled bun supports" do
+        let(:dependency_files) { project_dependency_files("bun/unsupported_lockfile_version") }
+
+        it "raises a DependencyFileNotSupported error" do
+          expect { dependencies }
+            .to raise_error(Dependabot::DependencyFileNotSupported) do |error|
+              expect(error.message).to include("Unsupported bun.lock 'lockfileVersion' 2")
+              expect(error.message).to include(
+                "supports up to #{Dependabot::Bun::BunPackageManager::MAX_SUPPORTED_LOCKFILE_VERSION}"
+              )
+            end
+        end
+      end
+
       context "when the configVersion is invalid" do
         let(:dependency_files) do
           [

--- a/bun/spec/fixtures/projects/bun/unsupported_lockfile_version/bun.lock
+++ b/bun/spec/fixtures/projects/bun/unsupported_lockfile_version/bun.lock
@@ -1,0 +1,15 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "unsupported_lockfile_version",
+      "dependencies": {
+        "etag": "^1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+  }
+}

--- a/bun/spec/fixtures/projects/bun/unsupported_lockfile_version/package.json
+++ b/bun/spec/fixtures/projects/bun/unsupported_lockfile_version/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "unsupported_lockfile_version",
+  "dependencies": {
+    "etag": "^1.0.0"
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #15848.

`BunLock#parsed` validated only that `lockfileVersion` was an `Integer >= 0`, so a `lockfileVersion` 2 lockfile parsed cleanly on the Ruby side. The updater then shells out to `bun install --save-text-lockfile --ignore-scripts` without `--frozen-lockfile`, so bun 1.3.x warns, **discards the lockfile it can't read**, re-resolves from scratch, writes a v1 lockfile back, and **exits 0**. The updater commits immediately after each install, so the downgraded file lands in the PR — a format downgrade plus silently changed resolutions, with no error anywhere.

`packageManager` offers no escape hatch: it only feeds `#requested_version` (a logging/metadata string), while `Helpers.bun_version` runs `bun --version` against the single image-baked binary.

This PR:

- Adds `BunPackageManager::MAX_SUPPORTED_LOCKFILE_VERSION` (currently `1`), beside the existing `MIN_SUPPORTED_VERSION`.
- Raises `Dependabot::DependencyFileNotSupported` from `BunLock#parsed` when a lockfile exceeds it.
- Bumps `ARG BUN_VERSION` `1.3.5` → `1.3.14`, superseding #15587. This is hygiene only and doesn't move the ceiling, since 1.3.14 still handles only `lockfileVersion` 1.

Bun 1.4 raised the default to 2 (oven-sh/bun#31539) and is still canary, so exposure is currently limited to repos generating lockfiles with canary. It becomes universal at 1.4 GA as repos regenerate lockfiles, so this should land before then.

### Anything you want to highlight for special attention from reviewers?

**Error class.** `DependencyFileNotSupported` rather than `DependencyFileNotParseable` (used by the neighbouring `raise_invalid!`): the file is well-formed and we read it fine, we just can't safely hand it to bun. Already mapped in `common/lib/dependabot/errors.rb`, so no error-mapping changes needed. `ToolVersionNotSupported` fits worse — it describes the tool, not the file.

**Constant over runtime `bun --version` detection.** Mirrors the existing `MIN_SUPPORTED_VERSION` precedent and keeps a shellout out of the parser. Trade-off: it must be bumped in lockstep with `ARG BUN_VERSION`, which the constant's comment states.

**This hard-fails the job** for affected repos. Intentional, given the alternative is a silent, wrong PR — but worth confirming that's the reaction we want.

**Out of scope**, both considered:

- `--frozen-lockfile` on read paths — also fails legitimately stale-but-updatable lockfiles.
- Per-repo bun version selection — larger, and a product decision; filed as #15897.

### How will you know you've accomplished your goal?

The #15848 reproduction is captured as a fixture at `bun/spec/fixtures/projects/bun/unsupported_lockfile_version/`, with a new context in `lockfile_parser_spec.rb` asserting `DependencyFileNotSupported` names the offending version. Raising `MAX_SUPPORTED_LOCKFILE_VERSION` to `2` makes that example fail, confirming it exercises the guard rather than passing incidentally.

Existing v0/v1 fixtures (`simple_v0`, `simple_v1`, `simple_v0_with_config_version`) are unaffected.

`bun` suite: 365 examples, 1 failure — `spec/bun_config_spec.rb`, which asserts container-only `NPM_CONFIG_*` env vars and fails identically at `HEAD`. It was run on the host rather than in Docker, which is why it appears. `rubocop` clean on changed files, `srb tc` clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass. <!-- `bun` gem suite, `rubocop` on changed files, repo-wide `srb tc`. One pre-existing environment-only failure noted above. -->
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

---

**Follow-up:** at bun 1.4 GA, `ARG BUN_VERSION` and `MAX_SUPPORTED_LOCKFILE_VERSION` must be bumped together.
