### PR TITLE
update preinstalled 8 and 9 .NET SDKs to latest

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,8 +27,8 @@
     "ghcr.io/devcontainers/features/rust": "latest",
     "ghcr.io/devcontainers/features/dotnet:2": {
       // these versions should be kept in sync with the files `nuget/Dockerfile` and `nuget/helpers/lib/NuGetUpdater/global.json`
-      "version": "8.0.418",
-      "additionalVersions": "9.0.311, 10.0.400"
+      "version": "8.0.424",
+      "additionalVersions": "9.0.317, 10.0.400"
     },
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "latest"

--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -44,7 +44,7 @@ RUN ARCH=$([ $TARGETARCH = "arm64" ] && echo "arm64" || echo "x64") \
 
 # Install .NET SDK
 # these versions should be kept in sync with the files `.devcontainer/devcontainer.json` and `nuget/helpers/lib/NuGetUpdater/global.json`
-ARG DOTNET_SDK_VERSIONS="8.0.418 9.0.311 10.0.400"
+ARG DOTNET_SDK_VERSIONS="8.0.424 9.0.317 10.0.400"
 ARG DOTNET_SDK_INSTALL_URL=https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh
 ENV DOTNET_INSTALL_DIR=/usr/local/dotnet/current
 ENV DOTNET_INSTALL_SCRIPT_PATH=/tmp/dotnet-install.sh


### PR DESCRIPTION
The NuGet updater image has .NET 8, 9, and 10 SDKs preinstalled.  The latest 10 SDK was just merged and this updates 8 and 9 as well.