### PR TITLE
bun: read subdependencies of non-registry bun.lock entries in the dependency grapher

### DIFF
--- a/bun/lib/dependabot/bun/dependency_grapher.rb
+++ b/bun/lib/dependabot/bun/dependency_grapher.rb
@@ -114,15 +114,18 @@ module Dependabot
         packages = parsed_lockfile.fetch("packages", nil)
         return {} unless packages.is_a?(Hash)
 
-        # bun.lock entries are arrays: ["{name}@{version}", registry, {details}, integrity]
+        # Registry entries are ["{name}@{version}", registry, {details}, integrity], but git, github, folder,
+        # link and tarball entries are ["{name}@{resolution}", {details}, ...] (git entries carry a trailing
+        # string), so the details object is located by shape rather than by index.
         packages.each_with_object({}) do |(_key, entry), rels|
           next unless entry.is_a?(Array) && entry.first.is_a?(String)
 
           parent_name = T.must(T.cast(entry.first, String).split(/(?<=\w)\@/).first)
-          children = entry.dig(2, "dependencies")&.keys
-          next unless children&.any?
+          details = entry.drop(1).find { |part| part.is_a?(Hash) }
+          children = details&.fetch("dependencies", nil)
+          next unless children.is_a?(Hash) && children.any?
 
-          rels[parent_name] = children
+          rels[parent_name] = children.keys
         end
       end
     end

--- a/bun/spec/dependabot/bun/dependency_grapher_spec.rb
+++ b/bun/spec/dependabot/bun/dependency_grapher_spec.rb
@@ -218,6 +218,37 @@ RSpec.describe Dependabot::Bun::DependencyGrapher do
       end
     end
 
+    context "with a lockfile containing a git dependency" do
+      let(:dependency_files) { project_dependency_files("bun/grapher_with_git_dependency") }
+
+      it "does not set the errored_fetching_subdependencies flag" do
+        grapher.resolved_dependencies
+
+        expect(grapher.errored_fetching_subdependencies).to be(false)
+        expect(grapher.subdependency_error).to be_nil
+      end
+
+      it "still includes subdependency edges for registry packages" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        fetch_factory = resolved_dependencies["pkg:npm/fetch-factory@0.0.1"]
+        expect(fetch_factory).not_to be_nil
+        expect(fetch_factory.dependencies).to contain_exactly(
+          "pkg:npm/es6-promise@3.3.1",
+          "pkg:npm/lodash@3.10.1"
+        )
+      end
+
+      it "reads the dependencies of non-registry entries" do
+        grapher.resolved_dependencies
+
+        expect(grapher.send(:package_relationships)).to include(
+          "is-number" => ["kind-of"],
+          "kind-of" => ["is-buffer"]
+        )
+      end
+    end
+
     context "when the lockfile is corrupt" do
       let(:dependency_files) { project_dependency_files("bun/grapher_with_subdeps") }
 

--- a/bun/spec/fixtures/projects/bun/grapher_with_git_dependency/bun.lock
+++ b/bun/spec/fixtures/projects/bun/grapher_with_git_dependency/bun.lock
@@ -1,0 +1,25 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "grapher-git-dependency-test",
+      "dependencies": {
+        "fetch-factory": "^0.0.1",
+        "is-number": "jonschlinkert/is-number",
+      },
+    },
+  },
+  "packages": {
+    "es6-promise": ["es6-promise@3.3.1", "", {}, "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="],
+
+    "fetch-factory": ["fetch-factory@0.0.1", "", { "dependencies": { "es6-promise": "^3.0.2", "lodash": "^3.10.1" } }, "sha512-gexRwqIhwzDJ2pJvL0UYfiZwW06/bdYWxAmswFFts7C87CF8i6liApihTk7TZFYMDcQjvvDIvyHv0q379z0aWA=="],
+
+    "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
+
+    "is-number": ["is-number@github:jonschlinkert/is-number#98e8ff1", { "dependencies": { "kind-of": "^3.0.2" } }, "jonschlinkert-is-number-98e8ff1"],
+
+    "kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
+
+    "lodash": ["lodash@3.10.1", "", {}, "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="],
+  }
+}

--- a/bun/spec/fixtures/projects/bun/grapher_with_git_dependency/package.json
+++ b/bun/spec/fixtures/projects/bun/grapher_with_git_dependency/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "grapher-git-dependency-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "fetch-factory": "^0.0.1",
+    "is-number": "jonschlinkert/is-number"
+  }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

`Dependabot::Bun::DependencyGrapher#fetch_package_relationships` reads each `bun.lock` `packages` entry as if it always had the registry shape `["name@version", registry, {details}, integrity]` and takes the details object from index 2.

That is only the shape of registry packages. Per bun's own writer, the other resolution kinds look like this:

```
npm      -> [ "name@version", registry, INFO, integrity ]
git      -> [ "name@git+repo",  INFO, <bun-tag> ]
github   -> [ "name@github:u/r", INFO, <bun-tag> ]
folder   -> [ "name@file:path", INFO ]
symlink  -> [ "name@link:path", INFO ]
tarball  -> [ "name@<url>",     INFO ]
workspace-> [ "name@workspace:path" ]
```

Two consequences today:

- For any lockfile that contains a git or github dependency, `entry.dig(2, "dependencies")` reaches the trailing bun-tag `String` and raises `TypeError` (`String does not have #dig method`). `DependencyGraphers::Base#safe_fetch_subdependencies` rescues it, sets `errored_fetching_subdependencies`, and every package in the submitted graph ends up with no relationships, not just the git one.
- Folder / link / tarball entries keep their details at index 1, so their dependencies were silently never read.

`FileParser::BunLock#parse_details` already handles both shapes; this makes the grapher do the same by locating the details `Hash` in the entry rather than hard-coding an index. The lockfile shape is identical for `lockfileVersion` 0, 1 and the upcoming 2, so this applies to all of them.

### Anything you want to highlight for special attention from reviewers?

Picking the first `Hash` after the resolution string is the smallest change that covers every shape above (workspace entries have none and are skipped; the `root:` entry's hash has no `dependencies` key and is skipped too). The alternative was to expose `BunLock#parse_details` and switch on whether the resolution is semver, which is more code for the same result.

Unrelated to, and independent of, #15896.

### How will you know you've accomplished your goal?

New fixture `bun/spec/fixtures/projects/bun/grapher_with_git_dependency` has one registry package with children and one github package with children. Against `main`, the three new examples fail: the error flag is set, `fetch-factory`'s edges come back empty, and the github package's edges are missing. With this change they pass.

Run on the host (not in the dev container): the `bun` suite is 367 examples, 1 failure, the failure being `spec/bun_config_spec.rb`, which asserts container-only environment variables and fails identically on `main`. `rubocop` is clean on the changed files and `srb tc` reports no errors.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass. — Partially: only the `bun` ecosystem suite (367 examples; 1 pre-existing container-only failure, identical on `main`), `rubocop` on the changed files, and `srb tc` were run on the host, not the full multi-ecosystem suite or the dev container. Relying on CI for the rest.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

This pull request was written by Claude on behalf of the Bun team, and a Bun maintainer is sponsoring it.

