### PR TITLE
Type Maven wrapper requirement access

### DIFF
--- a/common/lib/dependabot/dependency_requirement.rb
+++ b/common/lib/dependabot/dependency_requirement.rb
@@ -215,7 +215,9 @@ module Dependabot
       details = metadata
       return if details.nil?
 
-      details[key.to_sym] || details[key]
+      return details[key.to_sym] if details.key?(key.to_sym)
+
+      details[key]
     end
 
     sig { params(key: Symbol).returns(T.nilable(String)) }

--- a/common/lib/dependabot/dependency_requirement.rb
+++ b/common/lib/dependabot/dependency_requirement.rb
@@ -175,6 +175,16 @@ module Dependabot
       raise TypeError, "metadata #{key} must be a symbol or nil"
     end
 
+    # Reads a boolean metadata field such as "include_debug_script".
+    sig { params(key: String).returns(T.nilable(T::Boolean)) }
+    def metadata_boolean(key)
+      value = metadata_value(key)
+      return if value.nil?
+      return value if value == true || value == false
+
+      raise TypeError, "metadata #{key} must be a boolean or nil"
+    end
+
     # Reads a nested metadata hash whose values are all strings, such as
     # "dependency_set" (`{ group: "my.group", version: "1.4.0" }`). Keys are
     # symbolised so callers can read them with symbols regardless of how the

--- a/common/spec/dependabot/dependency_requirement_spec.rb
+++ b/common/spec/dependabot/dependency_requirement_spec.rb
@@ -262,6 +262,27 @@ RSpec.describe Dependabot::DependencyRequirement do
         .to raise_error(TypeError, "metadata type must be a symbol or nil")
     end
 
+    it "reads boolean metadata values with either key style" do
+      symbol_keyed = described_class.create(requirement_hash.merge(metadata: { enabled: true }))
+      string_keyed = described_class.create(requirement_hash.merge(metadata: { "enabled" => false }))
+
+      expect(symbol_keyed.metadata_boolean("enabled")).to be(true)
+      expect(string_keyed.metadata_boolean("enabled")).to be(false)
+    end
+
+    it "returns nil for an absent boolean metadata value" do
+      req = described_class.create(requirement_hash)
+
+      expect(req.metadata_boolean("enabled")).to be_nil
+    end
+
+    it "rejects a non-boolean metadata value" do
+      req = described_class.create(requirement_hash.merge(metadata: { enabled: "yes" }))
+
+      expect { req.metadata_boolean("enabled") }
+        .to raise_error(TypeError, "metadata enabled must be a boolean or nil")
+    end
+
     it "reads a metadata hash of strings" do
       req = described_class.create(
         requirement_hash.merge(metadata: { dependency_set: { group: "my.group", version: "1.4.0" } })

--- a/common/spec/dependabot/dependency_requirement_spec.rb
+++ b/common/spec/dependabot/dependency_requirement_spec.rb
@@ -263,11 +263,15 @@ RSpec.describe Dependabot::DependencyRequirement do
     end
 
     it "reads boolean metadata values with either key style" do
-      symbol_keyed = described_class.create(requirement_hash.merge(metadata: { enabled: true }))
-      string_keyed = described_class.create(requirement_hash.merge(metadata: { "enabled" => false }))
+      symbol_true = described_class.create(requirement_hash.merge(metadata: { enabled: true }))
+      symbol_false = described_class.create(requirement_hash.merge(metadata: { enabled: false }))
+      string_true = described_class.create(requirement_hash.merge(metadata: { "enabled" => true }))
+      string_false = described_class.create(requirement_hash.merge(metadata: { "enabled" => false }))
 
-      expect(symbol_keyed.metadata_boolean("enabled")).to be(true)
-      expect(string_keyed.metadata_boolean("enabled")).to be(false)
+      expect(symbol_true.metadata_boolean("enabled")).to be(true)
+      expect(symbol_false.metadata_boolean("enabled")).to be(false)
+      expect(string_true.metadata_boolean("enabled")).to be(true)
+      expect(string_false.metadata_boolean("enabled")).to be(false)
     end
 
     it "returns nil for an absent boolean metadata value" do

--- a/maven/lib/dependabot/maven/distributions.rb
+++ b/maven/lib/dependabot/maven/distributions.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/dependency_requirement"

--- a/maven/lib/dependabot/maven/distributions.rb
+++ b/maven/lib/dependabot/maven/distributions.rb
@@ -24,7 +24,7 @@ module Dependabot
         # Returns true if any requirement came from a maven-wrapper.properties
         # file rather than a pom.xml. Used as the primary guard throughout the
         # updater pipeline to short-circuit non-wrapper paths.
-        requirements.any? { |req| req.dig(:source, :type) == DISTRIBUTION_DEPENDENCY_TYPE }
+        requirements.any? { |req| req.source_string("type") == DISTRIBUTION_DEPENDENCY_TYPE }
       end
     end
   end

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -87,7 +87,7 @@ module Dependabot
       def version_from_metadata(dep, key)
         return nil unless dep
 
-        dep.requirements.find { |r| r.dig(:metadata, key) }&.dig(:metadata, key)
+        dep.requirements.filter_map { |requirement| requirement.metadata_string(key.to_s) }.first
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/maven/lib/dependabot/maven/file_updater/wrapper_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater/wrapper_updater.rb
@@ -231,34 +231,19 @@ module Dependabot
         def maven_wrapper_version_from_requirements
           return @wrapper_version_override if @wrapper_version_override
 
-          wrapper_version = dependency.requirements
-                                      .find { |r| r.dig(:metadata, :wrapper_version) }
-                                      &.dig(:metadata, :wrapper_version)
-          raise "Could not determine Maven Wrapper version from dependency requirements" unless wrapper_version
-
-          T.cast(wrapper_version, String)
+          required_metadata_string("wrapper_version", "Maven Wrapper version")
         end
 
         sig { returns(String) }
         def distribution_version_from_requirements
           return @distribution_version_override if @distribution_version_override
 
-          distribution_version = dependency.requirements
-                                           .find { |r| r.dig(:metadata, :distribution_version) }
-                                           &.dig(:metadata, :distribution_version)
-          raise "Could not determine distribution version from dependency requirements" unless distribution_version
-
-          T.cast(distribution_version, String)
+          required_metadata_string("distribution_version", "distribution version")
         end
 
         sig { returns(String) }
         def distribution_type_from_requirements
-          distribution_type = dependency.requirements
-                                        .find { |r| r.dig(:metadata, :distribution_type) }
-                                        &.dig(:metadata, :distribution_type)
-          raise "Could not determine distribution type from dependency requirements" unless distribution_type
-
-          T.cast(distribution_type, String)
+          required_metadata_string("distribution_type", "distribution type")
         end
 
         sig { returns(T::Array[String]) }
@@ -268,15 +253,23 @@ module Dependabot
           distribution_url = effective_distribution_url(properties)
           args << "-DdistributionUrl=#{distribution_url}" if distribution_url
           args.concat(enabled_persistence_args(properties))
-          include_debug = dependency.requirements
-                                    .find { |r| r.dig(:metadata, :include_debug_script) }
-                                    &.dig(:metadata, :include_debug_script)
+          include_debug = dependency.requirements.any? do |requirement|
+            requirement.metadata_boolean("include_debug_script")
+          end
           # The plugin exposes this via the `includeDebug` user property (the field is named
           # includeDebugScript internally). Passing -DincludeDebugScript is silently ignored, which
           # would drop the user's mvnwDebug scripts on every update.
           # https://maven.apache.org/tools/wrapper/maven-wrapper-plugin/wrapper-mojo.html
           args << "-DincludeDebug=true" if include_debug
           args
+        end
+
+        sig { params(key: String, description: String).returns(String) }
+        def required_metadata_string(key, description)
+          value = dependency.requirements.filter_map { |requirement| requirement.metadata_string(key) }.first
+          raise "Could not determine #{description} from dependency requirements" unless value
+
+          value
         end
 
         sig { params(properties: String).returns(T.nilable(String)) }
@@ -476,8 +469,11 @@ module Dependabot
           @wrapper_properties_file ||= T.let(
             begin
               req_file = dependency.requirements
-                                   .find { |r| r.dig(:source, :type) == Distributions::DISTRIBUTION_DEPENDENCY_TYPE }
-                                   &.fetch(:file, nil)
+                                   .find do |requirement|
+                                     requirement.source_string("type") ==
+                                       Distributions::DISTRIBUTION_DEPENDENCY_TYPE
+                                   end
+                                   &.file
               @dependency_files.find { |f| f.name == req_file } ||
                 @dependency_files.find { |f| f.name.end_with?("maven-wrapper.properties") }
             end,

--- a/maven/spec/dependabot/maven/file_updater/wrapper_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater/wrapper_updater_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe Dependabot::Maven::FileUpdater::WrapperUpdater do
   end
   let(:dependency_files) { [properties_file, mvnw_file] }
   let(:credentials) { [] }
+  let(:requirement_source) do
+    {
+      type: "maven-distribution",
+      url: "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip",
+      property: "distributionUrl"
+    }
+  end
+  let(:requirement_metadata) do
+    {
+      packaging_type: "pom",
+      wrapper_version: "3.3.4",
+      distribution_type: "only-script",
+      distribution_version: "3.9.9",
+      include_debug_script: false
+    }
+  end
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -43,14 +59,9 @@ RSpec.describe Dependabot::Maven::FileUpdater::WrapperUpdater do
       requirements: [{
         requirement: "3.9.9",
         file: ".mvn/wrapper/maven-wrapper.properties",
-        source: {
-          type: "maven-distribution",
-          url: "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip",
-          property: "distributionUrl"
-        },
+        source: requirement_source,
         groups: [],
-        metadata: { packaging_type: "pom", wrapper_version: "3.3.4", distribution_type: "only-script",
-                    distribution_version: "3.9.9", include_debug_script: false }
+        metadata: requirement_metadata
       }],
       previous_requirements: [{
         requirement: "3.9.8",
@@ -125,6 +136,77 @@ RSpec.describe Dependabot::Maven::FileUpdater::WrapperUpdater do
 
       before do
         allow(Dependabot::Maven::NativeHelpers).to receive(:run_mvnw_wrapper)
+      end
+    end
+
+    context "with string-keyed source and metadata" do
+      include_context "with native helpers stubbed"
+
+      let(:properties_content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+          "3.9.8/apache-maven-3.9.8-bin.zip\ndistributionType=only-script\nwrapperVersion=3.3.4\n"
+      end
+      let(:requirement_source) do
+        {
+          "type" => "maven-distribution",
+          "url" => "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+                   "3.9.9/apache-maven-3.9.9-bin.zip",
+          "property" => "distributionUrl"
+        }
+      end
+      let(:requirement_metadata) do
+        {
+          "packaging_type" => "pom",
+          "wrapper_version" => "3.3.4",
+          "distribution_type" => "only-script",
+          "distribution_version" => "3.9.9",
+          "include_debug_script" => true,
+          "custom" => "preserved"
+        }
+      end
+
+      it "passes the typed wrapper details to the native helper" do
+        received = {}
+        allow(Dependabot::Maven::NativeHelpers).to receive(:run_mvnw_wrapper) { |**kwargs| received = kwargs }
+
+        updater.update_files(buildfile)
+
+        expect(received).to include(
+          version: "3.9.9",
+          wrapper_plugin_version: "3.3.4",
+          distribution_type: "only-script"
+        )
+        expect(received[:extra_args]).to include("-DincludeDebug=true")
+      end
+    end
+
+    context "with malformed wrapper metadata" do
+      include_context "with native helpers stubbed"
+
+      let(:properties_content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+          "3.9.8/apache-maven-3.9.8-bin.zip\ndistributionType=only-script\nwrapperVersion=3.3.4\n"
+      end
+      let(:requirement_metadata) { super().merge(wrapper_version: 334) }
+
+      it "raises a type error" do
+        expect { updater.update_files(buildfile) }
+          .to raise_error(TypeError, "metadata wrapper_version must be a string or nil")
+      end
+    end
+
+    context "with malformed debug-script metadata" do
+      include_context "with native helpers stubbed"
+
+      let(:properties_content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+          "3.9.8/apache-maven-3.9.8-bin.zip\ndistributionType=only-script\nwrapperVersion=3.3.4\n"
+      end
+      let(:requirement_metadata) { super().merge(include_debug_script: "yes") }
+
+      it "raises a type error" do
+        expect { updater.update_files(buildfile) }
+          .to raise_error(TypeError, "metadata include_debug_script must be a boolean or nil")
       end
     end
 

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -1500,6 +1500,28 @@ RSpec.describe Dependabot::Maven::FileUpdater do
       expect(captured).to include(distribution_version: "3.9.11", wrapper_version: "3.3.5")
     end
 
+    context "with string-keyed source and metadata" do
+      before do
+        [distribution_dep, wrapper_dep].each do |dependency|
+          requirement = dependency.requirements.first
+          requirement[:source] = requirement.source_hash.transform_keys(&:to_s)
+          requirement[:metadata] = requirement.metadata.transform_keys(&:to_s)
+        end
+      end
+
+      it "passes both resolved target versions to the single generator" do
+        captured = nil
+        allow(wrapper_updater_class).to receive(:new) do |**kwargs|
+          captured = kwargs
+          wrapper_double
+        end
+
+        updater.updated_dependency_files
+
+        expect(captured).to include(distribution_version: "3.9.11", wrapper_version: "3.3.5")
+      end
+    end
+
     context "when the wrapper lives in a module (non-root)" do
       let(:properties_name) { "module/.mvn/wrapper/maven-wrapper.properties" }
       let(:module_pom) { Dependabot::DependencyFile.new(name: "module/pom.xml", content: "<project></project>") }


### PR DESCRIPTION
Uses typed source and metadata readers across Maven wrapper updates. Reduces Object-generic blockers from 22 to 10 and promotes Maven distributions to `typed: strong`.