### PR TITLE
Type vcpkg requirement access

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 923
+# Offense count: 922
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -400,4 +400,3 @@ Sorbet/ForbidTUntyped:
     - "vcpkg/lib/dependabot/vcpkg/file_parser.rb"
     - "vcpkg/lib/dependabot/vcpkg/file_updater.rb"
     - "vcpkg/lib/dependabot/vcpkg/package/package_details_fetcher.rb"
-    - "vcpkg/lib/dependabot/vcpkg/update_checker.rb"

--- a/vcpkg/lib/dependabot/vcpkg/file_updater.rb
+++ b/vcpkg/lib/dependabot/vcpkg/file_updater.rb
@@ -63,7 +63,7 @@ module Dependabot
         parsed_content = JSON.parse(content)
 
         dependencies
-          .filter_map { |dep| [dep, dep.requirements.find { |r| r[:file] == file.name }] }
+          .filter_map { |dep| [dep, dep.requirements.find { |requirement| requirement.file == file.name }] }
           .select { |_, requirement| requirement }
           .each { |dependency, _| update_dependency_in_content(parsed_content, dependency, file.name) }
 
@@ -80,7 +80,7 @@ module Dependabot
         parsed_content = JSON.parse(content)
 
         dependencies
-          .filter_map { |dep| [dep, dep.requirements.find { |r| r[:file] == file.name }] }
+          .filter_map { |dep| [dep, dep.requirements.find { |requirement| requirement.file == file.name }] }
           .select { |_, requirement| requirement }
           .each { |dependency, _| update_registry_dependency_in_content(parsed_content, dependency, file.name) }
 
@@ -120,11 +120,9 @@ module Dependabot
         params(dependency: Dependabot::Dependency, filename: String).returns(T.nilable(Symbol))
       end
       def remediation_for(dependency, filename)
-        requirement = dependency.requirements.find { |r| r[:file] == filename }
-        metadata = requirement&.dig(:metadata)
-        return nil unless metadata.is_a?(Hash)
-
-        metadata[:security_remediation]
+        dependency.requirements
+                  .find { |requirement| requirement.file == filename }
+                  &.metadata_symbol("security_remediation")
       end
 
       sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency).void }
@@ -185,7 +183,7 @@ module Dependabot
       def build_security_baseline
         commit_sha = dependencies
                      .flat_map(&:requirements)
-                     .filter_map { |requirement| requirement.dig(:metadata, :baseline_commit_sha) }
+                     .filter_map { |requirement| requirement.metadata_string("baseline_commit_sha") }
                      .first
         return nil unless commit_sha.is_a?(String)
 
@@ -245,19 +243,17 @@ module Dependabot
           .returns(T.nilable(T::Hash[String, String]))
       end
       def build_default_registry(dependency, filename)
-        requirement = dependency.requirements.find { |r| r[:file] == filename }
+        requirement = dependency.requirements.find { |candidate| candidate.file == filename }
         return unless requirement
 
-        case requirement[:source]
-        in { ref: String => baseline }
-          {
-            "kind" => "git",
-            "repository" => VCPKG_DEFAULT_REGISTRY_REPOSITORY,
-            "baseline" => baseline
-          }
-        else
-          nil
-        end
+        baseline = requirement.source_string("ref")
+        return unless baseline
+
+        {
+          "kind" => "git",
+          "repository" => VCPKG_DEFAULT_REGISTRY_REPOSITORY,
+          "baseline" => baseline
+        }
       end
 
       sig { params(content: T::Hash[String, T.untyped], dependency: Dependabot::Dependency, filename: String).void }
@@ -282,16 +278,12 @@ module Dependabot
       end
       def update_baseline_field(target, dependency, filename, field_name)
         # Find the requirement for this specific file
-        requirement = dependency.requirements.find { |r| r[:file] == filename }
+        requirement = dependency.requirements.find { |candidate| candidate.file == filename }
         return unless requirement
 
         # Extract and validate the new baseline
-        case requirement[:source]
-        in { ref: String => new_baseline }
-          target[field_name] = new_baseline
-        else
-          # Skip if source doesn't have the expected structure
-        end
+        new_baseline = requirement.source_string("ref")
+        target[field_name] = new_baseline if new_baseline
       end
 
       sig do
@@ -307,7 +299,7 @@ module Dependabot
           registries.find { |r| r.is_a?(Hash) && r["kind"] == "builtin" }
         else
           # For git registries, find by repository URL
-          repository_url = dependency.requirements.first&.dig(:source, :url)
+          repository_url = dependency.requirements.first&.source_string("url")
           registries.find { |r| r.is_a?(Hash) && r["repository"] == repository_url }
         end
       end

--- a/vcpkg/lib/dependabot/vcpkg/metadata_finder.rb
+++ b/vcpkg/lib/dependabot/vcpkg/metadata_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/metadata_finders"

--- a/vcpkg/lib/dependabot/vcpkg/metadata_finder.rb
+++ b/vcpkg/lib/dependabot/vcpkg/metadata_finder.rb
@@ -3,6 +3,7 @@
 
 require "dependabot/metadata_finders"
 require "dependabot/metadata_finders/base"
+require "dependabot/vcpkg"
 
 module Dependabot
   module Vcpkg
@@ -29,14 +30,8 @@ module Dependabot
       sig { override.returns(T.nilable(Dependabot::Source)) }
       def look_up_source
         # Check if this is a Git dependency with a specific source
-        info = dependency.requirements.filter_map { |r| r[:source] }.first
-
-        url =
-          if info.nil?
-            VCPKG_DEFAULT_BASELINE_URL
-          else
-            info[:url] || info.fetch("url", VCPKG_DEFAULT_BASELINE_URL)
-          end
+        requirement = dependency.requirements.find(&:source_hash)
+        url = requirement&.source_string("url") || VCPKG_DEFAULT_BASELINE_URL
         Source.from_url(url)
       end
 

--- a/vcpkg/lib/dependabot/vcpkg/update_checker.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/vcpkg/lib/dependabot/vcpkg/update_checker.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker.rb
@@ -63,27 +63,33 @@ module Dependabot
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
         fix = security_fix
-        return wrap_requirements(security_updated_requirements(fix)) if fix
+        return security_updated_requirements(fix) if fix
         return dependency.requirements unless latest_version
 
-        wrap_requirements(dependency.requirements.map { |requirement| updated_requirement(requirement) })
+        dependency.requirements.map { |requirement| updated_requirement(requirement) }
       end
 
       private
 
       sig do
-        params(requirement: T::Hash[Symbol, T.anything]).returns(T::Hash[Symbol, T.anything])
+        params(requirement: Dependabot::DependencyRequirement)
+          .returns(Dependabot::DependencyRequirement)
       end
       def updated_requirement(requirement)
-        source = T.cast(requirement[:source], T.nilable(T::Hash[Symbol, T.anything]))
+        source = requirement.source_hash
 
         if source && registry_dependency?
           # For git dependencies (baselines), update the git ref with the commit SHA
-          latest_commit_sha = latest_version_finder.latest_release_info&.details&.dig("commit_sha")
-          requirement.merge(source: source.merge(ref: latest_commit_sha))
-        elsif source.nil? && requirement[:requirement]
+          latest_commit_sha = T.cast(
+            latest_version_finder.latest_release_info&.details&.dig("commit_sha"),
+            T.nilable(String)
+          )
+          requirement.source_string("ref")
+          updated_source = hash_with_value(source, "ref", latest_commit_sha)
+          Dependabot::DependencyRequirement.create(requirement.merge(source: updated_source))
+        elsif source.nil? && requirement.requirement
           # For port dependencies (no source but has requirement), update the version constraint
-          requirement.merge(requirement: ">=#{latest_version}")
+          Dependabot::DependencyRequirement.create(requirement.merge(requirement: ">=#{latest_version}"))
         else
           # Keep the original requirement unchanged for other cases
           requirement
@@ -93,22 +99,47 @@ module Dependabot
       # Describes the manifest edit that fixes the advisory, so the file updater can apply it
       # without repeating the resolution.
       sig do
-        params(fix: SecurityFixResolver::Fix).returns(T::Array[T::Hash[Symbol, T.anything]])
+        params(fix: SecurityFixResolver::Fix)
+          .returns(T::Array[Dependabot::DependencyRequirement])
       end
       def security_updated_requirements(fix)
         dependency.requirements.map do |requirement|
-          metadata = T.cast(requirement[:metadata], T.nilable(T::Hash[Symbol, T.untyped])) || {}
-          updated = requirement.merge(
-            metadata: metadata.merge(
-              security_remediation: fix.kind,
-              security_version: fix.version.to_s,
-              baseline_commit_sha: fix.baseline_commit_sha,
-              baseline_tag: fix.baseline_tag
-            )
+          metadata = T.let(
+            requirement.metadata || {},
+            Dependabot::DependencyRequirement::ObjectHash
           )
+          metadata = hash_with_value(metadata, "security_remediation", fix.kind)
+          metadata = hash_with_value(metadata, "security_version", fix.version.to_s)
+          metadata = hash_with_value(metadata, "baseline_commit_sha", fix.baseline_commit_sha)
+          metadata = hash_with_value(metadata, "baseline_tag", fix.baseline_tag)
 
-          fix.kind == :version_constraint ? updated.merge(requirement: ">=#{fix.version}") : updated
+          updated = Dependabot::DependencyRequirement.create(requirement.merge(metadata: metadata))
+          next updated unless fix.kind == :version_constraint
+
+          Dependabot::DependencyRequirement.create(updated.merge(requirement: ">=#{fix.version}"))
         end
+      end
+
+      sig do
+        params(
+          details: Dependabot::DependencyRequirement::ObjectHash,
+          key: String,
+          value: Object
+        ).returns(Dependabot::DependencyRequirement::ObjectHash)
+      end
+      def hash_with_value(details, key, value)
+        updated = details.dup
+        actual_key = if details.key?(key.to_sym)
+                       key.to_sym
+                     elsif details.key?(key)
+                       key
+                     elsif details.empty? || details.keys.any?(Symbol)
+                       key.to_sym
+                     else
+                       key
+                     end
+        updated[actual_key] = value
+        updated
       end
 
       sig { returns(T.nilable(SecurityFixResolver::Fix)) }
@@ -134,13 +165,13 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def registry_dependency?
-        dependency.source_details(allowed_types: ["git"]) in { type: "git" }
+        dependency.source_string("type", allowed_types: ["git"]) == "git"
       end
 
       sig { returns(T::Boolean) }
       def port_dependency?
         # A port dependency has no git source but has a requirement constraint
-        !registry_dependency? && dependency.requirements.any? { |req| req[:requirement] }
+        !registry_dependency? && dependency.requirements.any?(&:requirement)
       end
 
       # A port whose version comes solely from the registry baseline.
@@ -149,7 +180,7 @@ module Dependabot
         return false if registry_dependency?
         return false unless dependency.numeric_version
 
-        dependency.requirements.none? { |requirement| requirement[:requirement] }
+        dependency.requirements.none?(&:requirement)
       end
 
       # `latest_version` may be a version vcpkg cannot order against the current one, which is

--- a/vcpkg/lib/dependabot/vcpkg/update_checker/security_fix_resolver.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker/security_fix_resolver.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/vcpkg/lib/dependabot/vcpkg/update_checker/security_fix_resolver.rb
+++ b/vcpkg/lib/dependabot/vcpkg/update_checker/security_fix_resolver.rb
@@ -253,8 +253,8 @@ module Dependabot
         def declared_constraint_version
           return @declared_constraint_version if @declared_constraint_version
 
-          constraint = dependency.requirements.filter_map { |req| req[:requirement] }.first
-          return nil unless constraint.is_a?(String)
+          constraint = dependency.requirements.filter_map(&:requirement_string).first
+          return nil unless constraint
 
           text = constraint.delete_prefix(">=").strip
           return nil unless Dependabot::Vcpkg::Version.correct?(text)

--- a/vcpkg/spec/dependabot/vcpkg/file_updater_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/file_updater_spec.rb
@@ -485,6 +485,19 @@ RSpec.describe Dependabot::Vcpkg::FileUpdater do
         expect(updated_content["default-registry"]["kind"]).to eq("git")
         expect(updated_content["default-registry"]["repository"]).to eq("https://github.com/custom/vcpkg")
       end
+
+      context "with string-keyed source details" do
+        before do
+          dependency.requirements.first[:source] =
+            dependency.requirements.first.source_hash.transform_keys(&:to_s)
+        end
+
+        it "updates the baseline in default-registry" do
+          updated_content = JSON.parse(updated_dependency_files.first.content)
+
+          expect(updated_content.dig("default-registry", "baseline")).to eq("new-commit-sha")
+        end
+      end
     end
 
     context "when updating builtin default-registry baseline" do
@@ -879,6 +892,28 @@ RSpec.describe Dependabot::Vcpkg::FileUpdater do
 
       it "adds no overrides" do
         expect(updated_content).not_to have_key("overrides")
+      end
+
+      context "with string-keyed security metadata" do
+        before do
+          requirement = dependencies.first.requirements.first
+          requirement[:metadata] = requirement.metadata.transform_keys(&:to_s).merge("custom" => "preserved")
+        end
+
+        it "moves the baseline" do
+          expect(updated_content["builtin-baseline"]).to eq(baseline_sha)
+        end
+      end
+
+      context "with malformed remediation metadata" do
+        before do
+          dependencies.first.requirements.first[:metadata][:security_remediation] = "baseline"
+        end
+
+        it "raises a type error" do
+          expect { updated_dependency_files }
+            .to raise_error(TypeError, "metadata security_remediation must be a symbol or nil")
+        end
       end
     end
 

--- a/vcpkg/spec/dependabot/vcpkg/metadata_finder_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/metadata_finder_spec.rb
@@ -67,6 +67,44 @@ RSpec.describe Dependabot::Vcpkg::MetadataFinder do
       it "returns the custom repository URL" do
         expect(finder.source_url).to eq("https://github.com/example/custom-package")
       end
+
+      context "with string-keyed source details" do
+        before do
+          dependency.requirements.first[:source] =
+            dependency.requirements.first.source_hash.transform_keys(&:to_s)
+        end
+
+        it "returns the custom repository URL" do
+          expect(finder.source_url).to eq("https://github.com/example/custom-package")
+        end
+      end
+
+      context "when an earlier requirement has no source" do
+        let(:requirements) do
+          [
+            {
+              requirement: nil,
+              groups: [],
+              source: nil,
+              file: "vcpkg.json"
+            },
+            {
+              requirement: nil,
+              groups: [],
+              source: {
+                type: "git",
+                url: "https://github.com/example/custom-package.git",
+                ref: "main"
+              },
+              file: "vcpkg-configuration.json"
+            }
+          ]
+        end
+
+        it "returns the custom repository URL" do
+          expect(finder.source_url).to eq("https://github.com/example/custom-package")
+        end
+      end
     end
   end
 

--- a/vcpkg/spec/dependabot/vcpkg/update_checker/security_fix_resolver_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker/security_fix_resolver_spec.rb
@@ -114,10 +114,18 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver do
     end
 
     it "resolves the advisory even when a constraint is declared below the new floor" do
-      allow(dependency).to receive(:requirements)
-        .and_return([{ requirement: ">=1.2.11", groups: [], source: nil, file: "vcpkg.json" }])
+      dependency.requirements.first[:requirement] = ">=1.2.11"
 
       expect(fix.kind).to eq(:baseline)
+    end
+
+    context "with a malformed declared constraint" do
+      let(:constraint) { 1 }
+
+      it "raises a type error" do
+        expect { fix }
+          .to raise_error(TypeError, "requirement must be a string, :unfixable, or nil")
+      end
     end
 
     context "when the release floors are all still vulnerable" do

--- a/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker_spec.rb
@@ -284,6 +284,34 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
         )
       end
 
+      context "with string-keyed source details" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: dependency_name,
+            version: dependency_version,
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              source: {
+                "type" => "git",
+                "url" => "https://github.com/microsoft/vcpkg.git",
+                "ref" => dependency_version,
+                "custom" => "preserved"
+              },
+              file: "vcpkg.json"
+            }],
+            package_manager: "vcpkg"
+          )
+        end
+
+        it "preserves the source payload and key style" do
+          source = updated_requirements.first.source_hash
+
+          expect(source).to include("ref" => commit_sha, "custom" => "preserved")
+          expect(source).not_to have_key(:ref)
+        end
+      end
+
       context "when requirement has no source" do
         let(:dependency) do
           Dependabot::Dependency.new(
@@ -605,6 +633,7 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
     let(:baseline_sha) { "fe1cde61e971d53c9687cf9a46308f8f55da19fa" }
     let(:fix) { nil }
     let(:port_constraint) { nil }
+    let(:port_metadata) { nil }
     let(:port_version) { "1.2.11" }
     let(:resolver) { instance_double(Dependabot::Vcpkg::UpdateChecker::SecurityFixResolver) }
 
@@ -623,7 +652,13 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
         name: "zlib",
         version: port_version,
         package_manager: "vcpkg",
-        requirements: [{ requirement: port_constraint, groups: [], source: nil, file: "vcpkg.json" }]
+        requirements: [{
+          requirement: port_constraint,
+          groups: [],
+          source: nil,
+          file: "vcpkg.json",
+          metadata: port_metadata
+        }]
       )
     end
 
@@ -684,6 +719,23 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker do
 
       it "leaves the constraint alone for a baseline remediation" do
         expect(security_checker.updated_requirements.first[:requirement]).to be_nil
+      end
+
+      context "with string-keyed metadata" do
+        let(:port_metadata) { { "custom" => "preserved" } }
+
+        it "preserves the metadata payload and key style" do
+          metadata = security_checker.updated_requirements.first.metadata
+
+          expect(metadata).to include(
+            "custom" => "preserved",
+            "security_remediation" => :baseline,
+            "security_version" => "1.2.13",
+            "baseline_commit_sha" => "c" * 40,
+            "baseline_tag" => "2023.01.09"
+          )
+          expect(metadata).not_to have_key(:security_remediation)
+        end
       end
 
       context "with a version constraint remediation" do


### PR DESCRIPTION
Uses typed requirement readers across vcpkg updates, security remediation, file updates, and metadata. Reduces Object-generic blockers from 10 to 6, lowers `Sorbet/ForbidTUntyped` from 923/159 to 922/158, and promotes three consumers to `typed: strong`.