### PR TITLE
Terraform: skip interpolated module sources instead of crashing the parse

### DIFF
--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -78,8 +78,14 @@ module Dependabot
               source = source_from(details)
               # Cannot update local path modules, skip
               next if source && source[:type] == "path"
+              # `source_from` returns nil for an interpolated source address, e.g.
+              # `?ref=${var.module_version}`, which Terraform >= 1.15 permits via a `const`
+              # input variable. There is no version to read and nothing to update, so skip the
+              # module — as the terragrunt path already does — rather than passing nil to
+              # `T.must` and aborting the parse for every other dependency in the repo.
+              next if source.nil?
 
-              dependency_set << build_terraform_dependency(file, name, T.must(source), details)
+              dependency_set << build_terraform_dependency(file, name, source, details)
             end
           end
 

--- a/terraform/lib/dependabot/terraform/file_parser.rb
+++ b/terraform/lib/dependabot/terraform/file_parser.rb
@@ -76,14 +76,11 @@ module Dependabot
               details = details.first
 
               source = source_from(details)
-              # Cannot update local path modules, skip
-              next if source && source[:type] == "path"
-              # `source_from` returns nil for an interpolated source address, e.g.
-              # `?ref=${var.module_version}`, which Terraform >= 1.15 permits via a `const`
-              # input variable. There is no version to read and nothing to update, so skip the
-              # module — as the terragrunt path already does — rather than passing nil to
-              # `T.must` and aborting the parse for every other dependency in the repo.
-              next if source.nil?
+              # Cannot update local path modules, and `source_from` returns nil for an
+              # interpolated source (Terraform >= 1.15 permits a `const` variable there), which
+              # has no version to read. Skip both, as the terragrunt path above does, rather
+              # than passing the nil to `T.must` and aborting the parse for the whole repo.
+              next if source.nil? || source[:type] == "path"
 
               dependency_set << build_terraform_dependency(file, name, source, details)
             end

--- a/terraform/spec/dependabot/terraform/file_parser_spec.rb
+++ b/terraform/spec/dependabot/terraform/file_parser_spec.rb
@@ -998,6 +998,26 @@ RSpec.describe Dependabot::Terraform::FileParser do
       end
     end
 
+    context "when a module source address is interpolated" do
+      let(:files) { project_dependency_files("interpolated_module_source") }
+
+      it "does not raise" do
+        expect { dependencies }.not_to raise_error
+      end
+
+      it "skips the interpolated module" do
+        expect(dependencies.map(&:name).any? { |name| name.start_with?("interpolated") }).to be(false)
+      end
+
+      it "still parses the provider requirement in the same file" do
+        expect(dependencies.map(&:name)).to include("hashicorp/aws")
+      end
+
+      it "still parses a sibling module whose ref is a literal" do
+        expect(dependencies.map(&:name)).to include("literal::github::example/modules::v1.2.3")
+      end
+    end
+
     context "with a toplevel provider" do
       let(:files) { project_dependency_files("provider") }
 

--- a/terraform/spec/fixtures/projects/interpolated_module_source/main.tf
+++ b/terraform/spec/fixtures/projects/interpolated_module_source/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.15.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.55.0"
+    }
+  }
+}
+
+# Terraform >= 1.15 allows a `const` input variable in a module source address, so the ref
+# here is not a literal and carries no readable version.
+variable "module_version" {
+  type    = string
+  default = "v0.6.0"
+}
+
+module "interpolated" {
+  source = "git::https://github.com/example/modules.git//modules/thing?ref=${var.module_version}"
+}
+
+module "literal" {
+  source = "git::https://github.com/example/modules.git//modules/other?ref=v1.2.3"
+}

--- a/terraform/spec/fixtures/projects/interpolated_module_source/main.tf
+++ b/terraform/spec/fixtures/projects/interpolated_module_source/main.tf
@@ -10,10 +10,12 @@ terraform {
 }
 
 # Terraform >= 1.15 allows a `const` input variable in a module source address, so the ref
-# here is not a literal and carries no readable version.
+# here is not a literal and carries no readable version. `const = true` is what makes the
+# interpolation below legal — an ordinary variable would be rejected by Terraform itself.
 variable "module_version" {
   type    = string
   default = "v0.6.0"
+  const   = true
 }
 
 module "interpolated" {


### PR DESCRIPTION
### The problem

`source_from` returns `nil` for a module whose source address contains an interpolation, but
`parse_terraform_files` passes that `nil` straight into `T.must`:

```ruby
source = source_from(details)
# Cannot update local path modules, skip
next if source && source[:type] == "path"

dependency_set << build_terraform_dependency(file, name, T.must(source), details)
```

The parse aborts with `Passed nil into T.must`, and the update job fails:

```
ERROR <job_…> Passed `nil` into T.must
  /home/dependabot/terraform/lib/dependabot/terraform/file_parser.rb:82
  /home/dependabot/terraform/lib/dependabot/terraform/file_parser.rb:75:in 'Hash#each'
  /home/dependabot/terraform/lib/dependabot/terraform/file_parser.rb:62:in 'Dependabot::Terraform::FileParser#parse_terraform_files'
```

Nothing in the repository is updated as a result — not the other modules, and not the provider
requirements read by the loop directly below, which have no relationship to the module that
tripped it.

### Why this is worth fixing rather than a user error

Terraform 1.15 permits a `const` input variable in a module source address, so this is valid,
current configuration:

```hcl
variable "shared_modules_version" {
  type    = string
  default = "v0.6.0"
}

module "lambda" {
  source = "git::https://github.com/acme/modules.git//modules/fn?ref=${var.shared_modules_version}"
}
```

A repository that adopts it loses the terraform ecosystem entirely and gets no signal: a failed
Dependabot run does not fail CI, does not open a PR, and does not notify. In our case four
repositories sat like that for ten days, drifting several provider releases behind, and it was only
found by reading Actions run lists.

### The change

`next if source.nil?` before the `T.must`, so an interpolated source is skipped and the rest of the
repository is parsed normally. This mirrors what the terragrunt path already does with the same
`nil`:

```ruby
next if source.nil? || source[:type] == "path"
```

Skipping is the right behaviour rather than a stopgap: an interpolated ref carries no literal
version to read or rewrite, so there is nothing to update even in principle.

### Tests

Adds a `interpolated_module_source` fixture with an interpolated module, a literal-ref sibling
module and a provider requirement, and specs asserting the parse does not raise, the interpolated
module is skipped, and the other two are still found.

I was not able to run the suite locally — the fixture and specs follow the existing conventions in
`file_parser_spec.rb`, and I would appreciate CI confirming them.