### PR TITLE
Report NuGet dependency directories

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: ${{ vars.SMOKE_TEST_BRANCH || 'main' }}
+  SMOKE_TEST_BRANCH: ${{ vars.SMOKE_TEST_BRANCH || 'dev/brettfo/nuget-dep-dir' }}
 permissions: {}
 
 jobs:

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.InsecureHttpFeed.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.InsecureHttpFeed.cs
@@ -164,6 +164,7 @@ public class EndToEndTests_InsecureHttpFeed
                         new()
                         {
                             Name = "Package.A",
+                            Directory = "/",
                             Version = "1.1.0",
                             Requirements = [
                                 new()
@@ -218,6 +219,7 @@ public class EndToEndTests_InsecureHttpFeed
                         new()
                         {
                             Name = "Package.B",
+                            Directory = "/",
                             Version = "2.1.0",
                             Requirements = [
                                 new()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/EndToEndTests.cs
@@ -97,6 +97,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Some.Package",
+                            Directory = "/",
                             Version = "2.0.0",
                             Requirements = [
                                 new()
@@ -231,6 +232,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Some.Package",
+                            Directory = "/",
                             Version = "2.0.0",
                             Requirements = [
                                 new()
@@ -378,6 +380,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Some.Package",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new()
@@ -560,6 +563,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Some.Package",
+                            Directory = "/",
                             Version = "2.0.0",
                             Requirements = [
                                 new()
@@ -753,6 +757,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Test.Tool",
+                            Directory = "/",
                             Version = "2.0.0",
                             Requirements = [
                                 new()
@@ -813,6 +818,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "TestSdk",
+                            Directory = "/",
                             Version = "3.10.3",
                             Requirements = [
                                 new()
@@ -1033,6 +1039,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Some.Package",
+                            Directory = "/",
                             Version = "2.0.0",
                             Requirements = [
                                 new()
@@ -1060,6 +1067,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Some.Package",
+                            Directory = "/",
                             Version = "2.0.0",
                             Requirements = [
                                 new()
@@ -1218,6 +1226,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Some.Package",
+                            Directory = "/src/project",
                             Version = "2.0.0",
                             Requirements = [
                                 new()
@@ -1521,6 +1530,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Some.Package",
+                            Directory = "/",
                             Version = "2.0.0",
                             Requirements = [
                                 new()
@@ -1548,6 +1558,7 @@ public class EndToEndTests
                         new()
                         {
                             Name = "Some.Package",
+                            Directory = "/",
                             Version = "2.0.0",
                             Requirements = [
                                 new()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MessageReportTests.cs
@@ -102,12 +102,14 @@ public class MessageReportTests
                     new()
                     {
                         Name = "Dependency1",
+                        Directory = "/",
                         Version = "1.2.3",
                         Requirements = [], // unused
                     },
                     new()
                     {
                         Name = "Dependency2",
+                        Directory = "/",
                         Version = "4.5.6",
                         Requirements = [], // unused
                     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -317,7 +317,14 @@ public class MiscellaneousTests
     [MemberData(nameof(GetMatchingPullRequestTestData))]
     public void GetMatchingPullRequest(Job job, IEnumerable<Dependency> dependencies, bool considerVersions, string? expectedGroupPrName, string[]? expectedPrDependencyNames)
     {
-        var existingPr = job.GetExistingPullRequestForDependencies(dependencies, considerVersions);
+        var reportedDependencies = dependencies.Select(d => new ReportedDependencyWithDirectory()
+        {
+            Name = d.Name,
+            Version = d.Version,
+            Requirements = [],
+            Directory = "/current",
+        });
+        var existingPr = job.GetExistingPullRequestForDependencies(reportedDependencies, considerVersions);
 
         if (expectedPrDependencyNames is null)
         {
@@ -336,6 +343,49 @@ public class MiscellaneousTests
             .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
         AssertEx.Equal(expectedPrDependencyNames, actualPrDependencyNames);
+    }
+
+    [Theory]
+    [InlineData("/current", true)]
+    [InlineData("/other", false)]
+    [InlineData(null, true)]
+    public void GetMatchingPullRequestConsidersDirectory(string? existingPullRequestDirectory, bool expectMatch)
+    {
+        var job = new Job()
+        {
+            Source = new JobSource()
+            {
+                Provider = "github",
+                Repo = "test/repo",
+            },
+            ExistingPullRequests = [
+                new PullRequest()
+                {
+                    Dependencies = [
+                        new PullRequestDependency()
+                        {
+                            DependencyName = "Dependency.A",
+                            DependencyVersion = NuGetVersion.Parse("1.0.0"),
+                            Directory = existingPullRequestDirectory,
+                        },
+                    ],
+                },
+            ],
+        };
+        var dependencies = new[]
+        {
+            new ReportedDependencyWithDirectory()
+            {
+                Name = "Dependency.A",
+                Version = "1.0.0",
+                Requirements = [],
+                Directory = "/current",
+            },
+        };
+
+        var existingPr = job.GetExistingPullRequestForDependencies(dependencies, considerVersions: true);
+
+        Assert.Equal(expectMatch, existingPr is not null);
     }
 
     public static IEnumerable<object?[]> GetMatchingPullRequestTestData()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -665,7 +665,7 @@ public class SerializationTests : TestBase
             : null;
         var create = new CreatePullRequest()
         {
-            Dependencies = [new() { Name = "dep", Version = "ver2", PreviousVersion = "ver1", Requirements = [new() { Requirement = "ver2", File = "project.csproj" }], PreviousRequirements = [new() { Requirement = "ver1", File = "project.csproj" }] }],
+            Dependencies = [new() { Name = "dep", Directory = "/", Version = "ver2", PreviousVersion = "ver1", Requirements = [new() { Requirement = "ver2", File = "project.csproj" }], PreviousRequirements = [new() { Requirement = "ver1", File = "project.csproj" }] }],
             UpdatedDependencyFiles = [new() { Name = "project.csproj", Directory = "/", Content = "updated content" }],
             BaseCommitSha = "TEST-COMMIT-SHA",
             CommitMessage = "commit message",
@@ -679,7 +679,7 @@ public class SerializationTests : TestBase
             ? """{"name":"test-group"}"""
             : "null";
         var expected = $$$"""
-            {"data":{"dependencies":[{"name":"dep","version":"ver2","requirements":[{"requirement":"ver2","file":"project.csproj","groups":[],"source":null}],"previous-version":"ver1","previous-requirements":[{"requirement":"ver1","file":"project.csproj","groups":[],"source":null}]}],"updated-dependency-files":[{"name":"project.csproj","content":"updated content","directory":"/","type":"file","support_file":false,"content_encoding":"utf-8","deleted":false,"operation":"update","mode":null}],"base-commit-sha":"TEST-COMMIT-SHA","commit-message":"commit message","pr-title":"pr title","pr-body":"pr body","dependency-group":{{{expectedDependencyGroupValue}}}}}
+            {"data":{"dependencies":[{"directory":"/","name":"dep","version":"ver2","requirements":[{"requirement":"ver2","file":"project.csproj","groups":[],"source":null}],"previous-version":"ver1","previous-requirements":[{"requirement":"ver1","file":"project.csproj","groups":[],"source":null}]}],"updated-dependency-files":[{"name":"project.csproj","content":"updated content","directory":"/","type":"file","support_file":false,"content_encoding":"utf-8","deleted":false,"operation":"update","mode":null}],"base-commit-sha":"TEST-COMMIT-SHA","commit-message":"commit message","pr-title":"pr title","pr-body":"pr body","dependency-group":{{{expectedDependencyGroupValue}}}}}
             """;
         Assert.Equal(expected, actual);
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandlerTests.cs
@@ -117,6 +117,7 @@ public class CreateSecurityUpdatePullRequestHandlerTests : UpdateHandlersTestsBa
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -264,6 +265,7 @@ public class CreateSecurityUpdatePullRequestHandlerTests : UpdateHandlersTestsBa
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project1.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -968,6 +970,7 @@ public class CreateSecurityUpdatePullRequestHandlerTests : UpdateHandlersTestsBa
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src/client",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/client/client.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
@@ -164,6 +164,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Production.Dependency.1",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -195,6 +196,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Production.Dependency.2",
+                            Directory = "/src",
                             Version = "4.0.0",
                             Requirements = [
                                 new() { Requirement = "4.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -240,6 +242,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Test.Dependency",
+                            Directory = "/test",
                             Version = "6.0.0",
                             Requirements = [
                                 new() { Requirement = "6.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -444,6 +447,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -456,6 +460,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Other.Dependency",
+                            Directory = "/src",
                             Version = "4.0.0",
                             Requirements = [
                                 new() { Requirement = "4.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -468,6 +473,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/test",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -480,6 +486,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Other.Dependency",
+                            Directory = "/test",
                             Version = "4.0.0",
                             Requirements = [
                                 new() { Requirement = "4.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -548,6 +555,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Ungrouped.Dependency",
+                            Directory = "/src",
                             Version = "6.0.0",
                             Requirements = [
                                 new() { Requirement = "6.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -609,6 +617,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Ungrouped.Dependency",
+                            Directory = "/test",
                             Version = "6.0.0",
                             Requirements = [
                                 new() { Requirement = "6.0.0", File = "/test/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -762,6 +771,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -948,6 +958,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Package.For.Group.One",
+                            Directory = "/src",
                             Version = "1.0.1",
                             Requirements = [
                                 new() { Requirement = "1.0.1", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -1122,6 +1133,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "1.1.0",
                             Requirements = [
                                 new() { Requirement = "1.1.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -1467,6 +1479,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "1.0.0.3",
                             Requirements = [
                                 new() { Requirement = "1.0.0.3", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -1628,6 +1641,7 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandlerTests.cs
@@ -688,6 +688,7 @@ public class RefreshGroupUpdatePullRequestHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.1",
                             Requirements = [
                                 new() { Requirement = "2.0.1", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -700,6 +701,7 @@ public class RefreshGroupUpdatePullRequestHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Other.Dependency",
+                            Directory = "/src",
                             Version = "4.0.1",
                             Requirements = [
                                 new() { Requirement = "4.0.1", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -834,6 +836,7 @@ public class RefreshGroupUpdatePullRequestHandlerTests : UpdateHandlersTestsBase
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandlerTests.cs
@@ -1058,6 +1058,7 @@ public class RefreshSecurityUpdatePullRequestHandlerTests : UpdateHandlersTestsB
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.1",
                             Requirements = [
                                 new() { Requirement = "2.0.1", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -1183,6 +1184,7 @@ public class RefreshSecurityUpdatePullRequestHandlerTests : UpdateHandlersTestsB
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandlerTests.cs
@@ -742,6 +742,7 @@ public class RefreshVersionUpdatePullRequestHandlerTests : UpdateHandlersTestsBa
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.1",
                             Requirements = [
                                 new() { Requirement = "2.0.1", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },
@@ -865,6 +866,7 @@ public class RefreshVersionUpdatePullRequestHandlerTests : UpdateHandlersTestsBa
                         new()
                         {
                             Name = "Some.Dependency",
+                            Directory = "/src",
                             Version = "2.0.0",
                             Requirements = [
                                 new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"], Source = new() { SourceUrl = null } },

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreatePullRequest.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/CreatePullRequest.cs
@@ -8,7 +8,7 @@ namespace NuGetUpdater.Core.Run.ApiModel;
 
 public sealed record CreatePullRequest : MessageBase
 {
-    public required ReportedDependency[] Dependencies { get; init; }
+    public required ReportedDependencyWithDirectory[] Dependencies { get; init; }
 
     [JsonPropertyName("updated-dependency-files")]
     public required DependencyFile[] UpdatedDependencyFiles { get; init; }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -102,25 +102,34 @@ public sealed record Job
         return existingPullRequests;
     }
 
-    public Tuple<string?, ImmutableArray<PullRequestDependency>>? GetExistingPullRequestForDependencies(IEnumerable<Dependency> dependencies, bool considerVersions)
+    public Tuple<string?, ImmutableArray<PullRequestDependency>>? GetExistingPullRequestForDependencies(IEnumerable<ReportedDependencyWithDirectory> dependencies, bool considerVersions)
     {
-        if (dependencies.Any(d => d.Version is null))
+        var desiredDependencies = dependencies.ToArray();
+        if (desiredDependencies.Any(d => d.Version is null))
         {
             return null;
         }
 
-        string CreateIdentifier(string dependencyName, string dependencyVersion)
+        bool NamesAndVersionsMatch(ReportedDependencyWithDirectory desiredDependency, PullRequestDependency existingDependency)
         {
-            return $"{dependencyName}/{(considerVersions ? dependencyVersion : null)}";
+            return desiredDependency.Name.Equals(existingDependency.DependencyName, StringComparison.OrdinalIgnoreCase) &&
+                (!considerVersions ||
+                    desiredDependency.Version!.Equals(existingDependency.DependencyVersion.ToString(), StringComparison.OrdinalIgnoreCase));
         }
 
-        var desiredDependencySet = dependencies.Select(d => CreateIdentifier(d.Name, d.Version!)).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        bool DependenciesMatch(ReportedDependencyWithDirectory desiredDependency, PullRequestDependency existingDependency)
+        {
+            return NamesAndVersionsMatch(desiredDependency, existingDependency) &&
+                (existingDependency.Directory is null ||
+                    desiredDependency.Directory.Equals(existingDependency.Directory, StringComparison.Ordinal));
+        }
+
         var existingPullRequests = GetAllExistingPullRequests();
         var existingPullRequest = existingPullRequests
             .FirstOrDefault(pr =>
             {
-                var prDependencySet = pr.Item2.Select(d => CreateIdentifier(d.DependencyName, d.DependencyVersion.ToString())).ToHashSet(StringComparer.OrdinalIgnoreCase);
-                return prDependencySet.SetEquals(desiredDependencySet);
+                return desiredDependencies.All(desired => pr.Item2.Any(existing => DependenciesMatch(desired, existing))) &&
+                    pr.Item2.All(existing => desiredDependencies.Any(desired => DependenciesMatch(desired, existing)));
             });
         return existingPullRequest;
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ReportedDependency.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ReportedDependency.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace NuGetUpdater.Core.Run.ApiModel;
 
-public sealed record ReportedDependency
+public record ReportedDependency
 {
     public required string Name { get; init; }
     public required string? Version { get; init; }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ReportedDependencyWithDirectory.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/ReportedDependencyWithDirectory.cs
@@ -1,0 +1,19 @@
+namespace NuGetUpdater.Core.Run.ApiModel;
+
+public sealed record ReportedDependencyWithDirectory : ReportedDependency
+{
+    public required string Directory { get; init; }
+
+    public static ReportedDependencyWithDirectory From(ReportedDependency dependency, string directory)
+    {
+        return new ReportedDependencyWithDirectory()
+        {
+            Name = dependency.Name,
+            Version = dependency.Version,
+            Requirements = dependency.Requirements,
+            PreviousVersion = dependency.PreviousVersion,
+            PreviousRequirements = dependency.PreviousRequirements,
+            Directory = directory,
+        };
+    }
+}

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/CreateSecurityUpdatePullRequestHandler.cs
@@ -150,7 +150,8 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
             var rawDependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)).ToArray();
             if (rawDependencies.Length > 0)
             {
-                var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
+                var reportedDependencies = updatedDependencies.Select(d => ReportedDependencyWithDirectory.From(d, directory));
+                var existingPullRequest = job.GetExistingPullRequestForDependencies(reportedDependencies, considerVersions: true);
                 if (existingPullRequest is not null)
                 {
                     await apiHandler.RecordUpdateJobError(new PullRequestExistsForSecurityUpdate(rawDependencies), logger);
@@ -165,7 +166,7 @@ internal class CreateSecurityUpdatePullRequestHandler : IUpdateHandler
                 var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
                 await apiHandler.CreatePullRequest(new CreatePullRequest()
                 {
-                    Dependencies = [.. updatedDependencies],
+                    Dependencies = [.. updatedDependencies.Select(d => ReportedDependencyWithDirectory.From(d, directory))],
                     UpdatedDependencyFiles = [.. updatedDependencyFiles],
                     BaseCommitSha = baseCommitSha,
                     CommitMessage = commitMessage,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -64,6 +64,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
             var groupMatcher = group.GetGroupMatcher();
             var updateOperationsPerformed = new List<UpdateOperationBase>();
             var updatedDependencies = new List<ReportedDependency>();
+            var updatedDependenciesWithDirectories = new List<ReportedDependencyWithDirectory>();
             var allUpdatedDependencyFiles = ImmutableArray.Create<DependencyFile>();
             foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
             {
@@ -142,6 +143,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                         .ToArray();
 
                     updatedDependencies.AddRange(updatedDependenciesForThis);
+                    updatedDependenciesWithDirectories.AddRange(updatedDependenciesForThis.Select(d => ReportedDependencyWithDirectory.From(d, directory)));
                     updateOperationsPerformed.AddRange(patchedUpdateOperations);
                     foreach (var o in patchedUpdateOperations)
                     {
@@ -156,7 +158,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
             if (updateOperationsPerformed.Count > 0)
             {
                 var existingPullRequest = job.GetExistingPullRequestForDependencies(
-                        dependencies: updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)),
+                        dependencies: updatedDependenciesWithDirectories,
                         considerVersions: true);
                 if (existingPullRequest is not null)
                 {
@@ -169,7 +171,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
                     await apiHandler.CreatePullRequest(new CreatePullRequest()
                     {
-                        Dependencies = [.. updatedDependencies],
+                        Dependencies = [.. updatedDependenciesWithDirectories],
                         UpdatedDependencyFiles = [.. allUpdatedDependencyFiles],
                         BaseCommitSha = baseCommitSha,
                         CommitMessage = commitMessage,
@@ -272,7 +274,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                 if (updateOperationsPerformed.Count > 0)
                 {
                     var existingPullRequest = job.GetExistingPullRequestForDependencies(
-                        dependencies: updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)),
+                        dependencies: updatedDependencies.Select(d => ReportedDependencyWithDirectory.From(d, directory)),
                         considerVersions: true);
                     if (existingPullRequest is not null)
                     {
@@ -285,7 +287,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                         var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
                         await apiHandler.CreatePullRequest(new CreatePullRequest()
                         {
-                            Dependencies = [.. updatedDependencies],
+                            Dependencies = [.. updatedDependencies.Select(d => ReportedDependencyWithDirectory.From(d, directory))],
                             UpdatedDependencyFiles = [.. updatedDependencyFiles],
                             BaseCommitSha = baseCommitSha,
                             CommitMessage = commitMessage,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -67,6 +67,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
         var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
         var updateOperationsPerformed = new List<UpdateOperationBase>();
         var updatedDependencies = new List<ReportedDependency>();
+        var updatedDependenciesWithDirectories = new List<ReportedDependencyWithDirectory>();
         var allUpdatedDependencyFiles = ImmutableArray.Create<DependencyFile>();
         var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
@@ -138,6 +139,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
                         .ToArray();
 
                     updatedDependencies.AddRange(updatedDependenciesForThis);
+                    updatedDependenciesWithDirectories.AddRange(updatedDependenciesForThis.Select(d => ReportedDependencyWithDirectory.From(d, directory)));
                     updateOperationsPerformed.AddRange(patchedUpdateOperations);
                     foreach (var o in patchedUpdateOperations)
                     {
@@ -162,7 +164,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
         var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
         var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
         var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
-        var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
+        var existingPullRequest = job.GetExistingPullRequestForDependencies(updatedDependenciesWithDirectories, considerVersions: true);
         if (existingPullRequest is not null)
         {
             await apiHandler.UpdatePullRequest(new UpdatePullRequest()
@@ -178,7 +180,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
         }
         else
         {
-            var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
+            var existingPrButDifferent = job.GetExistingPullRequestForDependencies(updatedDependenciesWithDirectories, considerVersions: false);
             if (existingPrButDifferent is not null)
             {
                 await apiHandler.ClosePullRequest(ClosePullRequest.WithDependenciesChanged(job));
@@ -186,7 +188,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
 
             await apiHandler.CreatePullRequest(new CreatePullRequest()
             {
-                Dependencies = [.. updatedDependencies],
+                Dependencies = [.. updatedDependenciesWithDirectories],
                 UpdatedDependencyFiles = [.. allUpdatedDependencyFiles],
                 BaseCommitSha = baseCommitSha,
                 CommitMessage = commitMessage,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshSecurityUpdatePullRequestHandler.cs
@@ -164,7 +164,8 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
                 var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
 
-                var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
+                var reportedDependencies = updatedDependencies.Select(d => ReportedDependencyWithDirectory.From(d, directory)).ToArray();
+                var existingPullRequest = job.GetExistingPullRequestForDependencies(reportedDependencies, considerVersions: true);
                 if (existingPullRequest is not null)
                 {
                     await apiHandler.UpdatePullRequest(new UpdatePullRequest()
@@ -181,7 +182,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
                 }
                 else
                 {
-                    var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
+                    var existingPrButDifferent = job.GetExistingPullRequestForDependencies(reportedDependencies, considerVersions: false);
                     if (existingPrButDifferent is not null)
                     {
                         await apiHandler.ClosePullRequest(ClosePullRequest.WithDependenciesChanged(job));
@@ -189,7 +190,7 @@ internal class RefreshSecurityUpdatePullRequestHandler : IUpdateHandler
 
                     await apiHandler.CreatePullRequest(new CreatePullRequest()
                     {
-                        Dependencies = [.. updatedDependencies],
+                        Dependencies = [.. updatedDependencies.Select(d => ReportedDependencyWithDirectory.From(d, directory))],
                         UpdatedDependencyFiles = [.. updatedDependencyFiles],
                         BaseCommitSha = baseCommitSha,
                         CommitMessage = commitMessage,

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshVersionUpdatePullRequestHandler.cs
@@ -154,7 +154,8 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                 var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
                 var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
 
-                var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
+                var reportedDependencies = updatedDependencies.Select(d => ReportedDependencyWithDirectory.From(d, directory)).ToArray();
+                var existingPullRequest = job.GetExistingPullRequestForDependencies(reportedDependencies, considerVersions: true);
                 if (existingPullRequest is not null)
                 {
                     await apiHandler.UpdatePullRequest(new UpdatePullRequest()
@@ -171,7 +172,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
                 }
                 else
                 {
-                    var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
+                    var existingPrButDifferent = job.GetExistingPullRequestForDependencies(reportedDependencies, considerVersions: false);
                     if (existingPrButDifferent is not null)
                     {
                         await apiHandler.ClosePullRequest(ClosePullRequest.WithDependenciesChanged(job));
@@ -179,7 +180,7 @@ internal class RefreshVersionUpdatePullRequestHandler : IUpdateHandler
 
                     await apiHandler.CreatePullRequest(new CreatePullRequest()
                     {
-                        Dependencies = [.. updatedDependencies],
+                        Dependencies = [.. updatedDependencies.Select(d => ReportedDependencyWithDirectory.From(d, directory))],
                         UpdatedDependencyFiles = [.. updatedDependencyFiles],
                         BaseCommitSha = baseCommitSha,
                         CommitMessage = commitMessage,


### PR DESCRIPTION
## This PR has a companion PR to update the smoke tests: https://github.com/dependabot/smoke-tests/pull/561

----

Currently the NuGet updater doesn't submit a value for `directory` for PR dependencies.  The result is that when subsequent jobs run the `existing-pull-request` entries also don't specify a directory.  This means that if a job ran in the directory `/client` and updated a package then a few hours later a different job ran in `/server` and happened to update the same package/version, then the first PR would get closed and a second created.  This is incorrect because the two PRs are different and one does not supercede the other.

The fix is to populate the `directory` value for PR dependencies and also to check the directory value when finding an existing PR to potentially close.

One caveat: for the next few days/week, it's possible that a PR was created with the old updater and no `directory` value but a subsequent job could run with these changes.  To prevent orphaned PRs from being left around, the old PR matching logic is still used, but only if the existing PR doesn't list a directory.  If it _does_ list a directory, then it must match to be considered the same PR.  This means that once this is deployed, there could be one more round if the incorrect PR getting detected as the same and incorrectly closed, but the issue is self-healing because all future PRs will have directory information so the correct matching logic will be used on the next run.