### PR TITLE
Type common runtime boundaries

### DIFF
--- a/.github/workflows/check-sorbet-typing-mode.yml
+++ b/.github/workflows/check-sorbet-typing-mode.yml
@@ -76,6 +76,9 @@ jobs:
 
       - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
 
+      - name: Test the T.unsafe ratchet
+        run: ruby script/test-sorbet-unsafe-ratchet
+
       - name: Ensure the Sorbet/ForbidTUntyped burndown only shrinks
         env:
           BASE_REF: origin/${{ github.base_ref }}

--- a/.github/workflows/check-sorbet-typing-mode.yml
+++ b/.github/workflows/check-sorbet-typing-mode.yml
@@ -80,3 +80,8 @@ jobs:
         env:
           BASE_REF: origin/${{ github.base_ref }}
         run: ruby script/sorbet-untyped-ratchet
+
+      - name: Ensure the T.unsafe burndown only shrinks
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: ruby script/sorbet-unsafe-ratchet

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 922
+# Offense count: 915
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -288,7 +288,6 @@ Sorbet/ForbidTUntyped:
     - "common/lib/dependabot/pull_request_updater/azure.rb"
     - "common/lib/dependabot/pull_request_updater/github.rb"
     - "common/lib/dependabot/pull_request_updater/gitlab.rb"
-    - "common/lib/dependabot/shared_helpers.rb"
     - "composer/lib/dependabot/composer/file_fetcher.rb"
     - "composer/lib/dependabot/composer/file_fetcher/path_dependency_builder.rb"
     - "composer/lib/dependabot/composer/file_parser.rb"

--- a/bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
+++ b/bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
@@ -200,15 +200,18 @@ module Dependabot
         def log_helper_subprocess_failure(dependency, error)
           # See `Dependabot::SharedHelpers.run_helper_subprocess` for details on error context
           context = error.error_context
+          function = T.cast(context[:function], T.nilable(String))
+          time_taken = T.cast(context[:time_taken], T.nilable(Float))
+          trace = T.cast(context[:trace], T.nilable(String))
 
           builder = ::StringIO.new
           builder << "VulnerabilityAuditor: "
-          builder << "#{context[:function]} " if context[:function]
+          builder << "#{function} " if function
           builder << "failed"
-          builder << " after #{context[:time_taken].truncate(2)}s" if context[:time_taken]
+          builder << " after #{time_taken.truncate(2)}s" if time_taken
           builder << " while auditing #{dependency.name}: "
           builder << error.message
-          builder << "\n" << context[:trace]
+          builder << "\n" << trace
 
           msg = builder.string
           Dependabot.logger.info(msg) # TODO: is this the right log level?

--- a/bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
+++ b/bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
@@ -202,7 +202,7 @@ module Dependabot
           context = error.error_context
           function = T.cast(context[:function], T.nilable(String))
           time_taken = T.cast(context[:time_taken], T.nilable(Float))
-          trace = T.cast(context[:trace], T.nilable(String))
+          trace = error.trace&.join("\n")
 
           builder = ::StringIO.new
           builder << "VulnerabilityAuditor: "
@@ -211,7 +211,7 @@ module Dependabot
           builder << " after #{time_taken.truncate(2)}s" if time_taken
           builder << " while auditing #{dependency.name}: "
           builder << error.message
-          builder << "\n" << trace
+          builder << "\n#{trace}" if trace
 
           msg = builder.string
           Dependabot.logger.info(msg) # TODO: is this the right log level?

--- a/bun/spec/dependabot/bun/update_checker/vulnerability_auditor_spec.rb
+++ b/bun/spec/dependabot/bun/update_checker/vulnerability_auditor_spec.rb
@@ -1,0 +1,52 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/bun/update_checker/vulnerability_auditor"
+require "dependabot/dependency"
+
+RSpec.describe Dependabot::Bun::UpdateChecker::VulnerabilityAuditor do
+  subject(:vulnerability_auditor) do
+    described_class.new(dependency_files: dependency_files, credentials: [])
+  end
+
+  let(:dependency_files) { project_dependency_files("javascript/no_lockfile") }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "etag",
+      version: "1.0.0",
+      requirements: [{
+        file: "package.json",
+        requirement: "^1.0.0",
+        groups: ["dependencies"],
+        source: nil
+      }],
+      package_manager: "bun"
+    )
+  end
+  let(:helper_error) do
+    Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+      message: "audit failed",
+      error_context: {
+        function: "npm:vulnerabilityAuditor",
+        time_taken: 1.25
+      },
+      trace: ["helper.rb:1", "helper.rb:2"]
+    )
+  end
+
+  before do
+    allow(Dependabot.logger).to receive(:info)
+    allow(Dependabot::SharedHelpers)
+      .to receive(:run_helper_subprocess).and_raise(helper_error)
+  end
+
+  it "logs helper traces and returns an unavailable fix" do
+    result = vulnerability_auditor.audit(dependency: dependency, security_advisories: [])
+
+    expect(Dependabot.logger)
+      .to have_received(:info)
+      .with(a_string_including("helper.rb:1\nhelper.rb:2"))
+    expect(result).to include("fix_available" => false)
+  end
+end

--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -1,7 +1,6 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
-require "open3"
 require "timeout"
 require "sorbet-runtime"
 require "shellwords"
@@ -23,11 +22,15 @@ module Dependabot
       T.nilable(T.proc.params(data: String).returns(T::Hash[Symbol, T.anything]))
     end
 
+    Environment = T.type_alias { T::Hash[String, String] }
+    SpawnOptions = T.type_alias { T::Hash[Symbol, T.anything] }
+
     EnvCmdItem = T.type_alias do
       T.any(
         String,
         T::Array[String],
-        T::Hash[T.any(String, Symbol), T.anything]
+        Environment,
+        SpawnOptions
       )
     end
 
@@ -101,25 +104,31 @@ module Dependabot
       start_time = Time.now
 
       begin
-        T.unsafe(Open3).popen3(*env_cmd) do |stdin, stdout_io, stderr_io, wait_thr| # rubocop:disable Metrics/BlockLength
+        stdout_io, stderr_io, wait_thr = open_process(env_cmd)
+        begin
           pid = wait_thr.pid
           command_string = command_string_for_logging(env_cmd)
           log_level = short_git_config_command?(command_string) ? :debug : :info
-          sanitized_env_cmd = if env_cmd.first.is_a?(Hash)
-                                [SharedHelpers.send(:sanitize_env_for_logging, env_cmd.first), *env_cmd[1..]]
-                              else
-                                env_cmd
-                              end
+          first_item = env_cmd.first
+          sanitized_env_cmd = T.let(
+            if first_item.is_a?(Hash)
+              environment = extract_environment(env_cmd.dup)
+              [T.must(SharedHelpers.sanitize_env_for_logging(environment)), *env_cmd.drop(1)]
+            else
+              env_cmd
+            end,
+            T::Array[EnvCmdItem]
+          )
           command_for_log = sanitized_env_cmd.map { |item| item.is_a?(Array) ? item.first : item }.join(" ")
           Dependabot.logger.public_send(log_level, "Started process PID: #{pid} with command: #{command_for_log}")
 
           # Write to stdin if input data is provided
           begin
-            stdin&.write(stdin_data) if stdin_data
+            stdout_io.write(stdin_data) if stdin_data
           rescue Errno::EPIPE
             # Process exited before reading stdin - continue to collect output
           end
-          stdin&.close
+          stdout_io.close_write
 
           stdout_io.sync = true
           stderr_io.sync = true
@@ -191,6 +200,10 @@ module Dependabot
 
           status = ProcessStatus.new(wait_thr.value)
           Dependabot.logger.public_send(log_level, "Process PID: #{pid} completed with status: #{status}")
+        ensure
+          stdout_io.close unless stdout_io.closed?
+          stderr_io.close unless stderr_io.closed?
+          wait_thr.join
         end
       rescue Timeout::Error => e
         Dependabot.logger.error("Process PID: #{pid} failed due to timeout: #{e.message}")
@@ -214,6 +227,61 @@ module Dependabot
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/CyclomaticComplexity
+
+    sig { params(env_cmd: T::Array[EnvCmdItem]).returns([IO, IO, Process::Waiter]) }
+    def self.open_process(env_cmd)
+      process_io = T.let(nil, T.nilable(IO))
+      stderr_io = T.let(nil, T.nilable(IO))
+      stderr_writer = T.let(nil, T.nilable(IO))
+      arguments = env_cmd.dup
+      environment = extract_environment(arguments)
+      options = extract_options(arguments)
+      command = command_for_popen(arguments)
+
+      stderr_io, stderr_writer = IO.pipe
+      options[:err] = stderr_writer
+      process_io = T.cast(IO.popen(environment, command, "r+", options), IO)
+      stderr_writer.close
+
+      wait_thread = T.cast(Process.detach(process_io.pid), Process::Waiter)
+      [process_io, stderr_io, wait_thread]
+    rescue StandardError
+      process_io.close if process_io && !process_io.closed?
+      stderr_io.close if stderr_io && !stderr_io.closed?
+      stderr_writer.close if stderr_writer && !stderr_writer.closed?
+      raise
+    end
+    private_class_method :open_process
+
+    sig { params(arguments: T::Array[EnvCmdItem]).returns(Environment) }
+    def self.extract_environment(arguments)
+      return {} unless arguments.first.is_a?(Hash)
+
+      T.cast(arguments.shift, Environment)
+    end
+    private_class_method :extract_environment
+
+    sig { params(arguments: T::Array[EnvCmdItem]).returns(SpawnOptions) }
+    def self.extract_options(arguments)
+      return {} unless arguments.last.is_a?(Hash)
+
+      T.cast(arguments.pop, SpawnOptions).dup
+    end
+    private_class_method :extract_options
+
+    sig do
+      params(arguments: T::Array[EnvCmdItem])
+        .returns(T.any(String, T::Array[T.any(String, T::Array[String])]))
+    end
+    def self.command_for_popen(arguments)
+      raise ArgumentError, "command must not be empty" if arguments.empty?
+
+      first_argument = arguments.first
+      return first_argument if arguments.one? && first_argument.is_a?(String)
+
+      T.cast(arguments, T::Array[T.any(String, T::Array[String])])
+    end
+    private_class_method :command_for_popen
 
     # Terminate a process by PID
     sig { params(pid: T.nilable(Integer)).void }

--- a/common/lib/dependabot/credential.rb
+++ b/common/lib/dependabot/credential.rb
@@ -9,9 +9,11 @@ module Dependabot
     extend T::Sig
     extend Forwardable
 
+    Value = T.type_alias { T.nilable(String) }
+
     def_delegators :@credential, :fetch, :keys, :[]=, :delete, :slice, :values, :entries
 
-    sig { params(credential: T::Hash[String, T.any(T::Boolean, String, T::Array[String])]).void }
+    sig { params(credential: T::Hash[String, T.nilable(T.any(T::Boolean, String, T::Array[String]))]).void }
     def initialize(credential)
       @replaces_base = T.let(credential["replaces-base"] == true, T::Boolean)
       credential.delete("replaces-base")
@@ -25,7 +27,14 @@ module Dependabot
         T.nilable(T::Array[String])
       )
 
-      @credential = T.let(T.unsafe(credential), T::Hash[String, String])
+      @credential = T.let(
+        credential.to_h do |key, value|
+          raise TypeError, "credential #{key} must be a string or nil" unless value.nil? || value.is_a?(String)
+
+          [key, value]
+        end,
+        T::Hash[String, Value]
+      )
     end
 
     sig { returns(T::Boolean) }
@@ -46,7 +55,7 @@ module Dependabot
       Credential.new(@credential.merge(other.to_h))
     end
 
-    sig { returns(T::Hash[String, String]) }
+    sig { returns(T::Hash[String, Value]) }
     def to_h
       @credential
     end

--- a/common/lib/dependabot/file_updaters/vendor_updater.rb
+++ b/common/lib/dependabot/file_updaters/vendor_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -27,7 +27,13 @@ module Dependabot
         super(repo_contents_path: @repo_contents_path, target_directory: @vendor_dir)
       end
 
-      T.unsafe(self).alias_method :updated_vendor_cache_files, :updated_files
+      sig do
+        params(base_directory: String, only_paths: T.nilable(T::Array[String]))
+          .returns(T::Array[Dependabot::DependencyFile])
+      end
+      def updated_vendor_cache_files(base_directory:, only_paths: nil)
+        updated_files(base_directory: base_directory, only_paths: only_paths)
+      end
 
       private
 

--- a/common/lib/dependabot/shared_helpers.rb
+++ b/common/lib/dependabot/shared_helpers.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "digest"
@@ -25,6 +25,9 @@ module Dependabot
 
     Command = T.type_alias { T.any(String, T::Array[String]) }
     CommandArguments = T.type_alias { T::Array[T.any(String, T::Array[String])] }
+    ErrorContext = T.type_alias { T::Hash[Symbol, Object] }
+    ExconOptions = T.type_alias { T::Hash[Symbol, Object] }
+    HelperResponse = T.type_alias { T::Hash[String, Object] }
     USER_AGENT = T.let(
       "dependabot-core/#{Dependabot::VERSION} " \
       "#{Excon::USER_AGENT} ruby/#{RUBY_VERSION} " \
@@ -93,7 +96,7 @@ module Dependabot
       sig { returns(String) }
       attr_reader :error_class
 
-      sig { returns(T::Hash[Symbol, T.untyped]) }
+      sig { returns(ErrorContext) }
       attr_reader :error_context
 
       sig { returns(T.nilable(T::Array[String])) }
@@ -102,7 +105,7 @@ module Dependabot
       sig do
         params(
           message: String,
-          error_context: T::Hash[Symbol, String],
+          error_context: ErrorContext,
           error_class: T.nilable(String),
           trace: T.nilable(T::Array[String])
         ).void
@@ -111,11 +114,12 @@ module Dependabot
         super(message)
         @error_class = T.let(error_class || "HelperSubprocessFailed", String)
         @error_context = error_context
-        @fingerprint = T.let(error_context[:fingerprint] || error_context[:command], T.nilable(String))
+        fingerprint = error_context[:fingerprint] || error_context[:command]
+        @fingerprint = T.let(fingerprint.is_a?(String) ? fingerprint : nil, T.nilable(String))
         @trace = trace
       end
 
-      sig { override.returns(T::Hash[Symbol, T.untyped]) }
+      sig { override.returns(ErrorContext) }
       def sentry_context
         { fingerprint: [@fingerprint], extra: @error_context.except(:stderr_output, :fingerprint) }
       end
@@ -153,14 +157,14 @@ module Dependabot
       params(
         command: String,
         function: String,
-        args: T.untyped,
+        args: Object,
         env: T.nilable(T::Hash[String, String]),
         stderr_to_stdout: T::Boolean,
         allow_unsafe_shell_command: T::Boolean,
         error_class: T.class_of(HelperSubprocessFailed),
         timeout: Integer
       )
-        .returns(T.untyped)
+        .returns(Object)
     end
     def self.run_helper_subprocess(
       command:,
@@ -173,7 +177,7 @@ module Dependabot
       timeout: CommandHelpers::TIMEOUTS::DEFAULT
     )
       start = Time.now
-      stdin_data = JSON.dump(function: function, args: args)
+      stdin_data = T.cast(JSON.dump(function: function, args: args), String)
       cmd = allow_unsafe_shell_command ? command : escape_command(command)
 
       # NOTE: For debugging native helpers in specs and dry-run: outputs the
@@ -182,7 +186,8 @@ module Dependabot
       if ENV["DEBUG_FUNCTION"] == function
         puts helper_subprocess_bash_command(stdin_data: stdin_data, command: cmd, env: env)
         # Pause execution so we can run helpers inside the temporary directory
-        T.unsafe(self).debugger
+        require "debug"
+        binding.break # rubocop:disable Lint/Debugger
       end
 
       env_cmd = [env, cmd].compact
@@ -221,25 +226,58 @@ module Dependabot
       check_out_of_memory_error(stderr, error_context, error_class)
 
       begin
-        response = JSON.parse(stdout)
+        response = parse_helper_response(stdout)
         return response["result"] if process&.success?
 
+        message, helper_error_class, trace = parse_helper_error(response)
+
         raise error_class.new(
-          message: response["error"],
-          error_class: response["error_class"],
+          message: message,
+          error_class: helper_error_class,
           error_context: error_context,
-          trace: response["trace"]
+          trace: trace
         )
       rescue JSON::ParserError
         raise handle_json_parse_error(stdout, stderr, error_context, error_class)
+      rescue TypeError => e
+        raise error_class.new(
+          message: e.message,
+          error_class: e.class.name,
+          error_context: error_context
+        )
       end
     end
+
+    sig { params(stdout: String).returns(HelperResponse) }
+    def self.parse_helper_response(stdout)
+      T.cast(JSON.parse(stdout), HelperResponse)
+    end
+    private_class_method :parse_helper_response
+
+    sig { params(response: HelperResponse).returns([String, T.nilable(String), T.nilable(T::Array[String])]) }
+    def self.parse_helper_error(response)
+      message = response["error"]
+      raise TypeError, "helper error must be a string" unless message.is_a?(String)
+
+      helper_error_class = response["error_class"]
+      unless helper_error_class.nil? || helper_error_class.is_a?(String)
+        raise TypeError, "helper error class must be a string or nil"
+      end
+
+      trace = response["trace"]
+      unless trace.nil? || (trace.is_a?(Array) && trace.all?(String))
+        raise TypeError, "helper trace must be an array of strings or nil"
+      end
+
+      [message, helper_error_class, T.cast(response["trace"], T.nilable(T::Array[String]))]
+    end
+    private_class_method :parse_helper_error
 
     sig do
       params(
         stdout: String,
         stderr: String,
-        error_context: T::Hash[Symbol, T.untyped],
+        error_context: ErrorContext,
         error_class: T.class_of(HelperSubprocessFailed)
       )
         .returns(HelperSubprocessFailed)
@@ -265,7 +303,7 @@ module Dependabot
     sig do
       params(
         stderr: T.nilable(String),
-        error_context: T::Hash[Symbol, String],
+        error_context: ErrorContext,
         error_class: T.class_of(HelperSubprocessFailed)
       ).void
     end
@@ -294,7 +332,7 @@ module Dependabot
       }.merge(headers)
     end
 
-    sig { params(options: T.nilable(T::Hash[Symbol, T.untyped])).returns(T::Hash[Symbol, T.untyped]) }
+    sig { params(options: T.nilable(ExconOptions)).returns(ExconOptions) }
     def self.excon_defaults(options = nil)
       options ||= {}
       headers = T.cast(options.delete(:headers), T.nilable(T::Hash[String, String]))
@@ -365,7 +403,6 @@ module Dependabot
       File.join(__dir__, "../../bin/git-credential-store-immutable")
     end
 
-    # rubocop:disable Metrics/PerceivedComplexity
     sig do
       params(
         credentials: T::Array[Dependabot::Credential],
@@ -418,27 +455,35 @@ module Dependabot
                             github_credentials +
                             [github_credential].compact
 
-      # Build the content for our credentials file
-      git_store_content = ""
-      deduped_credentials.each do |cred|
-        next unless cred["type"] == "git_source"
-        next unless cred["host"]
-
-        has_creds = cred["username"] && cred["password"]
-
-        # Build authenticated URL with credentials if available
-        creds = has_creds ? "#{cred.fetch('username')}:#{cred.fetch('password')}@" : ""
-        authenticated_url = "https://#{creds}#{cred.fetch('host')}"
-
-        git_store_content += authenticated_url + "\n"
-        configure_git_to_use_https(cred.fetch("host"))
-      end
-
-      # Save the file
-      File.write(git_store_path, git_store_content)
+      File.write(git_store_path, git_store_content(deduped_credentials))
     end
     # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/PerceivedComplexity
+
+    sig { params(credentials: T::Array[Credential]).returns(String) }
+    def self.git_store_content(credentials)
+      credentials.each_with_object(+"") do |credential, content|
+        next unless credential["type"] == "git_source"
+
+        host = credential["host"]
+        next unless host
+
+        content << authenticated_git_url(
+          username: credential["username"],
+          password: credential["password"],
+          host: host
+        ) << "\n"
+        configure_git_to_use_https(host)
+      end
+    end
+    private_class_method :git_store_content
+
+    sig { params(username: T.nilable(String), password: T.nilable(String), host: String).returns(String) }
+    def self.authenticated_git_url(username:, password:, host:)
+      credentials = username && password ? "#{username}:#{password}@" : ""
+
+      "https://#{credentials}#{host}"
+    end
+    private_class_method :authenticated_git_url
 
     sig { params(host: String).void }
     def self.configure_git_to_use_https(host)

--- a/common/lib/dependabot/workspace/git.rb
+++ b/common/lib/dependabot/workspace/git.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -152,9 +152,40 @@ module Dependabot
         run_shell_command("git clean -fx .")
       end
 
-      sig { params(args: SharedHelpers::Command, kwargs: T.any(T::Boolean, String)).returns(String) }
-      def run_shell_command(*args, **kwargs)
-        Dir.chdir(path) { T.unsafe(SharedHelpers).run_shell_command(*args, **kwargs) }
+      sig do
+        params(
+          command: SharedHelpers::Command,
+          allow_unsafe_shell_command: T::Boolean,
+          cwd: T.nilable(String),
+          env: T.nilable(T::Hash[String, String]),
+          fingerprint: T.nilable(String),
+          stderr_to_stdout: T::Boolean,
+          timeout: Integer,
+          output_observer: CommandHelpers::OutputObserver
+        ).returns(String)
+      end
+      def run_shell_command(
+        command,
+        allow_unsafe_shell_command: false,
+        cwd: nil,
+        env: {},
+        fingerprint: nil,
+        stderr_to_stdout: true,
+        timeout: CommandHelpers::TIMEOUTS::DEFAULT,
+        output_observer: nil
+      )
+        Dir.chdir(path) do
+          SharedHelpers.run_shell_command(
+            command,
+            allow_unsafe_shell_command: allow_unsafe_shell_command,
+            cwd: cwd,
+            env: env,
+            fingerprint: fingerprint,
+            stderr_to_stdout: stderr_to_stdout,
+            timeout: timeout,
+            output_observer: output_observer
+          )
+        end
       end
 
       sig { params(message: String).void }

--- a/common/spec/dependabot/command_helpers_spec.rb
+++ b/common/spec/dependabot/command_helpers_spec.rb
@@ -3,7 +3,8 @@
 
 require "spec_helper"
 require "dependabot/command_helpers"
-require "open3"
+require "rbconfig"
+require "tmpdir"
 
 RSpec.describe Dependabot::CommandHelpers do
   describe ".capture3_with_timeout" do
@@ -26,6 +27,27 @@ RSpec.describe Dependabot::CommandHelpers do
         expect(stderr).to eq("")
         expect(status.exitstatus).to eq(0)
         expect(elapsed_time).to be > 0
+      end
+
+      it "passes environment, stdin, and spawn options to an argument vector" do
+        options = { chdir: Dir.tmpdir }
+        command = [
+          { "PREFIX" => "prefix:" },
+          [RbConfig.ruby, RbConfig.ruby],
+          "-e",
+          "print ENV.fetch('PREFIX'); print STDIN.read; print ':'; print Dir.pwd",
+          options
+        ]
+
+        stdout, stderr, status, = described_class.capture3_with_timeout(
+          command,
+          stdin_data: "input"
+        )
+
+        expect(stdout).to eq("prefix:input:#{Dir.tmpdir}")
+        expect(stderr).to eq("")
+        expect(status).to be_success
+        expect(options).to eq(chdir: Dir.tmpdir)
       end
     end
 
@@ -129,37 +151,7 @@ RSpec.describe Dependabot::CommandHelpers do
         allow(Dependabot).to receive(:logger).and_return(logger)
       end
 
-      def stub_popen3_with_success
-        stdin = instance_double(IO, close: nil)
-        process_status = instance_double(
-          Process::Status,
-          success?: true,
-          exitstatus: 0,
-          pid: 12_345,
-          termsig: nil,
-          to_s: "pid 12345 exit 0"
-        )
-        wait_thr = instance_double(Process::Waiter, pid: 12_345, value: process_status)
-
-        allow(Open3).to receive(:popen3) do |*_args, &block|
-          stdout_read, stdout_write = IO.pipe
-          stderr_read, stderr_write = IO.pipe
-
-          stdout_write.close
-          stderr_write.close
-
-          begin
-            block.call(stdin, stdout_read, stderr_read, wait_thr)
-          ensure
-            stdout_read.close unless stdout_read.closed?
-            stderr_read.close unless stderr_read.closed?
-          end
-        end
-      end
-
       it "logs git config commands at debug level" do
-        stub_popen3_with_success
-
         described_class.capture3_with_timeout(
           ["git config --global --list"],
           timeout: timeout
@@ -171,8 +163,6 @@ RSpec.describe Dependabot::CommandHelpers do
       end
 
       it "logs direct-exec git config commands at debug level" do
-        stub_popen3_with_success
-
         described_class.capture3_with_timeout(
           [%w(git git), "config", "--global", "--list"],
           timeout: timeout
@@ -201,32 +191,21 @@ RSpec.describe Dependabot::CommandHelpers do
         allow(Dependabot).to receive(:logger).and_return(logger)
       end
 
-      # Simulates the race where `terminate_process` reaps the child via `Process.waitpid`
-      # before `wait_thr.value` is read, so the Open3 wait thread yields `nil` instead of a
-      # `Process::Status`.
-      def stub_popen3_with_nil_status
-        stdin = instance_double(IO, close: nil)
-        wait_thr = instance_double(Process::Waiter, pid: 12_345, value: nil)
+      let(:process_with_nil_status) do
+        process_io = IO.popen(["true"], "r+")
+        stderr_io, stderr_writer = IO.pipe
+        stderr_writer.close
+        wait_thr = instance_double(Process::Waiter, pid: process_io.pid, value: nil, join: nil)
 
-        allow(Open3).to receive(:popen3) do |*_args, &block|
-          stdout_read, stdout_write = IO.pipe
-          stderr_read, stderr_write = IO.pipe
+        [process_io, stderr_io, wait_thr]
+      end
 
-          stdout_write.close
-          stderr_write.close
-
-          begin
-            block.call(stdin, stdout_read, stderr_read, wait_thr)
-          ensure
-            stdout_read.close unless stdout_read.closed?
-            stderr_read.close unless stderr_read.closed?
-          end
-        end
+      before do
+        # Simulates `terminate_process` reaping the child before the wait thread reads its status.
+        allow(described_class).to receive(:open_process).and_return(process_with_nil_status)
       end
 
       it "does not raise and returns a nil-safe status" do
-        stub_popen3_with_nil_status
-
         stdout, stderr, status, elapsed_time = described_class.capture3_with_timeout(
           ["some-command"],
           timeout: timeout

--- a/common/spec/dependabot/command_helpers_spec.rb
+++ b/common/spec/dependabot/command_helpers_spec.rb
@@ -187,10 +187,6 @@ RSpec.describe Dependabot::CommandHelpers do
     context "when the wait thread reports no process status (child reaped externally)" do
       let(:logger) { instance_double(Logger, info: nil, debug: nil, warn: nil, error: nil) }
 
-      before do
-        allow(Dependabot).to receive(:logger).and_return(logger)
-      end
-
       let(:process_with_nil_status) do
         process_io = IO.popen(["true"], "r+")
         stderr_io, stderr_writer = IO.pipe
@@ -201,6 +197,8 @@ RSpec.describe Dependabot::CommandHelpers do
       end
 
       before do
+        allow(Dependabot).to receive(:logger).and_return(logger)
+
         # Simulates `terminate_process` reaping the child before the wait thread reads its status.
         allow(described_class).to receive(:open_process).and_return(process_with_nil_status)
       end

--- a/common/spec/dependabot/credential_spec.rb
+++ b/common/spec/dependabot/credential_spec.rb
@@ -97,4 +97,17 @@ RSpec.describe Dependabot::Credential do
       expect(merged["token"]).to eq("secret")
     end
   end
+
+  describe "value parsing" do
+    it "preserves nil credential values" do
+      cred = described_class.new({ "type" => "git_source", "username" => nil })
+
+      expect(cred.to_h).to eq("type" => "git_source", "username" => nil)
+    end
+
+    it "rejects non-string credential values" do
+      expect { described_class.new({ "type" => "npm_registry", "token" => false }) }
+        .to raise_error(TypeError, "credential token must be a string or nil")
+    end
+  end
 end

--- a/common/spec/dependabot/shared_helpers_spec.rb
+++ b/common/spec/dependabot/shared_helpers_spec.rb
@@ -207,6 +207,18 @@ RSpec.describe Dependabot::SharedHelpers do
       end
     end
 
+    context "when the subprocess returns a malformed error" do
+      let(:function) { "malformed_error" }
+
+      it "raises a HelperSubprocessFailed error" do
+        expect { run_subprocess }
+          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed) do |error|
+            expect(error.error_class).to eq("TypeError")
+            expect(error.message).to eq("helper error must be a string")
+          end
+      end
+    end
+
     context "when the subprocess is killed" do
       let(:function) { "killed" }
 

--- a/common/spec/helpers/test/run.rb
+++ b/common/spec/helpers/test/run.rb
@@ -19,6 +19,9 @@ when "useful_error"
 when "hard_error"
   puts "Oh no!"
   exit 0
+when "malformed_error"
+  $stdout.write(JSON.dump(error: nil))
+  exit 1
 when "killed"
   # SIGKILL the helper, which is what the kernel OOMKiller might do.
   Process.kill("KILL", Process.pid)

--- a/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
+++ b/composer/lib/dependabot/composer/file_updater/lockfile_updater.rb
@@ -122,21 +122,24 @@ module Dependabot
 
         sig { returns(T::Hash[String, String]) }
         def run_update_helper
-          SharedHelpers.with_git_configured(credentials: T.unsafe(credentials)) do
-            SharedHelpers.run_helper_subprocess(
-              command: "php -d memory_limit=-1 #{php_helper_path}",
-              allow_unsafe_shell_command: true,
-              function: "update",
-              env: credentials_env,
-              args: [
-                Dir.pwd,
-                dependency.name,
-                dependency.version,
-                git_credentials,
-                registry_credentials
-              ]
-            )
-          end
+          T.cast(
+            SharedHelpers.with_git_configured(credentials: credentials) do
+              SharedHelpers.run_helper_subprocess(
+                command: "php -d memory_limit=-1 #{php_helper_path}",
+                allow_unsafe_shell_command: true,
+                function: "update",
+                env: credentials_env,
+                args: [
+                  Dir.pwd,
+                  dependency.name,
+                  dependency.version,
+                  git_credentials,
+                  registry_credentials
+                ]
+              )
+            end,
+            T::Hash[String, String]
+          )
         end
 
         sig { returns(String) }
@@ -418,13 +421,15 @@ module Dependabot
           SharedHelpers.in_a_temporary_directory do
             File.write(PackageManager::MANIFEST_FILENAME, updated_composer_json_content)
 
-            content_hash =
+            content_hash = T.cast(
               SharedHelpers.run_helper_subprocess(
                 command: "#{Language::NAME} #{php_helper_path}",
                 function: "get_content_hash",
                 env: credentials_env,
                 args: [Dir.pwd]
-              )
+              ),
+              String
+            )
 
             content.gsub(existing_hash, content_hash)
           end

--- a/composer/lib/dependabot/composer/update_checker/version_resolver.rb
+++ b/composer/lib/dependabot/composer/update_checker/version_resolver.rb
@@ -188,19 +188,22 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def run_update_checker
-          SharedHelpers.with_git_configured(credentials: credentials) do
-            SharedHelpers.run_helper_subprocess(
-              command: "php -d memory_limit=-1 #{php_helper_path}",
-              allow_unsafe_shell_command: true,
-              function: "get_latest_resolvable_version",
-              args: [
-                Dir.pwd,
-                dependency.name.downcase,
-                git_credentials,
-                registry_credentials
-              ]
-            )
-          end
+          T.cast(
+            SharedHelpers.with_git_configured(credentials: credentials) do
+              SharedHelpers.run_helper_subprocess(
+                command: "php -d memory_limit=-1 #{php_helper_path}",
+                allow_unsafe_shell_command: true,
+                function: "get_latest_resolvable_version",
+                args: [
+                  Dir.pwd,
+                  dependency.name.downcase,
+                  git_credentials,
+                  registry_credentials
+                ]
+              )
+            end,
+            T.nilable(String)
+          )
         end
 
         sig { params(unlock_requirement: T::Boolean).returns(String) }

--- a/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
+++ b/hex/lib/dependabot/hex/file_updater/lockfile_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -29,13 +29,13 @@ module Dependabot
           @dependencies = dependencies
           @dependency_files = dependency_files
           @credentials = credentials
+          @updated_lockfile_content = T.let(nil, T.nilable(String))
         end
 
         sig { returns(String) }
         def updated_lockfile_content
-          @updated_lockfile_content = T.let(@updated_lockfile_content, T.nilable(String))
-          @updated_lockfile_content ||=
-            SharedHelpers.in_a_temporary_directory do
+          unless @updated_lockfile_content
+            result = SharedHelpers.in_a_temporary_directory do
               write_temporary_dependency_files
               FileUtils.cp(elixir_helper_do_update_path, "do_update.exs")
 
@@ -48,6 +48,9 @@ module Dependabot
                 )
               end
             end
+            content = T.cast(result, String)
+            @updated_lockfile_content = content
+          end
 
           post_process_lockfile(@updated_lockfile_content)
         rescue SharedHelpers::HelperSubprocessFailed => e

--- a/hex/lib/dependabot/hex/update_checker/version_resolver.rb
+++ b/hex/lib/dependabot/hex/update_checker/version_resolver.rb
@@ -79,12 +79,15 @@ module Dependabot
 
         sig { returns(String) }
         def run_elixir_update_checker
-          SharedHelpers.run_helper_subprocess(
-            env: mix_env,
-            command: "mix run #{elixir_helper_path}",
-            function: "get_latest_resolvable_version",
-            args: [Dir.pwd, dependency.name, CredentialHelpers.hex_credentials(credentials)],
-            stderr_to_stdout: true
+          T.cast(
+            SharedHelpers.run_helper_subprocess(
+              env: mix_env,
+              command: "mix run #{elixir_helper_path}",
+              function: "get_latest_resolvable_version",
+              args: [Dir.pwd, dependency.name, CredentialHelpers.hex_credentials(credentials)],
+              stderr_to_stdout: true
+            ),
+            String
           )
         end
 

--- a/julia/lib/dependabot/julia/registry_client.rb
+++ b/julia/lib/dependabot/julia/registry_client.rb
@@ -349,12 +349,15 @@ module Dependabot
         julia_project_dir = File.dirname(julia_helper_script)
         julia_command = "julia --project=#{julia_project_dir} #{julia_helper_script}"
 
-        SharedHelpers.run_helper_subprocess(
-          command: julia_command,
-          function: function,
-          args: args,
-          env: julia_env,
-          allow_unsafe_shell_command: true
+        T.cast(
+          SharedHelpers.run_helper_subprocess(
+            command: julia_command,
+            function: function,
+            args: args,
+            env: julia_env,
+            allow_unsafe_shell_command: true
+          ),
+          T::Hash[String, T.untyped]
         )
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -138,7 +138,7 @@ module Dependabot
         pnp_updater.updated_files(base_directory: base_dir, only_paths: [".pnp.cjs", ".pnp.data.json"]).each do |file|
           updated_files << file
         end
-        T.unsafe(vendor_updater).updated_vendor_cache_files(base_directory: base_dir).each do |file|
+        vendor_updater.updated_vendor_cache_files(base_directory: base_dir).each do |file|
           updated_files << file
         end
         install_state_updater.updated_files(base_directory: base_dir).each do |file|

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/subdependency_version_resolver.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/dependency"
@@ -352,15 +352,18 @@ module Dependabot
 
         sig { params(path: String, lockfile_name: String).returns(T::Hash[String, String]) }
         def run_npm6_updater(path, lockfile_name)
-          SharedHelpers.with_git_configured(credentials: credentials) do
-            Dir.chdir(path) do
-              SharedHelpers.run_helper_subprocess(
-                command: NativeHelpers.helper_path,
-                function: "npm6:updateSubdependency",
-                args: [Dir.pwd, lockfile_name, [dependency.to_h]]
-              )
-            end
-          end
+          T.cast(
+            SharedHelpers.with_git_configured(credentials: credentials) do
+              Dir.chdir(path) do
+                SharedHelpers.run_helper_subprocess(
+                  command: NativeHelpers.helper_path,
+                  function: "npm6:updateSubdependency",
+                  args: [Dir.pwd, lockfile_name, [dependency.to_h]]
+                )
+              end
+            end,
+            T::Hash[String, String]
+          )
         end
 
         sig { returns(T.class_of(Dependabot::Version)) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb
@@ -463,9 +463,11 @@ module Dependabot
           latest_types_version = latest_types_package_version
           return false unless latest_types_version
 
+          latest_types_version = T.cast(latest_types_version, Version)
+
           latest_allowable_ver = latest_allowable_version
           return false unless latest_allowable_ver.is_a?(Version) && latest_allowable_ver.backwards_compatible_with?(
-            T.unsafe(latest_types_version)
+            latest_types_version
           )
 
           return false unless version_class.correct?(types_pkg.version)
@@ -689,7 +691,8 @@ module Dependabot
             .possible_versions_with_details
             .select do |versions_with_details|
               version, details = versions_with_details
-              next false unless satisfies_peer_reqs_on_dep?(T.unsafe(version))
+              version = T.cast(version, T.any(String, Gem::Version))
+              next false unless satisfies_peer_reqs_on_dep?(version)
               next true unless details["peerDependencies"]
               next true if version == version_for_dependency(dependency)
 
@@ -899,15 +902,24 @@ module Dependabot
         def run_yarn_classic_checker(path:, version:)
           SharedHelpers.with_git_configured(credentials: credentials) do
             Dir.chdir(path) do
-              SharedHelpers.run_helper_subprocess(
-                command: NativeHelpers.helper_path,
-                function: "yarn:checkPeerDependencies",
-                args: [
-                  Dir.pwd,
-                  dependency.name,
-                  T.unsafe(version),
-                  requirements_for_path(dependency.requirements, path)
-                ]
+              T.cast(
+                SharedHelpers.run_helper_subprocess(
+                  command: NativeHelpers.helper_path,
+                  function: "yarn:checkPeerDependencies",
+                  args: [
+                    Dir.pwd,
+                    dependency.name,
+                    version,
+                    requirements_for_path(dependency.requirements, path)
+                  ]
+                ),
+                T.nilable(
+                  T.any(
+                    T::Hash[String, T.untyped],
+                    String,
+                    T::Array[T::Hash[String, T.untyped]]
+                  )
+                )
               )
             end
           end
@@ -929,16 +941,25 @@ module Dependabot
 
               return run_npm8_checker(version: version) if Dependabot::NpmAndYarn::Helpers.parse_npm8?(package_lock)
 
-              SharedHelpers.run_helper_subprocess(
-                command: NativeHelpers.helper_path,
-                function: "npm6:checkPeerDependencies",
-                args: [
-                  Dir.pwd,
-                  dependency.name,
-                  T.unsafe(version),
-                  requirements_for_path(dependency.requirements, path),
-                  top_level_dependencies.map(&:to_h)
-                ]
+              T.cast(
+                SharedHelpers.run_helper_subprocess(
+                  command: NativeHelpers.helper_path,
+                  function: "npm6:checkPeerDependencies",
+                  args: [
+                    Dir.pwd,
+                    dependency.name,
+                    version,
+                    requirements_for_path(dependency.requirements, path),
+                    top_level_dependencies.map(&:to_h)
+                  ]
+                ),
+                T.nilable(
+                  T.any(
+                    T::Hash[String, T.untyped],
+                    String,
+                    T::Array[T::Hash[String, T.untyped]]
+                  )
+                )
               )
             end
           end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -413,15 +413,18 @@ module Dependabot
         def log_helper_subprocess_failure(dependency, error)
           # See `Dependabot::SharedHelpers.run_helper_subprocess` for details on error context
           context = error.error_context
+          function = T.cast(context[:function], T.nilable(String))
+          time_taken = T.cast(context[:time_taken], T.nilable(Float))
+          trace = T.cast(context[:trace], T.nilable(String))
 
           builder = ::StringIO.new
           builder << "VulnerabilityAuditor: "
-          builder << "#{context[:function]} " if context[:function]
+          builder << "#{function} " if function
           builder << "failed"
-          builder << " after #{context[:time_taken].truncate(2)}s" if context[:time_taken]
+          builder << " after #{time_taken.truncate(2)}s" if time_taken
           builder << " while auditing #{dependency.name}: "
           builder << error.message
-          builder << "\n" << context[:trace]
+          builder << "\n" << trace
 
           msg = builder.string
           Dependabot.logger.info(msg) # TODO: is this the right log level?

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -415,7 +415,7 @@ module Dependabot
           context = error.error_context
           function = T.cast(context[:function], T.nilable(String))
           time_taken = T.cast(context[:time_taken], T.nilable(Float))
-          trace = T.cast(context[:trace], T.nilable(String))
+          trace = error.trace&.join("\n")
 
           builder = ::StringIO.new
           builder << "VulnerabilityAuditor: "
@@ -424,7 +424,7 @@ module Dependabot
           builder << " after #{time_taken.truncate(2)}s" if time_taken
           builder << " while auditing #{dependency.name}: "
           builder << error.message
-          builder << "\n" << trace
+          builder << "\n#{trace}" if trace
 
           msg = builder.string
           Dependabot.logger.info(msg) # TODO: is this the right log level?

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -608,6 +608,34 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
       end
     end
 
+    context "when the native helper error includes a trace" do
+      let(:dependency_files) { project_dependency_files("npm8/simple") }
+      let(:helper_error) do
+        Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+          message: "audit failed",
+          error_context: {
+            function: "npm:vulnerabilityAuditor",
+            time_taken: 1.25
+          },
+          trace: ["helper.rb:1", "helper.rb:2"]
+        )
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_helper_subprocess).and_raise(helper_error)
+      end
+
+      it "logs the trace and returns fix_available => false" do
+        result = vulnerability_auditor.audit(dependency: dependency, security_advisories: [])
+
+        expect(Dependabot.logger)
+          .to have_received(:info)
+          .with(a_string_including("helper.rb:1\nhelper.rb:2"))
+        expect(result).to include("fix_available" => false)
+      end
+    end
+
     context "when the audit report contains a vuln effects cycle" do
       let(:dependency_files) { project_dependency_files("npm8/transitive_dependency_effects_cycle") }
 

--- a/python/lib/dependabot/python/file_parser/setup_file_parser.rb
+++ b/python/lib/dependabot/python/file_parser/setup_file_parser.rb
@@ -68,10 +68,19 @@ module Dependabot
           SharedHelpers.in_a_temporary_directory do
             write_temporary_dependency_files
 
-            requirements = SharedHelpers.run_helper_subprocess(
-              command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
-              function: "parse_setup",
-              args: [Dir.pwd]
+            requirements = T.cast(
+              SharedHelpers.run_helper_subprocess(
+                command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
+                function: "parse_setup",
+                args: [Dir.pwd]
+              ),
+              T.nilable(
+                T.any(
+                  T::Hash[String, T.untyped],
+                  String,
+                  T::Array[T::Hash[String, T.untyped]]
+                )
+              )
             )
 
             check_requirements(requirements)
@@ -90,10 +99,19 @@ module Dependabot
           SharedHelpers.in_a_temporary_directory do
             write_sanitized_setup_file
 
-            requirements = SharedHelpers.run_helper_subprocess(
-              command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
-              function: "parse_setup",
-              args: [Dir.pwd]
+            requirements = T.cast(
+              SharedHelpers.run_helper_subprocess(
+                command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
+                function: "parse_setup",
+                args: [Dir.pwd]
+              ),
+              T.nilable(
+                T.any(
+                  T::Hash[String, T.untyped],
+                  String,
+                  T::Array[T::Hash[String, T.untyped]]
+                )
+              )
             )
 
             check_requirements(requirements)

--- a/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/pipfile_file_updater.rb
@@ -345,10 +345,19 @@ module Dependabot
         def pipfile_hash_for(pipfile_content)
           SharedHelpers.in_a_temporary_directory do |dir|
             File.write(File.join(dir, "Pipfile"), pipfile_content)
-            SharedHelpers.run_helper_subprocess(
-              command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
-              function: "get_pipfile_hash",
-              args: [T.cast(dir, Pathname).to_s]
+            T.cast(
+              SharedHelpers.run_helper_subprocess(
+                command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
+                function: "get_pipfile_hash",
+                args: [T.cast(dir, Pathname).to_s]
+              ),
+              T.nilable(
+                T.any(
+                  T::Hash[String, T.untyped],
+                  String,
+                  T::Array[T::Hash[String, T.untyped]]
+                )
+              )
             )
           end
         end

--- a/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
+++ b/python/lib/dependabot/python/file_updater/poetry_file_updater.rb
@@ -18,6 +18,16 @@ require "dependabot/package/release_cooldown_options"
 
 module Dependabot
   module Python
+    PoetryPyprojectHashResult = T.type_alias do
+      T.nilable(
+        T.any(
+          T::Hash[String, T.untyped],
+          String,
+          T::Array[T::Hash[String, T.untyped]]
+        )
+      )
+    end
+
     class FileUpdater
       class PoetryFileUpdater
         require_relative "pyproject_preparer"
@@ -367,17 +377,18 @@ module Dependabot
             .add_auth_env_vars(credentials)
         end
 
-        sig { params(pyproject_content: String).returns(T.nilable(T.any(T::Hash[String, T.untyped], String, T::Array[T::Hash[String, T.untyped]]))) }
+        sig { params(pyproject_content: String).returns(PoetryPyprojectHashResult) }
         def pyproject_hash_for(pyproject_content)
           SharedHelpers.in_a_temporary_directory do |dir|
             SharedHelpers.with_git_configured(credentials: credentials) do
               write_temporary_dependency_files(pyproject_content)
 
-              SharedHelpers.run_helper_subprocess(
+              result = SharedHelpers.run_helper_subprocess(
                 command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
                 function: "get_pyproject_hash",
                 args: [T.cast(dir, Pathname).to_s]
               )
+              T.cast(result, PoetryPyprojectHashResult)
             end
           end
         end

--- a/script/sorbet-unsafe-ratchet
+++ b/script/sorbet-unsafe-ratchet
@@ -12,20 +12,14 @@ require "open3"
 
 BASE_REF = ENV.fetch("BASE_REF", "origin/main")
 PATTERN = /T\.unsafe/
+PRODUCTION_RUBY_PATH = %r{\A[^/]+/lib/.*\.rb\z}
 
-def tracked_ruby_files
-  stdout, stderr, status = Open3.capture3(
-    "git",
-    "ls-files",
-    "-z",
-    "--",
-    "common/lib/**/*.rb",
-    "updater/lib/**/*.rb",
-    "*/lib/**/*.rb"
-  )
-  raise "git ls-files failed: #{stderr}" unless status.success?
+def tracked_ruby_files(ref = nil)
+  command = ref ? ["git", "ls-tree", "-r", "-z", "--name-only", ref] : ["git", "ls-files", "-z"]
+  stdout, stderr, status = Open3.capture3(*command)
+  raise "#{command.take(2).join(' ')} failed: #{stderr}" unless status.success?
 
-  stdout.split("\0")
+  stdout.split("\0").grep(PRODUCTION_RUBY_PATH)
 end
 
 def count_working_tree(files)
@@ -44,7 +38,7 @@ unless system("git", "rev-parse", "--verify", "--quiet", BASE_REF, out: File::NU
   exit 0
 end
 
-files = tracked_ruby_files
+files = tracked_ruby_files(BASE_REF) | tracked_ruby_files
 base_count = count_base(files)
 head_count = count_working_tree(files)
 

--- a/script/sorbet-unsafe-ratchet
+++ b/script/sorbet-unsafe-ratchet
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Non-regression ratchet for production `T.unsafe` calls.
+#
+# `Sorbet/ForbidTUnsafe` rejects `T.unsafe` in strong files, but strict files
+# can still introduce new calls. This script counts tracked Ruby files in the
+# working tree and at a base ref (default `origin/main`) and requires the total
+# to stay level or decrease.
+
+require "open3"
+
+BASE_REF = ENV.fetch("BASE_REF", "origin/main")
+PATTERN = /T\.unsafe/
+
+def tracked_ruby_files
+  stdout, stderr, status = Open3.capture3(
+    "git",
+    "ls-files",
+    "-z",
+    "--",
+    "common/lib/**/*.rb",
+    "updater/lib/**/*.rb",
+    "*/lib/**/*.rb"
+  )
+  raise "git ls-files failed: #{stderr}" unless status.success?
+
+  stdout.split("\0")
+end
+
+def count_working_tree(files)
+  files.sum { |file| File.exist?(file) ? File.read(file).scan(PATTERN).length : 0 }
+end
+
+def count_base(files)
+  files.sum do |file|
+    stdout, _stderr, status = Open3.capture3("git", "show", "#{BASE_REF}:#{file}")
+    status.success? ? stdout.scan(PATTERN).length : 0
+  end
+end
+
+unless system("git", "rev-parse", "--verify", "--quiet", BASE_REF, out: File::NULL)
+  puts "sorbet-unsafe-ratchet: base ref '#{BASE_REF}' unavailable; skipping (nothing to compare)."
+  exit 0
+end
+
+files = tracked_ruby_files
+base_count = count_base(files)
+head_count = count_working_tree(files)
+
+if head_count <= base_count
+  puts "sorbet-unsafe-ratchet: OK (calls #{base_count} -> #{head_count}, -#{base_count - head_count})."
+  exit 0
+end
+
+warn "sorbet-unsafe-ratchet: FAILED"
+warn "T.unsafe call count rose from #{base_count} to #{head_count}. The count may only shrink."
+exit 1

--- a/script/test-sorbet-unsafe-ratchet
+++ b/script/test-sorbet-unsafe-ratchet
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+# typed: strict
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+RATCHET = File.expand_path("sorbet-unsafe-ratchet", __dir__)
+
+Dir.mktmpdir do |directory|
+  FileUtils.mkdir_p(File.join(directory, "common/lib"))
+  File.write(File.join(directory, "common/lib/old.rb"), "T.unsafe(value)\n")
+
+  system("git", "init", "--quiet", directory, exception: true)
+  system("git", "-C", directory, "config", "user.email", "test@example.com", exception: true)
+  system("git", "-C", directory, "config", "user.name", "Test", exception: true)
+  system("git", "-C", directory, "add", ".", exception: true)
+  system("git", "-C", directory, "commit", "--quiet", "-m", "base", exception: true)
+
+  base_ref, stderr, status = Open3.capture3("git", "-C", directory, "rev-parse", "HEAD")
+  abort stderr unless status.success?
+  base_ref = base_ref.strip
+  FileUtils.mv(
+    File.join(directory, "common/lib/old.rb"),
+    File.join(directory, "common/lib/new.rb")
+  )
+  system("git", "-C", directory, "add", "--all", exception: true)
+
+  stdout, stderr, status = Open3.capture3(
+    { "BASE_REF" => base_ref },
+    RbConfig.ruby,
+    RATCHET,
+    chdir: directory
+  )
+  abort "#{stdout}#{stderr}" unless status.success?
+  abort "expected unchanged count, got: #{stdout}" unless stdout.include?("calls 1 -> 1")
+end

--- a/script/test-sorbet-unsafe-ratchet
+++ b/script/test-sorbet-unsafe-ratchet
@@ -22,10 +22,8 @@ Dir.mktmpdir do |directory|
   base_ref, stderr, status = Open3.capture3("git", "-C", directory, "rev-parse", "HEAD")
   abort stderr unless status.success?
   base_ref = base_ref.strip
-  FileUtils.mv(
-    File.join(directory, "common/lib/old.rb"),
-    File.join(directory, "common/lib/new.rb")
-  )
+  new_file = File.join(directory, "common/lib/new.rb")
+  FileUtils.mv(File.join(directory, "common/lib/old.rb"), new_file)
   system("git", "-C", directory, "add", "--all", exception: true)
 
   stdout, stderr, status = Open3.capture3(
@@ -36,4 +34,14 @@ Dir.mktmpdir do |directory|
   )
   abort "#{stdout}#{stderr}" unless status.success?
   abort "expected unchanged count, got: #{stdout}" unless stdout.include?("calls 1 -> 1")
+
+  File.write(new_file, "T.unsafe(value)\nT.unsafe(other)\n")
+  stdout, stderr, status = Open3.capture3(
+    { "BASE_REF" => base_ref },
+    RbConfig.ruby,
+    RATCHET,
+    chdir: directory
+  )
+  abort "expected an increased count to fail: #{stdout}" if status.success?
+  abort "expected increased-count error, got: #{stderr}" unless stderr.include?("rose from 1 to 2")
 end

--- a/sorbet/rbi/shims/debug.rbi
+++ b/sorbet/rbi/shims/debug.rbi
@@ -1,0 +1,7 @@
+# typed: strong
+# frozen_string_literal: true
+
+class Binding
+  sig { void }
+  def break; end
+end


### PR DESCRIPTION
Types shared process, helper, credential, vendor, and workspace boundaries. Adds a `T.unsafe` ratchet and moves six files to `typed: strong`.

Ratchets: `T.untyped` 922 to 915; `T.unsafe` 82 to 71.