### PR TITLE
Type common provider clients

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 915
+# Offense count: 882
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -275,12 +275,6 @@ Sorbet/ForbidTUntyped:
     - "bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb"
     - "bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb"
     - "bundler/lib/dependabot/bundler/update_checker/version_resolver.rb"
-    - "common/lib/dependabot/clients/azure.rb"
-    - "common/lib/dependabot/clients/bitbucket.rb"
-    - "common/lib/dependabot/clients/bitbucket_with_retries.rb"
-    - "common/lib/dependabot/clients/codecommit.rb"
-    - "common/lib/dependabot/clients/github_with_retries.rb"
-    - "common/lib/dependabot/clients/gitlab_with_retries.rb"
     - "common/lib/dependabot/file_fetchers/base.rb"
     - "common/lib/dependabot/metadata_finders/base/changelog_finder.rb"
     - "common/lib/dependabot/pull_request_creator/github.rb"

--- a/common/lib/dependabot/clients/azure.rb
+++ b/common/lib/dependabot/clients/azure.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
+require "dependabot/clients/json_response_parser"
 require "excon"
 require "sorbet-runtime"
 
@@ -10,6 +11,10 @@ module Dependabot
     # rubocop:disable Metrics/ClassLength
     class Azure
       extend T::Sig
+      include JsonResponseParser
+
+      JsonObject = T.type_alias { JsonResponseParser::JsonObject }
+      JsonObjects = T.type_alias { T::Array[JsonObject] }
 
       class NotFound < StandardError; end
 
@@ -74,7 +79,9 @@ module Dependabot
 
         raise NotFound if response.status == 400
 
-        JSON.parse(response.body).fetch("commit").fetch("commitId")
+        root = parse_json_object(response.body, "branch stats")
+        commit = object_field(root, "commit", "branch stats")
+        string_field(commit, "commitId", "branch stats")
       end
 
       sig { params(_repo: String).returns(String) }
@@ -85,7 +92,8 @@ module Dependabot
                     "/_apis/git/repositories/" + source.unscoped_repo
         )
 
-        JSON.parse(response.body).fetch("defaultBranch").gsub("refs/heads/", "")
+        root = parse_json_object(response.body, "repository")
+        string_field(root, "defaultBranch", "repository").gsub("refs/heads/", "")
       end
 
       sig do
@@ -93,7 +101,7 @@ module Dependabot
           commit: T.nilable(String),
           path: T.nilable(String)
         )
-          .returns(T::Array[T::Hash[String, T.untyped]])
+          .returns(JsonObjects)
       end
       def fetch_repo_contents(commit = nil, path = nil)
         tree = fetch_repo_contents_treeroot(commit, path)
@@ -105,7 +113,8 @@ module Dependabot
                     "/trees/" + tree + "?recursive=false"
         )
 
-        JSON.parse(response.body).fetch("treeEntries")
+        root = parse_json_object(response.body, "repository tree")
+        object_array_field(root, "treeEntries", "repository tree")
       end
 
       sig { params(commit: T.nilable(String), path: T.nilable(String)).returns(String) }
@@ -125,7 +134,8 @@ module Dependabot
 
         tree_response = get(tree_url)
 
-        JSON.parse(tree_response.body).fetch("objectId")
+        root = parse_json_object(tree_response.body, "repository item")
+        string_field(root, "objectId", "repository item")
       end
 
       sig { params(commit: String, path: String).returns(String) }
@@ -142,7 +152,7 @@ module Dependabot
         response.body
       end
 
-      sig { params(branch_name: T.nilable(String)).returns(T::Array[T::Hash[String, T.untyped]]) }
+      sig { params(branch_name: T.nilable(String)).returns(JsonObjects) }
       def commits(branch_name = nil)
         commits_url = T.must(source.api_endpoint) +
                       source.organization + "/" + source.project +
@@ -153,10 +163,11 @@ module Dependabot
 
         response = get(commits_url)
 
-        JSON.parse(response.body).fetch("value")
+        root = parse_json_object(response.body, "commits")
+        object_array_field(root, "value", "commits")
       end
 
-      sig { params(branch_name: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig { params(branch_name: String).returns(T.nilable(JsonObject)) }
       def branch(branch_name)
         response = get(
           T.must(source.api_endpoint) +
@@ -165,10 +176,11 @@ module Dependabot
                     "/refs?filter=heads/" + branch_name
         )
 
-        JSON.parse(response.body).fetch("value").first
+        root = parse_json_object(response.body, "branch")
+        object_array_field(root, "value", "branch").first
       end
 
-      sig { params(source_branch: String, target_branch: String).returns(T::Array[T::Hash[String, T.untyped]]) }
+      sig { params(source_branch: String, target_branch: String).returns(JsonObjects) }
       def pull_requests(source_branch, target_branch)
         response = get(
           T.must(source.api_endpoint) +
@@ -179,7 +191,8 @@ module Dependabot
                     "&searchCriteria.targetRefName=refs/heads/" + target_branch
         )
 
-        JSON.parse(response.body).fetch("value")
+        root = parse_json_object(response.body, "pull requests")
+        object_array_field(root, "value", "pull requests")
       end
 
       sig do
@@ -190,7 +203,7 @@ module Dependabot
           files: T::Array[Dependabot::DependencyFile],
           author_details: T.nilable(T::Hash[Symbol, String])
         )
-          .returns(T.untyped)
+          .returns(Excon::Response)
       end
       def create_commit(
         branch_name,
@@ -241,7 +254,7 @@ module Dependabot
           assignees: T.nilable(T::Array[String]),
           work_item: T.nilable(Integer)
         )
-          .returns(T.untyped)
+          .returns(Excon::Response)
       end
       def create_pull_request(
         pr_name,
@@ -283,7 +296,7 @@ module Dependabot
           trans_work_items: T::Boolean,
           ignore_config_ids: T::Array[String]
         )
-          .returns(T.untyped)
+          .returns(JsonObject)
       end
       def autocomplete_pull_request(
         pull_request_id,
@@ -317,10 +330,10 @@ module Dependabot
           content.to_json
         )
 
-        JSON.parse(response.body)
+        parse_json_object(response.body, "pull request autocomplete")
       end
 
-      sig { params(pull_request_id: String).returns(T::Hash[String, T.untyped]) }
+      sig { params(pull_request_id: String).returns(JsonObject) }
       def pull_request(pull_request_id)
         response = get(
           T.must(source.api_endpoint) +
@@ -328,10 +341,10 @@ module Dependabot
                     "/_apis/git/pullrequests/" + pull_request_id
         )
 
-        JSON.parse(response.body)
+        parse_json_object(response.body, "pull request")
       end
 
-      sig { params(branch_name: String, old_commit: String, new_commit: String).returns(T::Hash[String, T.untyped]) }
+      sig { params(branch_name: String, old_commit: String, new_commit: String).returns(JsonObject) }
       def update_ref(branch_name, old_commit, new_commit)
         content = [
           {
@@ -348,7 +361,8 @@ module Dependabot
           content.to_json
         )
 
-        JSON.parse(response.body).fetch("value").first
+        root = parse_json_object(response.body, "updated ref")
+        first_object_field(root, "value", "updated ref")
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -358,7 +372,7 @@ module Dependabot
           new_tag: T.nilable(String),
           type: String
         )
-          .returns(T::Array[T::Hash[String, T.untyped]])
+          .returns(JsonObjects)
       end
       def compare(previous_tag, new_tag, type)
         response = get(
@@ -371,7 +385,8 @@ module Dependabot
                                    "&searchCriteria.compareVersion.version=#{new_tag}"
         )
 
-        JSON.parse(response.body).fetch("value")
+        root = parse_json_object(response.body, "commit comparison")
+        object_array_field(root, "value", "commit comparison")
       end
 
       sig { params(url: String).returns(Excon::Response) }
@@ -472,6 +487,11 @@ module Dependabot
 
       private
 
+      sig { returns([String, String]) }
+      def response_identity
+        ["Azure", source.url]
+      end
+
       sig { params(blk: T.proc.void).void }
       def retry_connection_failures(&blk)
         retry_attempt = 0
@@ -512,7 +532,7 @@ module Dependabot
           reviewers: T.nilable(T::Array[String]),
           assignees: T.nilable(T::Array[String])
         )
-          .returns(T::Array[T::Hash[Symbol, T.untyped]])
+          .returns(T::Array[T::Hash[Symbol, Object]])
       end
       def pr_reviewers(reviewers, assignees)
         return [] unless reviewers || assignees

--- a/common/lib/dependabot/clients/bitbucket.rb
+++ b/common/lib/dependabot/clients/bitbucket.rb
@@ -4,12 +4,17 @@
 require "excon"
 require "sorbet-runtime"
 
+require "dependabot/clients/json_response_parser"
 require "dependabot/shared_helpers"
 
 module Dependabot
   module Clients
     class Bitbucket
       extend T::Sig
+      include JsonResponseParser
+
+      JsonObject = T.type_alias { JsonResponseParser::JsonObject }
+      JsonObjects = T.type_alias { T::Array[JsonObject] }
 
       class NotFound < StandardError; end
 
@@ -54,14 +59,18 @@ module Dependabot
         path = "#{repo}/refs/branches/#{branch}"
         response = get(base_url + path)
 
-        JSON.parse(response.body).fetch("target").fetch("hash")
+        root = parse_json_object(response.body, "branch")
+        target = object_field(root, "target", "branch")
+        string_field(target, "hash", "branch")
       end
 
       sig { params(repo: String).returns(String) }
       def fetch_default_branch(repo)
         response = get(base_url + repo)
 
-        JSON.parse(response.body).fetch("mainbranch").fetch("name")
+        root = parse_json_object(response.body, "repository")
+        main_branch = object_field(root, "mainbranch", "repository")
+        string_field(main_branch, "name", "repository")
       end
 
       sig do
@@ -70,7 +79,7 @@ module Dependabot
           commit: T.nilable(String),
           path: T.nilable(String)
         )
-          .returns(T::Array[T::Hash[String, T.untyped]])
+          .returns(JsonObjects)
       end
       def fetch_repo_contents(repo, commit = nil, path = nil)
         raise "Commit is required if path provided!" if commit.nil? && path
@@ -81,7 +90,8 @@ module Dependabot
         api_path += "?pagelen=100"
         response = get(base_url + api_path)
 
-        JSON.parse(response.body).fetch("values")
+        root = parse_json_object(response.body, "repository contents")
+        object_array_field(root, "values", "repository contents")
       end
 
       sig do
@@ -104,7 +114,7 @@ module Dependabot
           repo: String,
           branch_name: T.nilable(String)
         )
-          .returns(T::Enumerator[T::Hash[String, T.untyped]])
+          .returns(T::Enumerator[JsonObject])
       end
       def commits(repo, branch_name = nil)
         commits_path = "#{repo}/commits/#{branch_name}?pagelen=100"
@@ -117,13 +127,13 @@ module Dependabot
           repo: String,
           branch_name: String
         )
-          .returns(T::Hash[String, T.untyped])
+          .returns(JsonObject)
       end
       def branch(repo, branch_name)
         branch_path = "#{repo}/refs/branches/#{branch_name}"
         response = get(base_url + branch_path)
 
-        JSON.parse(response.body)
+        parse_json_object(response.body, "branch")
       end
 
       sig do
@@ -133,7 +143,7 @@ module Dependabot
           target_branch: T.nilable(String),
           status: T::Array[String]
         )
-          .returns(T::Array[T::Hash[String, T.untyped]])
+          .returns(JsonObjects)
       end
       def pull_requests(repo, source_branch, target_branch, status = %w(OPEN MERGED DECLINED SUPERSEDED))
         pr_path = "#{repo}/pullrequests?"
@@ -148,10 +158,14 @@ module Dependabot
           if source_branch.nil?
             source_branch_matches = true
           else
-            pr_source_branch = pr.fetch("source").fetch("branch").fetch("name")
+            source = object_field(pr, "source", "pull request")
+            source_branch_details = object_field(source, "branch", "pull request")
+            pr_source_branch = string_field(source_branch_details, "name", "pull request")
             source_branch_matches = pr_source_branch == source_branch
           end
-          pr_target_branch = pr.fetch("destination").fetch("branch").fetch("name")
+          destination = object_field(pr, "destination", "pull request")
+          target_branch_details = object_field(destination, "branch", "pull request")
+          pr_target_branch = string_field(target_branch_details, "name", "pull request")
           source_branch_matches && pr_target_branch == target_branch
         end
       end
@@ -262,12 +276,13 @@ module Dependabot
       def current_user
         base_url = "https://api.bitbucket.org/2.0/user?fields=uuid"
         response = get(base_url)
-        JSON.parse(response.body).fetch("uuid")
+        root = parse_json_object(response.body, "current user")
+        string_field(root, "uuid", "current user")
       rescue Unauthorized
         nil
       end
 
-      sig { params(repo: String).returns(T::Array[T::Hash[String, String]]) }
+      sig { params(repo: String).returns(T::Array[T::Hash[Symbol, String]]) }
       def default_reviewers(repo)
         current_uuid = current_user
         path = "#{repo}/default-reviewers?pagelen=100&fields=values.uuid,next"
@@ -278,18 +293,20 @@ module Dependabot
         reviewer_data = []
 
         default_reviewers.each do |reviewer|
-          reviewer_data.append({ uuid: reviewer.fetch("uuid") }) unless current_uuid == reviewer.fetch("uuid")
+          uuid = string_field(reviewer, "uuid", "default reviewer")
+          reviewer_data.append({ uuid: uuid }) unless current_uuid == uuid
         end
 
         reviewer_data
       end
 
-      sig { params(repo: String).returns(T::Array[T::Hash[String, String]]) }
+      sig { params(repo: String).returns(JsonObjects) }
       def tags(repo)
         path = "#{repo}/refs/tags?pagelen=100"
         response = get(base_url + path)
 
-        JSON.parse(response.body).fetch("values")
+        root = parse_json_object(response.body, "tags")
+        object_array_field(root, "values", "tags")
       end
 
       sig do
@@ -298,13 +315,18 @@ module Dependabot
           previous_tag: String,
           new_tag: String
         )
-          .returns(T::Array[T::Hash[String, T.untyped]])
+          .returns(JsonObjects)
       end
       def compare(repo, previous_tag, new_tag)
         path = "#{repo}/commits/?include=#{new_tag}&exclude=#{previous_tag}"
         response = get(base_url + path)
 
-        JSON.parse(response.body).fetch("values")
+        root = parse_json_object(response.body, "commit comparison")
+        commits = object_array_field(root, "values", "commit comparison")
+        commits.each do |commit|
+          validate_string_paths(commit, "commit comparison", [%w(hash), %w(summary raw), %w(links html href)])
+        end
+        commits
       end
 
       sig { params(url: String).returns(Excon::Response) }
@@ -396,21 +418,25 @@ module Dependabot
       #     response = post(url, body)
       #     first_page = JSON.parse(response.body)
       #     paginate(first_page)
-      sig do
-        type_parameters(:T)
-          .params(page: T.all(T.type_parameter(:T), T::Hash[String, T.untyped]))
-          .returns(T::Enumerator[T.type_parameter(:T)])
-      end
+      sig { params(page: JsonObject).returns(T::Enumerator[JsonObject]) }
       def paginate(page)
         Enumerator.new do |yielder|
           loop do
-            page.fetch("values", []).each { |value| yielder << value }
-            break unless page.key?("next")
+            values = page["values"]
+            object_array(values, "paginated response").each { |value| yielder << value } if values
 
-            next_page_url = page.fetch("next")
-            page = T.cast(JSON.parse(get(next_page_url).body), T.all(T::Hash[String, T.untyped], T.type_parameter(:T)))
+            next_page = page["next"]
+            break unless next_page
+
+            next_page_url = string_value(next_page, "paginated response")
+            page = parse_json_object(get(next_page_url).body, "paginated response")
           end
         end
+      end
+
+      sig { returns([String, String]) }
+      def response_identity
+        ["Bitbucket", base_url]
       end
 
       sig { returns(T::Hash[String, String]) }

--- a/common/lib/dependabot/clients/bitbucket_with_retries.rb
+++ b/common/lib/dependabot/clients/bitbucket_with_retries.rb
@@ -2,12 +2,13 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "delegate"
 
 require_relative "bitbucket"
 
 module Dependabot
   module Clients
-    class BitbucketWithRetries
+    class BitbucketWithRetries < SimpleDelegator
       extend T::Sig
 
       RETRYABLE_ERRORS = T.let(
@@ -37,24 +38,22 @@ module Dependabot
       def initialize(credentials:, max_retries: 3)
         @max_retries = T.let(max_retries || 3, Integer)
         @client = T.let(Bitbucket.new(credentials: credentials), Dependabot::Clients::Bitbucket)
+        super(@client)
       end
 
       sig do
         params(
           method_name: T.any(Symbol, String),
-          args: T.untyped,
-          block: T.nilable(T.proc.returns(T.untyped))
+          args: Object,
+          block: T.nilable(Proc)
         )
-          .returns(T.untyped)
+          .returns(T.anything)
       end
       def method_missing(method_name, *args, &block)
+        original_args = args
         retry_connection_failures do
-          if @client.respond_to?(method_name)
-            mutatable_args = args.map(&:dup)
-            T.unsafe(@client).public_send(method_name, *mutatable_args, &block)
-          else
-            super
-          end
+          args = original_args.map(&:dup)
+          super
         end
       end
 
@@ -66,7 +65,7 @@ module Dependabot
           .returns(T::Boolean)
       end
       def respond_to_missing?(method_name, include_private = false)
-        @client.respond_to?(method_name) || super
+        @client.respond_to?(method_name, include_private)
       end
 
       sig do
@@ -81,7 +80,7 @@ module Dependabot
           yield
         rescue *RETRYABLE_ERRORS
           retry_attempt += 1
-          retry_attempt <= @max_retries ? retry : raise
+          retry_attempt <= @max_retries ? retry : Kernel.raise
         end
       end
     end

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -83,7 +83,7 @@ module Dependabot
           commit: T.nilable(String),
           path: T.nilable(String)
         )
-          .returns(Aws::CodeCommit::Types::GetFolderOutput)
+          .returns(Seahorse::Client::Response)
       end
       def fetch_repo_contents(repo, commit = nil, path = nil)
         actual_path = path
@@ -94,8 +94,8 @@ module Dependabot
             repository_name: repo,
             commit_specifier: commit,
             folder_path: actual_path
-          ).data,
-          Aws::CodeCommit::Types::GetFolderOutput
+          ),
+          Seahorse::Client::Response
         )
       end
 

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -83,19 +83,19 @@ module Dependabot
           commit: T.nilable(String),
           path: T.nilable(String)
         )
-          # See PR 9344: should .returns(Seahorse::Client::Response)
-          # but it not extend Delegator, unblocking until shim or
-          # another fix is implemented
-          .returns(T.untyped)
+          .returns(Aws::CodeCommit::Types::GetFolderOutput)
       end
       def fetch_repo_contents(repo, commit = nil, path = nil)
         actual_path = path
         actual_path = "/" if path.to_s.empty?
 
-        cc_client.get_folder(
-          repository_name: repo,
-          commit_specifier: commit,
-          folder_path: actual_path
+        T.cast(
+          cc_client.get_folder(
+            repository_name: repo,
+            commit_specifier: commit,
+            folder_path: actual_path
+          ).data,
+          Aws::CodeCommit::Types::GetFolderOutput
         )
       end
 

--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -3,15 +3,17 @@
 
 require "octokit"
 require "sorbet-runtime"
+require "delegate"
 require "dependabot/credential"
 
 module Dependabot
   module Clients
-    class GithubWithRetries
+    class GithubWithRetries < SimpleDelegator
       extend T::Sig
 
       DEFAULT_OPEN_TIMEOUT_IN_SECONDS = 2
       DEFAULT_READ_TIMEOUT_IN_SECONDS = 5
+      ClientOptions = T.type_alias { T::Hash[Symbol, Object] }
 
       sig { returns(Integer) }
       def self.open_timeout_in_seconds
@@ -32,7 +34,7 @@ module Dependabot
             }
           }
         }.freeze,
-        T::Hash[Symbol, T.untyped]
+        ClientOptions
       )
 
       RETRYABLE_ERRORS = T.let(
@@ -88,30 +90,27 @@ module Dependabot
 
       sig { params(repo: String, branch: String).returns(String) }
       def fetch_commit(repo, branch)
-        response = T.unsafe(ref(repo, "heads/#{branch}"))
+        response = ref(repo, "heads/#{branch}")
 
-        raise Octokit::NotFound if response.is_a?(Array)
+        Kernel.raise Octokit::NotFound if response.is_a?(Array)
 
-        response.object.sha
+        object = T.cast(response[:object], Sawyer::Resource)
+        T.cast(object[:sha], String)
       end
 
       sig { params(repo: String).returns(String) }
       def fetch_default_branch(repo)
-        T.unsafe(repository(repo)).default_branch
+        T.cast(repository(repo)[:default_branch], String)
       end
 
       ############
       # Proxying #
       ############
 
-      sig { params(max_retries: T.nilable(Integer), args: T.untyped).void }
+      sig { params(max_retries: T.nilable(Integer), args: Object).void }
       def initialize(max_retries: 3, **args)
         args = DEFAULT_CLIENT_ARGS.merge(args)
-
-        access_tokens = args.delete(:access_tokens) || []
-        access_tokens << args[:access_token] if args[:access_token]
-        access_tokens << nil if access_tokens.empty?
-        access_tokens.uniq!
+        access_tokens = extract_access_tokens(args)
 
         # Explicitly set the proxy if one is set in the environment
         # as Faraday's find_proxy is very slow.
@@ -135,30 +134,29 @@ module Dependabot
           end,
           T::Array[Octokit::Client]
         )
+        super(T.must(@clients.last))
       end
 
       # TODO: Create all the methods that are called on the client
       sig do
         params(
           method_name: T.any(Symbol, String),
-          args: T.untyped,
-          block: T.nilable(T.proc.returns(T.untyped))
+          args: Object,
+          block: T.nilable(Proc)
         )
-          .returns(T.untyped)
+          .returns(T.anything)
       end
       def method_missing(method_name, *args, &block)
+        original_args = args
         untried_clients = @clients.dup
         client = untried_clients.pop
 
         begin
-          if client.respond_to?(method_name)
-            mutatable_args = args.map(&:dup)
-            T.unsafe(client).public_send(method_name, *mutatable_args, &block)
-          else
-            super
-          end
+          __setobj__(T.must(client))
+          args = original_args.map(&:dup)
+          super
         rescue Octokit::NotFound, Octokit::Unauthorized, Octokit::Forbidden
-          raise unless (client = untried_clients.pop)
+          Kernel.raise unless (client = untried_clients.pop)
 
           retry
         end
@@ -172,7 +170,41 @@ module Dependabot
           .returns(T::Boolean)
       end
       def respond_to_missing?(method_name, include_private = false)
-        @clients.first.respond_to?(method_name) || super
+        @clients.first.respond_to?(method_name, include_private)
+      end
+
+      private
+
+      sig { params(args: ClientOptions).returns(T::Array[T.nilable(String)]) }
+      def extract_access_tokens(args)
+        access_tokens = T.let([], T::Array[T.nilable(String)])
+        case (raw_access_tokens = args.delete(:access_tokens))
+        when nil
+          nil
+        when Array
+          raw_access_tokens.each do |raw_token|
+            token = T.cast(raw_token, Object)
+            case token
+            when nil, String then access_tokens << token
+            else Kernel.raise TypeError, "access_tokens must contain only strings or nil"
+            end
+          end
+        else
+          Kernel.raise TypeError, "access_tokens must be an array or nil"
+        end
+
+        access_token = args[:access_token]
+        case access_token
+        when nil
+          nil
+        when String
+          access_tokens << access_token
+        else
+          Kernel.raise TypeError, "access_token must be a string or nil"
+        end
+
+        access_tokens << nil if access_tokens.empty?
+        access_tokens.uniq
       end
     end
   end

--- a/common/lib/dependabot/clients/gitlab_with_retries.rb
+++ b/common/lib/dependabot/clients/gitlab_with_retries.rb
@@ -3,13 +3,16 @@
 
 require "gitlab"
 require "sorbet-runtime"
+require "delegate"
 
 require "dependabot/credential"
 
 module Dependabot
   module Clients
-    class GitlabWithRetries
+    class GitlabWithRetries < SimpleDelegator
       extend T::Sig
+
+      ClientOptions = T.type_alias { T::Hash[Symbol, Object] }
 
       RETRYABLE_ERRORS = T.let(
         [Gitlab::Error::BadGateway].freeze,
@@ -67,22 +70,24 @@ module Dependabot
 
       sig { params(repo: String, branch: String).returns(String) }
       def fetch_commit(repo, branch)
-        T.unsafe(branch(repo, branch)).commit.id
+        commit = T.cast(branch(repo, branch)["commit"], Gitlab::ObjectifiedHash)
+        T.cast(commit["id"], String)
       end
 
       sig { params(repo: String).returns(String) }
       def fetch_default_branch(repo)
-        T.unsafe(project(repo)).default_branch
+        T.cast(project(repo)["default_branch"], String)
       end
 
       ############
       # Proxying #
       ############
 
-      sig { params(max_retries: T.nilable(Integer), args: T.untyped).void }
+      sig { params(max_retries: T.nilable(Integer), args: Object).void }
       def initialize(max_retries: 3, **args)
         @max_retries = T.let(max_retries || 3, Integer)
         @client = T.let(::Gitlab::Client.new(args), ::Gitlab::Client)
+        super(@client)
       end
 
       # Create commit in gitlab repo with correctly mapped file actions
@@ -99,7 +104,7 @@ module Dependabot
           branch_name: String,
           commit_message: String,
           files: T::Array[Dependabot::DependencyFile],
-          options: T.untyped
+          options: Object
         )
           .returns(Gitlab::ObjectifiedHash)
       end
@@ -117,19 +122,16 @@ module Dependabot
       sig do
         params(
           method_name: T.any(Symbol, String),
-          args: T.untyped,
-          block: T.nilable(T.proc.returns(T.untyped))
+          args: Object,
+          block: T.nilable(Proc)
         )
-          .returns(T.untyped)
+          .returns(T.anything)
       end
       def method_missing(method_name, *args, &block)
+        original_args = args
         retry_connection_failures do
-          if @client.respond_to?(method_name)
-            mutatable_args = args.map(&:dup)
-            T.unsafe(@client).public_send(method_name, *mutatable_args, &block)
-          else
-            super
-          end
+          args = original_args.map(&:dup)
+          super
         end
       end
 
@@ -141,7 +143,7 @@ module Dependabot
           .returns(T::Boolean)
       end
       def respond_to_missing?(method_name, include_private = false)
-        @client.respond_to?(method_name) || super
+        @client.respond_to?(method_name, include_private)
       end
 
       sig do
@@ -156,7 +158,7 @@ module Dependabot
           yield
         rescue *RETRYABLE_ERRORS
           retry_attempt += 1
-          retry_attempt <= @max_retries ? retry : raise
+          retry_attempt <= @max_retries ? retry : Kernel.raise
         end
       end
 
@@ -166,7 +168,7 @@ module Dependabot
       #
       # @param [Array<Dependabot::DependencyFile>] files
       # @return [Array<Hash>]
-      sig { params(files: T::Array[Dependabot::DependencyFile]).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+      sig { params(files: T::Array[Dependabot::DependencyFile]).returns(T::Array[T::Hash[Symbol, Object]]) }
       def file_actions(files)
         files.map do |file|
           {

--- a/common/lib/dependabot/clients/json_response_parser.rb
+++ b/common/lib/dependabot/clients/json_response_parser.rb
@@ -1,0 +1,101 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "dependabot/errors"
+require "sorbet-runtime"
+
+module Dependabot
+  module Clients
+    module JsonResponseParser
+      extend T::Sig
+
+      JsonObject = T.type_alias { T::Hash[String, Object] }
+      JsonObjects = T.type_alias { T::Array[JsonObject] }
+
+      private
+
+      sig { params(body: String, context: String).returns(JsonObject) }
+      def parse_json_object(body, context)
+        value = T.cast(JSON.parse(body), Object)
+        return T.let(value, JsonObject) if value.is_a?(Hash)
+
+        raise_bad_response(context, "expected an object")
+      rescue JSON::ParserError => e
+        raise_bad_response(context, e.message)
+      end
+
+      sig { params(object: JsonObject, key: String, context: String).returns(JsonObject) }
+      def object_field(object, key, context)
+        value = object.fetch(key)
+        return T.let(value, JsonObject) if value.is_a?(Hash)
+
+        raise_bad_response(context, "#{key} must be an object")
+      rescue KeyError => e
+        raise_bad_response(context, e.message)
+      end
+
+      sig { params(object: JsonObject, key: String, context: String).returns(String) }
+      def string_field(object, key, context)
+        string_value(object.fetch(key), context)
+      rescue KeyError => e
+        raise_bad_response(context, e.message)
+      end
+
+      sig { params(value: Object, context: String).returns(String) }
+      def string_value(value, context)
+        return value if value.is_a?(String)
+
+        raise_bad_response(context, "expected a string")
+      end
+
+      sig { params(object: JsonObject, key: String, context: String).returns(JsonObjects) }
+      def object_array_field(object, key, context)
+        object_array(object.fetch(key), context)
+      rescue KeyError => e
+        raise_bad_response(context, e.message)
+      end
+
+      sig { params(value: Object, context: String).returns(JsonObjects) }
+      def object_array(value, context)
+        raise_bad_response(context, "expected an array") unless value.is_a?(Array)
+
+        value.map do |raw_entry|
+          entry = T.cast(raw_entry, Object)
+          next T.let(entry, JsonObject) if entry.is_a?(Hash)
+
+          raise_bad_response(context, "array entries must be objects")
+        end
+      end
+
+      sig { params(object: JsonObject, key: String, context: String).returns(JsonObject) }
+      def first_object_field(object, key, context)
+        value = object_array_field(object, key, context).first
+        return value if value
+
+        raise_bad_response(context, "#{key} must contain at least one object")
+      end
+
+      sig { params(object: JsonObject, context: String, paths: T::Array[T::Array[String]]).void }
+      def validate_string_paths(object, context, paths)
+        paths.each do |path|
+          current = T.must(path[0...-1]).reduce(object) { |value, key| object_field(value, key, context) }
+          string_field(current, T.must(path.last), context)
+        end
+      end
+
+      sig { params(context: String, message: String).returns(T.noreturn) }
+      def raise_bad_response(context, message)
+        provider, source = response_identity
+        Kernel.raise Dependabot::PrivateSourceBadResponse.new(
+          source,
+          "Malformed #{provider} response for #{context}: #{message}"
+        )
+      end
+
+      sig { returns([String, String]) }
+      def response_identity
+        Kernel.raise NotImplementedError
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/clients/json_response_parser.rb
+++ b/common/lib/dependabot/clients/json_response_parser.rb
@@ -1,6 +1,8 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "json"
+
 require "dependabot/errors"
 require "sorbet-runtime"
 

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -666,17 +666,19 @@ module Dependabot
         response = azure_client.fetch_repo_contents(commit, path)
 
         response.map do |entry|
-          type = case entry.fetch("gitObjectType")
+          object_type = T.cast(entry.fetch("gitObjectType"), String)
+          relative_path = T.cast(entry.fetch("relativePath"), String)
+          type = case object_type
                  when "blob" then "file"
                  when "tree" then "dir"
-                 else entry.fetch("gitObjectType")
+                 else object_type
                  end
 
           RepositoryContent.new(
-            name: File.basename(entry.fetch("relativePath")),
-            path: entry.fetch("relativePath"),
+            name: File.basename(relative_path),
+            path: relative_path,
             type: type,
-            size: entry.fetch("size")
+            size: T.cast(entry.fetch("size"), Integer)
           )
         end
       end
@@ -691,17 +693,19 @@ module Dependabot
                    )
 
         response.map do |file|
-          type = case file.fetch("type")
+          object_type = T.cast(file.fetch("type"), String)
+          path = T.cast(file.fetch("path"), String)
+          type = case object_type
                  when "commit_file" then "file"
                  when "commit_directory" then "dir"
-                 else file.fetch("type")
+                 else object_type
                  end
 
           RepositoryContent.new(
-            name: File.basename(file.fetch("path")),
-            path: file.fetch("path"),
+            name: File.basename(path),
+            path: path,
             type: type,
-            size: file.fetch("size", 0)
+            size: T.cast(file.fetch("size", 0), Integer)
           )
         end
       end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -718,7 +718,8 @@ module Dependabot
           path
         )
 
-        response.files.map do |file|
+        output = T.cast(response.data, Aws::CodeCommit::Types::GetFolderOutput)
+        output.files.map do |file|
           RepositoryContent.new(
             name: File.basename(file.relative_path),
             path: file.relative_path,

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -374,17 +374,19 @@ module Dependabot
         def fetch_bitbucket_file_list
           branch = default_bitbucket_branch
           bitbucket_client.fetch_repo_contents(T.must(source).repo).map do |file|
-            type = case file.fetch("type")
+            object_type = T.cast(file.fetch("type"), String)
+            path = T.cast(file.fetch("path"), String)
+            type = case object_type
                    when "commit_file" then "file"
                    when "commit_directory" then "dir"
-                   else file.fetch("type")
+                   else object_type
                    end
             ChangelogFile.new(
-              name: file.fetch("path").split("/").last,
+              name: T.must(path.split("/").last),
               type: type,
-              size: file.fetch("size", 100),
-              html_url: "#{T.must(source).url}/src/#{branch}/#{file['path']}",
-              download_url: "#{T.must(source).url}/raw/#{branch}/#{file['path']}"
+              size: T.cast(file.fetch("size", 100), Integer),
+              html_url: "#{T.must(source).url}/src/#{branch}/#{path}",
+              download_url: "#{T.must(source).url}/raw/#{branch}/#{path}"
             )
           end
         rescue Dependabot::Clients::Bitbucket::NotFound,
@@ -417,19 +419,21 @@ module Dependabot
         sig { returns(T.untyped) }
         def fetch_azure_file_list
           azure_client.fetch_repo_contents.map do |entry|
-            type = case entry.fetch("gitObjectType")
+            object_type = T.cast(entry.fetch("gitObjectType"), String)
+            relative_path = T.cast(entry.fetch("relativePath"), String)
+            type = case object_type
                    when "blob" then "file"
                    when "tree" then "dir"
-                   else entry.fetch("gitObjectType")
+                   else object_type
                    end
 
             ChangelogFile.new(
-              name: File.basename(entry.fetch("relativePath")),
+              name: File.basename(relative_path),
               type: type,
-              size: entry.fetch("size"),
-              path: entry.fetch("relativePath"),
-              html_url: "#{T.must(source).url}?path=/#{entry.fetch('relativePath')}",
-              download_url: entry.fetch("url")
+              size: T.cast(entry.fetch("size"), Integer),
+              path: relative_path,
+              html_url: "#{T.must(source).url}?path=/#{relative_path}",
+              download_url: T.cast(entry.fetch("url"), String)
             )
           end
         rescue Dependabot::Clients::Azure::NotFound,

--- a/common/lib/dependabot/metadata_finders/base/commits_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/commits_finder.rb
@@ -312,10 +312,13 @@ module Dependabot
           bitbucket_client
             .compare(T.must(source).repo, T.must(previous_tag), T.must(new_tag))
             .map do |commit|
+            summary = T.cast(commit.fetch("summary"), Dependabot::Clients::Bitbucket::JsonObject)
+            links = T.cast(commit.fetch("links"), Dependabot::Clients::Bitbucket::JsonObject)
+            html = T.cast(links.fetch("html"), Dependabot::Clients::Bitbucket::JsonObject)
             {
-              message: commit.dig("summary", "raw"),
-              sha: commit["hash"],
-              html_url: commit.dig("links", "html", "href")
+              message: T.cast(summary.fetch("raw"), String),
+              sha: T.cast(commit.fetch("hash"), String),
+              html_url: T.cast(html.fetch("href"), String)
             }
           end
         rescue Dependabot::Clients::Bitbucket::NotFound,

--- a/common/lib/dependabot/pull_request_creator/azure.rb
+++ b/common/lib/dependabot/pull_request_creator/azure.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/common/spec/dependabot/clients/azure_spec.rb
+++ b/common/spec/dependabot/clients/azure_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe Dependabot::Clients::Azure do
       it { is_expected.to eq("9c8376e9b2e943c2c72fac4b239876f377f0305a") }
     end
 
+    context "when the response has a malformed commit ID" do
+      before do
+        stub_request(:get, branch_url)
+          .with(basic_auth: [username, password])
+          .to_return(status: 200, body: '{"commit":{"commitId":42}}')
+      end
+
+      it "raises a bad response error" do
+        expect { fetch_commit }
+          .to raise_error(Dependabot::PrivateSourceBadResponse, /Malformed Azure response for branch stats/)
+      end
+    end
+
     context "when response is 404" do
       before do
         stub_request(:get, branch_url)

--- a/common/spec/dependabot/clients/bitbucket_spec.rb
+++ b/common/spec/dependabot/clients/bitbucket_spec.rb
@@ -32,6 +32,60 @@ RSpec.describe Dependabot::Clients::Bitbucket do
       .to_return(status: 200, body: fixture("bitbucket", "current_user.json"))
   end
 
+  describe "#fetch_commit" do
+    subject(:fetch_commit) { client.fetch_commit(repo, branch) }
+
+    let(:branch_url) { "#{api_base_url}#{repo}/refs/branches/#{branch}" }
+
+    context "when the branch response is valid" do
+      before do
+        stub_request(:get, branch_url)
+          .to_return(status: 200, body: fixture("bitbucket", "other_branch.json"))
+      end
+
+      it { is_expected.to eq("4c2ea65f2eb932c438557cb6ec29b984794c6108") }
+    end
+
+    context "when the branch response has a malformed target" do
+      before do
+        stub_request(:get, branch_url)
+          .to_return(status: 200, body: '{"target":[]}')
+      end
+
+      it "raises a bad response error" do
+        expect { fetch_commit }
+          .to raise_error(Dependabot::PrivateSourceBadResponse, /Malformed Bitbucket response for branch/)
+      end
+    end
+  end
+
+  describe "#compare" do
+    subject(:compare) { client.compare(repo, "v1.0.0", "v2.0.0") }
+
+    let(:compare_url) { "#{api_base_url}#{repo}/commits/?include=v2.0.0&exclude=v1.0.0" }
+
+    context "when the comparison response is valid" do
+      before do
+        stub_request(:get, compare_url)
+          .to_return(status: 200, body: fixture("bitbucket", "business_compare_commits.json"))
+      end
+
+      it { is_expected.not_to be_empty }
+    end
+
+    context "when a comparison commit is malformed" do
+      before do
+        stub_request(:get, compare_url)
+          .to_return(status: 200, body: '{"values":[{"hash":"abc"}]}')
+      end
+
+      it "raises a bad response error" do
+        expect { compare }
+          .to raise_error(Dependabot::PrivateSourceBadResponse, /Malformed Bitbucket response for commit comparison/)
+      end
+    end
+  end
+
   describe "#default_reviewers" do
     subject(:default_reviewers) do
       client.default_reviewers(repo)

--- a/common/spec/dependabot/clients/bitbucket_with_retries_spec.rb
+++ b/common/spec/dependabot/clients/bitbucket_with_retries_spec.rb
@@ -1,0 +1,33 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/clients/bitbucket_with_retries"
+
+RSpec.describe Dependabot::Clients::BitbucketWithRetries do
+  let(:client) { described_class.new(credentials: nil, max_retries: 1) }
+  let(:bitbucket_client) { client.__getobj__ }
+
+  it "retries delegated methods with fresh argument copies" do
+    attempts = 0
+    statuses = ["OPEN"]
+
+    allow(bitbucket_client).to receive(:pull_requests) do |_repo, _source, _target, received_statuses|
+      attempts += 1
+      received_statuses << "MUTATED"
+      raise Excon::Error::Timeout if attempts == 1
+
+      received_statuses
+    end
+
+    result = client.pull_requests("owner/repo", "source", "target", statuses)
+
+    expect(result).to eq(%w(OPEN MUTATED))
+    expect(statuses).to eq(["OPEN"])
+    expect(attempts).to eq(2)
+  end
+
+  it "reports delegated methods as supported" do
+    expect(client).to respond_to(:pull_requests)
+  end
+end

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -81,4 +81,22 @@ RSpec.describe Dependabot::Clients::CodeCommit do
       end
     end
   end
+
+  describe "#fetch_repo_contents" do
+    subject(:repo_contents) { client.fetch_repo_contents(repo, branch, "/") }
+
+    before do
+      stubbed_cc_client.stub_responses(
+        :get_folder,
+        commit_id: branch,
+        folder_path: "/",
+        files: [{ relative_path: "Gemfile" }]
+      )
+    end
+
+    it "returns the typed folder payload" do
+      expect(repo_contents).to be_a(Aws::CodeCommit::Types::GetFolderOutput)
+      expect(repo_contents.files.map(&:relative_path)).to eq(["Gemfile"])
+    end
+  end
 end

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -94,9 +94,10 @@ RSpec.describe Dependabot::Clients::CodeCommit do
       )
     end
 
-    it "returns the typed folder payload" do
-      expect(repo_contents).to be_a(Aws::CodeCommit::Types::GetFolderOutput)
-      expect(repo_contents.files.map(&:relative_path)).to eq(["Gemfile"])
+    it "preserves the response wrapper and typed folder payload" do
+      expect(repo_contents).to be_a(Seahorse::Client::Response)
+      expect(repo_contents.data).to be_a(Aws::CodeCommit::Types::GetFolderOutput)
+      expect(repo_contents.data.files.map(&:relative_path)).to eq(["Gemfile"])
     end
   end
 end

--- a/common/spec/dependabot/clients/json_response_parser_spec.rb
+++ b/common/spec/dependabot/clients/json_response_parser_spec.rb
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+require "open3"
+require "rbconfig"
+require "spec_helper"
+require "dependabot/clients/json_response_parser"
+
+RSpec.describe Dependabot::Clients::JsonResponseParser do
+  it "loads and parses JSON without another client loading JSON first" do
+    lib_path = File.expand_path("../../../lib", __dir__)
+    script = <<~RUBY
+      require "dependabot/clients/json_response_parser"
+
+      parser = Class.new do
+        include Dependabot::Clients::JsonResponseParser
+
+        def parse
+          parse_json_object("{}", "test")
+        end
+
+        def response_identity
+          ["test", "https://example.com"]
+        end
+      end
+
+      parser.new.parse
+    RUBY
+
+    _stdout, stderr, status = Open3.capture3(RbConfig.ruby, "-I", lib_path, "-e", script)
+
+    expect(stderr).to eq("")
+    expect(status).to be_success
+  end
+end

--- a/pre_commit/lib/dependabot/pre_commit/file_parser/hook_language_fetcher.rb
+++ b/pre_commit/lib/dependabot/pre_commit/file_parser/hook_language_fetcher.rb
@@ -99,15 +99,14 @@ module Dependabot
           ).returns(T.nilable(T::Array[T::Hash[String, Object]]))
         end
         def fetch_from_github(source, revision)
-          response = github_client.send(
-            :contents,
+          response = github_client.contents(
             source.repo,
             path: HOOKS_FILE,
             ref: revision
           )
-          return nil unless response
 
-          content = Base64.decode64(response.content)
+          resource = T.cast(response, Sawyer::Resource)
+          content = Base64.decode64(T.cast(resource[:content], String))
           parse_hooks_yaml(content)
         rescue Octokit::NotFound
           Dependabot.logger.debug("#{HOOKS_FILE} not found in #{source.repo}@#{revision}")

--- a/pre_commit/spec/dependabot/pre_commit/file_parser/hook_language_fetcher_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/file_parser/hook_language_fetcher_spec.rb
@@ -10,7 +10,7 @@ require "dependabot/pre_commit/file_parser/hook_language_fetcher"
 RSpec.describe Dependabot::PreCommit::FileParser::HookLanguageFetcher do
   let(:credentials) { [] }
   let(:fetcher) { described_class.new(credentials: credentials) }
-  let(:github_client) { double("github_client") }
+  let(:github_client) { instance_double(Octokit::Client) }
   let(:sawyer_agent) { Sawyer::Agent.new("https://api.github.com") }
 
   def github_content(content)

--- a/pre_commit/spec/dependabot/pre_commit/file_parser/hook_language_fetcher_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/file_parser/hook_language_fetcher_spec.rb
@@ -7,24 +7,18 @@ require "octokit"
 require "dependabot/pre_commit/file_parser"
 require "dependabot/pre_commit/file_parser/hook_language_fetcher"
 
-# Struct to mock GitHub API content response (Sawyer::Resource uses dynamic attributes)
-GithubContentResponse = Struct.new(:content)
-
 RSpec.describe Dependabot::PreCommit::FileParser::HookLanguageFetcher do
   let(:credentials) { [] }
   let(:fetcher) { described_class.new(credentials: credentials) }
-  let(:octokit_client) { instance_double(Octokit::Client) }
-  let(:github_client) { instance_double(Dependabot::Clients::GithubWithRetries) }
+  let(:github_client) { double("github_client") }
+  let(:sawyer_agent) { Sawyer::Agent.new("https://api.github.com") }
 
   def github_content(content)
-    GithubContentResponse.new(content: Base64.encode64(content))
+    Sawyer::Resource.new(sawyer_agent, content: Base64.encode64(content))
   end
 
   before do
     allow(fetcher).to receive(:github_client).and_return(github_client)
-    allow(github_client).to receive(:method_missing) do |method_name, *args, &block|
-      octokit_client.public_send(method_name, *args, &block)
-    end
   end
 
   describe "#fetch_language" do
@@ -47,7 +41,7 @@ RSpec.describe Dependabot::PreCommit::FileParser::HookLanguageFetcher do
       end
 
       before do
-        allow(octokit_client).to receive(:contents)
+        allow(github_client).to receive(:contents)
           .with("psf/black", hash_including(path: ".pre-commit-hooks.yaml", ref: "24.1.1"))
           .and_return(github_content(hooks_yaml))
       end
@@ -69,7 +63,7 @@ RSpec.describe Dependabot::PreCommit::FileParser::HookLanguageFetcher do
       end
 
       before do
-        allow(octokit_client).to receive(:contents)
+        allow(github_client).to receive(:contents)
           .with("psf/black", hash_including(path: ".pre-commit-hooks.yaml", ref: "24.1.1"))
           .and_return(github_content(hooks_yaml))
       end
@@ -82,7 +76,7 @@ RSpec.describe Dependabot::PreCommit::FileParser::HookLanguageFetcher do
 
     context "when hooks file doesn't exist (404)" do
       before do
-        allow(octokit_client).to receive(:contents)
+        allow(github_client).to receive(:contents)
           .with("psf/black", hash_including(path: ".pre-commit-hooks.yaml", ref: "24.1.1"))
           .and_raise(Octokit::NotFound)
       end
@@ -97,7 +91,7 @@ RSpec.describe Dependabot::PreCommit::FileParser::HookLanguageFetcher do
       let(:invalid_yaml) { "this is: not: valid: yaml: [" }
 
       before do
-        allow(octokit_client).to receive(:contents)
+        allow(github_client).to receive(:contents)
           .with("psf/black", hash_including(path: ".pre-commit-hooks.yaml", ref: "24.1.1"))
           .and_return(github_content(invalid_yaml))
       end
@@ -122,7 +116,7 @@ RSpec.describe Dependabot::PreCommit::FileParser::HookLanguageFetcher do
       end
 
       before do
-        allow(octokit_client).to receive(:contents)
+        allow(github_client).to receive(:contents)
           .with("pre-commit/mirrors-eslint", hash_including(path: ".pre-commit-hooks.yaml", ref: "v8.56.0"))
           .and_return(github_content(hooks_yaml))
       end
@@ -144,7 +138,7 @@ RSpec.describe Dependabot::PreCommit::FileParser::HookLanguageFetcher do
       end
 
       before do
-        allow(octokit_client).to receive(:contents)
+        allow(github_client).to receive(:contents)
           .with("psf/black", hash_including(path: ".pre-commit-hooks.yaml", ref: "24.1.1"))
           .and_return(github_content(hooks_yaml))
       end
@@ -154,7 +148,7 @@ RSpec.describe Dependabot::PreCommit::FileParser::HookLanguageFetcher do
         fetcher.fetch_language(repo_url: repo_url, revision: revision, hook_id: hook_id)
         fetcher.fetch_language(repo_url: repo_url, revision: revision, hook_id: "black-jupyter")
 
-        expect(octokit_client).to have_received(:contents).once
+        expect(github_client).to have_received(:contents).once
       end
     end
 

--- a/sorbet/rbi/shims/bitbucket_with_retries.rbi
+++ b/sorbet/rbi/shims/bitbucket_with_retries.rbi
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # Method signatures for Dependabot::Clients::Bitbucket methods delegated via method_missing.
-# These allow callers to use BitbucketWithRetries without T.unsafe wrappers.
+# These give callers concrete types for methods handled by the retry proxy.
 
 module Dependabot
   module Clients
@@ -18,17 +18,17 @@ module Dependabot
           repo: String,
           commit: T.nilable(String),
           path: T.nilable(String)
-        ).returns(T::Array[T::Hash[String, T.untyped]])
+        ).returns(T::Array[Bitbucket::JsonObject])
       end
       def fetch_repo_contents(repo, commit = nil, path = nil); end
 
       sig { params(repo: String, commit: String, path: String).returns(String) }
       def fetch_file_contents(repo, commit, path); end
 
-      sig { params(repo: String, branch_name: T.nilable(String)).returns(T::Enumerator[T::Hash[String, T.untyped]]) }
+      sig { params(repo: String, branch_name: T.nilable(String)).returns(T::Enumerator[Bitbucket::JsonObject]) }
       def commits(repo, branch_name = nil); end
 
-      sig { params(repo: String, branch_name: String).returns(T::Hash[String, T.untyped]) }
+      sig { params(repo: String, branch_name: String).returns(Bitbucket::JsonObject) }
       def branch(repo, branch_name); end
 
       sig do
@@ -37,17 +37,17 @@ module Dependabot
           source_branch: T.nilable(String),
           target_branch: T.nilable(String),
           status: T::Array[String]
-        ).returns(T::Array[T::Hash[String, T.untyped]])
+        ).returns(T::Array[Bitbucket::JsonObject])
       end
       def pull_requests(repo, source_branch, target_branch, status = []); end
 
       sig { params(url: String).returns(Excon::Response) }
       def get(url); end
 
-      sig { params(repo: String, previous_tag: String, new_tag: String).returns(T::Array[T::Hash[String, T.untyped]]) }
+      sig { params(repo: String, previous_tag: String, new_tag: String).returns(T::Array[Bitbucket::JsonObject]) }
       def compare(repo, previous_tag, new_tag); end
 
-      sig { params(repo: String).returns(T::Array[T::Hash[String, String]]) }
+      sig { params(repo: String).returns(T::Array[T::Hash[Symbol, String]]) }
       def default_reviewers(repo); end
     end
   end

--- a/sorbet/rbi/shims/github_with_retries.rbi
+++ b/sorbet/rbi/shims/github_with_retries.rbi
@@ -2,24 +2,24 @@
 # frozen_string_literal: true
 
 # Method signatures for Octokit::Client methods delegated via method_missing.
-# These allow callers to use GithubWithRetries without T.unsafe wrappers.
+# These give callers concrete types for methods handled by the retry proxy.
 
 module Dependabot
   module Clients
     class GithubWithRetries
       # Repositories
-      sig { params(repo: String, options: T.untyped).returns(Sawyer::Resource) }
+      sig { params(repo: String, options: ClientOptions).returns(Sawyer::Resource) }
       def repo(repo, options = {}); end
 
-      sig { params(repo: String, options: T.untyped).returns(Sawyer::Resource) }
+      sig { params(repo: String, options: ClientOptions).returns(Sawyer::Resource) }
       def repository(repo, options = {}); end
 
       # Contents
-      sig { params(repo: String, options: T.untyped).returns(T.any(Sawyer::Resource, T::Array[Sawyer::Resource])) }
+      sig { params(repo: String, options: ClientOptions).returns(T.any(Sawyer::Resource, T::Array[Sawyer::Resource])) }
       def contents(repo, options = {}); end
 
       # Commits
-      sig { params(repo: String, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
+      sig { params(repo: String, options: ClientOptions).returns(T::Array[Sawyer::Resource]) }
       def commits(repo, options = {}); end
 
       sig do
@@ -28,7 +28,7 @@ module Dependabot
           message: String,
           tree: String,
           parents: T.nilable(T.any(String, T::Array[String])),
-          options: T.untyped
+          options: ClientOptions
         ).returns(Sawyer::Resource)
       end
       def create_commit(repo, message, tree, parents = nil, options = {}); end
@@ -38,13 +38,13 @@ module Dependabot
           repo: String,
           start: String,
           endd: String,
-          options: T.untyped
+          options: ClientOptions
         ).returns(Sawyer::Resource)
       end
       def compare(repo, start, endd, options = {}); end
 
       # Git objects
-      sig { params(repo: String, blob_sha: String, options: T.untyped).returns(Sawyer::Resource) }
+      sig { params(repo: String, blob_sha: String, options: ClientOptions).returns(Sawyer::Resource) }
       def blob(repo, blob_sha, options = {}); end
 
       sig do
@@ -52,16 +52,25 @@ module Dependabot
           repo: String,
           content: String,
           encoding: T.nilable(String),
-          options: T.untyped
+          options: ClientOptions
         ).returns(String)
       end
       def create_blob(repo, content, encoding = nil, options = {}); end
 
-      sig { params(repo: String, tree: T.untyped, options: T.untyped).returns(Sawyer::Resource) }
+      sig do
+        params(
+          repo: String,
+          tree: T::Array[T::Hash[Symbol, Object]],
+          options: ClientOptions
+        ).returns(Sawyer::Resource)
+      end
       def create_tree(repo, tree, options = {}); end
 
       # Refs
-      sig { params(repo: String, ref: String, options: T.untyped).returns(Sawyer::Resource) }
+      sig do
+        params(repo: String, ref: String, options: ClientOptions)
+          .returns(T.any(Sawyer::Resource, T::Array[Sawyer::Resource]))
+      end
       def ref(repo, ref, options = {}); end
 
       sig do
@@ -69,7 +78,7 @@ module Dependabot
           repo: String,
           ref: String,
           sha: String,
-          options: T.untyped
+          options: ClientOptions
         ).returns(Sawyer::Resource)
       end
       def create_ref(repo, ref, sha, options = {}); end
@@ -80,49 +89,40 @@ module Dependabot
           ref: String,
           sha: String,
           force: T.nilable(T::Boolean),
-          options: T.untyped
+          options: ClientOptions
         ).returns(Sawyer::Resource)
       end
       def update_ref(repo, ref, sha, force = nil, options = {}); end
 
       # Branches
-      sig { params(repo: String, branch: String, options: T.untyped).returns(Sawyer::Resource) }
+      sig { params(repo: String, branch: String, options: ClientOptions).returns(Sawyer::Resource) }
       def branch(repo, branch, options = {}); end
 
       # Pull requests
-      sig { params(repo: String, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
+      sig { params(repo: String, options: ClientOptions).returns(T::Array[Sawyer::Resource]) }
       def pull_requests(repo, options = {}); end
 
-      sig { params(repo: String, number: Integer, options: T.untyped).returns(Sawyer::Resource) }
+      sig { params(repo: String, number: Integer, options: ClientOptions).returns(Sawyer::Resource) }
       def pull_request(repo, number, options = {}); end
 
-      sig do
-        params(
-          repo: String,
-          base: String,
-          head: String,
-          title: String,
-          body: T.nilable(String),
-          options: T.untyped
-        ).returns(Sawyer::Resource)
-      end
-      def create_pull_request(repo, base, head, title, body = nil, options = {}); end
+      sig { params(repo: String, base: String, head: String, title: String, args: Object).returns(Sawyer::Resource) }
+      def create_pull_request(repo, base, head, title, *args); end
 
-      sig { params(args: T.untyped).returns(Sawyer::Resource) }
+      sig { params(args: Object).returns(Sawyer::Resource) }
       def update_pull_request(*args); end
 
       sig do
         params(
           repo: String,
           number: Integer,
-          reviewers: T.nilable(T.any(T::Array[String], T::Hash[Symbol, T.untyped])),
-          options: T.untyped
+          reviewers: T.nilable(T.any(T::Array[String], T::Hash[Symbol, Object])),
+          options: ClientOptions
         ).returns(Sawyer::Resource)
       end
       def request_pull_request_review(repo, number, reviewers = nil, options = {}); end
 
       # Issues
-      sig { params(repo: String, number: Integer, comment: String, options: T.untyped).returns(Sawyer::Resource) }
+      sig { params(repo: String, number: Integer, comment: String, options: ClientOptions).returns(Sawyer::Resource) }
       def add_comment(repo, number, comment, options = {}); end
 
       sig do
@@ -130,17 +130,17 @@ module Dependabot
           repo: String,
           number: Integer,
           assignees: T::Array[String],
-          options: T.untyped
+          options: ClientOptions
         ).returns(Sawyer::Resource)
       end
       def add_assignees(repo, number, assignees, options = {}); end
 
-      sig { params(repo: String, number: Integer, args: T.untyped).returns(Sawyer::Resource) }
+      sig { params(repo: String, number: Integer, args: Object).returns(Sawyer::Resource) }
       def update_issue(repo, number, *args); end
 
       # Labels
-      sig { params(repo: String, per_page: T.untyped, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
-      def labels(repo, per_page = nil, options = {}); end
+      sig { params(repo: String, options: ClientOptions).returns(T::Array[Sawyer::Resource]) }
+      def labels(repo, options = {}); end
 
       sig { params(repo: String, number: Integer, labels: T::Array[String]).returns(T::Array[Sawyer::Resource]) }
       def add_labels_to_an_issue(repo, number, labels); end
@@ -150,25 +150,25 @@ module Dependabot
           repo: String,
           label: String,
           color: String,
-          options: T.untyped
+          options: ClientOptions
         ).returns(Sawyer::Resource)
       end
       def add_label(repo, label, color, options = {}); end
 
       # Releases
-      sig { params(repo: String, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
+      sig { params(repo: String, options: ClientOptions).returns(T::Array[Sawyer::Resource]) }
       def releases(repo, options = {}); end
 
       # Git data
-      sig { params(repo: String, sha: String, options: T.untyped).returns(Sawyer::Resource) }
+      sig { params(repo: String, sha: String, options: ClientOptions).returns(Sawyer::Resource) }
       def git_commit(repo, sha, options = {}); end
 
       # Pull request commits
-      sig { params(repo: String, number: Integer, options: T.untyped).returns(T::Array[Sawyer::Resource]) }
+      sig { params(repo: String, number: Integer, options: ClientOptions).returns(T::Array[Sawyer::Resource]) }
       def pull_request_commits(repo, number, options = {}); end
 
       # HTTP
-      sig { params(url: String, options: T.untyped).returns(Sawyer::Resource) }
+      sig { params(url: String, options: ClientOptions).returns(Sawyer::Resource) }
       def get(url, options = {}); end
 
       # Pagination

--- a/sorbet/rbi/shims/gitlab_with_retries.rbi
+++ b/sorbet/rbi/shims/gitlab_with_retries.rbi
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # Method signatures for Gitlab::Client methods delegated via method_missing.
-# These allow callers to use GitlabWithRetries without T.unsafe wrappers.
+# These give callers concrete types for methods handled by the retry proxy.
 
 module Dependabot
   module Clients
@@ -12,27 +12,27 @@ module Dependabot
       def branch(project, branch); end
 
       # Commits
-      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      sig { params(project: String, options: ClientOptions).returns(Gitlab::PaginatedResponse) }
       def commits(project, options = {}); end
 
       sig { params(project: String, sha: String).returns(Gitlab::ObjectifiedHash) }
       def commit(project, sha); end
 
       # Merge requests
-      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      sig { params(project: String, options: ClientOptions).returns(Gitlab::PaginatedResponse) }
       def merge_requests(project, options = {}); end
 
-      sig { params(project: String, id: Integer, options: T.untyped).returns(Gitlab::ObjectifiedHash) }
+      sig { params(project: String, id: Integer, options: ClientOptions).returns(Gitlab::ObjectifiedHash) }
       def merge_request(project, id, options = {}); end
 
-      sig { params(project: String, title: String, options: T.untyped).returns(Gitlab::ObjectifiedHash) }
+      sig { params(project: String, title: String, options: ClientOptions).returns(Gitlab::ObjectifiedHash) }
       def create_merge_request(project, title, options = {}); end
 
       sig do
         params(
           project: String,
           merge_request: Integer,
-          options: T.untyped
+          options: ClientOptions
         ).returns(Gitlab::ObjectifiedHash)
       end
       def create_merge_request_level_rule(project, merge_request, options = {}); end
@@ -42,17 +42,17 @@ module Dependabot
       def create_branch(project, branch, ref); end
 
       # Projects
-      sig { params(id: String, options: T.untyped).returns(Gitlab::ObjectifiedHash) }
+      sig { params(id: String, options: ClientOptions).returns(Gitlab::ObjectifiedHash) }
       def project(id, options = {}); end
 
       # Repository files
       sig { params(project: String, file_path: String, ref: String).returns(Gitlab::ObjectifiedHash) }
       def get_file(project, file_path, ref); end
 
-      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      sig { params(project: String, options: ClientOptions).returns(Gitlab::PaginatedResponse) }
       def repo_tree(project, options = {}); end
 
-      sig { params(project: String, submodule: String, options: T.untyped).returns(Gitlab::ObjectifiedHash) }
+      sig { params(project: String, submodule: String, options: ClientOptions).returns(Gitlab::ObjectifiedHash) }
       def edit_submodule(project, submodule, options = {}); end
 
       # Labels
@@ -61,16 +61,16 @@ module Dependabot
           project: String,
           name: String,
           color: String,
-          options: T.untyped
+          options: ClientOptions
         ).returns(Gitlab::ObjectifiedHash)
       end
       def create_label(project, name, color, options = {}); end
 
-      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      sig { params(project: String, options: ClientOptions).returns(Gitlab::PaginatedResponse) }
       def labels(project, options = {}); end
 
       # Tags
-      sig { params(project: String, options: T.untyped).returns(Gitlab::PaginatedResponse) }
+      sig { params(project: String, options: ClientOptions).returns(Gitlab::PaginatedResponse) }
       def tags(project, options = {}); end
 
       # Comparison


### PR DESCRIPTION
Types Azure, Bitbucket, CodeCommit, GitHub, and GitLab clients without changing provider response shapes. Retry proxies keep dynamic compatibility through `SimpleDelegator`.

Ratchets: `T.untyped` 915 to 882; `T.unsafe` 71 to 64.