### PR TITLE
Type common repository fetching

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 882
+# Offense count: 871
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -275,7 +275,6 @@ Sorbet/ForbidTUntyped:
     - "bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb"
     - "bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb"
     - "bundler/lib/dependabot/bundler/update_checker/version_resolver.rb"
-    - "common/lib/dependabot/file_fetchers/base.rb"
     - "common/lib/dependabot/metadata_finders/base/changelog_finder.rb"
     - "common/lib/dependabot/pull_request_creator/github.rb"
     - "common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb"

--- a/bazel/lib/dependabot/bazel/file_fetcher.rb
+++ b/bazel/lib/dependabot/bazel/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/file_fetchers"

--- a/bazel/lib/dependabot/bazel/file_fetcher.rb
+++ b/bazel/lib/dependabot/bazel/file_fetcher.rb
@@ -73,7 +73,7 @@ module Dependabot
         files = T.let([], T::Array[DependencyFile])
 
         module_file_items.each do |item|
-          file = fetch_file_if_present(T.must(item.name))
+          file = fetch_file_if_present(item.name)
           files << file if file
         end
 

--- a/common/lib/dependabot/clients/github_with_retries.rb
+++ b/common/lib/dependabot/clients/github_with_retries.rb
@@ -103,6 +103,14 @@ module Dependabot
         T.cast(repository(repo)[:default_branch], String)
       end
 
+      sig { params(repo: String, path: String, ref: String).returns(String) }
+      def raw_contents(repo, path:, ref:)
+        T.cast(
+          contents(repo, path: path, ref: ref, accept: "application/vnd.github.v3.raw"),
+          String
+        )
+      end
+
       ############
       # Proxying #
       ############

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -788,10 +788,13 @@ module Dependabot
             path: new_path
           )
         else
+          resolved_commit = commit
+          raise Octokit::NotFound unless resolved_commit
+
           RepositorySpecification.new(
             repo: source.repo,
             path: path,
-            commit: T.must(commit),
+            commit: resolved_commit,
             provider: source.provider
           )
         end

--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -19,40 +19,26 @@ require "dependabot/shared_helpers"
 # rubocop:disable Metrics/ClassLength
 module Dependabot
   module FileFetchers
-    class RepositoryContent
-      extend T::Sig
+    class RepositoryContent < T::ImmutableStruct
+      const :name, String
+      const :path, String
+      const :type, String
+      const :size, Integer
+      const :sha, T.nilable(String), default: nil
+    end
 
-      sig { returns(T.nilable(String)) }
-      attr_reader :name
+    class LinkedPath < T::ImmutableStruct
+      const :repo, String
+      const :provider, String
+      const :commit, String
+      const :path, String
+    end
 
-      sig { returns(T.nilable(String)) }
-      attr_reader :path
-
-      sig { returns(T.nilable(String)) }
-      attr_reader :type
-
-      sig { returns(T.nilable(Integer)) }
-      attr_reader :size
-
-      sig { returns(T.nilable(String)) }
-      attr_reader :sha
-
-      sig do
-        params(
-          name: T.nilable(String),
-          path: T.nilable(String),
-          type: T.nilable(String),
-          size: T.nilable(Integer),
-          sha: T.nilable(String)
-        ).void
-      end
-      def initialize(name: nil, path: nil, type: nil, size: nil, sha: nil)
-        @name = name
-        @path = path
-        @type = type
-        @size = size
-        @sha = sha
-      end
+    class RepositorySpecification < T::ImmutableStruct
+      const :provider, String
+      const :repo, String
+      const :path, String
+      const :commit, String
     end
 
     class Base
@@ -146,8 +132,9 @@ module Dependabot
         @repo_contents_path = repo_contents_path
         @update_config = T.let(update_config, T.nilable(Dependabot::Config::UpdateConfig))
         @exclude_paths = T.let(update_config&.exclude_paths || [], T::Array[String])
-        @linked_paths = T.let({}, T::Hash[T.untyped, T.untyped])
-        @submodules = T.let([], T::Array[T.untyped])
+        @linked_paths = T.let({}, T::Hash[String, LinkedPath])
+        @submodules = T.let([], T::Array[String])
+        @repo_contents = T.let(nil, T.nilable(T::Hash[String, T::Array[RepositoryContent]]))
         @options = options
 
         @files = T.let([], T::Array[DependencyFile])
@@ -202,7 +189,7 @@ module Dependabot
 
         branch = target_branch || default_branch_for_repo
 
-        @commit ||= T.let(T.unsafe(client_for_provider).fetch_commit(repo, branch), T.nilable(String))
+        @commit ||= T.let(fetch_commit_for_provider(repo, branch), T.nilable(String))
       rescue *CLIENT_NOT_FOUND_ERRORS
         raise Dependabot::BranchNotFound, branch
       rescue Octokit::Conflict => e
@@ -226,7 +213,7 @@ module Dependabot
         raise Dependabot::RepoNotFound.new(source, e.message)
       end
 
-      sig { overridable.returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { overridable.returns(T.nilable(T::Hash[Symbol, T.anything])) }
       def ecosystem_versions; end
 
       sig { abstract.returns(T::Array[DependencyFile]) }
@@ -236,7 +223,9 @@ module Dependabot
 
       sig { params(name: String).returns(T.nilable(Dependabot::DependencyFile)) }
       def fetch_support_file(name)
-        fetch_file_if_present(name)&.tap { |f| f.support_file = true }
+        file = fetch_file_if_present(name)
+        file.support_file = true if file
+        file
       end
 
       sig { params(filename: String, fetch_submodules: T::Boolean).returns(T.nilable(DependencyFile)) }
@@ -304,7 +293,10 @@ module Dependabot
 
         linked_path = symlinked_subpath(clean_path)
         type = "symlink" if linked_path
-        symlink_target = clean_path.sub(T.must(linked_path), @linked_paths.dig(linked_path, :path)) if type == "symlink"
+        if type == "symlink"
+          linked_path_details = T.must(@linked_paths[T.must(linked_path)])
+          symlink_target = clean_path.sub(T.must(linked_path), linked_path_details.path)
+        end
 
         DependencyFile.new(
           name: Pathname.new(filename).cleanpath.to_path,
@@ -342,7 +334,7 @@ module Dependabot
           raise_errors: T::Boolean,
           fetch_submodules: T::Boolean
         )
-          .returns(T::Array[T.untyped])
+          .returns(T::Array[RepositoryContent])
       end
       def repo_contents(
         dir: ".",
@@ -353,7 +345,7 @@ module Dependabot
         dir = File.join(directory, dir) unless ignore_base_directory
         path = Pathname.new(dir).cleanpath.to_path.gsub(%r{^/*}, "")
 
-        @repo_contents ||= T.let({}, T.nilable(T::Hash[String, T::Array[T.untyped]]))
+        @repo_contents ||= {}
         @repo_contents[dir.to_s] ||= if repo_contents_path
                                        _cloned_repo_contents(path)
                                      else
@@ -378,7 +370,7 @@ module Dependabot
 
       sig { returns(String) }
       def default_branch_for_repo
-        @default_branch_for_repo ||= T.let(T.unsafe(client_for_provider).fetch_default_branch(repo), T.nilable(String))
+        @default_branch_for_repo ||= T.let(fetch_default_branch_for_provider(repo), T.nilable(String))
       rescue *CLIENT_NOT_FOUND_ERRORS
         raise Dependabot::RepoNotFound, source
       end
@@ -390,49 +382,54 @@ module Dependabot
           commit: String,
           github_response: Sawyer::Resource
         )
-          .returns(T.nilable(T::Hash[String, T.untyped]))
+          .returns(T.nilable(LinkedPath))
       end
       def update_linked_paths(repo, path, commit, github_response)
-        case github_response[:type]
+        case sawyer_string(github_response, :type)
         when "submodule"
-          sub_source = Source.from_url(github_response[:submodule_git_url])
+          submodule_url = sawyer_optional_string(github_response, :submodule_git_url)
+          return unless submodule_url
+
+          sub_source = Source.from_url(submodule_url)
           return unless sub_source
 
-          @linked_paths[path] = {
+          @linked_paths[path] = LinkedPath.new(
             repo: sub_source.repo,
             provider: sub_source.provider,
-            commit: github_response[:sha],
+            commit: sawyer_string(github_response, :sha),
             path: "/"
-          }
+          )
         when "symlink"
-          updated_path = File.join(File.dirname(path), github_response[:target])
-          @linked_paths[path] = {
+          updated_path = File.join(File.dirname(path), sawyer_string(github_response, :target))
+          @linked_paths[path] = LinkedPath.new(
             repo: repo,
             provider: "github",
             commit: commit,
             path: Pathname.new(updated_path).cleanpath.to_path
-          }
+          )
         end
       end
 
-      sig do
-        returns(
-          T.any(
-            Dependabot::Clients::GithubWithRetries,
-            Dependabot::Clients::GitlabWithRetries,
-            Dependabot::Clients::Azure,
-            Dependabot::Clients::BitbucketWithRetries,
-            Dependabot::Clients::CodeCommit
-          )
-        )
-      end
-      def client_for_provider
+      sig { params(repo: String, branch: String).returns(String) }
+      def fetch_commit_for_provider(repo, branch)
         case source.provider
-        when "github" then github_client
-        when "gitlab" then gitlab_client
-        when "azure" then azure_client
-        when "bitbucket" then bitbucket_client
-        when "codecommit" then codecommit_client
+        when "github" then github_client.fetch_commit(repo, branch)
+        when "gitlab" then gitlab_client.fetch_commit(repo, branch)
+        when "azure" then azure_client.fetch_commit(repo, branch)
+        when "bitbucket" then bitbucket_client.fetch_commit(repo, branch)
+        when "codecommit" then codecommit_client.fetch_commit(repo, branch)
+        else raise "Unsupported provider '#{source.provider}'."
+        end
+      end
+
+      sig { params(repo: String).returns(String) }
+      def fetch_default_branch_for_provider(repo)
+        case source.provider
+        when "github" then github_client.fetch_default_branch(repo)
+        when "gitlab" then gitlab_client.fetch_default_branch(repo)
+        when "azure" then azure_client.fetch_default_branch(repo)
+        when "bitbucket" then bitbucket_client.fetch_default_branch(repo)
+        when "codecommit" then codecommit_client.fetch_default_branch(repo)
         else raise "Unsupported provider '#{source.provider}'."
         end
       end
@@ -508,9 +505,11 @@ module Dependabot
       end
       def _fetch_repo_contents(path, fetch_submodules: false, raise_errors: true) # rubocop:disable Metrics/PerceivedComplexity
         path = path.gsub(" ", "%20")
-        provider, repo, tmp_path, commit =
-          _full_specification_for(path, fetch_submodules: fetch_submodules)
-          .values_at(:provider, :repo, :path, :commit)
+        specification = _full_specification_for(path, fetch_submodules: fetch_submodules)
+        provider = specification.provider
+        repo = specification.repo
+        tmp_path = specification.path
+        commit = specification.commit
 
         entries = _fetch_repo_contents_fully_specified(provider, repo, tmp_path, commit)
         if Dependabot::Experiments.enabled?(:enable_exclude_paths_subdirectory_manifest_files)
@@ -529,7 +528,7 @@ module Dependabot
         # a retry to get its contents.
         updated_path =
           _full_specification_for(path, fetch_submodules: fetch_submodules)
-          .fetch(:path)
+          .path
         retry if updated_path != tmp_path
 
         return result.call unless fetch_submodules && !retrying
@@ -566,8 +565,8 @@ module Dependabot
         path = path.gsub(" ", "%20")
         github_response = github_client.contents(repo, path: path, ref: commit)
 
-        if github_response.respond_to?(:type)
-          update_linked_paths(repo, path, commit, T.unsafe(github_response))
+        if github_response.is_a?(Sawyer::Resource)
+          update_linked_paths(repo, path, commit, github_response)
           raise Octokit::NotFound
         end
 
@@ -606,7 +605,7 @@ module Dependabot
       end
 
       # Filters out any entries whose paths match one of the exclude_paths globs.
-      sig { params(entries: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+      sig { params(entries: T::Array[RepositoryContent]).returns(T::Array[RepositoryContent]) }
       def filter_excluded(entries)
         Dependabot.logger.info("DEBUG filter_excluded: entries=#{entries.length}, exclude_paths=#{@exclude_paths.inspect}") # rubocop:disable Layout/LineLength
 
@@ -628,33 +627,76 @@ module Dependabot
 
       sig { params(file: Sawyer::Resource).returns(RepositoryContent) }
       def _build_github_file_struct(file)
+        name = sawyer_string(file, :name)
         RepositoryContent.new(
-          name: file[:name],
-          path: file[:path],
-          type: file[:type],
-          sha: file[:sha],
-          size: file[:size]
+          name: name,
+          path: sawyer_optional_string(file, :path) || name,
+          type: sawyer_optional_string(file, :type) || "",
+          sha: sawyer_optional_string(file, :sha),
+          size: sawyer_optional_integer(file, :size) || 0
+        )
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol).returns(String) }
+      def sawyer_string(resource, key)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(String)
+
+        raise_bad_repository_response("GitHub", "#{key} must be a string")
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol).returns(T.nilable(String)) }
+      def sawyer_optional_string(resource, key)
+        value = T.cast(resource[key], Object)
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise_bad_repository_response("GitHub", "#{key} must be a string or nil")
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol).returns(T.nilable(Integer)) }
+      def sawyer_optional_integer(resource, key)
+        value = T.cast(resource[key], Object)
+        return if value.nil?
+        return value if value.is_a?(Integer)
+
+        raise_bad_repository_response("GitHub", "#{key} must be an integer or nil")
+      end
+
+      sig { params(resource: Gitlab::ObjectifiedHash, key: String).returns(String) }
+      def gitlab_string(resource, key)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(String)
+
+        raise_bad_repository_response("GitLab", "#{key} must be a string")
+      end
+
+      sig { params(provider: String, message: String).returns(T.noreturn) }
+      def raise_bad_repository_response(provider, message)
+        raise Dependabot::PrivateSourceBadResponse.new(
+          source.url,
+          "Malformed #{provider} repository response: #{message}"
         )
       end
 
       sig { params(repo: String, path: String, commit: String).returns(T::Array[RepositoryContent]) }
       def _gitlab_repo_contents(repo, path, commit)
-        T.unsafe(
-          gitlab_client
-                   .repo_tree(repo, path: path, ref: commit, per_page: 100)
-        )
-         .map do |file|
+        gitlab_client
+          .repo_tree(repo, path: path, ref: commit, per_page: 100)
+          .map do |raw_file|
+          file = raw_file
+          object_type = gitlab_string(file, "type")
           # GitLab API essentially returns the output from `git ls-tree`
-          type = case file.type
+          type = case object_type
                  when "blob" then "file"
                  when "tree" then "dir"
                  when "commit" then "submodule"
-                 else file.fetch("type")
+                 else object_type
                  end
 
           RepositoryContent.new(
-            name: file.name,
-            path: file.path,
+            name: gitlab_string(file, "name"),
+            path: gitlab_string(file, "path"),
             type: type,
             size: 0 # GitLab doesn't return file size
           )
@@ -729,29 +771,29 @@ module Dependabot
         end
       end
 
-      sig { params(path: String, fetch_submodules: T::Boolean).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(path: String, fetch_submodules: T::Boolean).returns(RepositorySpecification) }
       def _full_specification_for(path, fetch_submodules:)
         if fetch_submodules && _linked_dir_for(path)
-          linked_dir_details = @linked_paths[_linked_dir_for(path)]
+          linked_dir_details = T.must(@linked_paths[T.must(_linked_dir_for(path))])
           sub_path =
             path.gsub(%r{^#{Regexp.quote(T.must(_linked_dir_for(path)))}(/|$)}, "")
           new_path =
-            Pathname.new(File.join(linked_dir_details.fetch(:path), sub_path))
+            Pathname.new(File.join(linked_dir_details.path, sub_path))
                     .cleanpath.to_path
                     .gsub(%r{^/}, "")
-          {
-            repo: linked_dir_details.fetch(:repo),
-            commit: linked_dir_details.fetch(:commit),
-            provider: linked_dir_details.fetch(:provider),
+          RepositorySpecification.new(
+            repo: linked_dir_details.repo,
+            commit: linked_dir_details.commit,
+            provider: linked_dir_details.provider,
             path: new_path
-          }
+          )
         else
-          {
+          RepositorySpecification.new(
             repo: source.repo,
             path: path,
-            commit: commit,
+            commit: T.must(commit),
             provider: source.provider
-          }
+          )
         end
       end
 
@@ -759,9 +801,11 @@ module Dependabot
       def _fetch_file_content(path, fetch_submodules: false)
         path = path.gsub(%r{^/*}, "")
 
-        provider, repo, path, commit =
-          _full_specification_for(path, fetch_submodules: fetch_submodules)
-          .values_at(:provider, :repo, :path, :commit)
+        specification = _full_specification_for(path, fetch_submodules: fetch_submodules)
+        provider = specification.provider
+        repo = specification.repo
+        path = specification.path
+        commit = specification.commit
 
         _fetch_file_content_fully_specified(provider, repo, path, commit)
       rescue *CLIENT_NOT_FOUND_ERRORS
@@ -782,7 +826,7 @@ module Dependabot
         when "github"
           _fetch_file_content_from_github(path, repo, commit)
         when "gitlab"
-          tmp = T.unsafe(gitlab_client.get_file(repo, path, commit)).content
+          tmp = gitlab_string(gitlab_client.get_file(repo, path, commit), "content")
           decode_binary_string(tmp)
         when "azure"
           azure_client.fetch_file_contents(commit, path)
@@ -794,33 +838,17 @@ module Dependabot
         end
       end
 
-      # rubocop:disable Metrics/AbcSize
       sig { params(path: String, repo: String, commit: String).returns(String) }
       def _fetch_file_content_from_github(path, repo, commit)
-        tmp = github_client.contents(repo, path: path, ref: commit)
+        tmp = github_file_resource(path, repo, commit)
 
-        raise Octokit::NotFound if tmp.is_a?(Array)
-
-        if T.unsafe(tmp).type == "symlink"
-          @linked_paths[path] = {
-            repo: repo,
-            provider: "github",
-            commit: commit,
-            path: Pathname.new(T.unsafe(tmp).target).cleanpath.to_path
-          }
-          tmp = github_client.contents(
-            repo,
-            path: Pathname.new(T.unsafe(tmp).target).cleanpath.to_path,
-            ref: commit
-          )
-        end
-
-        if T.unsafe(tmp).content == ""
+        content = sawyer_string(tmp, :content)
+        if content == ""
           # The file may have exceeded the 1MB limit
           # see https://github.blog/changelog/2022-05-03-increased-file-size-limit-when-retrieving-file-contents-via-rest-api/
-          T.unsafe(github_client.contents(repo, path: path, ref: commit, accept: "application/vnd.github.v3.raw"))
+          github_client.raw_contents(repo, path: path, ref: commit)
         else
-          decode_binary_string(T.unsafe(tmp).content)
+          decode_binary_string(content)
         end
       rescue Octokit::Forbidden => e
         raise unless e.message.include?("too_large")
@@ -832,17 +860,37 @@ module Dependabot
         file_details = repo_contents(dir: dir).find { |f| f.name == basename }
         raise unless file_details
 
-        tmp = github_client.blob(repo, file_details.sha)
-        return T.unsafe(tmp).content if T.unsafe(tmp).encoding == "utf-8"
+        tmp = github_client.blob(repo, T.must(file_details.sha))
+        content = sawyer_string(tmp, :content)
+        return content if sawyer_string(tmp, :encoding) == "utf-8"
 
-        decode_binary_string(T.unsafe(tmp).content)
+        decode_binary_string(content)
       end
-      # rubocop:enable Metrics/AbcSize
+      sig { params(path: String, repo: String, commit: String).returns(Sawyer::Resource) }
+      def github_file_resource(path, repo, commit)
+        resource = github_client.contents(repo, path: path, ref: commit)
+        raise Octokit::NotFound if resource.is_a?(Array)
+        return resource unless sawyer_optional_string(resource, :type) == "symlink"
+
+        target = sawyer_string(resource, :target)
+        clean_target = Pathname.new(target).cleanpath.to_path
+        @linked_paths[path] = LinkedPath.new(
+          repo: repo,
+          provider: "github",
+          commit: commit,
+          path: clean_target
+        )
+
+        target_resource = github_client.contents(repo, path: clean_target, ref: commit)
+        return target_resource if target_resource.is_a?(Sawyer::Resource)
+
+        raise_bad_repository_response("GitHub", "symlink target must be a file")
+      end
 
       # Update the @linked_paths hash by exploiting a side-effect of
       # recursively calling `repo_contents` for each directory up the tree
       # until a submodule or symlink is found
-      sig { params(path: String).returns(T.nilable(T::Array[T.untyped])) }
+      sig { params(path: String).returns(T.nilable(T::Array[RepositoryContent])) }
       def _find_linked_dirs(path)
         path = Pathname.new(path).cleanpath.to_path.gsub(%r{^/*}, "")
         dir = File.dirname(path)

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -349,6 +349,35 @@ RSpec.describe Dependabot::FileFetchers::Base do
                      headers: { "content-type" => "application/json" })
       end
 
+      context "when the repository is empty" do
+        let(:repo_url) { "https://api.github.com/repos/#{repo}" }
+
+        before do
+          allow(file_fetcher_instance).to receive(:commit).and_call_original
+          stub_request(:get, repo_url)
+            .with(headers: { "Authorization" => "token token" })
+            .to_return(
+              status: 200,
+              body: fixture("github", "bump_repo.json"),
+              headers: { "content-type" => "application/json" }
+            )
+          stub_request(:get, "#{repo_url}/git/refs/heads/master")
+            .with(headers: { "Authorization" => "token token" })
+            .to_return(
+              status: 409,
+              body: fixture("github", "git_repo_empty.json"),
+              headers: { "content-type" => "application/json" }
+            )
+        end
+
+        it "raises a dependency file not found error" do
+          expect { file_fetcher_instance.files }
+            .to raise_error(Dependabot::DependencyFileNotFound) do |error|
+              expect(error.file_path).to eq("/requirements.txt")
+            end
+        end
+      end
+
       its(:length) { is_expected.to eq(1) }
 
       describe "the file" do
@@ -580,6 +609,19 @@ RSpec.describe Dependabot::FileFetchers::Base do
           end
 
           context "when the submodule URL is missing" do
+            let(:child_class) do
+              Class.new(described_class) do
+                def fetch_files
+                  [
+                    fetch_file_from_host(
+                      "some/dir/req.txt",
+                      fetch_submodules: true
+                    )
+                  ]
+                end
+              end
+            end
+
             before do
               submodule_without_url = JSON.parse(submodule_details)
               submodule_without_url["submodule_git_url"] = nil
@@ -590,6 +632,9 @@ RSpec.describe Dependabot::FileFetchers::Base do
                   body: JSON.dump(submodule_without_url),
                   headers: { "content-type" => "application/json" }
                 )
+              stub_request(:get, url + "some?ref=sha")
+                .with(headers: { "Authorization" => "token token" })
+                .to_return(status: 404)
             end
 
             it "skips the unavailable submodule" do
@@ -597,6 +642,8 @@ RSpec.describe Dependabot::FileFetchers::Base do
                 .to raise_error(Dependabot::DependencyFileNotFound) do |error|
                   expect(error.file_path).to eq("/some/dir/req.txt")
                 end
+              expect(WebMock)
+                .to have_requested(:get, url + "some/dir?ref=sha")
             end
           end
         end

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -515,13 +515,15 @@ RSpec.describe Dependabot::FileFetchers::Base do
         end
 
         context "when the file is in a submodule (shallow)" do
+          let(:submodule_details) do
+            fixture("github", "submodule.json")
+              .gsub("d70e943e00a09a3c98c0e4ac9daab112b749cf62", "sha2")
+          end
+
           before do
             stub_request(:get, url + "some/dir/req.txt?ref=sha")
               .with(headers: { "Authorization" => "token token" })
               .to_return(status: 404)
-            submodule_details =
-              fixture("github", "submodule.json")
-              .gsub("d70e943e00a09a3c98c0e4ac9daab112b749cf62", "sha2")
             stub_request(:get, url + "some/dir?ref=sha")
               .with(headers: { "Authorization" => "token token" })
               .to_return(
@@ -574,6 +576,27 @@ RSpec.describe Dependabot::FileFetchers::Base do
 
               it { is_expected.to be_a(Dependabot::DependencyFile) }
               its(:content) { is_expected.to include("octokit") }
+            end
+          end
+
+          context "when the submodule URL is missing" do
+            before do
+              submodule_without_url = JSON.parse(submodule_details)
+              submodule_without_url["submodule_git_url"] = nil
+              stub_request(:get, url + "some/dir?ref=sha")
+                .with(headers: { "Authorization" => "token token" })
+                .to_return(
+                  status: 200,
+                  body: JSON.dump(submodule_without_url),
+                  headers: { "content-type" => "application/json" }
+                )
+            end
+
+            it "skips the unavailable submodule" do
+              expect { file_fetcher_instance.files }
+                .to raise_error(Dependabot::DependencyFileNotFound) do |error|
+                  expect(error.file_path).to eq("/some/dir/req.txt")
+                end
             end
           end
         end

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -795,6 +795,41 @@ RSpec.describe Dependabot::FileFetchers::Base do
         end
       end
 
+      context "when file metadata omits the content" do
+        let(:raw_content) { "raw requirements\n" }
+
+        before do
+          metadata = JSON.parse(fixture("github", "gemfile_content.json"))
+          metadata["content"] = ""
+          stub_request(:get, url + "requirements.txt?ref=sha")
+            .with(headers: { "Authorization" => "token token" })
+            .to_return(
+              status: 200,
+              body: JSON.dump(metadata),
+              headers: { "content-type" => "application/json" }
+            )
+          stub_request(:get, url + "requirements.txt?ref=sha")
+            .with(
+              headers: {
+                "Accept" => "application/vnd.github.v3.raw",
+                "Authorization" => "token token"
+              }
+            )
+            .to_return(
+              status: 200,
+              body: raw_content,
+              headers: { "content-type" => "text/plain" }
+            )
+        end
+
+        it "fetches the raw file content" do
+          expect(files.first.content).to eq(raw_content)
+          expect(WebMock)
+            .to have_requested(:get, url + "requirements.txt?ref=sha")
+            .with(headers: { "Accept" => "application/vnd.github.v3.raw" })
+        end
+      end
+
       context "when a dependency file is too big to download" do
         let(:blob_url) do
           "https://api.github.com/repos/#{repo}/git/blobs/" \

--- a/devcontainers/lib/dependabot/devcontainers/file_fetcher.rb
+++ b/devcontainers/lib/dependabot/devcontainers/file_fetcher.rb
@@ -63,7 +63,7 @@ module Dependabot
         return [] unless devcontainer_directory
 
         custom_directories.flat_map do |directory|
-          fetch_config_and_lockfile_from(T.must(directory.path))
+          fetch_config_and_lockfile_from(directory.path)
         end
       end
 

--- a/docker/lib/dependabot/docker/file_fetcher.rb
+++ b/docker/lib/dependabot/docker/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/shared/utils/helpers"

--- a/docker/lib/dependabot/docker_compose/file_fetcher.rb
+++ b/docker/lib/dependabot/docker_compose/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/shared/shared_file_fetcher"

--- a/github_actions/lib/dependabot/github_actions/file_fetcher.rb
+++ b/github_actions/lib/dependabot/github_actions/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/gradle/lib/dependabot/gradle/file_fetcher.rb
+++ b/gradle/lib/dependabot/gradle/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/helm/lib/dependabot/helm/file_fetcher.rb
+++ b/helm/lib/dependabot/helm/file_fetcher.rb
@@ -41,7 +41,7 @@ module Dependabot
         @chart_locks ||=
           T.let(
             repo_contents(raise_errors: false)
-                      .select { |f| f.type == "file" && f.name.casecmp(CHART_LOCK_FILENAME).zero? }
+                      .select { |f| f.type == "file" && T.must(f.name.casecmp(CHART_LOCK_FILENAME)).zero? }
                       .map { |f| fetch_file_from_host(f.name) },
             T.nilable(T::Array[DependencyFile])
           )

--- a/helm/lib/dependabot/helm/file_fetcher.rb
+++ b/helm/lib/dependabot/helm/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/shared/shared_file_fetcher"

--- a/sbt/lib/dependabot/sbt/file_fetcher.rb
+++ b/sbt/lib/dependabot/sbt/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/sorbet/rbi/shims/gitlab.rbi
+++ b/sorbet/rbi/shims/gitlab.rbi
@@ -1,13 +1,25 @@
 # typed: strong
 # frozen_string_literal: true
 
-class Gitlab::PaginatedResponse
-  sig do
-    type_parameters(:U)
-      .params(
-        blk: T.proc.params(element: Object).returns(T.nilable(T.type_parameter(:U)))
-      )
-      .returns(T::Array[T.type_parameter(:U)])
+module Gitlab
+  class PaginatedResponse
+    sig do
+      type_parameters(:U)
+        .params(
+          blk: T.proc.params(element: Gitlab::ObjectifiedHash)
+                .returns(T.type_parameter(:U))
+        )
+        .returns(T::Array[T.type_parameter(:U)])
+    end
+    def map(&blk); end
+
+    sig do
+      type_parameters(:U)
+        .params(
+          blk: T.proc.params(element: Object).returns(T.nilable(T.type_parameter(:U)))
+        )
+        .returns(T::Array[T.type_parameter(:U)])
+    end
+    def filter_map(&blk); end
   end
-  def filter_map(&blk); end
 end

--- a/swift/lib/dependabot/swift/file_fetcher.rb
+++ b/swift/lib/dependabot/swift/file_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -267,7 +267,10 @@ module Dependabot
 
     sig { params(file_fetcher: Dependabot::FileFetchers::Base).void }
     def post_ecosystem_versions(file_fetcher)
-      ecosystem_versions = file_fetcher.ecosystem_versions
+      ecosystem_versions = T.cast(
+        file_fetcher.ecosystem_versions,
+        T.nilable(T::Hash[Symbol, Object])
+      )
       api_client.record_ecosystem_versions(ecosystem_versions) unless ecosystem_versions.nil?
     end
 

--- a/uv/lib/dependabot/uv/file_fetcher.rb
+++ b/uv/lib/dependabot/uv/file_fetcher.rb
@@ -276,7 +276,7 @@ module Dependabot
       def req_files_for_dir(requirements_dir)
         dir = directory.gsub(%r{(^/|/$)}, "")
         relative_reqs_dir =
-          requirements_dir.path&.gsub(%r{^/?#{Regexp.escape(dir)}/?}, "")
+          requirements_dir.path.gsub(%r{^/?#{Regexp.escape(dir)}/?}, "")
 
         fetch_requirement_files_from_path(relative_reqs_dir)
       end
@@ -321,7 +321,7 @@ module Dependabot
       sig { returns(T::Array[Dependabot::DependencyFile]) }
       def fetch_requirement_files_from_dirs
         repo_contents
-          .select { |f| T.unsafe(f).type == "dir" }
+          .select { |f| f.type == "dir" }
           .flat_map { |dir| req_files_for_dir(dir) }
       end
 
@@ -333,10 +333,10 @@ module Dependabot
       end
       def filter_requirement_files(contents, base_path: nil)
         contents
-          .select { |f| T.unsafe(f).type == "file" }
-          .select { |f| file_matches_requirement_pattern?(T.unsafe(f).name) }
-          .reject { |f| T.unsafe(f).size > MAX_FILE_SIZE }
-          .map { |f| fetch_file_with_path(T.unsafe(f).name, base_path) }
+          .select { |f| f.type == "file" }
+          .select { |f| file_matches_requirement_pattern?(f.name) }
+          .reject { |f| f.size > MAX_FILE_SIZE }
+          .map { |f| fetch_file_with_path(f.name, base_path) }
           .select { |f| T.must(REQUIREMENT_FILE_PATTERNS[:filenames]).include?(f.name) || requirements_file?(f) }
       end
 


### PR DESCRIPTION
Types repository listings, linked paths, symlinks, submodules, and file content across providers. `FileFetchers::Base` is now `typed: strong`.

Ratchets: `T.untyped` 882 to 871; `T.unsafe` 64 to 45.