### PR TITLE
Type common pull request reads

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 837
+# Offense count: 831
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -276,7 +276,6 @@ Sorbet/ForbidTUntyped:
     - "bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb"
     - "bundler/lib/dependabot/bundler/update_checker/version_resolver.rb"
     - "common/lib/dependabot/pull_request_creator/github.rb"
-    - "common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb"
     - "common/lib/dependabot/pull_request_updater/azure.rb"
     - "common/lib/dependabot/pull_request_updater/github.rb"
     - "common/lib/dependabot/pull_request_updater/gitlab.rb"

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -198,7 +198,9 @@ module Dependabot
 
         # sort the results by date
         output = T.cast(result.data, Aws::CodeCommit::Types::BatchGetCommitsOutput)
-        output.commits.sort! { |a, b| T.must(b.author.date <=> a.author.date) }
+        commits = output.commits
+        commits&.sort_by! { |commit| commit.author&.date || "" }
+        commits&.reverse!
         result
       end
 

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -183,18 +183,22 @@ module Dependabot
           repo: String,
           branch_name: String
         )
-          .returns(Aws::CodeCommit::Types::Commit)
+          .returns(Seahorse::Client::Response)
       end
       def commits(repo, branch_name = T.must(source.branch))
         retrieved_commits = fetch_commits(repo, branch_name, 5)
 
-        result = @cc_client.batch_get_commits(
-          commit_ids: retrieved_commits,
-          repository_name: repo
+        result = T.cast(
+          @cc_client.batch_get_commits(
+            commit_ids: retrieved_commits,
+            repository_name: repo
+          ),
+          Seahorse::Client::Response
         )
 
         # sort the results by date
-        result.commits.sort! { |a, b| b.author.date <=> a.author.date }
+        output = T.cast(result.data, Aws::CodeCommit::Types::BatchGetCommitsOutput)
+        output.commits.sort! { |a, b| T.must(b.author.date <=> a.author.date) }
         result
       end
 

--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -1,9 +1,10 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "octokit"
 require "sorbet-runtime"
 require "dependabot/pull_request_creator"
+require "dependabot/errors"
 require "dependabot/credential"
 
 module Dependabot
@@ -313,16 +314,13 @@ module Dependabot
       def fetch_github_labels
         client = github_client_for_source
 
-        labels = T.let(
-          T.unsafe(client.labels(source.repo, per_page: 100)).map(&:name),
-          T::Array[String]
-        )
+        labels = client.labels(source.repo, per_page: 100).map { |label| github_label_name(label) }
 
         next_link = T.let(client.last_response.rels[:next], T.nilable(Sawyer::Relation))
 
         while next_link
           next_page = T.let(next_link.get, Sawyer::Response)
-          labels += T.unsafe(next_page.data).map(&:name)
+          labels.concat(github_labels_from_page(next_page))
           next_link = next_page.rels[:next]
         end
 
@@ -331,12 +329,47 @@ module Dependabot
 
       sig { returns(T::Array[String]) }
       def fetch_gitlab_labels
-        T.unsafe(
-          gitlab_client_for_source
-                   .labels(source.repo, per_page: 100)
-                   .auto_paginate
+        gitlab_client_for_source
+          .labels(source.repo, per_page: 100)
+          .auto_paginate
+          .map { |label| gitlab_label_name(label) }
+      end
+
+      sig { params(label: Sawyer::Resource).returns(String) }
+      def github_label_name(label)
+        value = T.cast(label[:name], Object)
+        return value if value.is_a?(String)
+
+        raise_bad_label_response("GitHub", "name must be a string")
+      end
+
+      sig { params(response: Sawyer::Response).returns(T::Array[String]) }
+      def github_labels_from_page(response)
+        data = T.cast(response.data, Object)
+        raise_bad_label_response("GitHub", "page data must be an array") unless data.is_a?(Array)
+
+        data.map do |raw_label|
+          label = T.cast(raw_label, Object)
+          raise_bad_label_response("GitHub", "label must be an object") unless label.is_a?(Sawyer::Resource)
+
+          github_label_name(label)
+        end
+      end
+
+      sig { params(label: ::Gitlab::ObjectifiedHash).returns(String) }
+      def gitlab_label_name(label)
+        value = T.cast(label["name"], Object)
+        return value if value.is_a?(String)
+
+        raise_bad_label_response("GitLab", "name must be a string")
+      end
+
+      sig { params(provider: String, message: String).returns(T.noreturn) }
+      def raise_bad_label_response(provider, message)
+        raise Dependabot::PrivateSourceBadResponse.new(
+          source.url,
+          "Malformed #{provider} label response: #{message}"
         )
-         .map(&:name)
       end
 
       sig { returns(T::Array[String]) }
@@ -394,7 +427,7 @@ module Dependabot
         )
         @labels = [*@labels, DEFAULT_DEPENDENCIES_LABEL].uniq
       rescue Octokit::UnprocessableEntity => e
-        raise unless e.errors.first.fetch(:code) == "already_exists"
+        raise unless github_label_already_exists?(e)
 
         @labels = [*@labels, DEFAULT_DEPENDENCIES_LABEL].uniq
       end
@@ -421,7 +454,7 @@ module Dependabot
         )
         @labels = [*@labels, DEFAULT_SECURITY_LABEL].uniq
       rescue Octokit::UnprocessableEntity => e
-        raise unless e.errors.first.fetch(:code) == "already_exists"
+        raise unless github_label_already_exists?(e)
 
         @labels = [*@labels, DEFAULT_SECURITY_LABEL].uniq
       end
@@ -450,9 +483,22 @@ module Dependabot
         )
         @labels = [*@labels, language_name].uniq
       rescue Octokit::UnprocessableEntity => e
-        raise unless e.errors.first.fetch(:code) == "already_exists"
+        raise unless github_label_already_exists?(e)
 
         @labels = [*@labels, language_name].uniq.compact
+      end
+
+      sig { params(error: Octokit::UnprocessableEntity).returns(T::Boolean) }
+      def github_label_already_exists?(error)
+        errors = T.cast(error.errors, Object)
+        return false unless errors.is_a?(Array)
+
+        first_error = T.cast(errors.first, Object)
+        return false unless first_error.is_a?(Hash)
+
+        typed_error = T.let(first_error, T::Hash[T.any(Symbol, String), Object])
+        code = typed_error[:code] || typed_error["code"]
+        code == "already_exists"
       end
 
       sig { params(language: String).returns(String) }

--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -314,9 +314,10 @@ module Dependabot
       def fetch_github_labels
         client = github_client_for_source
 
-        labels = client.labels(source.repo, per_page: 100).map { |label| github_label_name(label) }
-
-        next_link = T.let(client.last_response.rels[:next], T.nilable(Sawyer::Relation))
+        client.labels(source.repo, per_page: 100)
+        first_page = client.last_response
+        labels = github_labels_from_page(first_page)
+        next_link = T.let(first_page.rels[:next], T.nilable(Sawyer::Relation))
 
         while next_link
           next_page = T.let(next_link.get, Sawyer::Response)

--- a/common/lib/dependabot/pull_request_creator/labeler.rb
+++ b/common/lib/dependabot/pull_request_creator/labeler.rb
@@ -314,10 +314,9 @@ module Dependabot
       def fetch_github_labels
         client = github_client_for_source
 
-        client.labels(source.repo, per_page: 100)
-        first_page = client.last_response
-        labels = github_labels_from_page(first_page)
-        next_link = T.let(first_page.rels[:next], T.nilable(Sawyer::Relation))
+        raw_labels = client.labels(source.repo, per_page: 100)
+        labels = github_label_names(raw_labels)
+        next_link = T.let(client.last_response.rels[:next], T.nilable(Sawyer::Relation))
 
         while next_link
           next_page = T.let(next_link.get, Sawyer::Response)
@@ -346,7 +345,11 @@ module Dependabot
 
       sig { params(response: Sawyer::Response).returns(T::Array[String]) }
       def github_labels_from_page(response)
-        data = T.cast(response.data, Object)
+        github_label_names(T.cast(response.data, Object))
+      end
+
+      sig { params(data: Object).returns(T::Array[String]) }
+      def github_label_names(data)
         raise_bad_label_response("GitHub", "page data must be an array") unless data.is_a?(Array)
 
         data.map do |raw_label|

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -491,10 +491,10 @@ module Dependabot
 
         response = codecommit_client_for_source.commits(source.repo)
         output = T.cast(response.data, Aws::CodeCommit::Types::BatchGetCommitsOutput)
-        @recent_codecommit_commits = output.commits.map do |commit|
+        @recent_codecommit_commits = (output.commits || []).map do |commit|
           RecentCommit.new(
             message: commit.message,
-            author_email: commit.author.email
+            author_email: commit.author&.email
           )
         end
       end

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -10,6 +10,7 @@ require "dependabot/clients/github_with_retries"
 require "dependabot/clients/gitlab_with_retries"
 require "dependabot/pull_request_creator"
 require "dependabot/pull_request_creator/commit_message_options"
+require "dependabot/errors"
 
 module Dependabot
   class PullRequestCreator
@@ -26,6 +27,13 @@ module Dependabot
         pencil2 penguin pushpin recycle rewind robot rocket rotating_light see_no_evil sparkles speech_balloon tada
         truck twisted_rightwards_arrows whale wheelchair white_check_mark wrench zap
       ).freeze
+
+      class RecentCommit < T::ImmutableStruct
+        const :message, T.nilable(String)
+        const :author_email, T.nilable(String), default: nil
+        const :author_name, T.nilable(String), default: nil
+        const :author_type, T.nilable(String), default: nil
+      end
 
       sig do
         params(
@@ -52,6 +60,11 @@ module Dependabot
           commit_message_options && CommitMessageOptions.from_hash(commit_message_options),
           T.nilable(CommitMessageOptions)
         )
+        @recent_github_commits = T.let(nil, T.nilable(T::Array[RecentCommit]))
+        @recent_gitlab_commits = T.let(nil, T.nilable(T::Array[RecentCommit]))
+        @recent_azure_commits = T.let(nil, T.nilable(T::Array[RecentCommit]))
+        @recent_bitbucket_commits = T.let(nil, T.nilable(T::Array[RecentCommit]))
+        @recent_codecommit_commits = T.let(nil, T.nilable(T::Array[RecentCommit]))
       end
 
       sig { returns(String) }
@@ -334,58 +347,46 @@ module Dependabot
       sig { returns(T::Array[String]) }
       def recent_github_commit_messages
         recent_github_commits
-          .reject { |c| c.author&.type == "Bot" }
-          .reject { |c| c.commit&.message&.start_with?("Merge") }
-          .map(&:commit)
+          .reject { |commit| commit.author_type == "Bot" }
+          .reject { |commit| commit.message&.start_with?("Merge") }
           .filter_map(&:message)
           .map(&:strip)
       end
 
       sig { returns(T::Array[String]) }
       def recent_gitlab_commit_messages
-        @recent_gitlab_commit_messages ||=
-          gitlab_client_for_source.commits(source.repo)
-
-        @recent_gitlab_commit_messages
-          .reject { |c| c.author_email == dependabot_email }
-          .reject { |c| c.message&.start_with?("merge !") }
+        recent_gitlab_commits
+          .reject { |commit| commit.author_email == dependabot_email }
+          .reject { |commit| commit.message&.start_with?("merge !") }
           .filter_map(&:message)
           .map(&:strip)
       end
 
       sig { returns(T::Array[String]) }
       def recent_azure_commit_messages
-        @recent_azure_commit_messages ||=
-          azure_client_for_source.commits
-
-        @recent_azure_commit_messages
-          .reject { |c| azure_commit_author_email(c) == dependabot_email }
-          .reject { |c| c.fetch("comment")&.start_with?("Merge") }
-          .filter_map { |c| c.fetch("comment") }
+        recent_azure_commits
+          .reject { |commit| commit.author_email == dependabot_email }
+          .reject { |commit| commit.message&.start_with?("Merge") }
+          .filter_map(&:message)
           .map(&:strip)
       end
 
       sig { returns(T::Array[String]) }
       def recent_bitbucket_commit_messages
-        @recent_bitbucket_commit_messages ||=
-          bitbucket_client_for_source.commits(source.repo)
-
-        @recent_bitbucket_commit_messages
-          .reject { |c| bitbucket_commit_author_email(c) == dependabot_email }
-          .filter_map { |c| c.fetch("message", nil) }
+        recent_bitbucket_commits
+          .reject { |commit| commit.author_email == dependabot_email }
+          .filter_map(&:message)
           .reject { |m| m.start_with?("Merge") }
           .map(&:strip)
       end
 
       sig { returns(T::Array[String]) }
       def recent_codecommit_commit_messages
-        @recent_codecommit_commit_messages ||=
-          T.unsafe(codecommit_client_for_source).commits
-        @recent_codecommit_commit_messages.commits
-                                          .reject { |c| c.author.email == dependabot_email }
-                                          .reject { |c| c.message&.start_with?("Merge") }
-                                          .filter_map(&:message)
-                                          .map(&:strip)
+        recent_codecommit_commits
+          .reject { |commit| commit.author_email == dependabot_email }
+          .reject { |commit| commit.message&.start_with?("Merge") }
+          .filter_map(&:message)
+          .map(&:strip)
       end
 
       sig { returns(T.nilable(String)) }
@@ -417,89 +418,189 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def last_github_dependabot_commit_message
         recent_github_commits
-          .reject { |c| c.commit&.message&.start_with?("Merge") }
-          .find { |c| c.commit.author&.name&.include?("dependabot") }
-          &.commit
+          .reject { |commit| commit.message&.start_with?("Merge") }
+          .find { |commit| commit.author_name&.include?("dependabot") }
           &.message
           &.strip
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Array[RecentCommit]) }
       def recent_github_commits
         @recent_github_commits ||=
-          T.let(
-            github_client_for_source.commits(source.repo, per_page: 100),
-            T.untyped
-          )
+          github_client_for_source
+          .commits(source.repo, per_page: 100)
+          .map { |commit| parse_github_commit(commit) }
       rescue Octokit::Conflict, Octokit::NotFound
         @recent_github_commits ||= []
       end
 
       sig { returns(T.nilable(String)) }
       def last_gitlab_dependabot_commit_message
-        @recent_gitlab_commit_messages ||=
-          T.let(
-            gitlab_client_for_source.commits(source.repo),
-            T.untyped
-          )
-
-        @recent_gitlab_commit_messages
-          .find { |c| c.author_email == dependabot_email }
+        recent_gitlab_commits
+          .find { |commit| commit.author_email == dependabot_email }
           &.message
           &.strip
       end
 
       sig { returns(T.nilable(String)) }
       def last_azure_dependabot_commit_message
-        @recent_azure_commit_messages ||=
-          T.let(
-            azure_client_for_source.commits,
-            T.untyped
-          )
-
-        @recent_azure_commit_messages
-          .find { |c| azure_commit_author_email(c) == dependabot_email }
+        recent_azure_commits
+          .find { |commit| commit.author_email == dependabot_email }
           &.message
           &.strip
       end
 
       sig { returns(T.nilable(String)) }
       def last_bitbucket_dependabot_commit_message
-        @recent_bitbucket_commit_messages ||=
-          T.let(
-            bitbucket_client_for_source.commits(source.repo),
-            T.untyped
-          )
-
-        @recent_bitbucket_commit_messages
-          .find { |c| bitbucket_commit_author_email(c) == dependabot_email }
-          &.fetch("message", nil)
+        recent_bitbucket_commits
+          .find { |commit| commit.author_email == dependabot_email }
+          &.message
           &.strip
       end
 
       sig { returns(T.nilable(String)) }
       def last_codecommit_dependabot_commit_message
-        @recent_codecommit_commit_messages ||=
-          T.let(
-            codecommit_client_for_source.commits(source.repo),
-            T.untyped
+        recent_codecommit_commits
+          .find { |commit| commit.author_email == dependabot_email }
+          &.message
+          &.strip
+      end
+
+      sig { returns(T::Array[RecentCommit]) }
+      def recent_gitlab_commits
+        @recent_gitlab_commits ||= gitlab_client_for_source
+                                   .commits(source.repo)
+                                   .map { |commit| parse_gitlab_commit(commit) }
+      end
+
+      sig { returns(T::Array[RecentCommit]) }
+      def recent_azure_commits
+        @recent_azure_commits ||= azure_client_for_source.commits.map { |commit| parse_azure_commit(commit) }
+      end
+
+      sig { returns(T::Array[RecentCommit]) }
+      def recent_bitbucket_commits
+        @recent_bitbucket_commits ||= bitbucket_client_for_source
+                                      .commits(source.repo)
+                                      .map { |commit| parse_bitbucket_commit(commit) }
+      end
+
+      sig { returns(T::Array[RecentCommit]) }
+      def recent_codecommit_commits
+        return @recent_codecommit_commits if @recent_codecommit_commits
+
+        response = codecommit_client_for_source.commits(source.repo)
+        output = T.cast(response.data, Aws::CodeCommit::Types::BatchGetCommitsOutput)
+        @recent_codecommit_commits = output.commits.map do |commit|
+          RecentCommit.new(
+            message: commit.message,
+            author_email: commit.author.email
           )
-
-        @recent_codecommit_commit_messages.commits
-                                          .find { |c| c.author.email == dependabot_email }
-                                          &.message
-                                          &.strip
+        end
       end
 
-      sig { params(commit: T::Hash[String, T::Hash[String, String]]).returns(String) }
-      def azure_commit_author_email(commit)
-        commit.fetch("author").fetch("email", "")
+      sig { params(commit: Sawyer::Resource).returns(RecentCommit) }
+      def parse_github_commit(commit)
+        details = sawyer_resource(commit, :commit, "commit details")
+        author = sawyer_optional_resource(commit, :author, "author")
+        commit_author = sawyer_optional_resource(details, :author, "commit author")
+        RecentCommit.new(
+          message: sawyer_optional_string(details, :message, "commit message"),
+          author_email: commit_author && sawyer_optional_string(commit_author, :email, "author email"),
+          author_name: commit_author && sawyer_optional_string(commit_author, :name, "author name"),
+          author_type: author && sawyer_optional_string(author, :type, "author type")
+        )
       end
 
-      sig { params(commit: T::Hash[String, T::Hash[String, String]]).returns(String) }
-      def bitbucket_commit_author_email(commit)
-        matches = commit.fetch("author").fetch("raw").match(/<(.*)>/)
-        matches ? T.must(matches[1]) : ""
+      sig { params(commit: ::Gitlab::ObjectifiedHash).returns(RecentCommit) }
+      def parse_gitlab_commit(commit)
+        RecentCommit.new(
+          message: gitlab_optional_string(commit, "message", "commit message"),
+          author_email: gitlab_optional_string(commit, "author_email", "author email")
+        )
+      end
+
+      sig { params(commit: Dependabot::Clients::Azure::JsonObject).returns(RecentCommit) }
+      def parse_azure_commit(commit)
+        author = object_hash(commit, "author", "Azure author")
+        RecentCommit.new(
+          message: object_optional_string(commit, "comment", "Azure commit message"),
+          author_email: object_optional_string(author, "email", "Azure author email")
+        )
+      end
+
+      sig { params(commit: Dependabot::Clients::Bitbucket::JsonObject).returns(RecentCommit) }
+      def parse_bitbucket_commit(commit)
+        author = object_hash(commit, "author", "Bitbucket author")
+        raw_author = object_optional_string(author, "raw", "Bitbucket author")
+        matches = raw_author&.match(/<(.*)>/)
+        RecentCommit.new(
+          message: object_optional_string(commit, "message", "Bitbucket commit message"),
+          author_email: matches ? T.must(matches[1]) : nil
+        )
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol, context: String).returns(Sawyer::Resource) }
+      def sawyer_resource(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(Sawyer::Resource)
+
+        raise_bad_commit_response("GitHub", "#{context} must be an object")
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol, context: String).returns(T.nilable(Sawyer::Resource)) }
+      def sawyer_optional_resource(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return if value.nil?
+        return value if value.is_a?(Sawyer::Resource)
+
+        raise_bad_commit_response("GitHub", "#{context} must be an object or nil")
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol, context: String).returns(T.nilable(String)) }
+      def sawyer_optional_string(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise_bad_commit_response("GitHub", "#{context} must be a string or nil")
+      end
+
+      sig { params(resource: ::Gitlab::ObjectifiedHash, key: String, context: String).returns(T.nilable(String)) }
+      def gitlab_optional_string(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise_bad_commit_response("GitLab", "#{context} must be a string or nil")
+      end
+
+      sig do
+        params(object: T::Hash[String, Object], key: String, context: String)
+          .returns(T::Hash[String, Object])
+      end
+      def object_hash(object, key, context)
+        value = object[key]
+        return T.let(value, T::Hash[String, Object]) if value.is_a?(Hash)
+
+        raise_bad_commit_response(source.provider, "#{context} must be an object")
+      end
+
+      sig { params(object: T::Hash[String, Object], key: String, context: String).returns(T.nilable(String)) }
+      def object_optional_string(object, key, context)
+        value = object[key]
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise_bad_commit_response(source.provider, "#{context} must be a string or nil")
+      end
+
+      sig { params(provider: String, message: String).returns(T.noreturn) }
+      def raise_bad_commit_response(provider, message)
+        raise Dependabot::PrivateSourceBadResponse.new(
+          source.url,
+          "Malformed #{provider} commit response: #{message}"
+        )
       end
 
       sig { returns(Dependabot::Clients::GithubWithRetries) }

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -104,6 +104,29 @@ RSpec.describe Dependabot::Clients::CodeCommit do
   describe "#commits" do
     subject(:commits) { client.commits(repo, branch) }
 
+    let(:batch_get_commits_response) do
+      {
+        commits: [
+          {
+            commit_id: "older",
+            author: {
+              date: "2024-01-01T00:00:00Z",
+              email: "support@dependabot.com"
+            },
+            message: "Older"
+          },
+          {
+            commit_id: "newer",
+            author: {
+              date: "2025-01-01T00:00:00Z",
+              email: "support@dependabot.com"
+            },
+            message: "Newer"
+          }
+        ]
+      }
+    end
+
     before do
       allow(Aws::CodeCommit::Client).to receive(:new).and_return(stubbed_cc_client)
       stubbed_cc_client.stub_responses(
@@ -132,24 +155,7 @@ RSpec.describe Dependabot::Clients::CodeCommit do
       )
       stubbed_cc_client.stub_responses(
         :batch_get_commits,
-        commits: [
-          {
-            commit_id: "older",
-            author: {
-              date: "2024-01-01T00:00:00Z",
-              email: "support@dependabot.com"
-            },
-            message: "Older"
-          },
-          {
-            commit_id: "newer",
-            author: {
-              date: "2025-01-01T00:00:00Z",
-              email: "support@dependabot.com"
-            },
-            message: "Newer"
-          }
-        ]
+        batch_get_commits_response
       )
     end
 
@@ -157,6 +163,26 @@ RSpec.describe Dependabot::Clients::CodeCommit do
       expect(commits).to be_a(Seahorse::Client::Response)
       expect(commits.data).to be_a(Aws::CodeCommit::Types::BatchGetCommitsOutput)
       expect(commits.data.commits.map(&:message)).to eq(%w(Newer Older))
+    end
+
+    context "when the response has no commits" do
+      let(:batch_get_commits_response) { {} }
+
+      it "preserves the empty response" do
+        expect(commits.data.commits).to be_nil
+      end
+    end
+
+    context "when a commit has no author" do
+      let(:batch_get_commits_response) do
+        {
+          commits: [{ commit_id: "newer", message: "No author" }]
+        }
+      end
+
+      it "does not fail while sorting" do
+        expect(commits.data.commits.map(&:message)).to eq(["No author"])
+      end
     end
   end
 end

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -100,4 +100,63 @@ RSpec.describe Dependabot::Clients::CodeCommit do
       expect(repo_contents.data.files.map(&:relative_path)).to eq(["Gemfile"])
     end
   end
+
+  describe "#commits" do
+    subject(:commits) { client.commits(repo, branch) }
+
+    before do
+      allow(Aws::CodeCommit::Client).to receive(:new).and_return(stubbed_cc_client)
+      stubbed_cc_client.stub_responses(
+        :get_branch,
+        branch: {
+          branch_name: branch,
+          commit_id: "newer"
+        }
+      )
+      stubbed_cc_client.stub_responses(
+        :get_commit,
+        [
+          {
+            commit: {
+              commit_id: "newer",
+              parents: ["older"]
+            }
+          },
+          {
+            commit: {
+              commit_id: "older",
+              parents: []
+            }
+          }
+        ]
+      )
+      stubbed_cc_client.stub_responses(
+        :batch_get_commits,
+        commits: [
+          {
+            commit_id: "older",
+            author: {
+              date: "2024-01-01T00:00:00Z",
+              email: "support@dependabot.com"
+            },
+            message: "Older"
+          },
+          {
+            commit_id: "newer",
+            author: {
+              date: "2025-01-01T00:00:00Z",
+              email: "support@dependabot.com"
+            },
+            message: "Newer"
+          }
+        ]
+      )
+    end
+
+    it "preserves the response wrapper and sorts commits by author date" do
+      expect(commits).to be_a(Seahorse::Client::Response)
+      expect(commits.data).to be_a(Aws::CodeCommit::Types::BatchGetCommitsOutput)
+      expect(commits.data.commits.map(&:message)).to eq(%w(Newer Older))
+    end
+  end
 end

--- a/common/spec/dependabot/pull_request_creator/labeler_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/labeler_spec.rb
@@ -583,6 +583,7 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
 
       context "when Octokit auto-pagination is enabled" do
         let(:repo_labels_url) { "#{repo_api_url}/labels?per_page=100" }
+        let(:custom_labels) { ["dependencies", "Dependency: Gems"] }
         let(:links_header) do
           {
             "Content-Type" => "application/json",
@@ -608,13 +609,13 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
           stub_request(:get, repo_labels_url + "&page=2")
             .to_return(
               status: 200,
-              body: fixture("github", "labels_without_dependencies.json"),
+              body: fixture("github", "labels_with_custom.json"),
               headers: json_header
             )
         end
 
         it "uses labels returned from every page" do
-          expect(labeler.labels_for_pr).to include("dependencies")
+          expect(labeler.labels_for_pr).to contain_exactly("dependencies", "Dependency: Gems")
         end
       end
 

--- a/common/spec/dependabot/pull_request_creator/labeler_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/labeler_spec.rb
@@ -164,6 +164,38 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
             expect(WebMock)
               .not_to have_requested(:post, "#{repo_api_url}/labels")
           end
+
+          context "when the paginated response is not an array" do
+            before do
+              stub_request(:get, repo_labels_url + "&page=2")
+                .to_return(
+                  status: 200,
+                  body: JSON.dump(name: "Dependency: Gems"),
+                  headers: json_header
+                )
+            end
+
+            it "raises a bad response error" do
+              expect { labeler.create_default_labels_if_required }
+                .to raise_error(Dependabot::PrivateSourceBadResponse, /page data must be an array/)
+            end
+          end
+
+          context "when the paginated response contains a non-object label" do
+            before do
+              stub_request(:get, repo_labels_url + "&page=2")
+                .to_return(
+                  status: 200,
+                  body: JSON.dump(["Dependency: Gems"]),
+                  headers: json_header
+                )
+            end
+
+            it "raises a bad response error" do
+              expect { labeler.create_default_labels_if_required }
+                .to raise_error(Dependabot::PrivateSourceBadResponse, /label must be an object/)
+            end
+          end
         end
 
         context "when considering the label that should be ignored" do
@@ -517,6 +549,22 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
                      headers: json_header)
       end
 
+      context "when a label name is malformed" do
+        before do
+          stub_request(:get, "#{repo_api_url}/labels?per_page=100")
+            .to_return(
+              status: 200,
+              body: JSON.dump([{ name: 1 }]),
+              headers: json_header
+            )
+        end
+
+        it "raises a bad response error" do
+          expect { labeler.labels_for_pr }
+            .to raise_error(Dependabot::PrivateSourceBadResponse, /name must be a string/)
+        end
+      end
+
       context "when a 'dependencies' label exists" do
         let(:labels_fixture_name) { "labels_with_dependencies.json" }
 
@@ -792,6 +840,22 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
           .to_return(status: 200,
                      body: fixture("gitlab", "labels_with_dependencies.json"),
                      headers: json_header)
+      end
+
+      context "when a label name is malformed" do
+        before do
+          stub_request(:get, "#{repo_api_url}/labels?per_page=100")
+            .to_return(
+              status: 200,
+              body: JSON.dump([{ name: 1 }]),
+              headers: json_header
+            )
+        end
+
+        it "raises a bad response error" do
+          expect { labeler.labels_for_pr }
+            .to raise_error(Dependabot::PrivateSourceBadResponse, /name must be a string/)
+        end
       end
 
       context "when a 'dependencies' label exists" do

--- a/common/spec/dependabot/pull_request_creator/labeler_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/labeler_spec.rb
@@ -565,6 +565,22 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
         end
       end
 
+      context "when the first page contains a non-object label" do
+        before do
+          stub_request(:get, "#{repo_api_url}/labels?per_page=100")
+            .to_return(
+              status: 200,
+              body: JSON.dump(["dependencies"]),
+              headers: json_header
+            )
+        end
+
+        it "raises a bad response error" do
+          expect { labeler.labels_for_pr }
+            .to raise_error(Dependabot::PrivateSourceBadResponse, /label must be an object/)
+        end
+      end
+
       context "when a 'dependencies' label exists" do
         let(:labels_fixture_name) { "labels_with_dependencies.json" }
 

--- a/common/spec/dependabot/pull_request_creator/labeler_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/labeler_spec.rb
@@ -581,6 +581,43 @@ RSpec.describe Dependabot::PullRequestCreator::Labeler do
         end
       end
 
+      context "when Octokit auto-pagination is enabled" do
+        let(:repo_labels_url) { "#{repo_api_url}/labels?per_page=100" }
+        let(:links_header) do
+          {
+            "Content-Type" => "application/json",
+            "Link" => "<#{repo_labels_url}&page=2>; rel=\"next\""
+          }
+        end
+
+        around do |example|
+          original = ENV.fetch("OCTOKIT_AUTO_PAGINATE", nil)
+          ENV["OCTOKIT_AUTO_PAGINATE"] = "true"
+          example.run
+        ensure
+          ENV["OCTOKIT_AUTO_PAGINATE"] = original
+        end
+
+        before do
+          stub_request(:get, repo_labels_url)
+            .to_return(
+              status: 200,
+              body: fixture("github", "labels_with_dependencies.json"),
+              headers: links_header
+            )
+          stub_request(:get, repo_labels_url + "&page=2")
+            .to_return(
+              status: 200,
+              body: fixture("github", "labels_without_dependencies.json"),
+              headers: json_header
+            )
+        end
+
+        it "uses labels returned from every page" do
+          expect(labeler.labels_for_pr).to include("dependencies")
+        end
+      end
+
       context "when a 'dependencies' label exists" do
         let(:labels_fixture_name) { "labels_with_dependencies.json" }
 

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -127,6 +127,15 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
         it { is_expected.to eq("build(deps): ") }
       end
 
+      context "when the GitHub commit response is malformed" do
+        let(:commits_response) { JSON.dump([{ commit: 1 }]) }
+
+        it "raises a bad response error" do
+          expect { pr_name_prefix }
+            .to raise_error(Dependabot::PrivateSourceBadResponse, /Malformed GitHub commit response/)
+        end
+      end
+
       context "when receiving a 409 response when asked for commits" do
         before do
           stub_request(:get, watched_repo_url + "/commits?per_page=100")
@@ -165,6 +174,17 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
         end
 
         it { is_expected.to eq("") }
+
+        context "when the commit response is malformed" do
+          let(:commits_response) do
+            JSON.dump([{ message: 1, author_email: "support@dependabot.com" }])
+          end
+
+          it "raises a bad response error" do
+            expect { pr_name_prefix }
+              .to raise_error(Dependabot::PrivateSourceBadResponse, /Malformed GitLab commit response/)
+          end
+        end
       end
 
       context "when dealing with Azure and no author email is present" do
@@ -192,6 +212,100 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
         end
 
         it { is_expected.to eq("") }
+
+        context "when the commit response is malformed" do
+          let(:commits_response) do
+            JSON.dump(
+              value: [{
+                comment: 1,
+                author: { email: "support@dependabot.com" }
+              }]
+            )
+          end
+
+          it "raises a bad response error" do
+            expect { pr_name_prefix }
+              .to raise_error(Dependabot::PrivateSourceBadResponse, /Malformed azure commit response/i)
+          end
+        end
+      end
+
+      context "when dealing with Bitbucket" do
+        let(:source) do
+          Dependabot::Source.new(provider: "bitbucket", repo: "gocardless/bump")
+        end
+        let(:bitbucket_commits_url) do
+          "https://api.bitbucket.org/2.0/repositories/gocardless/bump/commits/?pagelen=100"
+        end
+        let(:commits_response) do
+          JSON.dump(
+            values: [{
+              message: "build(deps): Bump business",
+              author: { raw: "dependabot <support@dependabot.com>" }
+            }]
+          )
+        end
+
+        before do
+          stub_request(:get, bitbucket_commits_url)
+            .to_return(
+              status: 200,
+              body: commits_response,
+              headers: json_header
+            )
+        end
+
+        it { is_expected.to eq("build(deps): ") }
+
+        context "when the commit response is malformed" do
+          let(:commits_response) do
+            JSON.dump(
+              values: [{
+                message: "build(deps): Bump business",
+                author: 1
+              }]
+            )
+          end
+
+          it "raises a bad response error" do
+            expect { pr_name_prefix }
+              .to raise_error(Dependabot::PrivateSourceBadResponse, /Malformed bitbucket commit response/i)
+          end
+        end
+      end
+
+      context "when dealing with CodeCommit" do
+        let(:source) do
+          Dependabot::Source.new(
+            provider: "codecommit",
+            repo: "gocardless",
+            branch: "master"
+          )
+        end
+        let(:stubbed_cc_client) { Aws::CodeCommit::Client.new(stub_responses: true) }
+        let(:codecommit_client) do
+          instance_double(
+            Dependabot::Clients::CodeCommit,
+            commits: stubbed_cc_client.batch_get_commits(
+              repository_name: source.repo,
+              commit_ids: ["commit"]
+            )
+          )
+        end
+
+        before do
+          stubbed_cc_client.stub_responses(
+            :batch_get_commits,
+            commits: [{
+              author: { email: "support@dependabot.com" },
+              message: "build(deps): Bump business"
+            }]
+          )
+          allow(Dependabot::Clients::CodeCommit)
+            .to receive(:for_source).and_return(codecommit_client)
+        end
+
+        it { is_expected.to eq("build(deps): ") }
       end
 
       context "with a security vulnerability fixed" do

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -283,6 +283,14 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
           )
         end
         let(:stubbed_cc_client) { Aws::CodeCommit::Client.new(stub_responses: true) }
+        let(:batch_get_commits_response) do
+          {
+            commits: [{
+              author: { email: "support@dependabot.com" },
+              message: "build(deps): Bump business"
+            }]
+          }
+        end
         let(:codecommit_client) do
           instance_double(
             Dependabot::Clients::CodeCommit,
@@ -296,16 +304,29 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
         before do
           stubbed_cc_client.stub_responses(
             :batch_get_commits,
-            commits: [{
-              author: { email: "support@dependabot.com" },
-              message: "build(deps): Bump business"
-            }]
+            batch_get_commits_response
           )
           allow(Dependabot::Clients::CodeCommit)
             .to receive(:for_source).and_return(codecommit_client)
         end
 
         it { is_expected.to eq("build(deps): ") }
+
+        context "when the response has no commits" do
+          let(:batch_get_commits_response) { {} }
+
+          it { is_expected.to eq("") }
+        end
+
+        context "when a commit has no author" do
+          let(:batch_get_commits_response) do
+            {
+              commits: [{ message: "build(deps): Bump business" }]
+            }
+          end
+
+          it { is_expected.to eq("build(deps): ") }
+        end
       end
 
       context "with a security vulnerability fixed" do

--- a/sorbet/rbi/shims/aws-sdk-codecommit.rbi
+++ b/sorbet/rbi/shims/aws-sdk-codecommit.rbi
@@ -10,12 +10,12 @@ module Aws
       end
 
       class BatchGetCommitsOutput
-        sig { returns(T::Array[Aws::CodeCommit::Types::Commit]) }
+        sig { returns(T.nilable(T::Array[Aws::CodeCommit::Types::Commit])) }
         attr_reader :commits
       end
 
       class Commit
-        sig { returns(Aws::CodeCommit::Types::UserInfo) }
+        sig { returns(T.nilable(Aws::CodeCommit::Types::UserInfo)) }
         attr_reader :author
 
         sig { returns(T.nilable(String)) }
@@ -26,7 +26,7 @@ module Aws
         sig { returns(T.nilable(String)) }
         attr_reader :email
 
-        sig { returns(String) }
+        sig { returns(T.nilable(String)) }
         attr_reader :date
       end
 

--- a/sorbet/rbi/shims/aws-sdk-codecommit.rbi
+++ b/sorbet/rbi/shims/aws-sdk-codecommit.rbi
@@ -9,6 +9,27 @@ module Aws
         attr_reader :files
       end
 
+      class BatchGetCommitsOutput
+        sig { returns(T::Array[Aws::CodeCommit::Types::Commit]) }
+        attr_reader :commits
+      end
+
+      class Commit
+        sig { returns(Aws::CodeCommit::Types::UserInfo) }
+        attr_reader :author
+
+        sig { returns(T.nilable(String)) }
+        attr_reader :message
+      end
+
+      class UserInfo
+        sig { returns(T.nilable(String)) }
+        attr_reader :email
+
+        sig { returns(String) }
+        attr_reader :date
+      end
+
       class File
         sig { returns(String) }
         attr_reader :relative_path

--- a/sorbet/rbi/shims/gitlab.rbi
+++ b/sorbet/rbi/shims/gitlab.rbi
@@ -3,6 +3,9 @@
 
 module Gitlab
   class PaginatedResponse
+    sig { params(block: T.nilable(Proc)).returns(T::Array[Gitlab::ObjectifiedHash]) }
+    def auto_paginate(&block); end
+
     sig do
       type_parameters(:U)
         .params(

--- a/sorbet/rbi/shims/gitlab.rbi
+++ b/sorbet/rbi/shims/gitlab.rbi
@@ -3,7 +3,13 @@
 
 module Gitlab
   class PaginatedResponse
-    sig { params(block: T.nilable(Proc)).returns(T::Array[Gitlab::ObjectifiedHash]) }
+    sig { returns(T::Array[Gitlab::ObjectifiedHash]) }
+    sig do
+      params(
+        block: T.proc.params(element: Gitlab::ObjectifiedHash).void
+      )
+        .returns(T::Enumerator[Gitlab::ObjectifiedHash])
+    end
     def auto_paginate(&block); end
 
     sig do


### PR DESCRIPTION
Types commit-prefix inference and label pagination across providers. `PrNamePrefixer` and `Labeler` are now `typed: strong`.

Ratchets: `T.untyped` 837 to 831; `T.unsafe` 34 to 30.