### PR TITLE
Type common pull request writes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 831
+# Offense count: 790
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -275,10 +275,6 @@ Sorbet/ForbidTUntyped:
     - "bundler/lib/dependabot/bundler/update_checker/latest_version_finder/dependency_source.rb"
     - "bundler/lib/dependabot/bundler/update_checker/shared_bundler_helpers.rb"
     - "bundler/lib/dependabot/bundler/update_checker/version_resolver.rb"
-    - "common/lib/dependabot/pull_request_creator/github.rb"
-    - "common/lib/dependabot/pull_request_updater/azure.rb"
-    - "common/lib/dependabot/pull_request_updater/github.rb"
-    - "common/lib/dependabot/pull_request_updater/gitlab.rb"
     - "composer/lib/dependabot/composer/file_fetcher.rb"
     - "composer/lib/dependabot/composer/file_fetcher/path_dependency_builder.rb"
     - "composer/lib/dependabot/composer/file_parser.rb"

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -121,12 +121,15 @@ module Dependabot
         params(
           branch_name: String
         )
-          .returns(String)
+          .returns(Seahorse::Client::Response)
       end
       def branch(branch_name)
-        cc_client.get_branch(
-          repository_name: source.unscoped_repo,
-          branch_name: branch_name
+        T.cast(
+          cc_client.get_branch(
+            repository_name: source.unscoped_repo,
+            branch_name: branch_name
+          ),
+          Seahorse::Client::Response
         )
       end
 
@@ -210,7 +213,7 @@ module Dependabot
           state: String,
           branch: String
         )
-          .returns(T::Array[Aws::CodeCommit::Types::PullRequest])
+          .returns(T::Array[Seahorse::Client::Response])
       end
       def pull_requests(repo, state, branch)
         pull_request_ids = @cc_client.list_pull_requests(
@@ -218,16 +221,20 @@ module Dependabot
           pull_request_status: state
         ).pull_request_ids
 
-        result = []
+        result = T.let([], T::Array[Seahorse::Client::Response])
         # list_pull_requests only gets us the pull request id
         # get_pull_request has all the info we need
         pull_request_ids.each do |id|
-          pr_hash = @cc_client.get_pull_request(
-            pull_request_id: id
+          pr_hash = T.cast(
+            @cc_client.get_pull_request(
+              pull_request_id: id
+            ),
+            Seahorse::Client::Response
           )
+          output = T.cast(pr_hash.data, Aws::CodeCommit::Types::GetPullRequestOutput)
           # only include PRs from the referenced branch
-          if pr_hash.pull_request.pull_request_targets[0]
-                    .source_reference.include? branch
+          if T.must(output.pull_request.pull_request_targets[0])
+              .source_reference.include? branch
             result << pr_hash
           end
         end

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -245,13 +245,16 @@ module Dependabot
           branch_name: String,
           commit_id: String
         )
-          .returns(Aws::CodeCommit::Types::BranchInfo)
+          .returns(Seahorse::Client::Response)
       end
       def create_branch(repo, branch_name, commit_id)
-        cc_client.create_branch(
-          repository_name: repo,
-          branch_name: branch_name,
-          commit_id: commit_id
+        T.cast(
+          cc_client.create_branch(
+            repository_name: repo,
+            branch_name: branch_name,
+            commit_id: commit_id
+          ),
+          Seahorse::Client::Response
         )
       end
 
@@ -263,7 +266,7 @@ module Dependabot
           commit_message: String,
           files: T::Array[Dependabot::DependencyFile]
         )
-          .returns(Aws::CodeCommit::Types::CreateCommitOutput)
+          .returns(Seahorse::Client::Response)
       end
       def create_commit(
         branch_name,
@@ -272,19 +275,22 @@ module Dependabot
         commit_message,
         files
       )
-        cc_client.create_commit(
-          repository_name: source.unscoped_repo,
-          branch_name: branch_name,
-          parent_commit_id: base_commit,
-          author_name: author_name,
-          commit_message: commit_message,
-          put_files: files.map do |file|
-            {
-              file_path: file.path,
-              file_mode: "NORMAL",
-              file_content: file.content
-            }
-          end
+        T.cast(
+          cc_client.create_commit(
+            repository_name: source.unscoped_repo,
+            branch_name: branch_name,
+            parent_commit_id: base_commit,
+            author_name: author_name,
+            commit_message: commit_message,
+            put_files: files.map do |file|
+              {
+                file_path: file.path,
+                file_mode: "NORMAL",
+                file_content: file.content
+              }
+            end
+          ),
+          Seahorse::Client::Response
         )
       end
 
@@ -295,7 +301,7 @@ module Dependabot
           source_branch: String,
           pr_description: String
         )
-          .returns(T.nilable(Aws::CodeCommit::Types::CreatePullRequestOutput))
+          .returns(Seahorse::Client::Response)
       end
       def create_pull_request(
         pr_name,
@@ -303,14 +309,17 @@ module Dependabot
         source_branch,
         pr_description
       )
-        cc_client.create_pull_request(
-          title: pr_name,
-          description: pr_description,
-          targets: [
-            { repository_name: source.unscoped_repo,
-              source_reference: target_branch,
-              destination_reference: source_branch }
-          ]
+        T.cast(
+          cc_client.create_pull_request(
+            title: pr_name,
+            description: pr_description,
+            targets: [
+              { repository_name: source.unscoped_repo,
+                source_reference: target_branch,
+                destination_reference: source_branch }
+            ]
+          ),
+          Seahorse::Client::Response
         )
       end
 

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -234,7 +234,7 @@ module Dependabot
           output = T.cast(pr_hash.data, Aws::CodeCommit::Types::GetPullRequestOutput)
           # only include PRs from the referenced branch
           if T.must(output.pull_request.pull_request_targets[0])
-              .source_reference.include? branch
+              .source_reference == branch
             result << pr_hash
           end
         end

--- a/common/lib/dependabot/clients/codecommit.rb
+++ b/common/lib/dependabot/clients/codecommit.rb
@@ -233,10 +233,8 @@ module Dependabot
           )
           output = T.cast(pr_hash.data, Aws::CodeCommit::Types::GetPullRequestOutput)
           # only include PRs from the referenced branch
-          if T.must(output.pull_request.pull_request_targets[0])
-              .source_reference == branch
-            result << pr_hash
-          end
+          source_reference = T.must(output.pull_request.pull_request_targets[0]).source_reference
+          result << pr_hash if source_reference.delete_prefix("refs/heads/") == branch.delete_prefix("refs/heads/")
         end
         result
       end

--- a/common/lib/dependabot/clients/github_resource_parser.rb
+++ b/common/lib/dependabot/clients/github_resource_parser.rb
@@ -1,0 +1,70 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "dependabot/errors"
+require "sorbet-runtime"
+
+module Dependabot
+  module Clients
+    module GithubResourceParser
+      extend T::Sig
+
+      private
+
+      sig { params(resource: Sawyer::Resource, key: Symbol, context: String).returns(String) }
+      def github_string(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(String)
+
+        raise_bad_github_response("#{context} #{key} must be a string")
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol, context: String).returns(T.nilable(String)) }
+      def github_optional_string(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise_bad_github_response("#{context} #{key} must be a string or nil")
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol, context: String).returns(Integer) }
+      def github_integer(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(Integer)
+
+        raise_bad_github_response("#{context} #{key} must be an integer")
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol, context: String).returns(T::Boolean) }
+      def github_boolean(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return value if value == true
+        return false if value.nil? || value == false
+
+        raise_bad_github_response("#{context} #{key} must be a boolean or nil")
+      end
+
+      sig { params(resource: Sawyer::Resource, key: Symbol, context: String).returns(Sawyer::Resource) }
+      def github_resource(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(Sawyer::Resource)
+
+        raise_bad_github_response("#{context} #{key} must be an object")
+      end
+
+      sig { params(message: String).returns(T.noreturn) }
+      def raise_bad_github_response(message)
+        Kernel.raise Dependabot::PrivateSourceBadResponse.new(
+          github_response_source,
+          "Malformed GitHub response: #{message}"
+        )
+      end
+
+      sig { returns(String) }
+      def github_response_source
+        Kernel.raise NotImplementedError
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/pull_request_creator/codecommit.rb
+++ b/common/lib/dependabot/pull_request_creator/codecommit.rb
@@ -180,7 +180,7 @@ module Dependabot
         pull_requests_for_branch.each do |pr|
           output = T.cast(pr.data, Aws::CodeCommit::Types::GetPullRequestOutput)
           target = T.must(output.pull_request.pull_request_targets[0])
-          unmerged_prs << pr unless target.merge_metadata.is_merged
+          unmerged_prs << pr unless target.merge_metadata&.is_merged
         end
         unmerged_prs.any?
       end

--- a/common/lib/dependabot/pull_request_creator/codecommit.rb
+++ b/common/lib/dependabot/pull_request_creator/codecommit.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -167,7 +167,7 @@ module Dependabot
       def branch_exists?(branch_name)
         @branch_ref ||= T.let(
           codecommit_client_for_source.branch(branch_name),
-          T.nilable(String)
+          T.nilable(Seahorse::Client::Response)
         )
         !@branch_ref.nil?
       rescue Aws::CodeCommit::Errors::BranchDoesNotExistException
@@ -178,15 +178,14 @@ module Dependabot
       def unmerged_pull_request_exists?
         unmerged_prs = []
         pull_requests_for_branch.each do |pr|
-          unless T.unsafe(pr).pull_request
-                  .pull_request_targets[0].merge_metadata.is_merged
-            unmerged_prs << pr
-          end
+          output = T.cast(pr.data, Aws::CodeCommit::Types::GetPullRequestOutput)
+          target = T.must(output.pull_request.pull_request_targets[0])
+          unmerged_prs << pr unless target.merge_metadata.is_merged
         end
         unmerged_prs.any?
       end
 
-      sig { returns(T::Array[Aws::CodeCommit::Types::PullRequest]) }
+      sig { returns(T::Array[Seahorse::Client::Response]) }
       def pull_requests_for_branch
         @pull_requests_for_branch ||=
           T.let(
@@ -204,7 +203,7 @@ module Dependabot
 
               [*open_prs, *closed_prs]
             end,
-            T.nilable(T::Array[Aws::CodeCommit::Types::PullRequest])
+            T.nilable(T::Array[Seahorse::Client::Response])
           )
       end
 

--- a/common/lib/dependabot/pull_request_creator/codecommit.rb
+++ b/common/lib/dependabot/pull_request_creator/codecommit.rb
@@ -193,12 +193,12 @@ module Dependabot
               open_prs = codecommit_client_for_source.pull_requests(
                 source.repo,
                 "open",
-                source.branch || default_branch
+                branch_name
               )
               closed_prs = codecommit_client_for_source.pull_requests(
                 source.repo,
                 "closed",
-                source.branch || default_branch
+                branch_name
               )
 
               [*open_prs, *closed_prs]

--- a/common/lib/dependabot/pull_request_creator/codecommit.rb
+++ b/common/lib/dependabot/pull_request_creator/codecommit.rb
@@ -110,7 +110,7 @@ module Dependabot
         ) == base_commit
       end
 
-      sig { returns(T.nilable(Aws::CodeCommit::Types::CreatePullRequestOutput)) }
+      sig { returns(T.nilable(Seahorse::Client::Response)) }
       def create_pull_request
         branch = create_or_get_branch(base_commit)
         return unless branch
@@ -124,7 +124,6 @@ module Dependabot
           pr_description
           # codecommit doesn't support PR labels
         )
-        return unless pull_request
 
         pull_request
       end

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "octokit"
@@ -6,6 +6,7 @@ require "securerandom"
 require "sorbet-runtime"
 
 require "dependabot/clients/github_with_retries"
+require "dependabot/clients/github_resource_parser"
 require "dependabot/pull_request_creator"
 require "dependabot/pull_request_creator/commit_signer"
 
@@ -14,6 +15,7 @@ module Dependabot
     # rubocop:disable Metrics/ClassLength
     class Github
       extend T::Sig
+      include Dependabot::Clients::GithubResourceParser
 
       # GitHub limits PR descriptions to a max of 65,536 characters:
       # https://github.com/orgs/community/discussions/27190#discussioncomment-3726017
@@ -121,7 +123,7 @@ module Dependabot
         @require_up_to_date_base = require_up_to_date_base
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(Sawyer::Resource) }
       def create
         Dependabot.logger.info(
           "Initiating Github pull request."
@@ -135,7 +137,8 @@ module Dependabot
         end
 
         if branch_exists?(branch_name) && open_pull_request_exists?
-          raise UnmergedPRExists, "PR ##{open_pull_requests.first.number} already exists"
+          number = github_integer(T.must(open_pull_requests.first), :number, "pull request")
+          raise UnmergedPRExists, "PR ##{number} already exists"
         end
         if require_up_to_date_base? && !base_commit_is_up_to_date?
           raise BaseCommitNotUpToDate, "HEAD #{head_commit} does not match base #{base_commit}"
@@ -186,12 +189,19 @@ module Dependabot
         open_pull_requests.any?
       end
 
-      sig { returns(T::Array[T.untyped]) }
+      sig { returns(T::Array[Sawyer::Resource]) }
       def open_pull_requests
-        pull_requests_for_branch.reject(&:closed).reject(&:merged)
+        pull_requests_for_branch
+          .reject { |pull_request| github_pull_request_closed?(pull_request) }
+          .reject { |pull_request| github_boolean(pull_request, :merged, "pull request") }
       end
 
-      sig { returns(T::Array[T.untyped]) }
+      sig { params(pull_request: Sawyer::Resource).returns(T::Boolean) }
+      def github_pull_request_closed?(pull_request)
+        github_boolean(pull_request, :closed, "pull request")
+      end
+
+      sig { returns(T::Array[Sawyer::Resource]) }
       def pull_requests_for_branch
         @pull_requests_for_branch ||=
           T.let(
@@ -217,7 +227,7 @@ module Dependabot
               )
               [*open_prs, *closed_prs]
             end,
-            T.nilable(T::Array[T.untyped])
+            T.nilable(T::Array[Sawyer::Resource])
           )
       end
 
@@ -234,7 +244,7 @@ module Dependabot
         )
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(Sawyer::Resource) }
       def create_annotated_pull_request
         commit = create_commit
         branch = create_or_update_branch(commit)
@@ -260,7 +270,7 @@ module Dependabot
         false
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(Sawyer::Resource) }
       def create_commit
         tree = create_tree
 
@@ -268,7 +278,7 @@ module Dependabot
           github_client_for_source.create_commit(
             source.repo,
             commit_message,
-            tree.sha,
+            github_string(tree, :sha, "tree"),
             base_commit,
             commit_options(tree)
           )
@@ -291,19 +301,21 @@ module Dependabot
         retry
       end
 
-      sig { params(tree: T.untyped).returns(T::Hash[Symbol, T.untyped]) }
+      sig { params(tree: Sawyer::Resource).returns(T::Hash[Symbol, Object]) }
       def commit_options(tree)
-        options = author_details&.any? ? { author: author_details } : {}
+        options = T.let({}, T::Hash[Symbol, Object])
+        author = author_details&.dup
+        options[:author] = author if author&.any?
 
-        if options[:author]&.any? && signature_key
-          options[:author][:date] = Time.now.utc.iso8601
-          options[:signature] = commit_signature(tree, options[:author])
+        if author&.any? && signature_key
+          author[:date] = Time.now.utc.iso8601
+          options[:signature] = commit_signature(tree, author)
         end
 
         options
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(Sawyer::Resource) }
       def create_tree
         file_trees = files.map do |file|
           if file.type == "submodule"
@@ -340,7 +352,7 @@ module Dependabot
         )
       end
 
-      sig { params(commit: T.untyped).returns(T.untyped) }
+      sig { params(commit: Sawyer::Resource).returns(T.nilable(Sawyer::Resource)) }
       def create_or_update_branch(commit)
         if branch_exists?(branch_name)
           update_branch(commit)
@@ -359,13 +371,13 @@ module Dependabot
         retry
       end
 
-      sig { params(commit: T.untyped).returns(T.untyped) }
+      sig { params(commit: Sawyer::Resource).returns(Sawyer::Resource) }
       def create_branch(commit)
         ref = "refs/heads/#{branch_name}"
 
         begin
           branch =
-            github_client_for_source.create_ref(source.repo, ref, commit.sha)
+            github_client_for_source.create_ref(source.repo, ref, github_string(commit, :sha, "commit"))
           @branch_name = ref.gsub(%r{^refs/heads/}, "")
           branch
         rescue Octokit::UnprocessableEntity => e
@@ -383,32 +395,32 @@ module Dependabot
         end
       end
 
-      sig { params(commit: T.untyped).void }
+      sig { params(commit: Sawyer::Resource).returns(Sawyer::Resource) }
       def update_branch(commit)
         github_client_for_source.update_ref(
           source.repo,
           "heads/#{branch_name}",
-          commit.sha,
+          github_string(commit, :sha, "commit"),
           true
         )
       end
 
-      sig { params(pull_request: T.untyped).void }
+      sig { params(pull_request: Sawyer::Resource).void }
       def annotate_pull_request(pull_request)
-        labeler.label_pull_request(pull_request.number)
+        labeler.label_pull_request(github_integer(pull_request, :number, "pull request"))
         add_reviewers_to_pull_request(pull_request) if reviewers&.any?
         add_assignees_to_pull_request(pull_request) if assignees&.any?
         add_milestone_to_pull_request(pull_request) if milestone
       end
 
-      sig { params(pull_request: T.untyped).void }
+      sig { params(pull_request: Sawyer::Resource).void }
       def add_reviewers_to_pull_request(pull_request)
         reviewers_hash =
           T.must(reviewers).keys.to_h { |k| [k.to_sym, T.must(reviewers)[k]] }
 
         github_client_for_source.request_pull_request_review(
           source.repo,
-          pull_request.number,
+          github_integer(pull_request, :number, "pull request"),
           reviewers: reviewers_hash[:reviewers] || [],
           team_reviewers: reviewers_hash[:team_reviewers] || []
         )
@@ -434,7 +446,7 @@ module Dependabot
         false
       end
 
-      sig { params(pull_request: T.untyped, message: String).void }
+      sig { params(pull_request: Sawyer::Resource, message: String).void }
       def comment_with_invalid_reviewer(pull_request, message)
         reviewers_hash =
           T.must(reviewers).keys.to_h { |k| [k.to_sym, T.must(reviewers)[k]] }
@@ -460,16 +472,16 @@ module Dependabot
 
         github_client_for_source.add_comment(
           source.repo,
-          pull_request.number,
+          github_integer(pull_request, :number, "pull request"),
           msg
         )
       end
 
-      sig { params(pull_request: T.untyped).void }
+      sig { params(pull_request: Sawyer::Resource).void }
       def add_assignees_to_pull_request(pull_request)
         github_client_for_source.add_assignees(
           source.repo,
-          pull_request.number,
+          github_integer(pull_request, :number, "pull request"),
           T.must(assignees)
         )
       rescue Octokit::NotFound
@@ -480,18 +492,18 @@ module Dependabot
         raise unless e.message.include?("Could not add assignees")
       end
 
-      sig { params(pull_request: T.untyped).void }
+      sig { params(pull_request: Sawyer::Resource).void }
       def add_milestone_to_pull_request(pull_request)
         github_client_for_source.update_issue(
           source.repo,
-          pull_request.number,
+          github_integer(pull_request, :number, "pull request"),
           milestone: milestone
         )
       rescue Octokit::UnprocessableEntity => e
         raise unless e.message.include?("code: invalid")
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(T.nilable(Sawyer::Resource)) }
       def create_pull_request
         github_client_for_source.create_pull_request(
           source.repo,
@@ -521,7 +533,7 @@ module Dependabot
       def default_branch
         @default_branch ||=
           T.let(
-            T.unsafe(github_client_for_source.repo(source.repo)).default_branch,
+            github_client_for_source.fetch_default_branch(source.repo),
             T.nilable(String)
           )
       end
@@ -539,13 +551,13 @@ module Dependabot
       end
 
       sig do
-        params(tree: T.untyped, author_details_with_date: T::Hash[Symbol, String]).returns(String)
+        params(tree: Sawyer::Resource, author_details_with_date: T::Hash[Symbol, String]).returns(String)
       end
       def commit_signature(tree, author_details_with_date)
         CommitSigner.new(
           author_details: author_details_with_date,
           commit_message: commit_message,
-          tree_sha: tree.sha,
+          tree_sha: github_string(tree, :sha, "tree"),
           parent_sha: base_commit,
           signature_key: T.must(signature_key)
         ).signature
@@ -568,6 +580,11 @@ module Dependabot
             ),
             T.nilable(Dependabot::Clients::GithubWithRetries)
           )
+      end
+
+      sig { returns(String) }
+      def github_response_source
+        source.url
       end
 
       sig { params(err: StandardError).returns(T.noreturn) }

--- a/common/lib/dependabot/pull_request_creator/github.rb
+++ b/common/lib/dependabot/pull_request_creator/github.rb
@@ -192,13 +192,16 @@ module Dependabot
       sig { returns(T::Array[Sawyer::Resource]) }
       def open_pull_requests
         pull_requests_for_branch
-          .reject { |pull_request| github_pull_request_closed?(pull_request) }
-          .reject { |pull_request| github_boolean(pull_request, :merged, "pull request") }
+          .reject { |pull_request| github_pull_request_merged?(pull_request) }
       end
 
       sig { params(pull_request: Sawyer::Resource).returns(T::Boolean) }
-      def github_pull_request_closed?(pull_request)
-        github_boolean(pull_request, :closed, "pull request")
+      def github_pull_request_merged?(pull_request)
+        merged_at = T.cast(pull_request[:merged_at], Object)
+        return false if merged_at.nil?
+        return true if merged_at.is_a?(String) || merged_at.is_a?(Time)
+
+        raise_bad_github_response("pull request merged_at must be a time, string, or nil")
       end
 
       sig { returns(T::Array[Sawyer::Resource]) }

--- a/common/lib/dependabot/pull_request_creator/gitlab.rb
+++ b/common/lib/dependabot/pull_request_creator/gitlab.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "gitlab"
@@ -6,6 +6,7 @@ require "sorbet-runtime"
 
 require "dependabot/clients/gitlab_with_retries"
 require "dependabot/pull_request_creator"
+require "dependabot/errors"
 
 module Dependabot
   class PullRequestCreator
@@ -158,18 +159,19 @@ module Dependabot
             gitlab_client_for_source.commits(source.repo, ref_name: branch_name),
             T.nilable(::Gitlab::PaginatedResponse)
           )
-        T.unsafe(@commits).first.message == commit_message
+        commit = @commits.first
+        return false unless commit
+
+        gitlab_string(commit, "message", "commit") == commit_message
       end
 
       sig { returns(T::Boolean) }
       def merge_request_exists?
-        T.unsafe(
-          gitlab_client_for_source.merge_requests(
-            (target_project_id || source.repo).to_s,
-            source_branch: branch_name,
-            target_branch: source.branch || default_branch,
-            state: "all"
-          )
+        gitlab_client_for_source.merge_requests(
+          (target_project_id || source.repo).to_s,
+          source_branch: branch_name,
+          target_branch: source.branch || default_branch,
+          state: "all"
         ).any?
       end
 
@@ -240,7 +242,7 @@ module Dependabot
 
         gitlab_client_for_source.create_merge_request_level_rule(
           (target_project_id || source.repo).to_s,
-          T.unsafe(merge_request).iid,
+          gitlab_integer(merge_request, "iid", "merge request"),
           name: "dependency-updates",
           approvals_required: 1,
           user_ids: approvers_hash[:approvers],
@@ -260,9 +262,33 @@ module Dependabot
       def default_branch
         @default_branch ||=
           T.let(
-            T.unsafe(gitlab_client_for_source.project(source.repo)).default_branch,
+            gitlab_client_for_source.fetch_default_branch(source.repo),
             T.nilable(String)
           )
+      end
+
+      sig { params(resource: ::Gitlab::ObjectifiedHash, key: String, context: String).returns(String) }
+      def gitlab_string(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(String)
+
+        raise_bad_gitlab_response("#{context} #{key} must be a string")
+      end
+
+      sig { params(resource: ::Gitlab::ObjectifiedHash, key: String, context: String).returns(Integer) }
+      def gitlab_integer(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(Integer)
+
+        raise_bad_gitlab_response("#{context} #{key} must be an integer")
+      end
+
+      sig { params(message: String).returns(T.noreturn) }
+      def raise_bad_gitlab_response(message)
+        raise Dependabot::PrivateSourceBadResponse.new(
+          source.url,
+          "Malformed GitLab response: #{message}"
+        )
       end
     end
   end

--- a/common/lib/dependabot/pull_request_updater.rb
+++ b/common/lib/dependabot/pull_request_updater.rb
@@ -11,6 +11,8 @@ module Dependabot
   class PullRequestUpdater
     extend T::Sig
 
+    UpdateResult = T.type_alias { T.nilable(T.any(Sawyer::Resource, String)) }
+
     class BranchProtected < StandardError; end
 
     sig { returns(Dependabot::Source) }
@@ -82,9 +84,7 @@ module Dependabot
       @provider_metadata   = provider_metadata
     end
 
-    # TODO: Each implementation returns a client-specific type.
-    #       We should standardise this to return a `Dependabot::Branch` type instead.
-    sig { returns(T.untyped) } # rubocop:disable Sorbet/ForbidTUntyped
+    sig { returns(UpdateResult) }
     def update
       case source.provider
       when "github" then github_updater.update

--- a/common/lib/dependabot/pull_request_updater/azure.rb
+++ b/common/lib/dependabot/pull_request_updater/azure.rb
@@ -151,7 +151,10 @@ module Dependabot
 
         root = T.cast(JSON.parse(response.body), Dependabot::Clients::Azure::JsonObject)
         ref_updates = object_array(root, "refUpdates", "created commit")
-        object_string(T.must(ref_updates.first), "newObjectId", "created commit")
+        ref_update = ref_updates.first
+        raise PullRequestUpdateFailed, "created commit refUpdates must contain at least one object" unless ref_update
+
+        object_string(ref_update, "newObjectId", "created commit")
       end
 
       sig { returns(String) }

--- a/common/lib/dependabot/pull_request_updater/azure.rb
+++ b/common/lib/dependabot/pull_request_updater/azure.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "securerandom"
@@ -114,22 +114,24 @@ module Dependabot
         # 3) Delete temp branch
         update_branch(temp_branch_name, new_commit, OBJECT_ID_FOR_BRANCH_DELETE)
 
-        raise PullRequestUpdateFailed, response.fetch("customMessage", nil) unless response.fetch("success", false)
+        return if object_boolean(response, "success", "updated ref")
+
+        raise PullRequestUpdateFailed, object_optional_string(response, "customMessage", "updated ref")
       end
 
-      sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig { returns(Dependabot::Clients::Azure::JsonObject) }
       def pull_request
         @pull_request ||=
           T.let(
             azure_client_for_source.pull_request(pull_request_number.to_s),
-            T.nilable(T::Hash[String, T.untyped])
+            T.nilable(Dependabot::Clients::Azure::JsonObject)
           )
       end
 
       sig { returns(String) }
       def source_branch_name
         @source_branch_name ||= T.let(
-          pull_request&.fetch("sourceRefName")&.gsub("refs/heads/", ""),
+          object_string(pull_request, "sourceRefName", "pull request").gsub("refs/heads/", ""),
           T.nilable(String)
         )
       end
@@ -147,7 +149,9 @@ module Dependabot
           author
         )
 
-        JSON.parse(response.body).fetch("refUpdates").first.fetch("newObjectId")
+        root = T.cast(JSON.parse(response.body), Dependabot::Clients::Azure::JsonObject)
+        ref_updates = object_array(root, "refUpdates", "created commit")
+        object_string(T.must(ref_updates.first), "newObjectId", "created commit")
       end
 
       sig { returns(String) }
@@ -159,7 +163,10 @@ module Dependabot
           )
       end
 
-      sig { params(branch_name: String, old_commit: String, new_commit: String).returns(T::Hash[String, T.untyped]) }
+      sig do
+        params(branch_name: String, old_commit: String, new_commit: String)
+          .returns(Dependabot::Clients::Azure::JsonObject)
+      end
       def update_branch(branch_name, old_commit, new_commit)
         azure_client_for_source.update_ref(
           branch_name,
@@ -169,23 +176,65 @@ module Dependabot
       end
 
       # For updating source branch, we require the latest commit for the source branch.
-      sig { returns(T::Hash[String, T.untyped]) }
+      sig { returns(Dependabot::Clients::Azure::JsonObject) }
       def commit_being_updated
         @commit_being_updated ||=
           T.let(
             T.must(azure_client_for_source.commits(source_branch_name).first),
-            T.nilable(T::Hash[String, T.untyped])
+            T.nilable(Dependabot::Clients::Azure::JsonObject)
           )
       end
 
       sig { returns(String) }
       def old_source_branch_commit
-        commit_being_updated.fetch("commitId")
+        object_string(commit_being_updated, "commitId", "commit")
       end
 
       sig { returns(String) }
       def commit_message
-        commit_being_updated.fetch("comment")
+        object_string(commit_being_updated, "comment", "commit")
+      end
+
+      sig { params(object: T::Hash[String, Object], key: String, context: String).returns(String) }
+      def object_string(object, key, context)
+        value = object[key]
+        return value if value.is_a?(String)
+
+        raise PullRequestUpdateFailed, "#{context} #{key} must be a string"
+      end
+
+      sig { params(object: T::Hash[String, Object], key: String, context: String).returns(T.nilable(String)) }
+      def object_optional_string(object, key, context)
+        value = object[key]
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise PullRequestUpdateFailed, "#{context} #{key} must be a string or nil"
+      end
+
+      sig { params(object: T::Hash[String, Object], key: String, context: String).returns(T::Boolean) }
+      def object_boolean(object, key, context)
+        value = object[key]
+        return value if value == true || value == false
+        return false if value.nil?
+
+        raise PullRequestUpdateFailed, "#{context} #{key} must be a boolean or nil"
+      end
+
+      sig do
+        params(object: T::Hash[String, Object], key: String, context: String)
+          .returns(T::Array[T::Hash[String, Object]])
+      end
+      def object_array(object, key, context)
+        value = object[key]
+        raise PullRequestUpdateFailed, "#{context} #{key} must be an array" unless value.is_a?(Array)
+
+        value.map do |entry|
+          parsed_entry = T.cast(entry, Object)
+          raise PullRequestUpdateFailed, "#{context} entry must be an object" unless parsed_entry.is_a?(Hash)
+
+          T.let(parsed_entry, T::Hash[String, Object])
+        end
       end
     end
   end

--- a/common/lib/dependabot/pull_request_updater/github.rb
+++ b/common/lib/dependabot/pull_request_updater/github.rb
@@ -1,10 +1,11 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "octokit"
 require "sorbet-runtime"
 
 require "dependabot/clients/github_with_retries"
+require "dependabot/clients/github_resource_parser"
 require "dependabot/pull_request_creator/commit_signer"
 require "dependabot/pull_request_updater"
 
@@ -12,6 +13,7 @@ module Dependabot
   class PullRequestUpdater
     class Github
       extend T::Sig
+      include Dependabot::Clients::GithubResourceParser
 
       sig { returns(Dependabot::Source) }
       attr_reader :source
@@ -31,7 +33,7 @@ module Dependabot
       sig { returns(Integer) }
       attr_reader :pull_request_number
 
-      sig { returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+      sig { returns(T.nilable(T::Hash[Symbol, String])) }
       attr_reader :author_details
 
       sig { returns(T.nilable(String)) }
@@ -45,7 +47,7 @@ module Dependabot
           files: T::Array[Dependabot::DependencyFile],
           credentials: T::Array[Dependabot::Credential],
           pull_request_number: Integer,
-          author_details: T.nilable(T::Hash[Symbol, T.untyped]),
+          author_details: T.nilable(T::Hash[Symbol, String]),
           signature_key: T.nilable(String),
           commit_message: T.nilable(String)
         )
@@ -76,7 +78,7 @@ module Dependabot
       sig { returns(T.nilable(Sawyer::Resource)) }
       def update
         return unless pull_request_exists?
-        return unless branch_exists?(pull_request.head.ref)
+        return unless branch_exists?(github_string(github_resource(pull_request, :head, "pull request"), :ref, "head"))
 
         commit = create_commit
         branch = update_branch(commit)
@@ -88,8 +90,10 @@ module Dependabot
 
       sig { void }
       def update_pull_request_target_branch
-        target_branch = source.branch || pull_request.base.repo.default_branch
-        return if target_branch == pull_request.base.ref
+        base = github_resource(pull_request, :base, "pull request")
+        base_repo = github_resource(base, :repo, "pull request base")
+        target_branch = source.branch || github_string(base_repo, :default_branch, "base repository")
+        return if target_branch == github_string(base, :ref, "pull request base")
 
         github_client_for_source.update_pull_request(
           source.repo,
@@ -125,6 +129,11 @@ module Dependabot
           )
       end
 
+      sig { returns(String) }
+      def github_response_source
+        source.url
+      end
+
       sig { returns(T::Boolean) }
       def pull_request_exists?
         pull_request
@@ -133,7 +142,7 @@ module Dependabot
         false
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(Sawyer::Resource) }
       def pull_request
         @pull_request ||=
           T.let(
@@ -141,7 +150,7 @@ module Dependabot
               source.repo,
               pull_request_number
             ),
-            T.untyped
+            T.nilable(Sawyer::Resource)
           )
       end
 
@@ -153,22 +162,24 @@ module Dependabot
         false
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(Sawyer::Resource) }
       def create_commit
         tree = create_tree
 
-        options = author_details&.any? ? { author: author_details } : {}
+        options = T.let({}, T::Hash[Symbol, Object])
+        author = author_details&.dup
+        options[:author] = author if author&.any?
 
-        if options[:author]&.any? && signature_key
-          options[:author][:date] = Time.now.utc.iso8601
-          options[:signature] = commit_signature(tree, options[:author])
+        if author&.any? && signature_key
+          author[:date] = Time.now.utc.iso8601
+          options[:signature] = commit_signature(tree, author)
         end
 
         begin
           github_client_for_source.create_commit(
             source.repo,
             commit_message,
-            tree.sha,
+            github_string(tree, :sha, "tree"),
             base_commit,
             options
           )
@@ -186,7 +197,7 @@ module Dependabot
         end
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(Sawyer::Resource) }
       def create_tree
         file_trees = files.map do |file|
           if file.type == "submodule"
@@ -238,12 +249,13 @@ module Dependabot
         T::Array[Regexp]
       )
 
-      sig { params(commit: T.untyped).returns(T.untyped) }
+      sig { params(commit: Sawyer::Resource).returns(T.nilable(Sawyer::Resource)) }
       def update_branch(commit)
+        head = github_resource(pull_request, :head, "pull request")
         github_client_for_source.update_ref(
           source.repo,
-          "heads/" + pull_request.head.ref,
-          commit.sha,
+          "heads/" + github_string(head, :ref, "pull request head"),
+          github_string(commit, :sha, "commit"),
           true
         )
       rescue Octokit::UnprocessableEntity => e
@@ -262,45 +274,43 @@ module Dependabot
         return msg unless msg.nil? || msg.empty?
 
         fallback_message =
-          "#{pull_request.title}" \
+          "#{github_string(pull_request, :title, 'pull request')}" \
           "\n\n" \
           "Dependabot couldn't find the original pull request head commit, " \
           "#{old_commit}."
 
         # Take the commit message from the old commit. If the old commit can't
         # be found, use the PR title as the commit message.
-        commit_being_updated&.message || fallback_message
+        commit = commit_being_updated
+        (commit && github_optional_string(commit, :message, "commit")) || fallback_message
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(T.nilable(Sawyer::Resource)) }
       def commit_being_updated
         return @commit_being_updated if defined?(@commit_being_updated)
 
         @commit_being_updated =
           T.let(
-            if pull_request.commits == 1
+            if github_integer(pull_request, :commits, "pull request") == 1
+              head = github_resource(pull_request, :head, "pull request")
               github_client_for_source
-               .git_commit(source.repo, pull_request.head.sha)
+               .git_commit(source.repo, github_string(head, :sha, "pull request head"))
             else
-              commits =
-                T.unsafe(
-                  github_client_for_source
-                                   .pull_request_commits(source.repo, pull_request_number)
-                )
+              commits = github_client_for_source.pull_request_commits(source.repo, pull_request_number)
 
-              commit = commits.find { |c| c.sha == old_commit }
-              commit&.commit
+              commit = commits.find { |candidate| github_string(candidate, :sha, "pull request commit") == old_commit }
+              commit && github_resource(commit, :commit, "pull request commit")
             end,
-            T.untyped
+            T.nilable(Sawyer::Resource)
           )
       end
 
-      sig { params(tree: T.untyped, author_details_with_date: T::Hash[Symbol, T.untyped]).returns(String) }
+      sig { params(tree: Sawyer::Resource, author_details_with_date: T::Hash[Symbol, String]).returns(String) }
       def commit_signature(tree, author_details_with_date)
         PullRequestCreator::CommitSigner.new(
           author_details: author_details_with_date,
           commit_message: commit_message,
-          tree_sha: tree.sha,
+          tree_sha: github_string(tree, :sha, "tree"),
           parent_sha: base_commit,
           signature_key: T.must(signature_key)
         ).signature

--- a/common/lib/dependabot/pull_request_updater/gitlab.rb
+++ b/common/lib/dependabot/pull_request_updater/gitlab.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "gitlab"
@@ -7,6 +7,7 @@ require "sorbet-runtime"
 require "dependabot/clients/gitlab_with_retries"
 require "dependabot/credential"
 require "dependabot/pull_request_creator"
+require "dependabot/errors"
 
 module Dependabot
   class PullRequestUpdater
@@ -67,10 +68,10 @@ module Dependabot
       sig { returns(T.nilable(String)) }
       def update
         return unless merge_request_exists?
-        return unless branch_exists?(merge_request.source_branch)
+        return unless branch_exists?(gitlab_string(merge_request, "source_branch", "merge request"))
 
         create_commit
-        merge_request.source_branch
+        gitlab_string(merge_request, "source_branch", "merge request")
       end
 
       private
@@ -83,14 +84,14 @@ module Dependabot
         false
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(::Gitlab::ObjectifiedHash) }
       def merge_request
         @merge_request ||= T.let(
-          T.unsafe(gitlab_client_for_source).merge_request(
-            target_project_id || source.repo,
+          gitlab_client_for_source.merge_request(
+            (target_project_id || source.repo).to_s,
             pull_request_number
           ),
-          T.untyped
+          T.nilable(::Gitlab::ObjectifiedHash)
         )
       end
 
@@ -113,8 +114,7 @@ module Dependabot
         false
       end
 
-      # TODO: This needs to be typed when the underlying client is
-      sig { returns(T.untyped) }
+      sig { returns(::Gitlab::ObjectifiedHash) }
       def commit_being_updated
         gitlab_client_for_source.commit(source.repo, old_commit)
       end
@@ -123,11 +123,22 @@ module Dependabot
       def create_commit
         gitlab_client_for_source.create_commit(
           source.repo,
-          merge_request.source_branch,
-          commit_being_updated.title,
+          gitlab_string(merge_request, "source_branch", "merge request"),
+          gitlab_string(commit_being_updated, "title", "commit"),
           files,
           force: true,
-          start_branch: merge_request.target_branch
+          start_branch: gitlab_string(merge_request, "target_branch", "merge request")
+        )
+      end
+
+      sig { params(resource: ::Gitlab::ObjectifiedHash, key: String, context: String).returns(String) }
+      def gitlab_string(resource, key, context)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(String)
+
+        raise Dependabot::PrivateSourceBadResponse.new(
+          source.url,
+          "Malformed GitLab response: #{context} #{key} must be a string"
         )
       end
     end

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -187,7 +187,9 @@ RSpec.describe Dependabot::Clients::CodeCommit do
   end
 
   describe "#pull_requests" do
-    subject(:pull_requests) { client.pull_requests(repo, "open", "feature") }
+    subject(:pull_requests) { client.pull_requests(repo, "open", branch_name) }
+
+    let(:branch_name) { "dependabot/bundler/business-1.5.0" }
 
     before do
       allow(Aws::CodeCommit::Client).to receive(:new).and_return(stubbed_cc_client)
@@ -202,7 +204,7 @@ RSpec.describe Dependabot::Clients::CodeCommit do
             pull_request: {
               pull_request_id: "matching",
               pull_request_targets: [{
-                source_reference: "refs/heads/feature"
+                source_reference: "refs/heads/#{branch_name}"
               }]
             }
           },

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Dependabot::Clients::CodeCommit do
   let(:source) do
     Dependabot::Source.new(
       provider: "codecommit",
-      repo: "",
+      repo: repo,
       directory: "/",
       branch: "master"
     )
@@ -225,6 +225,44 @@ RSpec.describe Dependabot::Clients::CodeCommit do
       expect(pull_requests.first).to be_a(Seahorse::Client::Response)
       expect(pull_requests.first.data).to be_a(Aws::CodeCommit::Types::GetPullRequestOutput)
       expect(pull_requests.first.data.pull_request.pull_request_id).to eq("matching")
+    end
+  end
+
+  describe "write operations" do
+    let(:dependency_file) do
+      Dependabot::DependencyFile.new(name: "Gemfile", content: "gem \"business\"")
+    end
+
+    it "preserves the create branch response wrapper" do
+      stubbed_cc_client.stub_responses(:create_branch, {})
+
+      response = client.create_branch(repo, "feature", "commit")
+
+      expect(response).to be_a(Seahorse::Client::Response)
+    end
+
+    it "preserves the create commit response wrapper" do
+      stubbed_cc_client.stub_responses(:create_commit, commit_id: "commit", tree_id: "tree")
+
+      response = client.create_commit("feature", nil, "base", "Bump dependency", [dependency_file])
+
+      expect(response).to be_a(Seahorse::Client::Response)
+      expect(response.data).to be_a(Aws::CodeCommit::Types::CreateCommitOutput)
+    end
+
+    it "preserves the create pull request response wrapper" do
+      stubbed_cc_client.stub_responses(
+        :create_pull_request,
+        pull_request: {
+          pull_request_id: "1",
+          pull_request_targets: []
+        }
+      )
+
+      response = client.create_pull_request("PR name", "feature", "main", "PR description")
+
+      expect(response).to be_a(Seahorse::Client::Response)
+      expect(response.data).to be_a(Aws::CodeCommit::Types::CreatePullRequestOutput)
     end
   end
 end

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Dependabot::Clients::CodeCommit do
             pull_request: {
               pull_request_id: "matching",
               pull_request_targets: [{
-                source_reference: "refs/heads/#{branch_name}"
+                source_reference: branch_name
               }]
             }
           },
@@ -212,7 +212,7 @@ RSpec.describe Dependabot::Clients::CodeCommit do
             pull_request: {
               pull_request_id: "other",
               pull_request_targets: [{
-                source_reference: "refs/heads/other"
+                source_reference: "#{branch_name}-next"
               }]
             }
           }

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -185,4 +185,44 @@ RSpec.describe Dependabot::Clients::CodeCommit do
       end
     end
   end
+
+  describe "#pull_requests" do
+    subject(:pull_requests) { client.pull_requests(repo, "open", "feature") }
+
+    before do
+      allow(Aws::CodeCommit::Client).to receive(:new).and_return(stubbed_cc_client)
+      stubbed_cc_client.stub_responses(
+        :list_pull_requests,
+        pull_request_ids: %w(matching other)
+      )
+      stubbed_cc_client.stub_responses(
+        :get_pull_request,
+        [
+          {
+            pull_request: {
+              pull_request_id: "matching",
+              pull_request_targets: [{
+                source_reference: "refs/heads/feature"
+              }]
+            }
+          },
+          {
+            pull_request: {
+              pull_request_id: "other",
+              pull_request_targets: [{
+                source_reference: "refs/heads/other"
+              }]
+            }
+          }
+        ]
+      )
+    end
+
+    it "preserves matching pull request response wrappers" do
+      expect(pull_requests.length).to eq(1)
+      expect(pull_requests.first).to be_a(Seahorse::Client::Response)
+      expect(pull_requests.first.data).to be_a(Aws::CodeCommit::Types::GetPullRequestOutput)
+      expect(pull_requests.first.data.pull_request.pull_request_id).to eq("matching")
+    end
+  end
 end

--- a/common/spec/dependabot/clients/codecommit_spec.rb
+++ b/common/spec/dependabot/clients/codecommit_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Dependabot::Clients::CodeCommit do
             pull_request: {
               pull_request_id: "matching",
               pull_request_targets: [{
-                source_reference: branch_name
+                source_reference: "refs/heads/#{branch_name}"
               }]
             }
           },
@@ -212,7 +212,7 @@ RSpec.describe Dependabot::Clients::CodeCommit do
             pull_request: {
               pull_request_id: "other",
               pull_request_targets: [{
-                source_reference: "#{branch_name}-next"
+                source_reference: "refs/heads/#{branch_name}-next"
               }]
             }
           }

--- a/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe Dependabot::PullRequestCreator::Codecommit do
   def pull_request_response(merge_metadata: nil)
     client = Aws::CodeCommit::Client.new(stub_responses: true)
     target = {
-      source_reference: branch_name,
-      destination_reference: "main"
+      source_reference: "refs/heads/#{branch_name}",
+      destination_reference: "refs/heads/main"
     }
     target[:merge_metadata] = merge_metadata if merge_metadata
     client.stub_responses(

--- a/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe Dependabot::PullRequestCreator::Codecommit do
   def pull_request_response(merge_metadata: nil)
     client = Aws::CodeCommit::Client.new(stub_responses: true)
     target = {
-      source_reference: "refs/heads/#{branch_name}",
-      destination_reference: "refs/heads/main"
+      source_reference: branch_name,
+      destination_reference: "main"
     }
     target[:merge_metadata] = merge_metadata if merge_metadata
     client.stub_responses(

--- a/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
@@ -53,10 +53,10 @@ RSpec.describe Dependabot::PullRequestCreator::Codecommit do
       .to receive(:for_source).and_return(codecommit_client)
     allow(codecommit_client).to receive(:branch).with(branch_name).and_return(branch_response)
     allow(codecommit_client)
-      .to receive(:pull_requests).with(source.repo, "open", source.branch)
+      .to receive(:pull_requests).with(source.repo, "open", branch_name)
       .and_return(open_pull_requests)
     allow(codecommit_client)
-      .to receive(:pull_requests).with(source.repo, "closed", source.branch)
+      .to receive(:pull_requests).with(source.repo, "closed", branch_name)
       .and_return(closed_pull_requests)
     allow(codecommit_client).to receive_messages(
       create_commit: Aws::CodeCommit::Types::CreateCommitOutput.new,

--- a/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
@@ -1,0 +1,116 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/pull_request_creator/codecommit"
+
+RSpec.describe Dependabot::PullRequestCreator::Codecommit do
+  subject(:creator) do
+    described_class.new(
+      source: source,
+      branch_name: branch_name,
+      base_commit: "base",
+      credentials: [],
+      files: [dependency_file],
+      commit_message: "Bump dependency",
+      pr_description: "PR description",
+      pr_name: "PR name",
+      author_details: nil,
+      labeler: nil,
+      require_up_to_date_base: false
+    )
+  end
+
+  let(:source) do
+    Dependabot::Source.new(
+      provider: "codecommit",
+      repo: "gocardless",
+      branch: "main"
+    )
+  end
+  let(:branch_name) { "dependabot/bundler/business-1.5.0" }
+  let(:dependency_file) do
+    Dependabot::DependencyFile.new(name: "Gemfile", content: "gem \"business\"")
+  end
+  let(:codecommit_client) { instance_double(Dependabot::Clients::CodeCommit) }
+  let(:branch_response) do
+    client = Aws::CodeCommit::Client.new(stub_responses: true)
+    client.stub_responses(
+      :get_branch,
+      branch: {
+        branch_name: branch_name,
+        commit_id: "base"
+      }
+    )
+    client.get_branch(repository_name: source.repo, branch_name: branch_name)
+  end
+  let(:open_pull_requests) { [] }
+  let(:closed_pull_requests) { [] }
+
+  before do
+    allow(Dependabot::Clients::CodeCommit)
+      .to receive(:for_source).and_return(codecommit_client)
+    allow(codecommit_client).to receive(:branch).with(branch_name).and_return(branch_response)
+    allow(codecommit_client)
+      .to receive(:pull_requests).with(source.repo, "open", source.branch)
+      .and_return(open_pull_requests)
+    allow(codecommit_client)
+      .to receive(:pull_requests).with(source.repo, "closed", source.branch)
+      .and_return(closed_pull_requests)
+    allow(codecommit_client).to receive_messages(
+      create_commit: Aws::CodeCommit::Types::CreateCommitOutput.new,
+      create_pull_request: Aws::CodeCommit::Types::CreatePullRequestOutput.new
+    )
+  end
+
+  context "when an open pull request has no merge metadata" do
+    let(:open_pull_requests) { [pull_request_response] }
+
+    it "treats the pull request as unmerged" do
+      expect { creator.create }.not_to raise_error
+      expect(codecommit_client).not_to have_received(:create_pull_request)
+    end
+  end
+
+  context "when an open pull request has no merged flag" do
+    let(:open_pull_requests) do
+      [pull_request_response(merge_metadata: {})]
+    end
+
+    it "treats the pull request as unmerged" do
+      expect { creator.create }.not_to raise_error
+      expect(codecommit_client).not_to have_received(:create_pull_request)
+    end
+  end
+
+  context "when the existing pull request was merged" do
+    let(:closed_pull_requests) do
+      [pull_request_response(merge_metadata: { is_merged: true })]
+    end
+
+    it "creates a new pull request" do
+      creator.create
+
+      expect(codecommit_client).to have_received(:create_commit)
+      expect(codecommit_client).to have_received(:create_pull_request)
+    end
+  end
+
+  def pull_request_response(merge_metadata: nil)
+    client = Aws::CodeCommit::Client.new(stub_responses: true)
+    target = {
+      source_reference: "refs/heads/#{branch_name}",
+      destination_reference: "refs/heads/main"
+    }
+    target[:merge_metadata] = merge_metadata if merge_metadata
+    client.stub_responses(
+      :get_pull_request,
+      pull_request: {
+        pull_request_id: "1",
+        pull_request_targets: [target]
+      }
+    )
+    client.get_pull_request(pull_request_id: "1")
+  end
+end

--- a/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/codecommit_spec.rb
@@ -47,6 +47,35 @@ RSpec.describe Dependabot::PullRequestCreator::Codecommit do
   end
   let(:open_pull_requests) { [] }
   let(:closed_pull_requests) { [] }
+  let(:create_commit_response) do
+    client = Aws::CodeCommit::Client.new(stub_responses: true)
+    client.stub_responses(:create_commit, commit_id: "commit", tree_id: "tree")
+    client.create_commit(
+      repository_name: source.repo,
+      branch_name: branch_name,
+      parent_commit_id: "base",
+      commit_message: "Bump dependency"
+    )
+  end
+  let(:create_pull_request_response) do
+    client = Aws::CodeCommit::Client.new(stub_responses: true)
+    client.stub_responses(
+      :create_pull_request,
+      pull_request: {
+        pull_request_id: "1",
+        pull_request_targets: []
+      }
+    )
+    client.create_pull_request(
+      title: "PR name",
+      description: "PR description",
+      targets: [{
+        repository_name: source.repo,
+        source_reference: branch_name,
+        destination_reference: source.branch
+      }]
+    )
+  end
 
   before do
     allow(Dependabot::Clients::CodeCommit)
@@ -59,8 +88,8 @@ RSpec.describe Dependabot::PullRequestCreator::Codecommit do
       .to receive(:pull_requests).with(source.repo, "closed", branch_name)
       .and_return(closed_pull_requests)
     allow(codecommit_client).to receive_messages(
-      create_commit: Aws::CodeCommit::Types::CreateCommitOutput.new,
-      create_pull_request: Aws::CodeCommit::Types::CreatePullRequestOutput.new
+      create_commit: create_commit_response,
+      create_pull_request: create_pull_request_response
     )
   end
 

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -599,6 +599,24 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
                   )
               end
             end
+
+            context "when the PR is closed but unmerged" do
+              before do
+                url = "#{repo_api_url}/pulls?head=gocardless:#{branch_name}" \
+                      "&state=all"
+                stub_request(:get, url).to_return(
+                  status: 200,
+                  body: '[{"number":1347,"state":"closed"}]',
+                  headers: json_header
+                )
+              end
+
+              it "does not recreate the pull request" do
+                expect { creator.create }
+                  .to raise_error(Dependabot::PullRequestCreator::UnmergedPRExists, /1347/)
+                expect(WebMock).not_to have_requested(:post, "#{repo_api_url}/pulls")
+              end
+            end
           end
         end
       end

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -541,7 +541,7 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
                   "&state=all"
             stub_request(:get, url).to_return(
               status: 200,
-              body: "[{ \"closed\": true }]",
+              body: '[{"state":"closed","merged_at":"2026-08-14T00:00:00Z"}]',
               headers: json_header
             )
             stub_request(
@@ -606,7 +606,7 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
                       "&state=all"
                 stub_request(:get, url).to_return(
                   status: 200,
-                  body: '[{"number":1347,"state":"closed"}]',
+                  body: '[{"number":1347,"state":"closed","merged_at":null}]',
                   headers: json_header
                 )
               end

--- a/common/spec/dependabot/pull_request_creator/github_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/github_spec.rb
@@ -140,6 +140,22 @@ RSpec.describe Dependabot::PullRequestCreator::Github do
   end
 
   describe "#create" do
+    context "when GitHub returns a malformed tree response" do
+      before do
+        stub_request(:post, "#{repo_api_url}/git/trees")
+          .to_return(
+            status: 200,
+            body: JSON.dump(sha: 1),
+            headers: json_header
+          )
+      end
+
+      it "raises a bad response error" do
+        expect { creator.create }
+          .to raise_error(Dependabot::PrivateSourceBadResponse, /tree sha must be a string/)
+      end
+    end
+
     it "pushes a commit to GitHub" do
       creator.create
 

--- a/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/gitlab_spec.rb
@@ -398,6 +398,23 @@ RSpec.describe Dependabot::PullRequestCreator::Gitlab do
             expect(WebMock)
               .to have_requested(:post, "#{repo_api_url}/merge_requests")
           end
+
+          context "when the commit response is malformed" do
+            before do
+              stub_request(:get, "#{repo_api_url}/repository/commits")
+                .with(query: { ref_name: branch_name })
+                .to_return(
+                  status: 200,
+                  body: JSON.dump([{ message: 1 }]),
+                  headers: json_header
+                )
+            end
+
+            it "raises a bad response error" do
+              expect { creator.create }
+                .to raise_error(Dependabot::PrivateSourceBadResponse, /commit message must be a string/)
+            end
+          end
         end
 
         context "when a commit already exists on that branch" do

--- a/common/spec/dependabot/pull_request_updater/azure_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/azure_spec.rb
@@ -189,6 +189,25 @@ RSpec.describe Dependabot::PullRequestUpdater::Azure do
 
         expect { updater.update }.to raise_error(Dependabot::PullRequestUpdater::Azure::PullRequestUpdateFailed)
       end
+
+      context "when the commit response has no ref updates" do
+        before do
+          stub_request(:post, create_commit_url)
+            .to_return(
+              status: 201,
+              body: JSON.dump(refUpdates: []),
+              headers: json_header
+            )
+        end
+
+        it "raises a helpful error" do
+          expect { updater.update }
+            .to raise_error(
+              Dependabot::PullRequestUpdater::Azure::PullRequestUpdateFailed,
+              "created commit refUpdates must contain at least one object"
+            )
+        end
+      end
     end
 
     context "with author details provided" do

--- a/common/spec/dependabot/pull_request_updater/github_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/github_spec.rb
@@ -90,6 +90,24 @@ RSpec.describe Dependabot::PullRequestUpdater::Github do
   end
 
   describe "#update" do
+    context "when GitHub returns a malformed pull request head" do
+      before do
+        pull_request = JSON.parse(fixture("github", "pull_request.json"))
+        pull_request["head"] = "invalid"
+        stub_request(:get, pull_request_url)
+          .to_return(
+            status: 200,
+            body: JSON.dump(pull_request),
+            headers: json_header
+          )
+      end
+
+      it "raises a bad response error" do
+        expect { updater.update }
+          .to raise_error(Dependabot::PrivateSourceBadResponse, /pull request head must be an object/)
+      end
+    end
+
     context "when the branch doesn't exist" do
       before { stub_request(:get, branch_url).to_return(status: 404) }
 

--- a/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
+++ b/common/spec/dependabot/pull_request_updater/gitlab_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe Dependabot::PullRequestUpdater::Gitlab do
   end
 
   describe "#update" do
+    context "when the merge request response is malformed" do
+      before do
+        merge_request = JSON.parse(fixture("gitlab", "merge_request.json"))
+        merge_request["source_branch"] = 1
+        stub_request(:get, merge_request_url)
+          .to_return(
+            status: 200,
+            body: JSON.dump(merge_request),
+            headers: json_header
+          )
+      end
+
+      it "raises a bad response error" do
+        expect { updater.update }
+          .to raise_error(Dependabot::PrivateSourceBadResponse, /merge request source_branch must be a string/)
+      end
+    end
+
     context "with forked project" do
       let(:target_project_id) { 1 }
       let(:merge_request_url) do

--- a/sorbet/rbi/shims/aws-sdk-codecommit.rbi
+++ b/sorbet/rbi/shims/aws-sdk-codecommit.rbi
@@ -30,6 +30,29 @@ module Aws
         attr_reader :date
       end
 
+      class GetPullRequestOutput
+        sig { returns(Aws::CodeCommit::Types::PullRequest) }
+        attr_reader :pull_request
+      end
+
+      class PullRequest
+        sig { returns(T::Array[Aws::CodeCommit::Types::PullRequestTarget]) }
+        attr_reader :pull_request_targets
+      end
+
+      class PullRequestTarget
+        sig { returns(String) }
+        attr_reader :source_reference
+
+        sig { returns(Aws::CodeCommit::Types::MergeMetadata) }
+        attr_reader :merge_metadata
+      end
+
+      class MergeMetadata
+        sig { returns(T::Boolean) }
+        attr_reader :is_merged
+      end
+
       class File
         sig { returns(String) }
         attr_reader :relative_path

--- a/sorbet/rbi/shims/aws-sdk-codecommit.rbi
+++ b/sorbet/rbi/shims/aws-sdk-codecommit.rbi
@@ -44,12 +44,12 @@ module Aws
         sig { returns(String) }
         attr_reader :source_reference
 
-        sig { returns(Aws::CodeCommit::Types::MergeMetadata) }
+        sig { returns(T.nilable(Aws::CodeCommit::Types::MergeMetadata)) }
         attr_reader :merge_metadata
       end
 
       class MergeMetadata
-        sig { returns(T::Boolean) }
+        sig { returns(T.nilable(T::Boolean)) }
         attr_reader :is_merged
       end
 

--- a/sorbet/rbi/shims/gitlab.rbi
+++ b/sorbet/rbi/shims/gitlab.rbi
@@ -3,6 +3,12 @@
 
 module Gitlab
   class PaginatedResponse
+    sig { returns(T.nilable(Gitlab::ObjectifiedHash)) }
+    def first; end
+
+    sig { returns(T::Boolean) }
+    def any?; end
+
     sig { returns(T::Array[Gitlab::ObjectifiedHash]) }
     sig do
       params(


### PR DESCRIPTION
Types GitHub, GitLab, Azure, and CodeCommit create and update paths. `common/lib` now contains no `T.untyped` or `T.unsafe`, and six write implementations are `typed: strong`.

Layer ratchets: `T.untyped` 831 to 790; `T.unsafe` 30 to 22. Stack total: 922 to 790 and 82 to 22.