### PR TITLE
Call `files_to_persist` in updater to pass only the persisted files instead of using the entire clone

### DIFF
--- a/common/lib/dependabot/file_fetchers/base.rb
+++ b/common/lib/dependabot/file_fetchers/base.rb
@@ -194,6 +194,15 @@ module Dependabot
         @files = files
       end
 
+      # The canonical set of files intended to cross the fetch/update trust
+      # boundary. Callers that persist fetched files should serialize exactly
+      # this set. Ecosystems may override this method to narrow the default
+      # full fetched set.
+      sig { overridable.returns(T::Array[DependencyFile]) }
+      def files_to_persist
+        files
+      end
+
       sig { returns(T.nilable(String)) }
       def commit
         resolved_cloned_commit = cloned_commit

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -12,7 +12,7 @@ require "octokit"
 require "sorbet-runtime"
 
 module Dependabot
-  class FileFetcherCommand < BaseCommand
+  class FileFetcherCommand < BaseCommand # rubocop:disable Metrics/ClassLength
     extend T::Sig
     include FileFetcherCommandConnectivity
 
@@ -87,13 +87,25 @@ module Dependabot
     sig { returns(Dependabot::FetchedFiles) }
     def files
       Dependabot::FetchedFiles.new(
-        dependency_files: T.must(job.source.directories ? dependency_files_for_multi_directories : dependency_files),
+        dependency_files: files_crossing_update_boundary,
         base_commit_sha: T.must(base_commit_sha),
         directory_fetch_errors: directory_fetch_errors
       )
     end
 
     private
+
+    # Under isolate_fetch_update only files_to_persist may cross into the clone-less update phase.
+    sig { returns(T::Array[Dependabot::DependencyFile]) }
+    def files_crossing_update_boundary
+      isolate = Experiments.enabled?(:isolate_fetch_update)
+      if job.source.directories
+        full_set = T.must(dependency_files_for_multi_directories)
+        isolate ? fetched_directory_fetchers.flat_map(&:files_to_persist) : full_set
+      else
+        isolate ? file_fetcher.files_to_persist : T.must(dependency_files)
+      end
+    end
 
     # When only a single directory is specified via `directories:` (plural), normalize it to use
     # `directory:` (singular) so the simpler, proven single-directory code path is used.
@@ -242,8 +254,14 @@ module Dependabot
           next
         end
         post_ecosystem_versions(ff) if should_record_ecosystem_versions?
+        fetched_directory_fetchers << ff
         files
       end&.compact
+    end
+
+    sig { returns(T::Array[Dependabot::FileFetchers::Base]) }
+    def fetched_directory_fetchers
+      @fetched_directory_fetchers ||= T.let([], T.nilable(T::Array[Dependabot::FileFetchers::Base]))
     end
 
     sig { returns(T.nilable(T::Array[Dependabot::DependencyFile])) }


### PR DESCRIPTION
### What are you trying to accomplish?
This wires the `files_to_persist` trust-boundary contract into the fetch → update hand-off so that, when the fetch and update phases are split into separate containers, the update phase receives **exactly** the set of files an ecosystem declares safe to cross the boundary — not the entire fetched working tree.

Concretely:

- **`common/lib/dependabot/file_fetchers/base.rb`** — adds the `files_to_persist` base method (`overridable`, defaults to `files`). This is the canonical set of files intended to cross the fetch/update trust boundary; ecosystems may override it to narrow the default full fetched set.
- **`updater/lib/dependabot/file_fetcher_command.rb`** — `FileFetcherCommand#files` (the single point where fetched files become the `FetchedFiles` handed to the update phase) now routes through `files_crossing_update_boundary`. Under the `isolate_fetch_update` experiment it serializes `files_to_persist`; otherwise it emits the full fetched set exactly as before. Multi-directory jobs union each successfully-fetched directory fetcher's `files_to_persist`.

The _why_: with the containers split, the update container should not silently inherit the whole clone. Standardizing the hand-off on `files_to_persist` gives each ecosystem an explicit, auditable contract for what leaves the fetch boundary, and lets the update phase run with no repo clone.
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
- **Gated behind `isolate_fetch_update`.** Non-isolated runs are byte-for-byte unchanged (full fetched set). Only when the update phase is truly isolated (clone dropped) is the set narrowed to `files_to_persist`. Since `update_files.rb` builds `UpdateFilesCommand` from this same `FileFetcherCommand#files`, both the cross-container hand-off and the in-process update consume the persisted set consistently.
- **Multi-directory correctness.** I track only the directory fetchers whose `files` fetched successfully (`fetched_directory_fetchers`, appended in `list_files_in_directory`) and union their `files_to_persist`. This avoids re-fetching and avoids re-raising on directories that legitimately failed (e.g. `DependencyFileNotFound`, or `PathDependenciesNotReachable` for graph jobs).
- **Default preserves today's behavior.** `files_to_persist` defaults to `files`, so ecosystems that don't override it persist everything exactly as now — no ecosystem is affected until it opts in.
- **Overlap note:** this branch carries its own copy of the base `files_to_persist` method, which also exists on `abhishekbhaskar/standardize-file-fetcher-exfilteration`. When these land/rebase together the definition reconciles to a single source.
- Added a class-level `# rubocop:disable Metrics/ClassLength` to `FileFetcherCommand`, matching the existing convention in the updater (`job.rb`, `api_client.rb`), since the cohesive addition pushed the class past the 350-line limit.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- **Tests:**
  - `updater/spec/dependabot/file_fetcher_command_spec.rb` — 33 examples, 0 failures.
  - `common/spec/dependabot/file_fetchers/base_spec.rb` — 123 examples, 0 failures (existing public-API guard still passes, since `files_to_persist` is defined on `Base`).
- **End-to-end:** a `pip` dry-run with `isolate_fetch_update=true` shows the update phase running with the clone dropped and resolving successfully (e.g. `pip-compile` on `pypa/warehouse`) using only the persisted set — demonstrating the update phase is self-contained on `files_to_persist`.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
