### PR TITLE
Use POM dates for Maven cooldowns

### DIFF
--- a/maven/lib/dependabot/maven/package/package_details_fetcher.rb
+++ b/maven/lib/dependabot/maven/package/package_details_fetcher.rb
@@ -35,6 +35,8 @@ module Dependabot
           @repository_finder = T.let(nil, T.nilable(Maven::FileParser::RepositoriesFinder))
           @repositories_cache = T.let(nil, T.nilable(T::Array[RepositoryDetails]))
           @package_details = T.let(nil, T.nilable(Dependabot::Package::PackageDetails))
+          @release_date_cache = T.let({}, T::Hash[String, T.nilable(Time)])
+          @fallback_logged = T.let(false, T::Boolean)
         end
 
         sig { override.returns(Dependabot::Dependency) }
@@ -71,6 +73,25 @@ module Dependabot
           fetch.releases
         end
 
+        sig { params(release: Dependabot::Package::PackageRelease).returns(Dependabot::Package::PackageRelease) }
+        def fetch_release_metadata(release:)
+          return release if release.released_at
+
+          url = release.url
+          return release unless url
+
+          cache_key = "#{url}\0#{release.version}"
+          released_at = if @release_date_cache.key?(cache_key)
+                          @release_date_cache[cache_key]
+                        else
+                          @release_date_cache[cache_key] =
+                            fetch_pom_last_modified(repository_url: url, version: release.version)
+                        end
+          return release unless released_at
+
+          build_release_with_date(release, released_at)
+        end
+
         # Assembles the list of Maven repositories to search: credential repos + POM repos.
         sig { override.returns(T::Array[RepositoryDetails]) }
         def repositories
@@ -92,6 +113,83 @@ module Dependabot
         end
 
         private
+
+        sig do
+          params(
+            repository_url: String,
+            version: Dependabot::Version
+          ).returns(T.nilable(Time))
+        end
+        def fetch_pom_last_modified(repository_url:, version:)
+          # release.url is the exact repository URL recorded when the version was
+          # discovered, so an exact match is sufficient (no trailing-slash cleanup).
+          repository_details = repositories.find do |details|
+            self.repository_url(details) == repository_url
+          end
+
+          unless repository_details
+            Dependabot.logger.debug(
+              "No configured repository matches #{repository_url} for #{dependency.name}; " \
+              "skipping POM Last-Modified fallback"
+            )
+            return
+          end
+
+          response = Dependabot::RegistryClient.head(
+            url: dependency_pom_url(repository_url, version),
+            headers: repository_auth_headers(repository_details)
+          )
+          return unless response.status < 400
+
+          last_modified = response.headers["Last-Modified"] || response.headers["last-modified"]
+          return unless last_modified
+
+          released_at = Time.httpdate(last_modified)
+          log_fallback_hit(repository_url: repository_url)
+          Dependabot.logger.debug(
+            "Using POM Last-Modified fallback for #{dependency.name} version #{version} from " \
+            "#{repository_url}: #{released_at}"
+          )
+          released_at
+        rescue StandardError => e
+          Dependabot.logger.debug(
+            "Failed POM Last-Modified fallback for #{dependency.name} version #{version} from " \
+            "#{repository_url}: #{e.message}"
+          )
+          nil
+        end
+
+        sig { params(repository_url: String).void }
+        def log_fallback_hit(repository_url:)
+          return if @fallback_logged
+
+          Dependabot.logger.info(
+            "Using POM Last-Modified fallback release dates for #{dependency.name} from #{repository_url}"
+          )
+          @fallback_logged = true
+        end
+
+        sig do
+          params(
+            release: Dependabot::Package::PackageRelease,
+            released_at: Time
+          ).returns(Dependabot::Package::PackageRelease)
+        end
+        def build_release_with_date(release, released_at)
+          Dependabot::Package::PackageRelease.new(
+            version: release.version,
+            released_at: released_at,
+            latest: release.latest,
+            yanked: release.yanked,
+            yanked_reason: release.yanked_reason,
+            downloads: release.downloads,
+            url: release.url,
+            package_type: release.package_type,
+            language: release.language,
+            tag: release.tag,
+            details: release.details
+          )
+        end
 
         sig { returns(Maven::FileParser::RepositoriesFinder) }
         def repository_finder

--- a/maven/lib/dependabot/maven/shared/base_version_finder.rb
+++ b/maven/lib/dependabot/maven/shared/base_version_finder.rb
@@ -75,12 +75,31 @@ module Dependabot
           possible_releases = filter_date_based_versions(possible_releases)
           possible_releases = filter_version_types(possible_releases)
           possible_releases = filter_ignored_versions(possible_releases)
-          possible_releases = filter_by_cooldown(possible_releases)
           possible_releases_reverse = possible_releases.reverse
 
-          possible_releases_reverse.find do |r|
-            released?(r.version)
+          return possible_releases_reverse.find { |r| released?(r.version) } unless cooldown_options
+
+          cooldown_filtered_releases = 0
+          latest_release = possible_releases_reverse.find do |release|
+            if in_cooldown_period?(release)
+              Dependabot.logger.info("Filtered out (cooldown) : #{release}")
+              cooldown_filtered_releases += 1
+              next false
+            end
+
+            released?(release.version)
           end
+
+          if cooldown_filtered_releases.positive?
+            Dependabot.logger.info(
+              "Filtered out #{cooldown_filtered_releases} version(s) due to cooldown"
+            )
+          end
+
+          latest_release ||= current_version_fallback_release(
+            possible_releases_reverse, cooldown_filtered_releases
+          )
+          latest_release
         end
 
         sig do
@@ -103,6 +122,34 @@ module Dependabot
         end
 
         private
+
+        # When every candidate was filtered out by cooldown, stay on the current
+        # version (if released) instead of reporting no latest version at all.
+        sig do
+          params(
+            possible_releases: T::Array[Dependabot::Package::PackageRelease],
+            cooldown_filtered_releases: Integer
+          ).returns(T.nilable(Dependabot::Package::PackageRelease))
+        end
+        def current_version_fallback_release(possible_releases, cooldown_filtered_releases)
+          return if possible_releases.empty?
+          return unless cooldown_filtered_releases == possible_releases.length
+
+          current_version_str = dependency.version
+          return unless current_version_str
+
+          Dependabot.logger.info(
+            "All versions filtered by cooldown for #{dependency.name}, " \
+            "falling back to current version #{current_version_str}"
+          )
+
+          current_release = Dependabot::Package::PackageRelease.new(
+            version: version_class.new(current_version_str),
+            released_at: nil,
+            tag: nil
+          )
+          current_release if released?(current_release.version)
+        end
 
         sig { abstract.params(version: Dependabot::Version).returns(T::Boolean) }
         def released?(version); end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -58,6 +58,20 @@ module Dependabot
           @package_details ||= package_details_fetcher.fetch
         end
 
+        protected
+
+        sig { override.params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
+        def in_cooldown_period?(release)
+          return super if release.released_at
+          return false if Dependabot::UpdateCheckers::CooldownCalculation.skip_cooldown?(
+            cooldown_options,
+            dependency.name,
+            cooldown_enabled: cooldown_enabled?
+          )
+
+          super(package_details_fetcher.fetch_release_metadata(release: release))
+        end
+
         private
 
         sig { override.params(version: Dependabot::Version).returns(T::Boolean) }

--- a/maven/spec/dependabot/maven/package/package_details_fetcher_spec.rb
+++ b/maven/spec/dependabot/maven/package/package_details_fetcher_spec.rb
@@ -87,6 +87,56 @@ RSpec.describe Dependabot::Maven::Package::PackageDetailsFetcher do
     end
   end
 
+  describe "#fetch_release_metadata" do
+    let(:release) do
+      Dependabot::Package::PackageRelease.new(
+        version: Dependabot::Maven::Version.new("23.3-jre"),
+        released_at: released_at,
+        url: "https://repo.maven.apache.org/maven2",
+        details: { "source" => "maven" }
+      )
+    end
+    let(:released_at) { nil }
+    let(:version_pom_url) do
+      "https://repo.maven.apache.org/maven2/com/google/guava/guava/23.3-jre/guava-23.3-jre.pom"
+    end
+
+    it "uses the versioned pom Last-Modified header when the release date is missing" do
+      stub_request(:head, version_pom_url).to_return(
+        status: 200,
+        headers: { "Last-Modified" => "Mon, 10 Aug 2026 10:08:43 GMT" }
+      )
+
+      hydrated_release = fetcher.fetch_release_metadata(release: release)
+
+      expect(hydrated_release.released_at).to eq(Time.utc(2026, 8, 10, 10, 8, 43))
+      expect(hydrated_release.url).to eq(release.url)
+      expect(hydrated_release.details).to eq(release.details)
+    end
+
+    context "when a release date is already present" do
+      let(:released_at) { Time.utc(2026, 8, 1) }
+
+      it "returns the original release without requesting the pom" do
+        hydrated_release = fetcher.fetch_release_metadata(release: release)
+
+        expect(hydrated_release).to equal(release)
+        expect(a_request(:head, version_pom_url)).not_to have_been_made
+      end
+    end
+
+    it "caches the fallback lookup by repository and version" do
+      stub_request(:head, version_pom_url).to_return(
+        status: 200,
+        headers: { "Last-Modified" => "Mon, 10 Aug 2026 10:08:43 GMT" }
+      )
+
+      2.times { fetcher.fetch_release_metadata(release: release) }
+
+      expect(a_request(:head, version_pom_url)).to have_been_made.once
+    end
+  end
+
   describe "#released?" do
     subject(:released_check) { fetcher.released?(version) }
 

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -775,6 +775,137 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
       end
     end
 
+    context "with cooldown options and a repository without directory listings" do
+      let(:dependency_version) { "1.0.0" }
+      let(:cooldown_options) do
+        Dependabot::Package::ReleaseCooldownOptions.new(default_days: 14)
+      end
+      let(:maven_metadata) do
+        <<~XML
+          <metadata>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <versioning>
+              <latest>1.2.0</latest>
+              <release>1.2.0</release>
+              <versions>
+                <version>1.0.0</version>
+                <version>1.1.0</version>
+                <version>1.2.0</version>
+              </versions>
+            </versioning>
+          </metadata>
+        XML
+      end
+      let(:version_1_2_pom_url) do
+        "https://repo.maven.apache.org/maven2/com/google/guava/guava/1.2.0/guava-1.2.0.pom"
+      end
+      let(:version_1_1_pom_url) do
+        "https://repo.maven.apache.org/maven2/com/google/guava/guava/1.1.0/guava-1.1.0.pom"
+      end
+      let(:version_1_0_pom_url) do
+        "https://repo.maven.apache.org/maven2/com/google/guava/guava/1.0.0/guava-1.0.0.pom"
+      end
+      let(:version_1_1_jar_url) do
+        "https://repo.maven.apache.org/maven2/com/google/guava/guava/1.1.0/guava-1.1.0.jar"
+      end
+      let(:version_1_2_jar_url) do
+        "https://repo.maven.apache.org/maven2/com/google/guava/guava/1.2.0/guava-1.2.0.jar"
+      end
+      let(:version_1_0_jar_url) do
+        "https://repo.maven.apache.org/maven2/com/google/guava/guava/1.0.0/guava-1.0.0.jar"
+      end
+
+      before do
+        allow(Time).to receive(:now).and_return(Time.utc(2026, 8, 17))
+        stub_request(:get, maven_central_metadata_url).to_return(status: 200, body: maven_metadata)
+        stub_request(:get, maven_central_base_url_with_slash).to_return(status: 404)
+        stub_request(:head, version_1_2_pom_url).to_return(
+          status: 200,
+          headers: { "Last-Modified" => "Mon, 10 Aug 2026 10:08:43 GMT" }
+        )
+        stub_request(:head, version_1_1_pom_url).to_return(
+          status: 200,
+          headers: { "Last-Modified" => "Wed, 01 Jul 2026 10:08:43 GMT" }
+        )
+        stub_request(:head, version_1_1_jar_url).to_return(status: 200)
+      end
+
+      it "selects the newest release outside the cooldown window" do
+        expect(latest_version_details[:version]).to eq(version_class.new("1.1.0"))
+      end
+
+      it "loads fallback metadata lazily" do
+        latest_version_details
+
+        expect(a_request(:head, version_1_2_pom_url)).to have_been_made.once
+        expect(a_request(:head, version_1_1_pom_url)).to have_been_made.once
+        expect(a_request(:head, version_1_0_pom_url)).not_to have_been_made
+      end
+
+      context "when the fallback cannot resolve a release date" do
+        before do
+          stub_request(:head, version_1_2_pom_url).to_return(status: 200, headers: {})
+          stub_request(:head, version_1_2_jar_url).to_return(status: 200)
+        end
+
+        it "treats the release as outside the cooldown window" do
+          expect(latest_version_details[:version]).to eq(version_class.new("1.2.0"))
+        end
+      end
+
+      context "when the dependency is not included in the cooldown configuration" do
+        let(:cooldown_options) do
+          Dependabot::Package::ReleaseCooldownOptions.new(default_days: 14, include: ["org.example:*"])
+        end
+
+        before do
+          stub_request(:head, version_1_2_jar_url).to_return(status: 200)
+        end
+
+        it "selects the newest release without issuing fallback requests" do
+          expect(latest_version_details[:version]).to eq(version_class.new("1.2.0"))
+          expect(a_request(:head, version_1_2_pom_url)).not_to have_been_made
+          expect(a_request(:head, version_1_1_pom_url)).not_to have_been_made
+          expect(a_request(:head, version_1_0_pom_url)).not_to have_been_made
+        end
+      end
+
+      context "when the newest eligible release is not actually published" do
+        before do
+          stub_request(:head, version_1_1_pom_url).to_return(status: 404)
+          stub_request(:head, version_1_1_jar_url).to_return(status: 404)
+          stub_request(:head, version_1_0_pom_url).to_return(
+            status: 200,
+            headers: { "Last-Modified" => "Wed, 01 Jul 2026 10:08:43 GMT" }
+          )
+          stub_request(:head, version_1_0_jar_url).to_return(status: 200)
+        end
+
+        it "continues to the next released version" do
+          expect(latest_version_details[:version]).to eq(version_class.new("1.0.0"))
+        end
+      end
+
+      context "when every release is inside the cooldown window" do
+        before do
+          stub_request(:head, version_1_1_pom_url).to_return(
+            status: 200,
+            headers: { "Last-Modified" => "Mon, 10 Aug 2026 10:08:43 GMT" }
+          )
+          stub_request(:head, version_1_0_pom_url).to_return(
+            status: 200,
+            headers: { "Last-Modified" => "Mon, 10 Aug 2026 10:08:43 GMT" }
+          )
+          stub_request(:head, version_1_0_jar_url).to_return(status: 200)
+        end
+
+        it "falls back to the current version" do
+          expect(latest_version_details[:version]).to eq(version_class.new("1.0.0"))
+        end
+      end
+    end
+
     context "when the release has a nil version" do
       before do
         allow(finder).to receive(:fetch_latest_release).and_return(


### PR DESCRIPTION
### What are you trying to accomplish?

Make Maven cooldown filtering work with repositories such as Google Artifact Registry that expose `maven-metadata.xml` but not dated directory listings.

When release dates are unavailable, Dependabot now falls back to the versioned POM's `Last-Modified` header.

Related to #15802 and #15803.

### Anything you want to highlight for special attention from reviewers?

The fallback:

- Only runs when the normal release date is missing.
- Uses the repository that supplied the version, avoiding timestamps from another configured registry.
- Caches lookups by repository and version.
- Evaluates candidates lazily to avoid issuing HEAD requests for every available version.

### How will you know you've accomplished your goal?

The regression test simulates a GAR-style repository where:

- `maven-metadata.xml` is available.
- The directory listing returns 404.
- The newest version is inside the cooldown window.
- The preceding version is old enough to select.

It verifies that Dependabot selects the newest eligible version and does not request metadata for older candidates unnecessarily.

The complete Maven test suite passes: 865 examples, 0 failures. RuboCop reports no offenses for the changed files.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured the code is well-documented and easy to understand.