### PR TITLE
Fix Maven wrapper subprocess failure from double shell-escaping

### DIFF
--- a/maven/lib/dependabot/maven/native_helpers.rb
+++ b/maven/lib/dependabot/maven/native_helpers.rb
@@ -3,7 +3,6 @@
 
 require "fileutils"
 require "open3"
-require "shellwords"
 require "uri"
 require "sorbet-runtime"
 require "nokogiri"
@@ -85,7 +84,12 @@ module Dependabot
           "--no-transfer-progress"
         ] + extra_args
 
-        cmd = Shellwords.join(["mvn"] + standard_args)
+        # Pass the argument vector directly instead of a pre-joined shell string.
+        # `run_shell_command` shell-escapes string commands internally, so building
+        # the command with `Shellwords.join` here would double-escape arguments
+        # (e.g. `-Dmaven=3.6.3` becoming `-Dmaven\=3.6.3`), which Maven then fails
+        # to parse. An argument vector is executed without an intermediate shell.
+        cmd = ["mvn"] + standard_args
         run_cwd = cwd && cwd != "." ? cwd : nil
         SharedHelpers.run_shell_command(cmd, env: env, cwd: run_cwd)
       end

--- a/maven/spec/dependabot/maven/native_helpers_spec.rb
+++ b/maven/spec/dependabot/maven/native_helpers_spec.rb
@@ -35,4 +35,66 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
       end.to raise_error(Dependabot::DependabotError)
     end
   end
+
+  describe "run_mvnw_wrapper" do
+    let(:env) { { "SOME_VAR" => "value" } }
+
+    it "passes an argument vector (not a pre-escaped shell string) to run_shell_command" do
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd, **_kwargs|
+        expect(cmd).to be_an(Array)
+        expect(cmd).to eq(
+          [
+            "mvn",
+            "org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper",
+            "-Dmaven=3.6.3",
+            "-Dtype=only-script",
+            "--no-transfer-progress"
+          ]
+        )
+        # No shell escaping should leak into the arguments.
+        expect(cmd.join(" ")).not_to include("\\")
+        ""
+      end
+
+      described_class.run_mvnw_wrapper(
+        version: "3.6.3",
+        wrapper_plugin_version: "3.3.4",
+        env: env,
+        distribution_type: "only-script"
+      )
+    end
+
+    it "appends extra_args and forwards a non-'.' cwd" do
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd, **kwargs|
+        expect(cmd.last).to eq("-DdistributionUrl=https://example.com/apache-maven-3.6.3-bin.zip")
+        expect(kwargs[:cwd]).to eq("subdir")
+        expect(kwargs[:env]).to eq(env)
+        ""
+      end
+
+      described_class.run_mvnw_wrapper(
+        version: "3.6.3",
+        wrapper_plugin_version: "3.3.4",
+        env: env,
+        distribution_type: "bin",
+        extra_args: ["-DdistributionUrl=https://example.com/apache-maven-3.6.3-bin.zip"],
+        cwd: "subdir"
+      )
+    end
+
+    it "passes cwd as nil when cwd is '.'" do
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command) do |_cmd, **kwargs|
+        expect(kwargs[:cwd]).to be_nil
+        ""
+      end
+
+      described_class.run_mvnw_wrapper(
+        version: "3.6.3",
+        wrapper_plugin_version: "3.3.4",
+        env: env,
+        distribution_type: "bin",
+        cwd: "."
+      )
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Recently the Maven wrapper update feature began failing in production with `Dependabot::Updater::SubprocessFailed` when regenerating wrapper scripts. The `mvn ...maven-wrapper-plugin:wrapper` invocation was failing because its arguments arrived at Maven mangled — property flags such as `-Dmaven=<version>` reached the process as `-Dmaven\=<version>` with stray backslashes, so Maven could not parse them.

The root cause is a double shell-escaping: the wrapper command was pre-escaped into a shell string before being handed to a helper that escapes shell-string commands a second time. Every argument containing an `=` (the distribution version, distribution type, and any private-registry `distributionUrl`) was affected, so the feature was broken for these jobs.

This PR makes the wrapper invocation pass an argument vector instead of a pre-escaped shell string, so Maven receives each argument verbatim and no shell-escaping is applied at all.

### Anything you want to highlight for special attention from reviewers?

The argument-vector form is already an established, committed pattern for the shared command runner (see `Dependabot::Workspace::Git#commit`), which avoids shell parsing for exactly this class of problem. Reusing it keeps the fix consistent with the rest of the codebase and removes the escaping ambiguity entirely rather than patching it.

### How will you know you've accomplished your goal?

- The exact production symptom (`-Dmaven\\\=<version>`) is reproducible from the old escaping path and is eliminated by the new one; the argument now reaches Maven as `-Dmaven=<version>`.
- Added and existing specs pass, covering the command shape passed to the runner, `cwd` handling, and extra-argument forwarding.
- The existing wrapper updater specs continue to pass, and the linter is clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
