### PR TITLE
Classify Maven Wrapper subprocess failures for better observability

### DIFF
--- a/common/lib/dependabot/errors.rb
+++ b/common/lib/dependabot/errors.rb
@@ -580,7 +580,10 @@ module Dependabot
     end
     def initialize(tool_name, tool_message)
       @tool_name = tool_name
-      @tool_message = tool_message
+      # Sanitize here as well as via `super`: the raw `tool_message` attribute is read
+      # directly during error serialization (see `updater_error_details`), so it must not
+      # carry credentials (e.g. basic-auth URLs) that the base message sanitization strips.
+      @tool_message = T.let(filter_sensitive_data(tool_message), String)
 
       msg = "Dependabot detected that #{tool_name} is misconfigured in this repository. " \
             "Running `#{tool_name.downcase}` results in the following error: #{tool_message}"

--- a/common/spec/dependabot/dependabot_error_spec.rb
+++ b/common/spec/dependabot/dependabot_error_spec.rb
@@ -218,4 +218,32 @@ RSpec.describe Dependabot::DependabotError do
       end
     end
   end
+
+  describe Dependabot::MisconfiguredTooling do
+    let(:error) { described_class.new("Maven Wrapper", tool_message) }
+    let(:tool_message) do
+      "Failed to download from https://user:s3cr3t@repo.example.com/maven/artifact.jar"
+    end
+
+    it "redacts basic-auth credentials from #tool_message" do
+      expect(error.tool_message).to eq(
+        "Failed to download from https://repo.example.com/maven/artifact.jar"
+      )
+    end
+
+    it "redacts basic-auth credentials from #message" do
+      expect(error.message).to include("https://repo.example.com/maven/artifact.jar")
+      expect(error.message).not_to include("s3cr3t")
+    end
+
+    it "redacts basic-auth credentials from the serialized error details" do
+      details = Dependabot.updater_error_details(error)
+
+      expect(details.error_type).to eq("misconfigured_tooling")
+      expect(details.error_detail[:message]).to eq(
+        "Failed to download from https://repo.example.com/maven/artifact.jar"
+      )
+      expect(details.error_detail[:message]).not_to include("s3cr3t")
+    end
+  end
 end

--- a/maven/lib/dependabot/maven/native_helpers.rb
+++ b/maven/lib/dependabot/maven/native_helpers.rb
@@ -6,12 +6,31 @@ require "open3"
 require "uri"
 require "sorbet-runtime"
 require "nokogiri"
+require "dependabot/errors"
 require "dependabot/shared_helpers"
 
 module Dependabot
   module Maven
     module NativeHelpers
       extend T::Sig
+
+      # Matches Maven's "Could not transfer artifact" failures, capturing the
+      # repository URL and HTTP status so we can classify auth vs. other errors.
+      TRANSFER_FAILURE_REGEX = T.let(
+        %r{Could not transfer artifact (?<artifact>[^ ]+) from/to (?<repository_name>[^ ]+) \((?<repository_url>[^ ]+)\): status code: (?<status_code>[0-9]+)}, # rubocop:disable Layout/LineLength
+        Regexp
+      )
+
+      # Matches Maven's "Plugin ... could not be resolved" failures, used to
+      # detect when the wrapper plugin itself is unavailable behind the proxy.
+      WRAPPER_PLUGIN_UNRESOLVED_REGEX = T.let(
+        /Plugin org\.apache\.maven\.plugins:maven-wrapper-plugin[^ ]* .*could not be resolved/,
+        Regexp
+      )
+
+      # Upper bound on the length of the Maven error summary included in raised errors,
+      # to avoid oversized error payloads while retaining the relevant failure detail.
+      MAX_ERROR_SUMMARY_LENGTH = 2_000
 
       pom_path = File.join(__dir__, "pom.xml")
 
@@ -43,9 +62,8 @@ module Dependabot
 
       sig { params(output: String).void }
       def self.handle_tool_error(output)
-        if (match = output.match(
-          %r{Could not transfer artifact (?<artifact>[^ ]+) from/to (?<repository_name>[^ ]+) \((?<repository_url>[^ ]+)\): status code: (?<status_code>[0-9]+)} # rubocop:disable Layout/LineLength
-        )) && (match[:status_code] == "403" || match[:status_code] == "401")
+        if (match = output.match(TRANSFER_FAILURE_REGEX)) &&
+           (match[:status_code] == "403" || match[:status_code] == "401")
           raise Dependabot::PrivateSourceAuthenticationFailure, match[:repository_url]
         end
 
@@ -91,7 +109,48 @@ module Dependabot
         # to parse. An argument vector is executed without an intermediate shell.
         cmd = ["mvn"] + standard_args
         run_cwd = cwd && cwd != "." ? cwd : nil
-        SharedHelpers.run_shell_command(cmd, env: env, cwd: run_cwd)
+
+        output = SharedHelpers.run_shell_command(cmd, env: env, cwd: run_cwd)
+        Dependabot.logger.info("mvn wrapper output: STDOUT:#{output}")
+        output
+      rescue SharedHelpers::HelperSubprocessFailed => e
+        # `run_shell_command` raises HelperSubprocessFailed on a non-zero exit, and the
+        # updater sanitizes that into an opaque `SubprocessFailed` that only reports the
+        # command and hides the real Maven output. Log the full output and re-raise a
+        # classified Dependabot error so operators get an actionable message, mirroring
+        # the `run_mvn_dependency_tree_plugin` path.
+        Dependabot.logger.warn("mvn wrapper command failed:\n#{e.message}")
+        handle_wrapper_error(e.message)
+      end
+
+      # Classifies a failed Maven Wrapper invocation into an actionable Dependabot
+      # error. Known auth and plugin-resolution failures are mapped to their specific
+      # error types; anything else surfaces the actual Maven error via MisconfiguredTooling
+      # instead of an opaque subprocess failure.
+      sig { params(output: String).returns(T.noreturn) }
+      def self.handle_wrapper_error(output)
+        if (match = output.match(TRANSFER_FAILURE_REGEX)) &&
+           (match[:status_code] == "403" || match[:status_code] == "401")
+          raise Dependabot::PrivateSourceAuthenticationFailure, match[:repository_url]
+        end
+
+        if output.match?(WRAPPER_PLUGIN_UNRESOLVED_REGEX)
+          raise Dependabot::DependencyFileNotResolvable,
+                "Could not resolve the Maven Wrapper plugin. #{mvn_error_summary(output)}"
+        end
+
+        raise Dependabot::MisconfiguredTooling.new("Maven Wrapper", mvn_error_summary(output))
+      end
+
+      # Extracts Maven's own `[ERROR]` lines from the combined tool output so that raised
+      # errors surface the relevant failure reason without leaking unrelated build noise.
+      # Falls back to the trimmed output when no `[ERROR]` lines are present, and caps the
+      # length to keep error payloads reasonable.
+      sig { params(output: String).returns(String) }
+      def self.mvn_error_summary(output)
+        error_lines = output.lines.map(&:chomp).select { |line| line.include?("[ERROR]") }
+        summary = error_lines.empty? ? output.strip : error_lines.join("\n")
+        summary.length > MAX_ERROR_SUMMARY_LENGTH ? "#{summary[0, MAX_ERROR_SUMMARY_LENGTH]}..." : summary
       end
     end
   end

--- a/maven/lib/dependabot/maven/native_helpers.rb
+++ b/maven/lib/dependabot/maven/native_helpers.rb
@@ -16,17 +16,13 @@ module Dependabot
 
       # Matches Maven's "Could not transfer artifact" failures, capturing the
       # repository URL and HTTP status so we can classify auth vs. other errors.
-      TRANSFER_FAILURE_REGEX = T.let(
-        %r{Could not transfer artifact (?<artifact>[^ ]+) from/to (?<repository_name>[^ ]+) \((?<repository_url>[^ ]+)\): status code: (?<status_code>[0-9]+)}, # rubocop:disable Layout/LineLength
-        Regexp
-      )
+      TRANSFER_FAILURE_REGEX =
+        %r{Could not transfer artifact (?<artifact>[^ ]+) from/to (?<repository_name>[^ ]+) \((?<repository_url>[^ ]+)\): status code: (?<status_code>[0-9]+)} # rubocop:disable Layout/LineLength
 
       # Matches Maven's "Plugin ... could not be resolved" failures, used to
       # detect when the wrapper plugin itself is unavailable behind the proxy.
-      WRAPPER_PLUGIN_UNRESOLVED_REGEX = T.let(
-        /Plugin org\.apache\.maven\.plugins:maven-wrapper-plugin[^ ]* .*could not be resolved/,
-        Regexp
-      )
+      WRAPPER_PLUGIN_UNRESOLVED_REGEX =
+        /Plugin org\.apache\.maven\.plugins:maven-wrapper-plugin[^ ]* .*could not be resolved/
 
       # Upper bound on the length of the Maven error summary included in raised errors,
       # to avoid oversized error payloads while retaining the relevant failure detail.

--- a/maven/lib/dependabot/maven/native_helpers.rb
+++ b/maven/lib/dependabot/maven/native_helpers.rb
@@ -120,36 +120,49 @@ module Dependabot
         # classified Dependabot error so operators get an actionable message, mirroring
         # the `run_mvn_dependency_tree_plugin` path.
         Dependabot.logger.warn("mvn wrapper command failed:\n#{e.message}")
-        handle_wrapper_error(e.message)
+        handle_wrapper_error(e)
       end
 
       # Classifies a failed Maven Wrapper invocation into an actionable Dependabot
       # error. Known auth and plugin-resolution failures are mapped to their specific
-      # error types; anything else surfaces the actual Maven error via MisconfiguredTooling
-      # instead of an opaque subprocess failure.
-      sig { params(output: String).returns(T.noreturn) }
-      def self.handle_wrapper_error(output)
+      # error types, and genuine Maven diagnostics are surfaced via MisconfiguredTooling.
+      # `run_shell_command` also reports inactivity timeouts and a missing `mvn`
+      # executable as HelperSubprocessFailed; those carry no Maven `[ERROR]` markers, so
+      # we re-raise the original error and let it follow normal unknown-error routing
+      # instead of mislabelling infrastructure/runtime failures as tooling misconfigurations.
+      sig { params(error: SharedHelpers::HelperSubprocessFailed).returns(T.noreturn) }
+      def self.handle_wrapper_error(error)
+        output = error.message
+
         if (match = output.match(TRANSFER_FAILURE_REGEX)) &&
            (match[:status_code] == "403" || match[:status_code] == "401")
           raise Dependabot::PrivateSourceAuthenticationFailure, match[:repository_url]
         end
 
         if output.match?(WRAPPER_PLUGIN_UNRESOLVED_REGEX)
-          raise Dependabot::DependencyFileNotResolvable,
-                "Could not resolve the Maven Wrapper plugin. #{mvn_error_summary(output)}"
+          raise Dependabot::DependencyFileNotResolvable, "Could not resolve the Maven Wrapper plugin."
         end
 
-        raise Dependabot::MisconfiguredTooling.new("Maven Wrapper", mvn_error_summary(output))
+        # Only reclassify when Maven emitted its own `[ERROR]` diagnostics. Otherwise the
+        # failure is not a Maven misconfiguration (e.g. timeout or missing executable), so
+        # re-raise the original error; its full output is already in the job log.
+        summary = mvn_error_summary(output)
+        raise error unless summary
+
+        raise Dependabot::MisconfiguredTooling.new("Maven Wrapper", summary)
       end
 
       # Extracts Maven's own `[ERROR]` lines from the combined tool output so that raised
-      # errors surface the relevant failure reason without leaking unrelated build noise.
-      # Falls back to the trimmed output when no `[ERROR]` lines are present, and caps the
-      # length to keep error payloads reasonable.
-      sig { params(output: String).returns(String) }
+      # errors surface the relevant failure reason without leaking unrelated build noise or
+      # arbitrary subprocess output (which may contain sensitive file contents or paths) into
+      # the reported error. Returns nil when Maven produced no `[ERROR]` diagnostics, and caps
+      # the length to keep error payloads reasonable.
+      sig { params(output: String).returns(T.nilable(String)) }
       def self.mvn_error_summary(output)
         error_lines = output.lines.map(&:chomp).select { |line| line.include?("[ERROR]") }
-        summary = error_lines.empty? ? output.strip : error_lines.join("\n")
+        return nil if error_lines.empty?
+
+        summary = error_lines.join("\n")
         summary.length > MAX_ERROR_SUMMARY_LENGTH ? "#{summary[0, MAX_ERROR_SUMMARY_LENGTH]}..." : summary
       end
     end

--- a/maven/lib/dependabot/maven/native_helpers.rb
+++ b/maven/lib/dependabot/maven/native_helpers.rb
@@ -28,6 +28,11 @@ module Dependabot
       # to avoid oversized error payloads while retaining the relevant failure detail.
       MAX_ERROR_SUMMARY_LENGTH = 2_000
 
+      # Matches ANSI/VT100 control sequences. Maven can be configured to emit colored
+      # output (e.g. `-Dstyle.color=always`), wrapping markers like `[ERROR]` in escape
+      # codes; we strip these so classification and the surfaced summary see plain text.
+      ANSI_ESCAPE_REGEX = %r{\e\[[0-9;?]*[ -/]*[@-~]}
+
       pom_path = File.join(__dir__, "pom.xml")
 
       version = File.open(pom_path) do |f|
@@ -128,7 +133,9 @@ module Dependabot
       # instead of mislabelling infrastructure/runtime failures as tooling misconfigurations.
       sig { params(error: SharedHelpers::HelperSubprocessFailed).returns(T.noreturn) }
       def self.handle_wrapper_error(error)
-        output = error.message
+        # Strip ANSI color codes up front so classification and the surfaced summary see
+        # plain text even when Maven is configured to emit colored output.
+        output = error.message.gsub(ANSI_ESCAPE_REGEX, "")
 
         if (match = output.match(TRANSFER_FAILURE_REGEX)) &&
            (match[:status_code] == "403" || match[:status_code] == "401")

--- a/maven/spec/dependabot/maven/native_helpers_spec.rb
+++ b/maven/spec/dependabot/maven/native_helpers_spec.rb
@@ -7,6 +7,13 @@ require "spec_helper"
 require "dependabot/maven/native_helpers"
 
 RSpec.describe Dependabot::Maven::NativeHelpers do
+  def capture_wrapper_error(output)
+    described_class.handle_wrapper_error(output)
+    nil
+  rescue Dependabot::DependabotError => e
+    e
+  end
+
   describe "handle_tool_error" do
     context "when the output contains a 403 error" do
       let(:output) { "Could not transfer artifact com.example:example:jar:1.0.0 from/to example-repo (https://example.com/repo): status code: 403" }
@@ -33,6 +40,64 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
       expect do
         described_class.handle_tool_error(output)
       end.to raise_error(Dependabot::DependabotError)
+    end
+  end
+
+  describe "handle_wrapper_error" do
+    it "raises PrivateSourceAuthenticationFailure on a 401 transfer failure" do
+      output = "[ERROR] Could not transfer artifact org.apache.maven:apache-maven:zip:3.9.9 " \
+               "from/to central (https://repo.example.com/maven): status code: 401"
+      expect do
+        described_class.handle_wrapper_error(output)
+      end.to raise_error(Dependabot::PrivateSourceAuthenticationFailure, /repo\.example\.com/)
+    end
+
+    it "raises PrivateSourceAuthenticationFailure on a 403 transfer failure" do
+      output = "[ERROR] Could not transfer artifact org.apache.maven:apache-maven:zip:3.9.9 " \
+               "from/to central (https://repo.example.com/maven): status code: 403"
+      expect do
+        described_class.handle_wrapper_error(output)
+      end.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
+    end
+
+    it "raises DependencyFileNotResolvable when the wrapper plugin cannot be resolved" do
+      output = <<~OUTPUT
+        [INFO] Scanning for projects...
+        [ERROR] Plugin org.apache.maven.plugins:maven-wrapper-plugin:3.3.4 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-wrapper-plugin:pom:3.3.4 (absent)
+        [ERROR] -> [Help 1]
+      OUTPUT
+      expect do
+        described_class.handle_wrapper_error(output)
+      end.to raise_error(Dependabot::DependencyFileNotResolvable, /Maven Wrapper plugin/)
+    end
+
+    it "raises MisconfiguredTooling surfacing the Maven error for unclassified failures" do
+      output = <<~OUTPUT
+        [INFO] Scanning for projects...
+        [ERROR] Failed to execute goal on project demo: proxy host could not be reached
+        [ERROR] -> [Help 1]
+      OUTPUT
+      error = capture_wrapper_error(output)
+      expect(error).to be_a(Dependabot::MisconfiguredTooling)
+      expect(error.tool_name).to eq("Maven Wrapper")
+      expect(error.tool_message).to include("proxy host could not be reached")
+      # Only the [ERROR] lines are surfaced, not the [INFO] noise.
+      expect(error.tool_message).not_to include("Scanning for projects")
+    end
+
+    it "falls back to the raw output when there are no [ERROR] lines" do
+      output = "some unexpected failure without maven error markers"
+      expect do
+        described_class.handle_wrapper_error(output)
+      end.to raise_error(Dependabot::MisconfiguredTooling, /some unexpected failure/)
+    end
+
+    it "truncates an overly long error summary" do
+      output = "[ERROR] #{'x' * 5_000}"
+      error = capture_wrapper_error(output)
+      expect(error).to be_a(Dependabot::MisconfiguredTooling)
+      expect(error.tool_message.length).to be <= 2_003 # 2000 chars + "..."
+      expect(error.tool_message).to end_with("...")
     end
   end
 
@@ -95,6 +160,48 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
         distribution_type: "bin",
         cwd: "."
       )
+    end
+
+    context "when the subprocess fails" do
+      let(:mvn_output) do
+        "[ERROR] Plugin org.apache.maven.plugins:maven-wrapper-plugin:3.3.4 or one of its " \
+          "dependencies could not be resolved: absent"
+      end
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_raise(
+          Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+            message: mvn_output,
+            error_context: { command: "mvn ..." }
+          )
+        )
+      end
+
+      it "logs the full Maven output before re-raising" do
+        expect(Dependabot.logger).to receive(:warn).with(a_string_including(mvn_output))
+
+        expect do
+          described_class.run_mvnw_wrapper(
+            version: "3.6.3",
+            wrapper_plugin_version: "3.3.4",
+            env: env,
+            distribution_type: "only-script"
+          )
+        end.to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
+
+      it "re-raises a classified Dependabot error, not the raw HelperSubprocessFailed" do
+        # DependencyFileNotResolvable is not a HelperSubprocessFailed, so the updater
+        # will surface an actionable error type rather than an opaque SubprocessFailed.
+        expect do
+          described_class.run_mvnw_wrapper(
+            version: "3.6.3",
+            wrapper_plugin_version: "3.3.4",
+            env: env,
+            distribution_type: "only-script"
+          )
+        end.to raise_error(Dependabot::DependencyFileNotResolvable)
+      end
     end
   end
 end

--- a/maven/spec/dependabot/maven/native_helpers_spec.rb
+++ b/maven/spec/dependabot/maven/native_helpers_spec.rb
@@ -110,6 +110,25 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
       expect(error.tool_message.length).to be <= 2_003 # 2000 chars + "..."
       expect(error.tool_message).to end_with("...")
     end
+
+    it "strips ANSI color codes so colored [ERROR] markers are still classified" do
+      # Maven can be configured (e.g. `-Dstyle.color=always`) to wrap markers in ANSI
+      # escape codes; the summary must still detect and surface the diagnostic.
+      output = "[\e[1;34mINFO\e[m] Scanning for projects...\n" \
+               "[\e[1;31mERROR\e[m] Failed to execute goal on project demo: proxy host could not be reached\n"
+      error = capture_wrapper_error(output)
+      expect(error).to be_a(Dependabot::MisconfiguredTooling)
+      expect(error.tool_message).to include("proxy host could not be reached")
+      expect(error.tool_message).not_to include("\e[")
+    end
+
+    it "sanitizes basic-auth credentials from the surfaced summary" do
+      output = "[ERROR] Failed to download from https://user:secret@repo.example.com/maven/artifact.jar"
+      error = capture_wrapper_error(output)
+      expect(error).to be_a(Dependabot::MisconfiguredTooling)
+      expect(error.tool_message).not_to include("secret")
+      expect(error.tool_message).to include("repo.example.com")
+    end
   end
 
   describe "run_mvnw_wrapper" do

--- a/maven/spec/dependabot/maven/native_helpers_spec.rb
+++ b/maven/spec/dependabot/maven/native_helpers_spec.rb
@@ -7,8 +7,15 @@ require "spec_helper"
 require "dependabot/maven/native_helpers"
 
 RSpec.describe Dependabot::Maven::NativeHelpers do
+  def wrapper_failure(output)
+    Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+      message: output,
+      error_context: { command: "mvn ..." }
+    )
+  end
+
   def capture_wrapper_error(output)
-    described_class.handle_wrapper_error(output)
+    described_class.handle_wrapper_error(wrapper_failure(output))
     nil
   rescue Dependabot::DependabotError => e
     e
@@ -48,7 +55,7 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
       output = "[ERROR] Could not transfer artifact org.apache.maven:apache-maven:zip:3.9.9 " \
                "from/to central (https://repo.example.com/maven): status code: 401"
       expect do
-        described_class.handle_wrapper_error(output)
+        described_class.handle_wrapper_error(wrapper_failure(output))
       end.to raise_error(Dependabot::PrivateSourceAuthenticationFailure, /repo\.example\.com/)
     end
 
@@ -56,7 +63,7 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
       output = "[ERROR] Could not transfer artifact org.apache.maven:apache-maven:zip:3.9.9 " \
                "from/to central (https://repo.example.com/maven): status code: 403"
       expect do
-        described_class.handle_wrapper_error(output)
+        described_class.handle_wrapper_error(wrapper_failure(output))
       end.to raise_error(Dependabot::PrivateSourceAuthenticationFailure)
     end
 
@@ -67,7 +74,7 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
         [ERROR] -> [Help 1]
       OUTPUT
       expect do
-        described_class.handle_wrapper_error(output)
+        described_class.handle_wrapper_error(wrapper_failure(output))
       end.to raise_error(Dependabot::DependencyFileNotResolvable, /Maven Wrapper plugin/)
     end
 
@@ -85,11 +92,15 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
       expect(error.tool_message).not_to include("Scanning for projects")
     end
 
-    it "falls back to the raw output when there are no [ERROR] lines" do
+    it "re-raises the original HelperSubprocessFailed when there are no [ERROR] lines" do
+      # Inactivity timeouts and a missing `mvn` executable surface as
+      # HelperSubprocessFailed without Maven `[ERROR]` markers. These are not tooling
+      # misconfigurations, so the original error is re-raised for normal unknown-error
+      # routing rather than serialized as MisconfiguredTooling.
       output = "some unexpected failure without maven error markers"
       expect do
-        described_class.handle_wrapper_error(output)
-      end.to raise_error(Dependabot::MisconfiguredTooling, /some unexpected failure/)
+        described_class.handle_wrapper_error(wrapper_failure(output))
+      end.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed, /some unexpected failure/)
     end
 
     it "truncates an overly long error summary" do


### PR DESCRIPTION
### What are you trying to accomplish?

The newly-shipped Maven Wrapper feature is producing a wave of `Dependabot::Updater::SubprocessFailed` errors that are effectively undiagnosable. When the `mvn ...maven-wrapper-plugin:wrapper` subprocess exits non-zero, `run_shell_command` raises `HelperSubprocessFailed`, which the updater deliberately sanitizes into an opaque `SubprocessFailed` that reports only the command and says "Check the job logs" — the actual Maven output (the real reason for the failure) never reaches our error reporting.

Because of this, a broad range of distinct root causes (plugin resolution behind the proxy, private-registry auth failures, distribution download problems, tooling misconfiguration) all collapse into the same generic, unactionable error across every plugin version, Maven target, and registry. There is no way to tell them apart or route them without pulling individual customer job logs.

This PR brings the wrapper invocation to parity with the existing `dependency:tree` path: it logs the full Maven output and classifies the failure into a proper Dependabot error, so each failure mode surfaces an actionable error type instead of an opaque subprocess failure.

### Anything you want to highlight for special attention from reviewers?

The classification mirrors the established pattern already used by `run_mvn_dependency_tree_plugin` / `handle_tool_error`, and reuses the same transfer-failure detection. Known failures map to their existing, already-registered Dependabot error types; anything unrecognized is surfaced via `MisconfiguredTooling`, which carries a trimmed summary of Maven's own `[ERROR]` lines (bounded in length, `[INFO]` noise excluded) so operators see the real cause without leaking unrelated build output.

This is intentionally an observability/error-classification change — it does not attempt to change how the wrapper command itself is invoked.

### How will you know you've accomplished your goal?

- Reproduced the production failure locally and confirmed the raw Maven error is now logged and classified rather than discarded.
- Added unit tests covering each classification branch (auth failure, wrapper-plugin-unresolved, generic tooling misconfiguration, no-`[ERROR]`-lines fallback, and summary truncation) plus the invocation path that logs the full output and re-raises a classified error.
- Existing Maven Wrapper specs continue to pass and the linter is clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
