### PR TITLE
Fix npm/pnpm/yarn native release-age gates rejecting Dependabot's own updates

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -24,10 +24,6 @@ module Dependabot
       require_relative "file_updater/pnpm_lockfile_updater"
       require_relative "file_updater/pnpm_workspace_updater"
 
-      # Mirrors the updater's `Job::DEFAULT_COOLDOWN_DAYS`, which cannot be
-      # referenced from an ecosystem gem.
-      DEFAULT_RELEASE_AGE_DAYS = 3
-
       class NoChangeError < StandardError
         extend T::Sig
         include Dependabot::HasSentryContext
@@ -462,10 +458,10 @@ module Dependabot
       # (ours and the user's), whereas these are all windows we applied ourselves,
       # and taking the highest would reject the update selected under the shortest.
       #
-      # A group containing a cooldown-excluded dependency cannot be expressed in a
-      # global flag, so it falls back to the default floor rather than dropping the
-      # gate below the platform baseline. Excluded dependencies are still held to
-      # that floor, so a release younger than it can still be refused.
+      # A global flag cannot express `include`/`exclude`, and selection gives an
+      # excluded dependency a zero-day window, so any gate at all could reject a
+      # version it approved. The gate is therefore skipped unless every dependency
+      # in the invocation is cooldown-included.
       sig { returns(T.nilable(Integer)) }
       def cooldown_release_age_days
         return nil if options.fetch(:security_updates_only, false)
@@ -476,11 +472,9 @@ module Dependabot
         )
         return nil if cooldown.nil?
         return nil if dependencies.empty?
+        return nil unless dependencies.all? { |dep| cooldown.included?(dep.name) }
 
-        windows = dependencies.map { |dep| selection_cooldown_days(cooldown, dep) }
-        windows << DEFAULT_RELEASE_AGE_DAYS unless dependencies.all? { |dep| cooldown.included?(dep.name) }
-
-        days = windows.min
+        days = dependencies.map { |dep| selection_cooldown_days(cooldown, dep) }.min
         days&.positive? ? days : nil
       end
 
@@ -498,11 +492,17 @@ module Dependabot
         new_version = parsed_version(dependency.version)
         return cooldown.default_days if new_version.nil?
 
-        Dependabot::UpdateCheckers::CooldownCalculation.cooldown_days_for(
+        semver_days = Dependabot::UpdateCheckers::CooldownCalculation.cooldown_days_for(
           cooldown,
           parsed_version(dependency.previous_version),
           new_version
         )
+
+        # A dependency absent from the lockfile is selected under `default_days`,
+        # because the checker has no current version, yet `previous_version` is
+        # later inferred from the manifest requirement. Capping keeps the gate from
+        # exceeding whichever of the two windows selection actually used.
+        [semver_days, cooldown.default_days].min
       end
 
       sig { params(version: T.nilable(String)).returns(T.nilable(Dependabot::NpmAndYarn::Version)) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -456,6 +456,11 @@ module Dependabot
       #   cooldown, since a global flag would gate it anyway, and
       # - otherwise the *smallest* of the per-update cooldown days, so it never
       #   exceeds the window any of the selected versions were approved under.
+      #
+      # The smallest is deliberately the opposite of the highest-wins rule in
+      # `Helpers.higher_release_age_gate`: that reconciles two *competing* policies
+      # (ours and the user's), whereas these are all windows we applied ourselves,
+      # and taking the highest would reject the update selected under the shortest.
       sig { returns(T.nilable(Integer)) }
       def cooldown_release_age_days
         return nil if options.fetch(:security_updates_only, false)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -24,6 +24,10 @@ module Dependabot
       require_relative "file_updater/pnpm_lockfile_updater"
       require_relative "file_updater/pnpm_workspace_updater"
 
+      # Mirrors the updater's `Job::DEFAULT_COOLDOWN_DAYS`, which cannot be
+      # referenced from an ecosystem gem.
+      DEFAULT_RELEASE_AGE_DAYS = 3
+
       class NoChangeError < StandardError
         extend T::Sig
         include Dependabot::HasSentryContext
@@ -449,18 +453,19 @@ module Dependabot
       # express per-semver-type days or include/exclude patterns. Passing a value
       # stricter than the rule that selected a version makes the package manager
       # refuse the install it was just asked to perform, which surfaces as a skipped
-      # update or a hung resolver (dependabot/dependabot-core#15937). To stay
-      # consistent by construction the gate is therefore:
-      #
-      # - skipped entirely when *any* dependency in the invocation is excluded from
-      #   cooldown, since a global flag would gate it anyway, and
-      # - otherwise the *smallest* of the per-update cooldown days, so it never
-      #   exceeds the window any of the selected versions were approved under.
+      # update or a hung resolver (dependabot/dependabot-core#15937). The gate is
+      # therefore the *smallest* of the per-update cooldown days, so it never
+      # exceeds the window any of the selected versions was approved under.
       #
       # The smallest is deliberately the opposite of the highest-wins rule in
       # `Helpers.higher_release_age_gate`: that reconciles two *competing* policies
       # (ours and the user's), whereas these are all windows we applied ourselves,
       # and taking the highest would reject the update selected under the shortest.
+      #
+      # A group containing a cooldown-excluded dependency cannot be expressed in a
+      # global flag, so it falls back to the default floor rather than dropping the
+      # gate below the platform baseline. Excluded dependencies are still held to
+      # that floor, so a release younger than it can still be refused.
       sig { returns(T.nilable(Integer)) }
       def cooldown_release_age_days
         return nil if options.fetch(:security_updates_only, false)
@@ -471,9 +476,11 @@ module Dependabot
         )
         return nil if cooldown.nil?
         return nil if dependencies.empty?
-        return nil unless dependencies.all? { |dep| cooldown.included?(dep.name) }
 
-        days = dependencies.map { |dep| selection_cooldown_days(cooldown, dep) }.min
+        windows = dependencies.map { |dep| selection_cooldown_days(cooldown, dep) }
+        windows << DEFAULT_RELEASE_AGE_DAYS unless dependencies.all? { |dep| cooldown.included?(dep.name) }
+
+        days = windows.min
         days&.positive? ? days : nil
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater.rb
@@ -7,8 +7,10 @@ require "dependabot/file_updaters/vendor_updater"
 require "dependabot/file_updaters/artifact_updater"
 require "dependabot/errors"
 require "dependabot/package/release_cooldown_options"
+require "dependabot/update_checkers/cooldown_calculation"
 require "dependabot/npm_and_yarn/dependency_files_filterer"
 require "dependabot/npm_and_yarn/sub_dependency_files_filterer"
+require "dependabot/npm_and_yarn/version"
 require "sorbet-runtime"
 
 module Dependabot
@@ -442,12 +444,18 @@ module Dependabot
       # Dependabot can constrain the versions the package manager resolves for the
       # transitive tree. Returns nil for security updates (which must never be
       # blocked by a release-age gate) or when no positive cooldown is configured.
-      # `default_days` is used because the native gates are a single global value
-      # and cannot express per-semver-type days or include/exclude patterns.
       #
-      # The gate is also skipped when none of the dependencies being updated are
-      # subject to the cooldown (per its `include`/`exclude` patterns), so an
-      # update the user explicitly opted out of cooldown for is not gated.
+      # The native gates are a single global value per invocation, so they cannot
+      # express per-semver-type days or include/exclude patterns. Passing a value
+      # stricter than the rule that selected a version makes the package manager
+      # refuse the install it was just asked to perform, which surfaces as a skipped
+      # update or a hung resolver (dependabot/dependabot-core#15937). To stay
+      # consistent by construction the gate is therefore:
+      #
+      # - skipped entirely when *any* dependency in the invocation is excluded from
+      #   cooldown, since a global flag would gate it anyway, and
+      # - otherwise the *smallest* of the per-update cooldown days, so it never
+      #   exceeds the window any of the selected versions were approved under.
       sig { returns(T.nilable(Integer)) }
       def cooldown_release_age_days
         return nil if options.fetch(:security_updates_only, false)
@@ -457,10 +465,39 @@ module Dependabot
           T.nilable(Dependabot::Package::ReleaseCooldownOptions)
         )
         return nil if cooldown.nil?
-        return nil unless dependencies.any? { |dep| cooldown.included?(dep.name) }
+        return nil if dependencies.empty?
+        return nil unless dependencies.all? { |dep| cooldown.included?(dep.name) }
 
-        days = cooldown.default_days
-        days.positive? ? days : nil
+        days = dependencies.map { |dep| selection_cooldown_days(cooldown, dep) }.min
+        days&.positive? ? days : nil
+      end
+
+      # The cooldown window the update checker applied when it selected this
+      # dependency's target version, so the native gate can never reject a version
+      # Dependabot itself chose. Falls back to `default_days` for versions we cannot
+      # parse, matching how `CooldownCalculation` treats an unknown current version.
+      sig do
+        params(
+          cooldown: Dependabot::Package::ReleaseCooldownOptions,
+          dependency: Dependabot::Dependency
+        ).returns(Integer)
+      end
+      def selection_cooldown_days(cooldown, dependency)
+        new_version = parsed_version(dependency.version)
+        return cooldown.default_days if new_version.nil?
+
+        Dependabot::UpdateCheckers::CooldownCalculation.cooldown_days_for(
+          cooldown,
+          parsed_version(dependency.previous_version),
+          new_version
+        )
+      end
+
+      sig { params(version: T.nilable(String)).returns(T.nilable(Dependabot::NpmAndYarn::Version)) }
+      def parsed_version(version)
+        return nil unless version && Dependabot::NpmAndYarn::Version.correct?(version)
+
+        Dependabot::NpmAndYarn::Version.new(version)
       end
 
       sig { returns(Dependabot::NpmAndYarn::FileUpdater::YarnLockfileUpdater) }

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -107,6 +107,10 @@ module Dependabot
         # pnpm 11 stopped reading non-registry settings (e.g. minimum-release-age)
         # from .npmrc, so a .npmrc release-age gate is only effective on pnpm 10.x.
         PNPM_NPMRC_RELEASE_AGE_DROPPED_VERSION = "11.0"
+        # `trustLockfile` (pnpm 11.3) skips the verification pass that re-applies
+        # minimumReleaseAge/trustPolicy to entries already in the lockfile, without
+        # relaxing the gate for versions pnpm resolves now.
+        PNPM_TRUST_LOCKFILE_VERSION = "11.3"
 
         UNREACHABLE_GIT = %r{Command failed with exit code 128: git ls-remote (?<url>.*github\.com/[^/]+/[^ ]+)}
         UNREACHABLE_GIT_V8 = %r{ERR_PNPM_FETCH_404[ [^:print]]+GET (?<url>https://codeload\.github\.com/[^/]+/[^/]+)/}
@@ -336,12 +340,35 @@ module Dependabot
         end
 
         # Builds the pnpm `--config.minimumReleaseAge` args for `minutes`, adding
-        # the strict toggle only when appropriate (see `disable_strict_release_age?`).
+        # the strict toggle only when appropriate (see `disable_strict_release_age?`)
+        # and trusting the existing lockfile where that is safe (see
+        # `trust_existing_lockfile?`).
         sig { params(minutes: Integer).returns(String) }
         def minimum_release_age_gate_args(minutes)
           args = "--config.minimumReleaseAge=#{minutes}"
           args += " --config.minimumReleaseAgeStrict=false" if disable_strict_release_age?
+          args += " --config.trustLockfile=true" if trust_existing_lockfile?
           args
+        end
+
+        # pnpm re-applies the gate to every entry already in the lockfile, so a
+        # version a human committed inside the cooldown window fails the whole
+        # command even though Dependabot neither introduced it nor can fix it
+        # (dependabot/dependabot-core#15937). Trusting the lockfile keeps the
+        # cooldown enforced for the versions pnpm resolves now, rather than dropping
+        # it wholesale, so an update is still delivered under the gate.
+        #
+        # It is skipped when the repo states its own lockfile-verification policy:
+        # `trustLockfile` is the user's to set, and `trustPolicy` re-verification of
+        # loaded entries is an independent supply-chain control that this must not
+        # silently disable. Those repos fall back to the ungated retry.
+        sig { returns(T::Boolean) }
+        def trust_existing_lockfile?
+          return false if security_updates_only?
+          return false unless pnpm_supports_trust_lockfile?
+          return false if pnpm_lockfile_verification_configured?
+
+          true
         end
 
         # pnpm defaults `minimumReleaseAgeStrict` to *on* when `minimumReleaseAge`
@@ -359,6 +386,7 @@ module Dependabot
         def fingerprint_minimum_release_age_config
           args = "--config.minimumReleaseAge=<minutes>"
           args += " --config.minimumReleaseAgeStrict=false" if disable_strict_release_age?
+          args += " --config.trustLockfile=true" if trust_existing_lockfile?
           args
         end
 
@@ -392,6 +420,29 @@ module Dependabot
         def pnpm_supports_minimum_release_age_strict?
           version = pnpm_version
           !version.nil? && version >= Version.new(PNPM_MINIMUM_RELEASE_AGE_STRICT_VERSION)
+        end
+
+        sig { returns(T::Boolean) }
+        def pnpm_supports_trust_lockfile?
+          version = pnpm_version
+          !version.nil? && version >= Version.new(PNPM_TRUST_LOCKFILE_VERSION)
+        end
+
+        # Whether the repo states its own policy for verifying loaded lockfile
+        # entries, via `trustLockfile` or `trustPolicy` in pnpm-workspace.yaml.
+        sig { returns(T::Boolean) }
+        def pnpm_lockfile_verification_configured?
+          dependency_files.any? do |file|
+            next false unless File.basename(file.name) == "pnpm-workspace.yaml"
+
+            content = file.content.to_s
+            yaml_setting_present?(content, "trustLockfile") || yaml_setting_present?(content, "trustPolicy")
+          end
+        end
+
+        sig { params(content: String, key: String).returns(T::Boolean) }
+        def yaml_setting_present?(content, key)
+          content.match?(/^\s*["']?#{Regexp.escape(key)}["']?\s*:/)
         end
 
         # pnpm 10.x ignores `minimumReleaseAge` when `shared-workspace-lockfile` is

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -101,9 +101,6 @@ module Dependabot
         # `minimumReleaseAgeStrict` toggle in 11.0; older versions ignore them.
         PNPM_MINIMUM_RELEASE_AGE_VERSION = "10.16"
         PNPM_MINIMUM_RELEASE_AGE_STRICT_VERSION = "11.0"
-        # pnpm 11.3 added `trustLockfile`, which skips the supply-chain verification
-        # pass that re-applies the release-age gate to entries already in the lockfile.
-        PNPM_TRUST_LOCKFILE_VERSION = "11.3"
         # pnpm 10.x ignores minimumReleaseAge when shared-workspace-lockfile is
         # disabled (pnpm/pnpm#10008); the fix ships in pnpm 11.
         PNPM_WORKSPACE_RELEASE_AGE_FIX_VERSION = "11.0"
@@ -237,12 +234,27 @@ module Dependabot
           run_pnpm_command_with_release_age_gate("install --lockfile-only")
         end
 
-        # pnpm's `minimumReleaseAge` needs the registry `time` field, which is
-        # absent from the abbreviated metadata pnpm uses for some packages during
-        # `pnpm update`, raising ERR_PNPM_MISSING_TIME. When that happens for a
-        # cooldown-derived gate we retry without it so the update still succeeds,
-        # rather than failing the whole job. Security bypass (`=0`) never triggers
-        # this because it disables the age lookup entirely.
+        # Failures that mean the cooldown gate itself cannot be applied to this
+        # repo, rather than that the update is wrong. Each is retried once without
+        # the gate so a transitive-cooldown preference never blocks the update:
+        #
+        # - ERR_PNPM_MISSING_TIME: `minimumReleaseAge` needs the registry `time`
+        #   field, absent from the abbreviated metadata pnpm uses for some packages.
+        # - ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION: pnpm re-applies the gate to every
+        #   entry of the lockfile it loads, so a version committed inside the cooldown
+        #   window fails the command even though Dependabot neither introduced nor
+        #   can fix it.
+        RELEASE_AGE_GATE_INAPPLICABLE = T.let(
+          {
+            "ERR_PNPM_MISSING_TIME" => "the registry metadata is missing the \"time\" field",
+            "ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION" =>
+              "the existing lockfile contains entries published inside the cooldown window"
+          }.freeze,
+          T::Hash[String, String]
+        )
+
+        # Security bypass (`=0`) never triggers these, because it disables the age
+        # lookup entirely, so it is always re-raised.
         sig { params(cmd: String, fingerprint: T.nilable(String)).returns(T.nilable(String)) }
         def run_pnpm_command_with_release_age_gate(cmd, fingerprint = nil)
           gate = release_age_gate_config
@@ -253,12 +265,14 @@ module Dependabot
           begin
             execute_pnpm_command("#{cmd} #{gate}", gated_fingerprint)
           rescue SharedHelpers::HelperSubprocessFailed => e
-            raise if security_updates_only? || !e.message.include?("ERR_PNPM_MISSING_TIME")
+            raise if security_updates_only?
+
+            code, reason = RELEASE_AGE_GATE_INAPPLICABLE.find { |error_code, _| e.message.include?(error_code) }
+            raise unless code
 
             Dependabot.logger.warn(
-              "pnpm could not apply the cooldown release-age gate because the registry metadata " \
-              "is missing the \"time\" field (ERR_PNPM_MISSING_TIME); retrying without the " \
-              "transitive cooldown gate so the update is not blocked."
+              "pnpm could not apply the cooldown release-age gate because #{reason} (#{code}); " \
+              "retrying without the transitive cooldown gate so the update is not blocked."
             )
             execute_pnpm_command(cmd, fingerprint)
           end
@@ -326,23 +340,7 @@ module Dependabot
         def minimum_release_age_gate_args(minutes)
           args = "--config.minimumReleaseAge=#{minutes}"
           args += " --config.minimumReleaseAgeStrict=false" if disable_strict_release_age?
-          args += " --config.trustLockfile=true" if trust_existing_lockfile?
           args
-        end
-
-        # pnpm re-applies the effective `minimumReleaseAge` to every entry of the
-        # lockfile it loads, so a version committed inside the cooldown window fails
-        # the whole command with ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION even though
-        # Dependabot neither introduced nor can fix it. `trustLockfile` (pnpm 11.3+)
-        # skips that verification pass, leaving our CLI override to gate the versions
-        # this update actually resolves. Security updates pass `minimumReleaseAge=0`,
-        # which has nothing to verify, so their args are left untouched.
-        sig { returns(T::Boolean) }
-        def trust_existing_lockfile?
-          return false if security_updates_only?
-
-          version = pnpm_version
-          !version.nil? && version >= Version.new(PNPM_TRUST_LOCKFILE_VERSION)
         end
 
         # pnpm defaults `minimumReleaseAgeStrict` to *on* when `minimumReleaseAge`
@@ -360,7 +358,6 @@ module Dependabot
         def fingerprint_minimum_release_age_config
           args = "--config.minimumReleaseAge=<minutes>"
           args += " --config.minimumReleaseAgeStrict=false" if disable_strict_release_age?
-          args += " --config.trustLockfile=true" if trust_existing_lockfile?
           args
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -101,6 +101,9 @@ module Dependabot
         # `minimumReleaseAgeStrict` toggle in 11.0; older versions ignore them.
         PNPM_MINIMUM_RELEASE_AGE_VERSION = "10.16"
         PNPM_MINIMUM_RELEASE_AGE_STRICT_VERSION = "11.0"
+        # pnpm 11.3 added `trustLockfile`, which skips the supply-chain verification
+        # pass that re-applies the release-age gate to entries already in the lockfile.
+        PNPM_TRUST_LOCKFILE_VERSION = "11.3"
         # pnpm 10.x ignores minimumReleaseAge when shared-workspace-lockfile is
         # disabled (pnpm/pnpm#10008); the fix ships in pnpm 11.
         PNPM_WORKSPACE_RELEASE_AGE_FIX_VERSION = "11.0"
@@ -323,7 +326,23 @@ module Dependabot
         def minimum_release_age_gate_args(minutes)
           args = "--config.minimumReleaseAge=#{minutes}"
           args += " --config.minimumReleaseAgeStrict=false" if disable_strict_release_age?
+          args += " --config.trustLockfile=true" if trust_existing_lockfile?
           args
+        end
+
+        # pnpm re-applies the effective `minimumReleaseAge` to every entry of the
+        # lockfile it loads, so a version committed inside the cooldown window fails
+        # the whole command with ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION even though
+        # Dependabot neither introduced nor can fix it. `trustLockfile` (pnpm 11.3+)
+        # skips that verification pass, leaving our CLI override to gate the versions
+        # this update actually resolves. Security updates pass `minimumReleaseAge=0`,
+        # which has nothing to verify, so their args are left untouched.
+        sig { returns(T::Boolean) }
+        def trust_existing_lockfile?
+          return false if security_updates_only?
+
+          version = pnpm_version
+          !version.nil? && version >= Version.new(PNPM_TRUST_LOCKFILE_VERSION)
         end
 
         # pnpm defaults `minimumReleaseAgeStrict` to *on* when `minimumReleaseAge`
@@ -341,6 +360,7 @@ module Dependabot
         def fingerprint_minimum_release_age_config
           args = "--config.minimumReleaseAge=<minutes>"
           args += " --config.minimumReleaseAgeStrict=false" if disable_strict_release_age?
+          args += " --config.trustLockfile=true" if trust_existing_lockfile?
           args
         end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -41,6 +41,7 @@ module Dependabot
           @credentials = credentials
           @security_updates_only = security_updates_only
           @release_age_days = release_age_days
+          @trust_existing_lockfile = T.let(nil, T.nilable(T::Boolean))
           @error_handler = T.let(
             PnpmErrorHandler.new(
               dependencies: dependencies,
@@ -280,10 +281,21 @@ module Dependabot
 
             Dependabot.logger.warn(
               "pnpm could not apply the cooldown release-age gate because #{reason}; " \
-              "retrying without the transitive cooldown gate so the update is not blocked."
+              "retrying without Dependabot's release-age override so the update is not blocked. " \
+              "#{fallback_release_age_description}"
             )
             execute_pnpm_command(cmd, fingerprint)
           end
+        end
+
+        # What still gates transitive dependencies once Dependabot's override is
+        # dropped, so the warning does not imply the retry is ungated.
+        sig { returns(String) }
+        def fallback_release_age_description
+          configured = pnpm_configured_minimum_release_age
+          return "pnpm falls back to its own minimumReleaseAge default." if configured.nil?
+
+          "pnpm falls back to the repo's own minimumReleaseAge (#{configured} minutes)."
         end
 
         sig { params(cmd: String, fingerprint: T.nilable(String)).returns(T.nilable(String)) }
@@ -365,11 +377,28 @@ module Dependabot
         # `trustLockfile` is the user's to set, and `trustPolicy` re-verification of
         # loaded entries is an independent supply-chain control that this must not
         # silently disable. Those repos fall back to the ungated retry.
+        #
+        # Memoized so the decision is logged once per update, not per command.
         sig { returns(T::Boolean) }
         def trust_existing_lockfile?
+          @trust_existing_lockfile = compute_trust_existing_lockfile? if @trust_existing_lockfile.nil?
+          @trust_existing_lockfile
+        end
+
+        sig { returns(T::Boolean) }
+        def compute_trust_existing_lockfile?
           return false if security_updates_only?
           return false unless pnpm_supports_trust_lockfile?
-          return false if pnpm_lockfile_verification_configured?
+
+          configured = configured_lockfile_verification_settings
+          unless configured.empty?
+            Dependabot.logger.info(
+              "pnpm-workspace.yaml sets #{configured.join(', ')}, so Dependabot will not pass " \
+              "trustLockfile; entries already in the lockfile are still verified against the " \
+              "cooldown window, and a violation there falls back to an ungated retry."
+            )
+            return false
+          end
 
           true
         end
@@ -431,15 +460,16 @@ module Dependabot
           !version.nil? && version >= Version.new(PNPM_TRUST_LOCKFILE_VERSION)
         end
 
-        # Whether the repo states its own policy for verifying loaded lockfile
-        # entries, via `trustLockfile` or `trustPolicy` in pnpm-workspace.yaml.
-        sig { returns(T::Boolean) }
-        def pnpm_lockfile_verification_configured?
-          dependency_files.any? do |file|
-            next false unless File.basename(file.name) == "pnpm-workspace.yaml"
+        # The lockfile-verification settings the repo states for itself, via
+        # pnpm-workspace.yaml. Named rather than boolean so the log can say which
+        # setting held `trustLockfile` back.
+        sig { returns(T::Array[String]) }
+        def configured_lockfile_verification_settings
+          dependency_files.flat_map do |file|
+            next [] unless File.basename(file.name) == "pnpm-workspace.yaml"
 
-            workspace_setting_names(file.content.to_s).intersect?(LOCKFILE_VERIFICATION_SETTINGS)
-          end
+            workspace_setting_names(file.content.to_s) & LOCKFILE_VERIFICATION_SETTINGS
+          end.uniq
         end
 
         # Top-level keys of a pnpm-workspace.yaml. Parsed as YAML rather than

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -234,23 +234,24 @@ module Dependabot
           run_pnpm_command_with_release_age_gate("install --lockfile-only")
         end
 
-        # Failures that mean the cooldown gate itself cannot be applied to this
-        # repo, rather than that the update is wrong. Each is retried once without
-        # the gate so a transitive-cooldown preference never blocks the update:
+        # Failures that mean the cooldown gate cannot be applied to this repo,
+        # rather than that the update is wrong. Each is retried once without the
+        # gate so a transitive-cooldown preference never blocks the update.
         #
-        # - ERR_PNPM_MISSING_TIME: `minimumReleaseAge` needs the registry `time`
-        #   field, absent from the abbreviated metadata pnpm uses for some packages.
-        # - ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION: pnpm re-applies the gate to every
-        #   entry of the lockfile it loads, so a version committed inside the cooldown
-        #   window fails the command even though Dependabot neither introduced nor
-        #   can fix it.
+        # The release-age violation is matched on pnpm's lockfile-verification
+        # wording rather than the bare error code, because pnpm raises the same
+        # code when a *newly resolved* version is too young. Retrying ungated
+        # there would admit the very release the cooldown exists to reject, so
+        # only the verification pass over entries already in the lockfile — which
+        # Dependabot neither introduced nor can fix — is treated as inapplicable.
         RELEASE_AGE_GATE_INAPPLICABLE = T.let(
           {
-            "ERR_PNPM_MISSING_TIME" => "the registry metadata is missing the \"time\" field",
-            "ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION" =>
+            /ERR_PNPM_MISSING_TIME/ =>
+              "the registry metadata is missing the \"time\" field",
+            /ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION[\s\S]*lockfile entries failed verification/ =>
               "the existing lockfile contains entries published inside the cooldown window"
           }.freeze,
-          T::Hash[String, String]
+          T::Hash[Regexp, String]
         )
 
         # Security bypass (`=0`) never triggers these, because it disables the age
@@ -267,11 +268,11 @@ module Dependabot
           rescue SharedHelpers::HelperSubprocessFailed => e
             raise if security_updates_only?
 
-            code, reason = RELEASE_AGE_GATE_INAPPLICABLE.find { |error_code, _| e.message.include?(error_code) }
-            raise unless code
+            _, reason = RELEASE_AGE_GATE_INAPPLICABLE.find { |matcher, _| e.message.match?(matcher) }
+            raise unless reason
 
             Dependabot.logger.warn(
-              "pnpm could not apply the cooldown release-age gate because #{reason} (#{code}); " \
+              "pnpm could not apply the cooldown release-age gate because #{reason}; " \
               "retrying without the transitive cooldown gate so the update is not blocked."
             )
             execute_pnpm_command(cmd, fingerprint)

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -111,6 +111,9 @@ module Dependabot
         # minimumReleaseAge/trustPolicy to entries already in the lockfile, without
         # relaxing the gate for versions pnpm resolves now.
         PNPM_TRUST_LOCKFILE_VERSION = "11.3"
+        # pnpm-workspace.yaml settings that govern verification of loaded lockfile
+        # entries, and so must not be overridden by `trustLockfile=true`.
+        LOCKFILE_VERIFICATION_SETTINGS = T.let(%w(trustLockfile trustPolicy).freeze, T::Array[String])
 
         UNREACHABLE_GIT = %r{Command failed with exit code 128: git ls-remote (?<url>.*github\.com/[^/]+/[^ ]+)}
         UNREACHABLE_GIT_V8 = %r{ERR_PNPM_FETCH_404[ [^:print]]+GET (?<url>https://codeload\.github\.com/[^/]+/[^/]+)/}
@@ -435,14 +438,17 @@ module Dependabot
           dependency_files.any? do |file|
             next false unless File.basename(file.name) == "pnpm-workspace.yaml"
 
-            content = file.content.to_s
-            yaml_setting_present?(content, "trustLockfile") || yaml_setting_present?(content, "trustPolicy")
+            workspace_setting_names(file.content.to_s).intersect?(LOCKFILE_VERIFICATION_SETTINGS)
           end
         end
 
-        sig { params(content: String, key: String).returns(T::Boolean) }
-        def yaml_setting_present?(content, key)
-          content.match?(/^\s*["']?#{Regexp.escape(key)}["']?\s*:/)
+        # Top-level keys of a pnpm-workspace.yaml. Parsed as YAML rather than
+        # matched per line so flow-style mappings (`{ trustPolicy: no-downgrade }`)
+        # are seen.
+        sig { params(content: String).returns(T::Array[String]) }
+        def workspace_setting_names(content)
+          parsed = YAML.safe_load(content, aliases: true)
+          parsed.is_a?(Hash) ? parsed.keys.map(&:to_s) : []
         end
 
         # pnpm 10.x ignores `minimumReleaseAge` when `shared-workspace-lockfile` is

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -880,7 +880,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           ""
         end
 
-        updater.send(:run_pnpm_install)
+        updated_pnpm_lock_content
 
         expect(commands).not_to be_empty
         expect(commands.join(" ")).not_to include("trustLockfile")
@@ -1057,6 +1057,28 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
             project_dependency_files(project_name) +
               [Dependabot::DependencyFile.new(
                 name: "pnpm-workspace.yaml", content: "trustPolicy: 'no-downgrade'\n"
+              )]
+          end
+
+          it "does not disable the repo's supply-chain verification" do
+            commands = []
+            allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+              commands << cmd
+              ""
+            end
+
+            updated_pnpm_lock_content
+
+            expect(commands).not_to be_empty
+            expect(commands.join(" ")).not_to include("trustLockfile")
+          end
+        end
+
+        context "when the repo configures trustPolicy in flow style" do
+          let(:files) do
+            project_dependency_files(project_name) +
+              [Dependabot::DependencyFile.new(
+                name: "pnpm-workspace.yaml", content: "{ trustPolicy: no-downgrade }\n"
               )]
           end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -988,6 +988,22 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         updater.send(:run_pnpm_update_packages)
       end
 
+      # pnpm raises the same code when a newly resolved version is too young;
+      # retrying without the gate there would admit the release the cooldown exists
+      # to reject.
+      it "re-raises a release-age violation that is not from lockfile verification" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |_cmd, **|
+          raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+            message: "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] no version of foo satisfies " \
+                     "the minimumReleaseAge constraint",
+            error_context: {}
+          )
+        end
+
+        expect { updater.send(:run_pnpm_update_packages) }
+          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+      end
+
       # Regression coverage for dependabot/dependabot-core#13165: when a repo sets
       # `minimumReleaseAge` in pnpm-workspace.yaml *and* a Dependabot `cooldown`,
       # the longest release-age of the two takes precedence so neither policy is

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -997,6 +997,33 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         expect(updates.last).not_to include("--config.minimumReleaseAge")
       end
 
+      context "when the repo sets its own minimumReleaseAge" do
+        let(:files) do
+          project_dependency_files(project_name) +
+            [Dependabot::DependencyFile.new(name: "pnpm-workspace.yaml", content: "minimumReleaseAge: 1440\n")]
+        end
+
+        it "reports the gate the retry falls back to, rather than implying none" do
+          allow(Dependabot.logger).to receive(:warn)
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+            if cmd.include?("--config.minimumReleaseAge=10080")
+              raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                message: "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification",
+                error_context: {}
+              )
+            end
+            ""
+          end
+
+          updated_pnpm_lock_content
+
+          expect(Dependabot.logger)
+            .to have_received(:warn)
+            .with(/falls back to the repo's own minimumReleaseAge \(1440 minutes\)/)
+            .at_least(:once)
+        end
+      end
+
       it "does not trust the lockfile on pnpm older than 11.3" do
         commands = []
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
@@ -1062,6 +1089,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
 
           it "does not disable the repo's supply-chain verification" do
             commands = []
+            allow(Dependabot.logger).to receive(:info)
             allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
               commands << cmd
               ""
@@ -1071,6 +1099,8 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
 
             expect(commands).not_to be_empty
             expect(commands.join(" ")).not_to include("trustLockfile")
+            expect(Dependabot.logger)
+              .to have_received(:info).with(/pnpm-workspace\.yaml sets trustPolicy/).at_least(:once)
           end
         end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -955,6 +955,39 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         expect(call_count).to eq(2)
       end
 
+      # Regression coverage for dependabot/dependabot-core#15937: pnpm re-applies the
+      # gate to entries already in the lockfile, which Dependabot did not introduce
+      # and cannot fix, so the gate is dropped rather than failing the update.
+      it "retries without the gate when pnpm raises ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION" do
+        call_count = 0
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          call_count += 1
+          if call_count == 1
+            expect(cmd).to include("--config.minimumReleaseAge=10080")
+            raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification: " \
+                       "esrap@2.3.4 was published at 2026-08-14T20:24:13.000Z",
+              error_context: {}
+            )
+          end
+          expect(cmd).not_to include("--config.minimumReleaseAge")
+          ""
+        end
+
+        updater.send(:run_pnpm_update_packages)
+        expect(call_count).to eq(2)
+      end
+
+      it "never disables pnpm's own lockfile verification" do
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          # trustLockfile would also switch off trustPolicy checks for every entry.
+          expect(cmd).not_to include("trustLockfile")
+          ""
+        end.at_least(:once)
+
+        updater.send(:run_pnpm_update_packages)
+      end
+
       # Regression coverage for dependabot/dependabot-core#13165: when a repo sets
       # `minimumReleaseAge` in pnpm-workspace.yaml *and* a Dependabot `cooldown`,
       # the longest release-age of the two takes precedence so neither policy is
@@ -1261,56 +1294,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           end
         end
       end
-
-      # pnpm re-applies the CLI gate to every entry of the lockfile it loads, so a
-      # version committed inside the cooldown window would fail the update with
-      # ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION even though Dependabot did not
-      # introduce it.
-      context "when pnpm is 11.3+ (trustLockfile)" do
-        before do
-          allow(Dependabot::NpmAndYarn::Helpers)
-            .to receive(:pnpm_version).and_return(Dependabot::NpmAndYarn::Version.new("11.17.0"))
-        end
-
-        it "trusts the existing lockfile so pre-existing entries do not fail the gate" do
-          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
-            expect(cmd).to include("--config.minimumReleaseAge=10080")
-            expect(cmd).to include("--config.trustLockfile=true")
-            ""
-          end.at_least(:once)
-
-          updater.send(:run_pnpm_update_packages)
-        end
-
-        it "includes trustLockfile in the fingerprint so it matches the command run" do
-          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |_cmd, fingerprint:|
-            expect(fingerprint).to include("--config.trustLockfile=true")
-            ""
-          end.at_least(:once)
-
-          updater.send(:run_pnpm_update_packages)
-        end
-      end
-
-      context "when pnpm predates trustLockfile (< 11.3)" do
-        before do
-          allow(Dependabot::NpmAndYarn::Helpers)
-            .to receive(:pnpm_version).and_return(Dependabot::NpmAndYarn::Version.new("11.0.0"))
-        end
-
-        it "does not pass the unsupported trustLockfile setting" do
-          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
-            expect(cmd).to include("--config.minimumReleaseAge=10080")
-            expect(cmd).not_to include("trustLockfile")
-            ""
-          end.at_least(:once)
-
-          updater.send(:run_pnpm_update_packages)
-        end
-      end
     end
 
-    context "when security_updates_only is true on pnpm 11.3+" do
+    context "when security_updates_only is true and pnpm reports a release-age violation" do
       let(:updater) do
         described_class.new(
           dependency_files: files,
@@ -1321,19 +1307,16 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         )
       end
 
-      before do
-        allow(Dependabot::NpmAndYarn::Helpers)
-          .to receive(:pnpm_version).and_return(Dependabot::NpmAndYarn::Version.new("11.17.0"))
-      end
+      it "re-raises rather than retrying, since =0 cannot be the cause" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |_cmd, **|
+          raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+            message: "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification",
+            error_context: {}
+          )
+        end
 
-      it "does not trust the lockfile (minimumReleaseAge=0 has nothing to verify)" do
-        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
-          expect(cmd).to include("--config.minimumReleaseAge=0")
-          expect(cmd).not_to include("trustLockfile")
-          ""
-        end.at_least(:once)
-
-        updater.send(:run_pnpm_update_packages)
+        expect { updater.send(:run_pnpm_update_packages) }
+          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -1261,6 +1261,80 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           end
         end
       end
+
+      # pnpm re-applies the CLI gate to every entry of the lockfile it loads, so a
+      # version committed inside the cooldown window would fail the update with
+      # ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION even though Dependabot did not
+      # introduce it.
+      context "when pnpm is 11.3+ (trustLockfile)" do
+        before do
+          allow(Dependabot::NpmAndYarn::Helpers)
+            .to receive(:pnpm_version).and_return(Dependabot::NpmAndYarn::Version.new("11.17.0"))
+        end
+
+        it "trusts the existing lockfile so pre-existing entries do not fail the gate" do
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+            expect(cmd).to include("--config.minimumReleaseAge=10080")
+            expect(cmd).to include("--config.trustLockfile=true")
+            ""
+          end.at_least(:once)
+
+          updater.send(:run_pnpm_update_packages)
+        end
+
+        it "includes trustLockfile in the fingerprint so it matches the command run" do
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |_cmd, fingerprint:|
+            expect(fingerprint).to include("--config.trustLockfile=true")
+            ""
+          end.at_least(:once)
+
+          updater.send(:run_pnpm_update_packages)
+        end
+      end
+
+      context "when pnpm predates trustLockfile (< 11.3)" do
+        before do
+          allow(Dependabot::NpmAndYarn::Helpers)
+            .to receive(:pnpm_version).and_return(Dependabot::NpmAndYarn::Version.new("11.0.0"))
+        end
+
+        it "does not pass the unsupported trustLockfile setting" do
+          expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+            expect(cmd).to include("--config.minimumReleaseAge=10080")
+            expect(cmd).not_to include("trustLockfile")
+            ""
+          end.at_least(:once)
+
+          updater.send(:run_pnpm_update_packages)
+        end
+      end
+    end
+
+    context "when security_updates_only is true on pnpm 11.3+" do
+      let(:updater) do
+        described_class.new(
+          dependency_files: files,
+          dependencies: dependencies,
+          credentials: credentials,
+          repo_contents_path: repo_contents_path,
+          security_updates_only: true
+        )
+      end
+
+      before do
+        allow(Dependabot::NpmAndYarn::Helpers)
+          .to receive(:pnpm_version).and_return(Dependabot::NpmAndYarn::Version.new("11.17.0"))
+      end
+
+      it "does not trust the lockfile (minimumReleaseAge=0 has nothing to verify)" do
+        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          expect(cmd).to include("--config.minimumReleaseAge=0")
+          expect(cmd).not_to include("trustLockfile")
+          ""
+        end.at_least(:once)
+
+        updater.send(:run_pnpm_update_packages)
+      end
     end
   end
 end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -1337,7 +1337,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
       end
 
       it "re-raises rather than retrying, since =0 cannot be the cause" do
-        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |_cmd, **|
+        commands = []
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          commands << cmd
           raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
             message: "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification",
             error_context: {}
@@ -1345,6 +1347,10 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         end
 
         expect { updated_pnpm_lock_content }.to raise_error(StandardError)
+
+        updates = commands.select { |cmd| cmd.include?("--no-save") }
+        expect(updates.length).to eq(1)
+        expect(updates.first).to include("--config.minimumReleaseAge=0")
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -870,6 +870,21 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
 
         updater.send(:run_pnpm_install)
       end
+
+      it "does not trust the lockfile, leaving the repo's verification policy alone" do
+        allow(Dependabot::NpmAndYarn::Helpers)
+          .to receive(:pnpm_version).and_return(Dependabot::NpmAndYarn::Version.new("11.3.0"))
+        commands = []
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          commands << cmd
+          ""
+        end
+
+        updater.send(:run_pnpm_install)
+
+        expect(commands).not_to be_empty
+        expect(commands.join(" ")).not_to include("trustLockfile")
+      end
     end
 
     context "when security_updates_only is false (default)" do
@@ -955,9 +970,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         expect(call_count).to eq(2)
       end
 
-      # Regression coverage for dependabot/dependabot-core#15937: pnpm re-applies the
-      # gate to entries already in the lockfile, which Dependabot did not introduce
-      # and cannot fix, so the gate is dropped rather than failing the update.
+      # Regression coverage for dependabot/dependabot-core#15937 on pnpm too old for
+      # `trustLockfile` (added in 11.3): the gate is dropped rather than failing the
+      # update, because the offending entries are ones Dependabot cannot fix.
       it "retries without the gate when pnpm reports a lockfile-verification violation" do
         commands = []
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
@@ -982,7 +997,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         expect(updates.last).not_to include("--config.minimumReleaseAge")
       end
 
-      it "never disables pnpm's own lockfile verification" do
+      it "does not trust the lockfile on pnpm older than 11.3" do
         commands = []
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
           commands << cmd
@@ -992,8 +1007,72 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         updated_pnpm_lock_content
 
         expect(commands).not_to be_empty
-        # trustLockfile would also switch off trustPolicy checks for every entry.
         expect(commands.join(" ")).not_to include("trustLockfile")
+      end
+
+      # On pnpm 11.3+ the cooldown is kept and the existing lockfile is trusted, so
+      # an entry a human committed inside the window no longer costs the whole gate.
+      context "when the running pnpm supports trustLockfile" do
+        before do
+          allow(Dependabot::NpmAndYarn::Helpers)
+            .to receive(:pnpm_version).and_return(Dependabot::NpmAndYarn::Version.new("11.3.0"))
+        end
+
+        it "keeps the gate and trusts entries already in the lockfile" do
+          commands = []
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+            commands << cmd
+            ""
+          end
+
+          updated_pnpm_lock_content
+
+          gated = commands.select { |cmd| cmd.include?("--config.minimumReleaseAge=10080") }
+          expect(gated).not_to be_empty
+          expect(gated).to all(include("--config.trustLockfile=true"))
+        end
+
+        context "when the repo sets trustLockfile itself" do
+          let(:files) do
+            project_dependency_files(project_name) +
+              [Dependabot::DependencyFile.new(name: "pnpm-workspace.yaml", content: "trustLockfile: false\n")]
+          end
+
+          it "leaves the repo's lockfile-verification policy untouched" do
+            commands = []
+            allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+              commands << cmd
+              ""
+            end
+
+            updated_pnpm_lock_content
+
+            expect(commands).not_to be_empty
+            expect(commands.join(" ")).not_to include("trustLockfile=true")
+          end
+        end
+
+        context "when the repo configures trustPolicy" do
+          let(:files) do
+            project_dependency_files(project_name) +
+              [Dependabot::DependencyFile.new(
+                name: "pnpm-workspace.yaml", content: "trustPolicy: 'no-downgrade'\n"
+              )]
+          end
+
+          it "does not disable the repo's supply-chain verification" do
+            commands = []
+            allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+              commands << cmd
+              ""
+            end
+
+            updated_pnpm_lock_content
+
+            expect(commands).not_to be_empty
+            expect(commands.join(" ")).not_to include("trustLockfile")
+          end
+        end
       end
 
       # pnpm raises the same code when a newly resolved version is too young;

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -958,50 +958,63 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
       # Regression coverage for dependabot/dependabot-core#15937: pnpm re-applies the
       # gate to entries already in the lockfile, which Dependabot did not introduce
       # and cannot fix, so the gate is dropped rather than failing the update.
-      it "retries without the gate when pnpm raises ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION" do
-        call_count = 0
+      it "retries without the gate when pnpm reports a lockfile-verification violation" do
+        commands = []
         allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
-          call_count += 1
-          if call_count == 1
-            expect(cmd).to include("--config.minimumReleaseAge=10080")
+          commands << cmd
+          if commands.one?
             raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
               message: "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification: " \
                        "esrap@2.3.4 was published at 2026-08-14T20:24:13.000Z",
               error_context: {}
             )
           end
-          expect(cmd).not_to include("--config.minimumReleaseAge")
           ""
         end
 
-        updater.send(:run_pnpm_update_packages)
-        expect(call_count).to eq(2)
+        updated_pnpm_lock_content
+
+        # The deep-update fallback issues its own gated command, so scope to the
+        # `update --no-save` pair: the gated attempt and its ungated retry.
+        updates = commands.select { |cmd| cmd.include?("--no-save") }
+        expect(updates.length).to eq(2)
+        expect(updates.first).to include("--config.minimumReleaseAge=10080")
+        expect(updates.last).not_to include("--config.minimumReleaseAge")
       end
 
       it "never disables pnpm's own lockfile verification" do
-        expect(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
-          # trustLockfile would also switch off trustPolicy checks for every entry.
-          expect(cmd).not_to include("trustLockfile")
+        commands = []
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          commands << cmd
           ""
-        end.at_least(:once)
+        end
 
-        updater.send(:run_pnpm_update_packages)
+        updated_pnpm_lock_content
+
+        expect(commands).not_to be_empty
+        # trustLockfile would also switch off trustPolicy checks for every entry.
+        expect(commands.join(" ")).not_to include("trustLockfile")
       end
 
       # pnpm raises the same code when a newly resolved version is too young;
       # retrying without the gate there would admit the release the cooldown exists
       # to reject.
-      it "re-raises a release-age violation that is not from lockfile verification" do
-        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |_cmd, **|
-          raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
-            message: "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] no version of foo satisfies " \
-                     "the minimumReleaseAge constraint",
-            error_context: {}
-          )
+      it "does not retry when the violation is not from lockfile verification" do
+        commands = []
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          commands << cmd
+          if cmd.start_with?("update ")
+            raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: "[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] no version of foo satisfies " \
+                       "the minimumReleaseAge constraint",
+              error_context: {}
+            )
+          end
+          ""
         end
 
-        expect { updater.send(:run_pnpm_update_packages) }
-          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+        expect { updated_pnpm_lock_content }.to raise_error(StandardError)
+        expect(commands.count { |cmd| cmd.include?("--no-save") }).to eq(1)
       end
 
       # Regression coverage for dependabot/dependabot-core#13165: when a repo sets
@@ -1331,8 +1344,7 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
           )
         end
 
-        expect { updater.send(:run_pnpm_update_packages) }
-          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+        expect { updated_pnpm_lock_content }.to raise_error(StandardError)
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -1388,6 +1388,41 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         end
       end
 
+      # Regression coverage for dependabot/dependabot-core#15937: asserts the
+      # derived cooldown reaches the npm invocation, not just that the derivation
+      # returns the right number.
+      context "when a cooldown with per-semver days is configured" do
+        let(:files) { project_dependency_files("npm8/simple") }
+        let(:updater) do
+          described_class.new(
+            dependency_files: files,
+            dependencies: dependencies,
+            credentials: credentials,
+            repo_contents_path: repo_contents_path,
+            options: {
+              update_cooldown: Dependabot::Package::ReleaseCooldownOptions.new(
+                default_days: 14,
+                semver_patch_days: 3
+              )
+            }
+          )
+        end
+
+        it "invokes npm with the patch window, not default_days" do
+          commands = []
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command).and_wrap_original do |original, *args, **kwargs|
+            commands << args.first
+            original.call(*args, **kwargs)
+          end
+
+          expect(updated_files.count).to eq(2)
+
+          gated = commands.select { |command| command.include?("--min-release-age") }
+          expect(gated).not_to be_empty
+          expect(gated).to all(include("--min-release-age=3"))
+        end
+      end
+
       context "when a tarball URL will incorrectly swap to http" do
         let(:files) { project_dependency_files("npm8/tarball_bug") }
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -1410,10 +1410,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
 
         it "invokes npm with the patch window, not default_days" do
           commands = []
-          allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command).and_wrap_original do |original, *args, **kwargs|
-            commands << args.first
-            original.call(*args, **kwargs)
-          end
+          allow(Dependabot::NpmAndYarn::Helpers)
+            .to receive(:run_npm_command).and_wrap_original do |original, *args, **kwargs|
+              commands << args.first
+              original.call(*args, **kwargs)
+            end
 
           expect(updated_files.count).to eq(2)
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -4396,7 +4396,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     end
   end
 
-  describe "#cooldown_release_age_days (transitive gate include/exclude)" do
+  describe "#updated_dependency_files (transitive cooldown gate)" do
+    subject(:updated_files) { updater.updated_dependency_files }
+
     let(:files) { project_dependency_files("npm8/simple") }
     let(:include_patterns) { [] }
     let(:exclude_patterns) { [] }
@@ -4423,50 +4425,101 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         options: updater_options
       )
     end
+    let(:etag_dependency) do
+      Dependabot::Dependency.new(
+        name: "etag",
+        version: "2.0.0",
+        previous_version: "1.0.0",
+        requirements: [{
+          file: "package.json", requirement: "^2.0.0", groups: ["devDependencies"], source: nil
+        }],
+        previous_requirements: [{
+          file: "package.json", requirement: "^1.0.0", groups: ["devDependencies"], source: nil
+        }],
+        package_manager: "npm_and_yarn"
+      )
+    end
+    let(:npm_commands) { [] }
+
+    before do
+      allow(Dependabot::NpmAndYarn::Helpers).to receive(:npm_supports_min_release_age?).and_return(true)
+      allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_npm_command) do |cmd, **|
+        npm_commands << cmd
+        ""
+      end
+    end
+
+    # Asserting on the flag npm actually receives, rather than on the derivation,
+    # keeps these examples honest if the derived value stops reaching the command.
+    def release_age_gates
+      updated_files
+      npm_commands.filter_map { |cmd| cmd[/--min-release-age=\d+/] }
+    end
 
     context "when the updated dependency is subject to the cooldown (no patterns)" do
-      it "returns the cooldown day count" do
-        expect(updater.send(:cooldown_release_age_days)).to eq(7)
+      it "gates npm at the cooldown window" do
+        gates = release_age_gates
+
+        expect(gates).not_to be_empty
+        expect(gates).to all(eq("--min-release-age=7"))
       end
     end
 
     context "when the updated dependency is excluded from the cooldown" do
       let(:exclude_patterns) { ["fetch-factory"] }
 
-      it "falls back to the default floor rather than dropping the gate" do
-        expect(updater.send(:cooldown_release_age_days)).to eq(3)
+      it "invokes npm without a gate, because selection gave it no window" do
+        expect(release_age_gates).to be_empty
+        expect(npm_commands).not_to be_empty
       end
     end
 
     context "when an include list does not match the updated dependency" do
       let(:include_patterns) { ["some-other-dep"] }
 
-      it "falls back to the default floor rather than dropping the gate" do
-        expect(updater.send(:cooldown_release_age_days)).to eq(3)
+      it "invokes npm without a gate, because selection gave it no window" do
+        expect(release_age_gates).to be_empty
+        expect(npm_commands).not_to be_empty
       end
     end
 
     context "when an include list matches the updated dependency" do
       let(:include_patterns) { ["fetch-factory"] }
 
-      it "returns the cooldown day count" do
-        expect(updater.send(:cooldown_release_age_days)).to eq(7)
+      it "gates npm at the cooldown window" do
+        gates = release_age_gates
+
+        expect(gates).not_to be_empty
+        expect(gates).to all(eq("--min-release-age=7"))
       end
     end
 
     context "when it is a security update" do
       let(:updater_options) { { update_cooldown: cooldown, security_updates_only: true } }
 
-      it "returns nil regardless of include/exclude" do
-        expect(updater.send(:cooldown_release_age_days)).to be_nil
+      it "disables the gate so a fix is never blocked" do
+        gates = release_age_gates
+
+        expect(gates).not_to be_empty
+        expect(gates).to all(eq("--min-release-age=0"))
       end
     end
 
     context "when no cooldown is configured" do
       let(:updater_options) { {} }
 
-      it "returns nil" do
-        expect(updater.send(:cooldown_release_age_days)).to be_nil
+      it "invokes npm without a gate" do
+        expect(release_age_gates).to be_empty
+        expect(npm_commands).not_to be_empty
+      end
+    end
+
+    context "when the cooldown is explicitly disabled" do
+      let(:cooldown) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 0) }
+
+      it "invokes npm without a gate" do
+        expect(release_age_gates).to be_empty
+        expect(npm_commands).not_to be_empty
       end
     end
 
@@ -4479,35 +4532,34 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       let(:semver_minor_days) { 14 }
       let(:semver_patch_days) { 3 }
 
-      it "uses the days that selected the version, not default_days" do
+      it "gates npm with the days that selected the version, not default_days" do
         # fetch-factory 0.0.1 -> 0.0.2 is a patch bump, approved under 3 days.
-        expect(updater.send(:cooldown_release_age_days)).to eq(3)
+        gates = release_age_gates
+
+        expect(gates).not_to be_empty
+        expect(gates).to all(eq("--min-release-age=3"))
       end
 
       context "when the bump is a major" do
         let(:previous_version) { "1.0.0" }
         let(:version) { "2.0.0" }
 
-        it "uses the major window" do
-          expect(updater.send(:cooldown_release_age_days)).to eq(21)
+        it "caps the major window at default_days, which selection may have used" do
+          gates = release_age_gates
+
+          expect(gates).not_to be_empty
+          expect(gates).to all(eq("--min-release-age=7"))
         end
       end
 
       context "when a group mixes bump types" do
-        let(:other_dependency) do
-          Dependabot::Dependency.new(
-            name: "etag",
-            version: "2.0.0",
-            previous_version: "1.0.0",
-            requirements: requirements,
-            previous_requirements: previous_requirements,
-            package_manager: "npm_and_yarn"
-          )
-        end
-        let(:dependencies) { [dependency, other_dependency] }
+        let(:dependencies) { [dependency, etag_dependency] }
 
-        it "uses the smallest window so no selected version is rejected" do
-          expect(updater.send(:cooldown_release_age_days)).to eq(3)
+        it "gates at the smallest window so no selected version is rejected" do
+          gates = release_age_gates
+
+          expect(gates).not_to be_empty
+          expect(gates).to all(eq("--min-release-age=3"))
         end
       end
 
@@ -4515,45 +4567,21 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
         let(:version) { "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0" }
 
         it "falls back to default_days" do
-          expect(updater.send(:cooldown_release_age_days)).to eq(7)
+          gates = release_age_gates
+
+          expect(gates).not_to be_empty
+          expect(gates).to all(eq("--min-release-age=7"))
         end
       end
     end
 
     context "when only some dependencies in the group are excluded" do
-      let(:exclude_patterns) { ["@myorg-*/*"] }
-      let(:other_dependency) do
-        Dependabot::Dependency.new(
-          name: "@myorg-team/lib",
-          version: "1.0.1",
-          previous_version: "1.0.0",
-          requirements: requirements,
-          previous_requirements: previous_requirements,
-          package_manager: "npm_and_yarn"
-        )
-      end
-      let(:dependencies) { [dependency, other_dependency] }
+      let(:exclude_patterns) { ["etag"] }
+      let(:dependencies) { [dependency, etag_dependency] }
 
-      it "falls back to the default floor rather than dropping the gate" do
-        expect(updater.send(:cooldown_release_age_days)).to eq(3)
-      end
-
-      context "when the cooldown is explicitly disabled" do
-        let(:cooldown) do
-          Dependabot::Package::ReleaseCooldownOptions.new(default_days: 0, exclude: exclude_patterns)
-        end
-
-        it "applies no gate" do
-          expect(updater.send(:cooldown_release_age_days)).to be_nil
-        end
-      end
-
-      context "when a selected window is shorter than the floor" do
-        let(:semver_patch_days) { 1 }
-
-        it "does not exceed that window" do
-          expect(updater.send(:cooldown_release_age_days)).to eq(1)
-        end
+      it "invokes npm without a gate, because the excluded dependency has no window" do
+        expect(release_age_gates).to be_empty
+        expect(npm_commands).not_to be_empty
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -4364,9 +4364,15 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     let(:files) { project_dependency_files("npm8/simple") }
     let(:include_patterns) { [] }
     let(:exclude_patterns) { [] }
+    let(:semver_major_days) { nil }
+    let(:semver_minor_days) { nil }
+    let(:semver_patch_days) { nil }
     let(:cooldown) do
       Dependabot::Package::ReleaseCooldownOptions.new(
         default_days: 7,
+        semver_major_days: semver_major_days,
+        semver_minor_days: semver_minor_days,
+        semver_patch_days: semver_patch_days,
         include: include_patterns,
         exclude: exclude_patterns
       )
@@ -4424,6 +4430,75 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       let(:updater_options) { {} }
 
       it "returns nil" do
+        expect(updater.send(:cooldown_release_age_days)).to be_nil
+      end
+    end
+
+    # Regression coverage for dependabot/dependabot-core#15937: the native gate is
+    # a single global value, so a value stricter than the rule that selected a
+    # version makes the package manager refuse the install it was just asked to
+    # perform (skipped update, or a hung npm resolver).
+    context "when the cooldown sets per-semver-type days" do
+      let(:semver_major_days) { 21 }
+      let(:semver_minor_days) { 14 }
+      let(:semver_patch_days) { 3 }
+
+      it "uses the days that selected the version, not default_days" do
+        # fetch-factory 0.0.1 -> 0.0.2 is a patch bump, approved under 3 days.
+        expect(updater.send(:cooldown_release_age_days)).to eq(3)
+      end
+
+      context "when the bump is a major" do
+        let(:previous_version) { "1.0.0" }
+        let(:version) { "2.0.0" }
+
+        it "uses the major window" do
+          expect(updater.send(:cooldown_release_age_days)).to eq(21)
+        end
+      end
+
+      context "when a group mixes bump types" do
+        let(:other_dependency) do
+          Dependabot::Dependency.new(
+            name: "etag",
+            version: "2.0.0",
+            previous_version: "1.0.0",
+            requirements: requirements,
+            previous_requirements: previous_requirements,
+            package_manager: "npm_and_yarn"
+          )
+        end
+        let(:dependencies) { [dependency, other_dependency] }
+
+        it "uses the smallest window so no selected version is rejected" do
+          expect(updater.send(:cooldown_release_age_days)).to eq(3)
+        end
+      end
+
+      context "when the version cannot be parsed" do
+        let(:version) { "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0" }
+
+        it "falls back to default_days" do
+          expect(updater.send(:cooldown_release_age_days)).to eq(7)
+        end
+      end
+    end
+
+    context "when only some dependencies in the group are excluded" do
+      let(:exclude_patterns) { ["@myorg-*/*"] }
+      let(:other_dependency) do
+        Dependabot::Dependency.new(
+          name: "@myorg-team/lib",
+          version: "1.0.1",
+          previous_version: "1.0.0",
+          requirements: requirements,
+          previous_requirements: previous_requirements,
+          package_manager: "npm_and_yarn"
+        )
+      end
+      let(:dependencies) { [dependency, other_dependency] }
+
+      it "skips the gate, which would otherwise apply to the excluded dependency" do
         expect(updater.send(:cooldown_release_age_days)).to be_nil
       end
     end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater_spec.rb
@@ -4433,16 +4433,16 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
     context "when the updated dependency is excluded from the cooldown" do
       let(:exclude_patterns) { ["fetch-factory"] }
 
-      it "returns nil so the transitive gate is skipped" do
-        expect(updater.send(:cooldown_release_age_days)).to be_nil
+      it "falls back to the default floor rather than dropping the gate" do
+        expect(updater.send(:cooldown_release_age_days)).to eq(3)
       end
     end
 
     context "when an include list does not match the updated dependency" do
       let(:include_patterns) { ["some-other-dep"] }
 
-      it "returns nil so the transitive gate is skipped" do
-        expect(updater.send(:cooldown_release_age_days)).to be_nil
+      it "falls back to the default floor rather than dropping the gate" do
+        expect(updater.send(:cooldown_release_age_days)).to eq(3)
       end
     end
 
@@ -4534,8 +4534,26 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater do
       end
       let(:dependencies) { [dependency, other_dependency] }
 
-      it "skips the gate, which would otherwise apply to the excluded dependency" do
-        expect(updater.send(:cooldown_release_age_days)).to be_nil
+      it "falls back to the default floor rather than dropping the gate" do
+        expect(updater.send(:cooldown_release_age_days)).to eq(3)
+      end
+
+      context "when the cooldown is explicitly disabled" do
+        let(:cooldown) do
+          Dependabot::Package::ReleaseCooldownOptions.new(default_days: 0, exclude: exclude_patterns)
+        end
+
+        it "applies no gate" do
+          expect(updater.send(:cooldown_release_age_days)).to be_nil
+        end
+      end
+
+      context "when a selected window is shorter than the floor" do
+        let(:semver_patch_days) { 1 }
+
+        it "does not exceed that window" do
+          expect(updater.send(:cooldown_release_age_days)).to eq(1)
+        end
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

The native release-age gate from #15485 is a single global value per invocation, but we derived it in ways that contradict the update being performed, so the package manager rejects the install we just asked for.

- **Fixes #15937** — the gate used `default_days` while version selection uses `cooldown_days_for(current, target)`. With `default-days: 14` / `semver-patch-days: 7`, a 7-day-old patch gets selected and then rejected (`npm error notarget`), which shows up as a skipped update or a hung resolver (npm/cli#9891). The gate is now the **min** of the per-update cooldown days, each **capped at `default_days`**, and is **skipped entirely unless every dependency in the invocation is cooldown-included**.
- **pnpm** re-verifies entries *already in the lockfile* against the gate, so versions a human committed inside the window fail the whole command (`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`) even though Dependabot neither introduced them nor can fix them. On pnpm 11.3+ we now pass `--config.trustLockfile=true`, which skips **only** that verification pass over loaded entries.

The guiding principle is best effort: **enforce the cooldown and still deliver an update**. A zero cooldown means no gate at all; a configured cooldown is applied to everything pnpm resolves now, and pre-existing lockfile entries — which Dependabot cannot do anything about — no longer cost us the gate entirely.

Two details worth stating explicitly, because both were reviewer-driven course corrections:

**`trustLockfile` is applied narrowly, not unconditionally.** pnpm's own changelog for 11.3 describes it as skipping "the supply-chain verification pass that re-applies `minimumReleaseAge` / `trustPolicy='no-downgrade'` to every entry in the loaded lockfile" — it does *not* relax the gate for versions being resolved. Because it also suppresses `trustPolicy` re-verification of those entries, it is skipped whenever the repo states its own policy (`trustLockfile` or `trustPolicy` in `pnpm-workspace.yaml`), so an independent supply-chain control is never silently disabled. Security updates are untouched: they already pass `minimumReleaseAge=0`.

**The ungated retry is now a last resort, not the primary path.** For pnpm 10.16–11.2 (no `trustLockfile`) and for repos that set their own verification policy, a lockfile-verification violation still drops the gate for one retry so the update is not blocked. That retry is matched on pnpm's verification wording rather than the bare error code:

```ruby
/ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION[\s\S]*lockfile entries failed verification/
```

pnpm raises the same code when a *newly resolved* transitive version is too young, and retrying ungated there would admit exactly the release the cooldown exists to reject. A resolution-time violation is re-raised as before.

**Each per-dependency window is capped at `default_days`.** A dependency absent from the lockfile is selected using `default_days`, because the checker has no current version, but `VersionResolver#resolve_latest_previous_version` later infers a `previous_version` from the manifest requirement. Without the cap, that inference could produce a stricter semver window (e.g. a 21-day major gate on a release selected under 7 days) — the same select-then-reject contradiction this PR exists to remove.

### Anything you want to highlight for special attention from reviewers?

The remaining coverage tradeoffs, all in service of not breaking the update:

- a group containing a cooldown-excluded dependency gets **no** gate at all, because selection gives that dependency a zero-day window and any global value could reject a version it approved;
- a mixed group is gated at its **smallest** window;
- a semver window longer than `default_days` is capped down to it;
- on pnpm < 11.3, or where the repo sets its own verification policy, a pre-existing lockfile entry inside the window still costs the gate for that command.

Push back if any of those is the wrong call.

### How will you know you've accomplished your goal?

**pnpm half — reproduced and fixed.** A real job on a pnpm repo failed `eslint-plugin-svelte` and `svelte` with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` on lockfile entries it hadn't introduced (`svelte-eslint-parser@1.8.1`, `esrap@2.3.4`), reporting 2 errors and no PR. Re-running the same job at the same commit with this branch produces a PR with all 17 dependencies and no job errors.

A second local run against a different repo (`cooldown: default-days: 3`) confirms the derivation end to end: pnpm is invoked with `--config.minimumReleaseAge=4320`, matching the 3-day cutoff pnpm itself reports, and the run proceeds instead of erroring.

**npm half — still not reproduced against a live npm job.** It is covered by specs that drive the public `updated_dependency_files` path and assert the flag npm actually receives, rather than the derived number: the per-semver case invokes `--min-release-age=3` (the patch window) instead of `=14`, and an excluded or non-included dependency produces no `--min-release-age` argument at all. Reverting the derivation to `default_days` makes those examples fail with `expected: "--min-release-age=3" got: "--min-release-age=7"`, which is the reported bug.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
