### PR TITLE
Fix Gradle substitution security checks

### DIFF
--- a/gradle/lib/dependabot/gradle/file_parser.rb
+++ b/gradle/lib/dependabot/gradle/file_parser.rb
@@ -38,7 +38,14 @@ module Dependabot
 
       PART = %r{[^\s,@'":/\\]+}
       VSN_PART = %r{[^\s,'":/\\]+}
-      DEPENDENCY_DECLARATION_REGEX = /(?:\(|\s)\s*['"](?<declaration>#{PART}:#{PART}:#{VSN_PART})['"]/o
+      DEPENDENCY_SUBSTITUTION_DECLARATION_TYPE = "dependency_substitution"
+      DEPENDENCY_DECLARATION_REGEX = /
+        (?:
+          (?<dependency_substitution>\b(?:substitute|using)\s*(?:\(\s*)?module\s*\(\s*)|
+          (?:\(|\s)\s*
+        )
+        ['"](?<declaration>#{PART}:#{PART}:#{VSN_PART})['"]
+      /ox
 
       DEPENDENCY_SET_DECLARATION_REGEX = /(?:^|\s)dependencySet\((?<arguments>[^\)]+)\)\s*\{/
       DEPENDENCY_SET_ENTRY_REGEX = /entry\s+['"](?<name>#{PART})['"]/o
@@ -270,11 +277,16 @@ module Dependabot
         dependency_set = DependencySet.new
 
         prepared_content(buildfile).scan(DEPENDENCY_DECLARATION_REGEX) do
-          declaration = T.must(Regexp.last_match).named_captures.fetch("declaration")
+          match = T.must(Regexp.last_match)
+          captures = match.named_captures
+          declaration = captures.fetch("declaration")
 
           group, name, version = T.must(declaration).split(":")
           version, _packaging_type = T.must(version).split("@")
           details = { group: group, name: name, version: version }
+          if captures.fetch("dependency_substitution")
+            details[:declaration_type] = DEPENDENCY_SUBSTITUTION_DECLARATION_TYPE
+          end
 
           dep = dependency_from(details_hash: details, buildfile: buildfile)
           dependency_set << dep if dep
@@ -465,11 +477,13 @@ module Dependabot
           T.cast(details_hash[:version], String)
            .match(PROPERTY_REGEX)
            &.named_captures&.fetch("property_name")
+        declaration_type = T.cast(details_hash[:declaration_type], T.nilable(String))
 
-        return unless version_property_name || in_dependency_set
+        return unless version_property_name || in_dependency_set || declaration_type
 
         metadata = T.let({}, T::Hash[Symbol, T.any(String, T::Hash[Symbol, String])])
         metadata[:property_name] = version_property_name if version_property_name
+        metadata[:declaration_type] = declaration_type if declaration_type
         if in_dependency_set
           metadata[:dependency_set] = T.let(
             {

--- a/gradle/lib/dependabot/gradle/file_updater.rb
+++ b/gradle/lib/dependabot/gradle/file_updater.rb
@@ -67,6 +67,7 @@ module Dependabot
         # dependencies may have multiple requirements targeting the same file or build dir
         # we keep the last one by path to later run its native helpers
         buildfiles_processed = T.let({}, T::Hash[String, Dependabot::DependencyFile])
+        applied_text_changes = T.let(Set.new, T::Set[T::Array[String]])
 
         # The UpdateChecker ensures the order of requirements is preserved
         # when updating, so we can zip them together in new/old pairs.
@@ -93,6 +94,13 @@ module Dependabot
           elsif new_req.metadata_string_hash("dependency_set")
             files = update_files_for_dep_set_change(files, old_req, new_req)
           else
+            text_change_key = [
+              T.must(new_req.file),
+              old_req.requirement.to_s,
+              new_req.requirement.to_s
+            ]
+            next unless applied_text_changes.add?(text_change_key)
+
             files[T.must(files.index(buildfile))] = update_version_in_buildfile(dependency, buildfile, old_req, new_req)
           end
 
@@ -229,7 +237,8 @@ module Dependabot
         original_content = T.must(buildfile.content.dup)
 
         updated_content =
-          original_buildfile_declarations(dependency, previous_req).reduce(original_content) do |content, declaration|
+          original_buildfile_declarations(dependency, previous_req, buildfile)
+          .reduce(original_content) do |content, declaration|
             content.gsub(
               declaration,
               updated_buildfile_declaration(declaration, previous_req, requirement)
@@ -241,19 +250,18 @@ module Dependabot
         updated_file(file: buildfile, content: updated_content)
       end
 
-      # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/PerceivedComplexity
       sig do
         params(
           dependency: Dependabot::Dependency,
-          requirement: Dependabot::DependencyRequirement
+          requirement: Dependabot::DependencyRequirement,
+          buildfile: Dependabot::DependencyFile
         ).returns(T::Array[String])
       end
-      def original_buildfile_declarations(dependency, requirement)
+      def original_buildfile_declarations(dependency, requirement, buildfile)
         # This implementation is limited to declarations that appear on a
         # single line.
         file = T.must(requirement.file)
-        buildfile = T.must(buildfiles.find { |f| f.name == file })
 
         T.must(buildfile.content).lines.select do |line|
           line = evaluate_properties(line, buildfile)
@@ -276,7 +284,6 @@ module Dependabot
           line.include?(T.must(requirement.requirement_string))
         end
       end
-      # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/PerceivedComplexity
 
       sig { params(string: String, buildfile: Dependabot::DependencyFile).returns(String) }

--- a/gradle/spec/dependabot/gradle/file_parser_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_parser_spec.rb
@@ -452,6 +452,44 @@ RSpec.describe Dependabot::Gradle::FileParser do
       its(:length) { is_expected.to eq(20) }
     end
 
+    context "with a dependency substitution target" do
+      let(:build_plugin_name) { "com.example:build-plugin" }
+      let(:substitution_dependency_name) { "com.fasterxml.jackson.core:jackson-databind" }
+      let(:versioned_substitution_dependency_name) { "com.example:versioned-substitution" }
+      let(:substitution_declaration_type) do
+        described_class::DEPENDENCY_SUBSTITUTION_DECLARATION_TYPE
+      end
+      let(:files) { [settings_file] }
+      let(:settings_file) do
+        Dependabot::DependencyFile.new(
+          name: "settings.gradle",
+          content: fixture("settings_files", "dependency_substitution_settings.gradle")
+        )
+      end
+
+      it "marks substitution declarations while keeping them parsed" do
+        expect(dependencies.map(&:name)).to contain_exactly(
+          build_plugin_name,
+          substitution_dependency_name,
+          versioned_substitution_dependency_name
+        )
+
+        build_plugin = dependencies.find { |dependency| dependency.name == build_plugin_name }
+        substitution = dependencies.find { |dependency| dependency.name == substitution_dependency_name }
+        versioned_substitution = dependencies.find do |dependency|
+          dependency.name == versioned_substitution_dependency_name
+        end
+        expect(build_plugin.requirements.first.metadata).to be_nil
+        expect(substitution.requirements.first.metadata).to eq(
+          { declaration_type: substitution_declaration_type }
+        )
+        expect(versioned_substitution.requirements.map(&:metadata)).to contain_exactly(
+          { declaration_type: substitution_declaration_type },
+          { declaration_type: substitution_declaration_type }
+        )
+      end
+    end
+
     context "with kotlin" do
       let(:buildfile) do
         Dependabot::DependencyFile.new(

--- a/gradle/spec/dependabot/gradle/file_updater_spec.rb
+++ b/gradle/spec/dependabot/gradle/file_updater_spec.rb
@@ -8,6 +8,29 @@ require "dependabot/gradle/file_updater"
 require_common_spec "file_updaters/shared_examples_for_file_updaters"
 
 RSpec.describe Dependabot::Gradle::FileUpdater do
+  def substitution_requirement(version, file: "settings.gradle")
+    {
+      file: file,
+      requirement: version,
+      groups: [],
+      source: nil,
+      metadata: {
+        declaration_type:
+          Dependabot::Gradle::FileParser::DEPENDENCY_SUBSTITUTION_DECLARATION_TYPE
+      }
+    }
+  end
+
+  def regular_requirement(version)
+    {
+      file: "build.gradle",
+      requirement: version,
+      groups: [],
+      source: nil,
+      metadata: nil
+    }
+  end
+
   let(:dependency) do
     Dependabot::Dependency.new(
       name: "co.aikar:acf-paper",
@@ -83,6 +106,73 @@ RSpec.describe Dependabot::Gradle::FileUpdater do
     end
 
     its(:length) { is_expected.to eq(1) }
+
+    context "with multiple substitution requirements on the same line" do
+      let(:dependency_files) { [buildfile] }
+      let(:buildfile) do
+        Dependabot::DependencyFile.new(
+          name: "settings.gradle",
+          content: fixture("settings_files", "dependency_substitution_settings.gradle")
+        )
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "com.example:versioned-substitution",
+          version: "3.0.0",
+          previous_version: "2.0.0",
+          requirements: [
+            substitution_requirement("3.0.0"),
+            substitution_requirement("3.0.0")
+          ],
+          previous_requirements: [
+            substitution_requirement("1.0.0"),
+            substitution_requirement("2.0.0")
+          ],
+          package_manager: "gradle"
+        )
+      end
+
+      it "updates the source and target without processing the line twice" do
+        expect(updated_files.first.content).to include(
+          "substitute(module('com.example:versioned-substitution:3.0.0'))" \
+          ".using(module('com.example:versioned-substitution:3.0.0'))"
+        )
+      end
+    end
+
+    context "with a regular declaration and substitution target on the same line" do
+      let(:dependency_files) { [buildfile] }
+      let(:buildfile) do
+        Dependabot::DependencyFile.new(
+          name: "build.gradle",
+          content: fixture("buildfiles", "dependency_and_substitution_same_line.gradle")
+        )
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "com.example:mixed-declaration",
+          version: "2.0.0",
+          previous_version: "1.0.0",
+          requirements: [
+            regular_requirement("2.0.0"),
+            substitution_requirement("2.0.0", file: "build.gradle")
+          ],
+          previous_requirements: [
+            regular_requirement("1.0.0"),
+            substitution_requirement("1.0.0", file: "build.gradle")
+          ],
+          package_manager: "gradle"
+        )
+      end
+
+      it "updates both declarations without processing the line twice" do
+        expect(updated_files.first.content).to include(
+          "implementation('com.example:mixed-declaration:2.0.0'); " \
+          "substitute module('com.example:mixed-declaration') " \
+          "using module('com.example:mixed-declaration:2.0.0')"
+        )
+      end
+    end
 
     describe "the updated build.gradle file" do
       subject(:updated_buildfile) do

--- a/gradle/spec/fixtures/buildfiles/dependency_and_substitution_same_line.gradle
+++ b/gradle/spec/fixtures/buildfiles/dependency_and_substitution_same_line.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation('com.example:mixed-declaration:1.0.0'); substitute module('com.example:mixed-declaration') using module('com.example:mixed-declaration:1.0.0')
+}

--- a/gradle/spec/fixtures/settings_files/dependency_substitution_settings.gradle
+++ b/gradle/spec/fixtures/settings_files/dependency_substitution_settings.gradle
@@ -1,0 +1,15 @@
+buildscript {
+    dependencies {
+        classpath module('com.example:build-plugin:1.0.0')
+    }
+}
+
+gradle.beforeProject { project ->
+    project.configurations.configureEach { configuration ->
+        configuration.resolutionStrategy.dependencySubstitution { substitutions ->
+            substitutions.substitute module('com.fasterxml.jackson.core:jackson-databind') using
+                module('com.fasterxml.jackson.core:jackson-databind:2.22.1')
+            substitutions.substitute(module('com.example:versioned-substitution:1.0.0')).using(module('com.example:versioned-substitution:2.0.0'))
+        }
+    }
+}

--- a/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_security_update_pull_request.rb
@@ -127,7 +127,7 @@ module Dependabot
           unless checker.vulnerable?
             # The current dependency isn't vulnerable if the version is correct and
             # can be matched against the advisories affected versions
-            if checker.version_class.correct?(checker.dependency.version)
+            if resolved_version_known_for_security_update?(checker)
               return record_security_update_not_needed_error(checker.dependency)
             end
 
@@ -232,6 +232,24 @@ module Dependabot
           return dependency unless vulnerable_dependency
 
           vulnerable_dependency
+        end
+
+        sig { params(checker: Dependabot::UpdateCheckers::Base).returns(T::Boolean) }
+        def resolved_version_known_for_security_update?(checker)
+          return false if dependency_substitution_only?(checker.dependency)
+
+          checker.version_class.correct?(checker.dependency.version)
+        end
+
+        sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
+        def dependency_substitution_only?(dependency)
+          return false unless job.package_manager == "gradle"
+          return false if dependency.requirements.empty?
+
+          dependency.requirements.all? do |requirement|
+            requirement.metadata_string("declaration_type") ==
+              Dependabot::Gradle::FileParser::DEPENDENCY_SUBSTITUTION_DECLARATION_TYPE
+          end
         end
 
         sig { params(dependency: Dependabot::Dependency).returns(Dependabot::UpdateCheckers::Base) }

--- a/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_security_update_pull_request_spec.rb
@@ -14,6 +14,7 @@ require "dependabot/dependency_change_builder"
 require "dependabot/notices"
 
 require "dependabot/bundler"
+require "dependabot/gradle/file_parser"
 
 RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest do
   include DependencyFileHelpers
@@ -235,6 +236,13 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
   end
 
   describe "#perform" do
+    let(:substitution_dependency_name) { "com.fasterxml.jackson.core:jackson-databind" }
+    let(:substitution_dependency_version) { "2.22.1" }
+    let(:substitution_declaration_type) do
+      Dependabot::Gradle::FileParser::DEPENDENCY_SUBSTITUTION_DECLARATION_TYPE
+    end
+    let(:substitution_file) { "settings.gradle" }
+
     before do
       allow(dependency_snapshot).to receive(
         :dependencies
@@ -270,6 +278,124 @@ RSpec.describe Dependabot::Updater::Operations::CreateSecurityUpdatePullRequest 
         expect(mock_error_handler).not_to receive(
           :handle_dependency_error
         )
+        perform
+      end
+    end
+
+    context "when the dependency version comes only from a substitution target" do
+      before do
+        allow(job).to receive(:package_manager).and_return("gradle")
+        allow(job).to receive_messages(blocked_versions_for?: false, allowed_update?: true)
+        allow(create_security_update_pull_request).to receive(:update_checker_for).and_return(stub_update_checker)
+      end
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: substitution_dependency_name,
+          version: substitution_dependency_version,
+          requirements: [{
+            file: substitution_file,
+            requirement: substitution_dependency_version,
+            groups: [],
+            source: nil,
+            metadata: { declaration_type: substitution_declaration_type }
+          }],
+          package_manager: "gradle"
+        )
+      end
+
+      context "when the declared version is not vulnerable" do
+        before do
+          allow(stub_update_checker).to receive(:vulnerable?).and_return(false)
+        end
+
+        it "does not use the substitution as proof that the resolved dependency is safe" do
+          expect(create_security_update_pull_request).not_to receive(:create_pull_request)
+          expect(mock_service).to receive(:record_update_job_error).with(
+            error_type: "dependency_file_not_supported",
+            error_details: { "dependency-name": substitution_dependency_name }
+          )
+
+          perform
+        end
+      end
+
+      context "when the declared version is vulnerable" do
+        it "continues through the normal security update path" do
+          expect(create_security_update_pull_request)
+            .to receive(:create_pull_request)
+            .with(stub_dependency_change)
+
+          perform
+        end
+      end
+    end
+
+    context "when the dependency also has a regular declaration" do
+      before do
+        allow(job).to receive(:package_manager).and_return("gradle")
+        allow(job).to receive_messages(blocked_versions_for?: false, allowed_update?: true)
+        allow(create_security_update_pull_request).to receive(:update_checker_for).and_return(stub_update_checker)
+      end
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: substitution_dependency_name,
+          version: substitution_dependency_version,
+          requirements: [
+            {
+              file: substitution_file,
+              requirement: substitution_dependency_version,
+              groups: [],
+              source: nil,
+              metadata: { declaration_type: substitution_declaration_type }
+            },
+            {
+              file: "build.gradle",
+              requirement: substitution_dependency_version,
+              groups: [],
+              source: nil
+            }
+          ],
+          package_manager: "gradle"
+        )
+      end
+
+      it "continues through the normal security update path" do
+        expect(create_security_update_pull_request)
+          .to receive(:create_pull_request)
+          .with(stub_dependency_change)
+
+        perform
+      end
+    end
+
+    context "when a non-Gradle dependency has substitution metadata" do
+      before do
+        allow(stub_update_checker).to receive(:vulnerable?).and_return(false)
+      end
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: substitution_dependency_name,
+          version: substitution_dependency_version,
+          requirements: [{
+            file: substitution_file,
+            requirement: substitution_dependency_version,
+            groups: [],
+            source: nil,
+            metadata: { declaration_type: substitution_declaration_type }
+          }],
+          package_manager: "bundler"
+        )
+      end
+
+      it "uses the normal non-vulnerable result" do
+        expect(mock_service).to receive(:record_update_job_error).with(
+          error_type: "security_update_not_needed",
+          error_details: { "dependency-name": substitution_dependency_name }
+        )
+
         perform
       end
     end


### PR DESCRIPTION
###What are you trying to accomplish?

Dependabot incorrectly reported that  jackson-databind  was no longer vulnerable because the Gradle parser treated a safe version from a dependency substitution rule as the resolved dependency version.

For example,  settings.gradle  contained a substitution targeting  2.22.1 , while the Spring Boot buildscript classpath still resolved vulnerable  2.21.4 . Substitution rules do not necessarily apply to every Gradle configuration, particularly the buildscript classpath.

This PR:

• marks versioned  substitute module(...)  and  using module(...)  declarations as dependency substitutions;
• avoids using substitution-only versions as proof that the resolved dependency is safe;
• reports  dependency_file_not_supported  instead of the misleading  security_update_not_needed ;
• preserves security updates when the declared substitution version is vulnerable;
• preserves normal handling when a regular dependency declaration also exists.

###Anything you want to highlight for special attention from reviewers?

1. Scoped to Gradle security updates — other ecosystems and regular Gradle version updates are unchanged.
2. Vulnerable substitutions remain updateable — the special handling occurs only after the update checker determines that the substitution literal is not vulnerable.
3. Both substitution sides are identified — versioned source and target declarations are tagged, including chained and multiline Gradle syntax.
4. No repeated prefix allocations — substitution context is captured during the existing regex scan without using  MatchData#pre_match .
5. This does not resolve Gradle dependency graphs — Dependabot still cannot identify the transitive  2.21.4  buildscript occurrence without executing Gradle or consuming a lockfile. Returning  dependency_file_not_supported  is the accurate result in that case.

###How will you know you've accomplished your goal?

The regression scenarios validate that:

1. A safe substitution-only version does not produce  security_update_not_needed .
2. A vulnerable substitution-only version continues through normal PR creation.
3. A dependency with regular and substitution declarations follows the normal security-update path.
4. Both versioned substitution sources and targets are tagged.
5. The customer’s multiline  using module(...)  syntax is parsed correctly.

Gradle parser: 88 examples passing. Updater operation: 17 examples passing. RuboCop and Sorbet are clean.

###Checklist

✓ I have run the relevant test suites and linters.
✓ I have thoroughly tested the changes, including regression coverage.
✓ I have written a clear and descriptive commit message.
✓ I have provided a detailed description of the problem and implementation.
✓ I have reviewed my changes.

