### PR TITLE
Type provider response boundaries

### DIFF
--- a/bazel/lib/dependabot/bazel/update_checker/registry_client.rb
+++ b/bazel/lib/dependabot/bazel/update_checker/registry_client.rb
@@ -3,6 +3,7 @@
 
 require "json"
 require "base64"
+require "time"
 require "sorbet-runtime"
 require "dependabot/shared_helpers"
 require "dependabot/clients/github_with_retries"
@@ -66,10 +67,8 @@ module Dependabot
           file_path = "modules/#{module_name}/#{version}/source.json"
 
           begin
-            content = T.unsafe(github_client.contents(GITHUB_REPO, path: file_path))
-            return nil unless content
-
-            decoded_content = Base64.decode64(content.content)
+            content = github_file_content(file_path)
+            decoded_content = Base64.decode64(content)
             JSON.parse(decoded_content)
           rescue StandardError => e
             Dependabot.logger.warn("Failed to get source for #{module_name}@#{version}: #{e.message}")
@@ -82,10 +81,7 @@ module Dependabot
           file_path = "modules/#{module_name}/#{version}/MODULE.bazel"
 
           begin
-            content = T.unsafe(github_client.contents(GITHUB_REPO, path: file_path))
-            return nil unless content
-
-            Base64.decode64(content.content)
+            Base64.decode64(github_file_content(file_path))
           rescue StandardError => e
             Dependabot.logger.warn("Failed to get MODULE.bazel for #{module_name}@#{version}: #{e.message}")
             nil
@@ -102,17 +98,44 @@ module Dependabot
           file_path = "modules/#{module_name}/#{version}/MODULE.bazel"
 
           commits = begin
-            T.unsafe(github_client).commits("bazelbuild/bazel-central-registry", path: file_path, per_page: 1)
+            github_client.commits("bazelbuild/bazel-central-registry", path: file_path, per_page: 1)
           rescue StandardError => e
             Dependabot.logger.warn("Failed to get release date for #{module_name} #{version}: #{e.message}")
+            nil
           end
 
-          return nil unless commits&.any?
+          commit = commits&.first
+          return nil unless commit
 
-          T.unsafe(commits).first.commit.committer.date
+          commit_details = resource_field(commit, :commit, "commit details")
+          committer = resource_field(commit_details, :committer, "committer")
+          value = T.cast(committer[:date], Object)
+          return value if value.is_a?(Time)
+          return Time.parse(value) if value.is_a?(String)
+
+          raise TypeError, "committer date must be a time or string"
         end
 
         private
+
+        sig { params(file_path: String).returns(String) }
+        def github_file_content(file_path)
+          response = github_client.contents(GITHUB_REPO, path: file_path)
+          raise TypeError, "GitHub file response must be an object" unless response.is_a?(Sawyer::Resource)
+
+          value = T.cast(response[:content], Object)
+          return value if value.is_a?(String)
+
+          raise TypeError, "GitHub file content must be a string"
+        end
+
+        sig { params(resource: Sawyer::Resource, key: Symbol, context: String).returns(Sawyer::Resource) }
+        def resource_field(resource, key, context)
+          value = T.cast(resource[key], Object)
+          return value if value.is_a?(Sawyer::Resource)
+
+          raise TypeError, "#{context} must be an object"
+        end
 
         sig { returns(Dependabot::Clients::GithubWithRetries) }
         def github_client

--- a/bazel/spec/dependabot/bazel/update_checker/registry_client_spec.rb
+++ b/bazel/spec/dependabot/bazel/update_checker/registry_client_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe Dependabot::Bazel::UpdateChecker::RegistryClient do
   let(:client) { described_class.new(credentials: credentials) }
   let(:octokit_client) { instance_double(Octokit::Client) }
   let(:github_client) { instance_double(Dependabot::Clients::GithubWithRetries) }
+  let(:sawyer_agent) { instance_double(Sawyer::Agent) }
 
   before do
     allow(client).to receive(:github_client).and_return(github_client)
     allow(github_client).to receive(:method_missing) do |method_name, *args, &block|
       octokit_client.public_send(method_name, *args, &block)
     end
+    allow(sawyer_agent).to receive(:parse_links) { |value| [value, {}] }
   end
 
   describe "#all_module_versions" do
@@ -164,7 +166,7 @@ RSpec.describe Dependabot::Bazel::UpdateChecker::RegistryClient do
 
         # Simulate GitHub API returning base64 encoded content
         encoded_content = Base64.encode64(source_content)
-        github_response = Data.define(:content).new(encoded_content)
+        github_response = Sawyer::Resource.new(sawyer_agent, { content: encoded_content })
 
         allow(octokit_client).to receive(:contents)
           .with("bazelbuild/bazel-central-registry", hash_including(path: "modules/rules_go/0.57.0/source.json"))
@@ -194,7 +196,7 @@ RSpec.describe Dependabot::Bazel::UpdateChecker::RegistryClient do
       it "returns nil and logs warning" do
         # Simulate GitHub API returning base64 encoded invalid content
         encoded_content = Base64.encode64("invalid json content")
-        github_response = Data.define(:content).new(encoded_content)
+        github_response = Sawyer::Resource.new(sawyer_agent, { content: encoded_content })
 
         allow(octokit_client).to receive(:contents)
           .and_return(github_response)
@@ -222,7 +224,7 @@ RSpec.describe Dependabot::Bazel::UpdateChecker::RegistryClient do
 
         # Simulate GitHub API returning base64 encoded content
         encoded_content = Base64.encode64(module_content)
-        github_response = Data.define(:content).new(encoded_content)
+        github_response = Sawyer::Resource.new(sawyer_agent, { content: encoded_content })
 
         allow(octokit_client).to receive(:contents)
           .with("bazelbuild/bazel-central-registry", hash_including(path: "modules/rules_go/0.57.0/MODULE.bazel"))
@@ -265,6 +267,25 @@ RSpec.describe Dependabot::Bazel::UpdateChecker::RegistryClient do
       exists = client.module_version_exists?("rules_go", "nonexistent")
 
       expect(exists).to be false
+    end
+  end
+
+  describe "#get_version_release_date" do
+    it "returns the latest commit date" do
+      github_response = Sawyer::Resource.new(
+        sawyer_agent,
+        { commit: { committer: { date: "2026-08-15T12:34:56Z" } } }
+      )
+
+      allow(octokit_client).to receive(:commits)
+        .with(
+          "bazelbuild/bazel-central-registry",
+          { path: "modules/rules_go/0.57.0/MODULE.bazel", per_page: 1 }
+        )
+        .and_return([github_response])
+
+      expect(client.get_version_release_date("rules_go", "0.57.0"))
+        .to eq(Time.utc(2026, 8, 15, 12, 34, 56))
     end
   end
 end

--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -264,6 +264,9 @@ module Dependabot
         def fetch_github_file(file_source, file)
           # Hitting the download URL directly causes encoding problems
           response = github_client_for_source(file_source).get(T.must(file.api_url))
+          raise_bad_metadata_response("GitHub", "file response must be an object", source_url: file_source.url) unless
+            response.is_a?(Sawyer::Resource)
+
           raw_content = sawyer_string(response, :content, source_url: file_source.url)
           Base64.decode64(raw_content).force_encoding("UTF-8").encode
         end

--- a/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
+++ b/git_submodules/lib/dependabot/git_submodules/file_fetcher.rb
@@ -75,7 +75,7 @@ module Dependabot
                  fetch_github_submodule_commit(path)
                when "gitlab"
                  tmp_path = path.gsub(%r{^/*}, "")
-                 T.unsafe(gitlab_client.get_file(repo, tmp_path, T.must(commit))).blob_id
+                 gitlab_string(gitlab_client.get_file(repo, tmp_path, T.must(commit)), "blob_id")
                when "azure"
                  azure_client.fetch_file_contents(T.must(commit), path)
                else raise "Unsupported provider '#{source.provider}'."
@@ -100,9 +100,23 @@ module Dependabot
           path: path,
           ref: commit
         )
-        raise Dependabot::DependencyFileNotFound, path if content.is_a?(Array) || T.unsafe(content).type != "submodule"
+        raise Dependabot::DependencyFileNotFound, path unless content.is_a?(Sawyer::Resource)
 
-        T.unsafe(content).sha
+        type = T.cast(content[:type], Object)
+        raise Dependabot::DependencyFileNotFound, path unless type == "submodule"
+
+        value = T.cast(content[:sha], Object)
+        return value if value.is_a?(String)
+
+        raise Dependabot::DependencyFileNotFound, path
+      end
+
+      sig { params(resource: Gitlab::ObjectifiedHash, key: String).returns(String) }
+      def gitlab_string(resource, key)
+        value = T.cast(resource[key], Object)
+        return value if value.is_a?(String)
+
+        raise Dependabot::PrivateSourceBadResponse.new(source.url, "Malformed GitLab response: #{key} must be a string")
       end
     end
   end

--- a/nix/lib/dependabot/nix/package/package_details_fetcher.rb
+++ b/nix/lib/dependabot/nix/package/package_details_fetcher.rb
@@ -89,7 +89,7 @@ module Dependabot
 
           Dependabot.logger.info("Fetching branch-tip history for Nix flake input: #{dependency.name}")
           entries = fetch_activity_entries(T.must(url), T.must(ref))
-          return nil unless entries.is_a?(Array) && entries.any?
+          return nil unless entries.any?
 
           trim_entries_to_locked_sha(entries)
         rescue Octokit::Error => e
@@ -106,31 +106,34 @@ module Dependabot
           nil
         end
 
-        sig { params(url: String, ref: String).returns(T.untyped) }
+        sig { params(url: String, ref: String).returns(T::Array[Sawyer::Resource]) }
         def fetch_activity_entries(url, ref)
-          T.unsafe(github_client).get( # rubocop:disable Sorbet/ForbidTUnsafe
+          response = github_client.get(
             "/repos/#{github_repo_path(url)}/activity",
             ref: "refs/heads/#{ref}",
             activity_type: ACTIVITY_TYPES,
             per_page: 100
           )
+          raise TypeError, "GitHub activity response must be an array" unless response.is_a?(Array)
+
+          response
         end
 
         # Trim to entries up to and including the currently locked SHA, stopping
         # once that SHA is reached so we don't introduce candidates older than
         # `dependency.version`.
-        sig { params(entries: T::Array[T.untyped]).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+        sig { params(entries: T::Array[Sawyer::Resource]).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
         def trim_entries_to_locked_sha(entries)
           locked = dependency.version
           result = T.let([], T::Array[T::Hash[Symbol, T.untyped]])
           entries.each do |e|
-            after_sha = e[:after]
-            result << { tag: after_sha, release_date: format_timestamp(e[:timestamp]) }
+            after_sha = activity_string(e, :after)
+            result << { tag: after_sha, release_date: format_timestamp(T.cast(e[:timestamp], T.nilable(Object))) }
 
             next unless locked
             break if after_sha == locked
 
-            if e[:before] == locked
+            if T.cast(e[:before], Object) == locked
               result << { tag: locked, release_date: nil } unless result.last&.fetch(:tag) == locked
               break
             end
@@ -138,12 +141,20 @@ module Dependabot
           result
         end
 
-        sig { params(timestamp: T.untyped).returns(T.nilable(String)) }
+        sig { params(timestamp: T.nilable(Object)).returns(T.nilable(String)) }
         def format_timestamp(timestamp)
-          return nil if timestamp.nil?
-          return timestamp.iso8601 if timestamp.respond_to?(:iso8601)
+          return if timestamp.nil?
+          return timestamp.iso8601 if timestamp.is_a?(Time)
 
           timestamp.to_s
+        end
+
+        sig { params(entry: Sawyer::Resource, key: Symbol).returns(String) }
+        def activity_string(entry, key)
+          value = T.cast(entry[key], Object)
+          return value if value.is_a?(String)
+
+          raise TypeError, "GitHub activity #{key} must be a string"
         end
 
         sig { params(url: T.nilable(String), ref: T.nilable(String)).returns(T::Boolean) }

--- a/sorbet/rbi/shims/github_with_retries.rbi
+++ b/sorbet/rbi/shims/github_with_retries.rbi
@@ -168,7 +168,7 @@ module Dependabot
       def pull_request_commits(repo, number, options = {}); end
 
       # HTTP
-      sig { params(url: String, options: ClientOptions).returns(Sawyer::Resource) }
+      sig { params(url: String, options: ClientOptions).returns(T.any(Sawyer::Resource, T::Array[Sawyer::Resource])) }
       def get(url, options = {}); end
 
       # Pagination

--- a/uv/lib/dependabot/uv/file_fetcher/workspace_fetcher.rb
+++ b/uv/lib/dependabot/uv/file_fetcher/workspace_fetcher.rb
@@ -277,8 +277,8 @@ module Dependabot
           normalized_directory = directory.gsub(%r{(^/|/$)}, "")
 
           repo_contents(dir: base_dir, raise_errors: false)
-            .select { |file| T.unsafe(file).type == "dir" }
-            .map { |f| T.unsafe(f).path.gsub(%r{^/?#{Regexp.escape(normalized_directory)}/?}, "") }
+            .select { |file| file.type == "dir" }
+            .map { |file| file.path.gsub(%r{^/?#{Regexp.escape(normalized_directory)}/?}, "") }
         end
 
         sig { params(paths: T::Array[String], pattern: String).returns(T::Array[String]) }


### PR DESCRIPTION
Remove 10 `T.unsafe` calls from Bazel, git submodules, Nix, and UV provider responses.

`T.unsafe`: 22 -> 12.