### PR TITLE
Type version resolution boundaries

### DIFF
--- a/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
+++ b/bun/lib/dependabot/bun/update_checker/latest_version_finder.rb
@@ -141,7 +141,7 @@ module Dependabot
             secure_versions =
               Dependabot::UpdateCheckers::VersionFilters
               .filter_vulnerable_versions(
-                T.unsafe(secure_versions),
+                secure_versions,
                 security_advisories
               )
             secure_versions = filter_ignored_versions(secure_versions)
@@ -237,7 +237,7 @@ module Dependabot
         def possible_previous_releases
           (package_details&.releases || [])
             .reject do |r|
-            r.version.prerelease? && !related_to_current_pre?(T.unsafe(r.version))
+            r.version.prerelease? && !related_to_current_pre?(r.version)
           end
             .sort_by(&:version).reverse
         end

--- a/bun/lib/dependabot/bun/update_checker/version_resolver.rb
+++ b/bun/lib/dependabot/bun/update_checker/version_resolver.rb
@@ -341,11 +341,11 @@ module Dependabot
           return false unless types_pkg
 
           latest_types_version = latest_types_package_version
-          return false unless latest_types_version
+          return false unless latest_types_version.is_a?(Version)
 
           latest_allowable_ver = latest_allowable_version
           return false unless latest_allowable_ver.is_a?(Version) && latest_allowable_ver.backwards_compatible_with?(
-            T.unsafe(latest_types_version)
+            latest_types_version
           )
 
           return false unless version_class.correct?(types_pkg.version)
@@ -512,7 +512,7 @@ module Dependabot
             .possible_versions_with_details
             .select do |versions_with_details|
               version, details = versions_with_details
-              next false unless satisfies_peer_reqs_on_dep?(T.unsafe(version))
+              next false unless satisfies_peer_reqs_on_dep?(version)
               next true unless details["peerDependencies"]
               next true if version == version_for_dependency(dependency)
 

--- a/bun/lib/dependabot/bun/update_checker/version_resolver.rb
+++ b/bun/lib/dependabot/bun/update_checker/version_resolver.rb
@@ -341,7 +341,9 @@ module Dependabot
           return false unless types_pkg
 
           latest_types_version = latest_types_package_version
-          return false unless latest_types_version.is_a?(Version)
+          return false unless latest_types_version
+
+          latest_types_version = T.cast(latest_types_version, Version)
 
           latest_allowable_ver = latest_allowable_version
           return false unless latest_allowable_ver.is_a?(Version) && latest_allowable_ver.backwards_compatible_with?(

--- a/go_modules/lib/dependabot/go_modules/version.rb
+++ b/go_modules/lib/dependabot/go_modules/version.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 # Go pre-release versions use 1.0.1-rc1 syntax, which Gem::Version

--- a/go_modules/lib/dependabot/go_modules/version.rb
+++ b/go_modules/lib/dependabot/go_modules/version.rb
@@ -72,8 +72,11 @@ module Dependabot
         return if result.nil?
         return result unless result.zero?
 
-        other = self.class.new(other.to_s) unless other.is_a?(Version)
-        compare_prerelease(@prerelease_suffix || "", T.unsafe(other).prerelease_suffix || "")
+        other_version = T.cast(
+          other.is_a?(Dependabot::GoModules::Version) ? other : Dependabot::GoModules::Version.new(other.to_s),
+          Dependabot::GoModules::Version
+        )
+        compare_prerelease(@prerelease_suffix || "", other_version.prerelease_suffix || "")
       end
 
       protected

--- a/go_modules/lib/dependabot/go_modules/version.rb
+++ b/go_modules/lib/dependabot/go_modules/version.rb
@@ -73,7 +73,7 @@ module Dependabot
         return result unless result.zero?
 
         other_version = T.cast(
-          other.is_a?(Dependabot::GoModules::Version) ? other : Dependabot::GoModules::Version.new(other.to_s),
+          other.is_a?(Dependabot::GoModules::Version) ? other : self.class.new(other.to_s),
           Dependabot::GoModules::Version
         )
         compare_prerelease(@prerelease_suffix || "", other_version.prerelease_suffix || "")

--- a/go_modules/spec/dependabot/go_modules/version_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/version_spec.rb
@@ -134,6 +134,14 @@ RSpec.describe Dependabot::GoModules::Version do
   end
 
   describe "<=>" do
+    it "uses the receiver class when coercing another value" do
+      version_class = Class.new(described_class)
+      version = version_class.new("v1.0.0-pre1")
+
+      expect(version_class).to receive(:new).with("v1.0.0-pre1").twice.and_call_original
+      expect(version).to eq("v1.0.0-pre1")
+    end
+
     # These identifiers come from the Go docs: https://go.dev/ref/mod#pseudo-versions
     it "sorts major versions correctly" do
       expect(described_class.new("v1.0.0-0.20231231120000-abcdefabcdef")).to be < described_class.new("v1.0.0")

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb
@@ -141,7 +141,7 @@ module Dependabot
             secure_versions =
               Dependabot::UpdateCheckers::VersionFilters
               .filter_vulnerable_versions(
-                T.unsafe(secure_versions),
+                secure_versions,
                 security_advisories
               )
             secure_versions = filter_ignored_versions(secure_versions)
@@ -237,7 +237,7 @@ module Dependabot
         def possible_previous_releases
           (package_details&.releases || [])
             .reject do |r|
-            r.version.prerelease? && !related_to_current_pre?(T.unsafe(r.version))
+            r.version.prerelease? && !related_to_current_pre?(r.version)
           end
             .sort_by(&:version).reverse
         end


### PR DESCRIPTION
Remove seven `T.unsafe` calls from npm, Bun, and Go Modules version handling. Go Modules `Version` is now `typed: strong`.

`T.unsafe`: 12 -> 5.