### PR TITLE
Type helper payloads

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/npm_and_yarn/helpers"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -882,7 +882,7 @@ module Dependabot
         sig { params(pnpm_lock: Dependabot::DependencyFile).returns(String) }
         def npmrc_content(pnpm_lock)
           NpmrcBuilder.new(
-            credentials: T.unsafe(credentials),
+            credentials: credentials,
             dependency_files: dependency_files,
             dependencies: lockfile_dependencies(pnpm_lock)
           ).npmrc_content

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -477,8 +477,10 @@ module Dependabot
         # are seen.
         sig { params(content: String).returns(T::Array[String]) }
         def workspace_setting_names(content)
-          parsed = YAML.safe_load(content, aliases: true)
-          parsed.is_a?(Hash) ? parsed.keys.map(&:to_s) : []
+          parsed = T.cast(YAML.safe_load(content, aliases: true), Object)
+          return [] unless parsed.is_a?(Hash)
+
+          parsed.keys.map { |key| T.cast(key, Object).to_s }
         end
 
         # pnpm 10.x ignores `minimumReleaseAge` when `shared-workspace-lockfile` is

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb
@@ -455,12 +455,10 @@ module Dependabot
             SharedHelpers.run_helper_subprocess(
               command: NativeHelpers.helper_path,
               function: "yarn:update",
-              args: T.unsafe(
-                [
-                  Dir.pwd,
-                  top_level_dependency_updates
-                ]
-              )
+              args: [
+                Dir.pwd,
+                top_level_dependency_updates
+              ]
             ),
             T::Hash[String, String]
           )
@@ -728,7 +726,7 @@ module Dependabot
             NpmAndYarn::FileParser.new(
               dependency_files: [lockfile, *package_files],
               source: nil,
-              credentials: T.unsafe(credentials)
+              credentials: credentials
             ).parse
         end
 
@@ -845,7 +843,7 @@ module Dependabot
         sig { returns(String) }
         def yarnrc_content
           NpmrcBuilder.new(
-            credentials: T.unsafe(credentials),
+            credentials: credentials,
             dependency_files: dependency_files
           ).yarnrc_content
         end

--- a/pub/lib/dependabot/pub/helpers.rb
+++ b/pub/lib/dependabot/pub/helpers.rb
@@ -344,17 +344,12 @@ module Dependabot
           .returns(Dependabot::Dependency)
       end
       def parse_updated_dependency(json, requirements_update_strategy)
-        params = {
-          name: json["name"],
-          version: json["version"],
-          package_manager: "pub",
-          requirements: []
-        }
+        requirements = []
         constraint_field = constraint_field_from_update_strategy(requirements_update_strategy)
 
         if json["kind"] != "transitive" && !json[constraint_field].nil?
           constraint = json[constraint_field]
-          params[:requirements] << {
+          requirements << {
             requirement: constraint,
             groups: [json["kind"]],
             source: nil, # TODO: Expose some information about the source
@@ -362,23 +357,25 @@ module Dependabot
           }
         end
 
-        if json["previousVersion"]
-          params = {
-            **params,
-            previous_version: json["previousVersion"],
-            previous_requirements: []
+        previous_requirements = []
+        if json["previousVersion"] && json["kind"] != "transitive" && !json["previousConstraint"].nil?
+          constraint = json["previousConstraint"]
+          previous_requirements << {
+            requirement: constraint,
+            groups: [json["kind"]],
+            source: nil, # TODO: Expose some information about the source
+            file: "pubspec.yaml"
           }
-          if json["kind"] != "transitive" && !json["previousConstraint"].nil?
-            constraint = json["previousConstraint"]
-            params[:previous_requirements] << {
-              requirement: constraint,
-              groups: [json["kind"]],
-              source: nil, # TODO: Expose some information about the source
-              file: "pubspec.yaml"
-            }
-          end
         end
-        Dependency.new(**T.unsafe(params))
+
+        Dependency.new(
+          name: json["name"],
+          version: json["version"],
+          package_manager: "pub",
+          requirements: requirements,
+          previous_version: json["previousVersion"],
+          previous_requirements: json["previousVersion"] ? previous_requirements : nil
+        )
       end
 
       # expects "auto" to already have been resolved to one of the other


### PR DESCRIPTION
Remove the final five `T.unsafe` calls from npm helper payloads and Pub dependency parsing. The pnpm lockfile updater is now `typed: strong`.

`T.unsafe`: 5 -> 0.