### PR TITLE
docker: skip unparseable YAML files

### DIFF
--- a/docker/lib/dependabot/docker/file_parser.rb
+++ b/docker/lib/dependabot/docker/file_parser.rb
@@ -52,8 +52,16 @@ module Dependabot
           end
         end
 
+        parsed_manifest_file = T.let(false, T::Boolean)
         manifest_files.each do |file|
           dependency_set += workfile_file_dependencies(file)
+          parsed_manifest_file = true
+        rescue Dependabot::DependencyFileNotParseable => e
+          Dependabot.logger.warn("Failed to parse YAML file #{file.path}: #{e.message}")
+        end
+
+        if dockerfiles.empty? && manifest_files.any? && !parsed_manifest_file
+          raise Dependabot::DependencyFileNotFound.new(nil, "No parseable Dockerfiles or YAML files found")
         end
 
         dependency_set.dependencies
@@ -107,7 +115,6 @@ module Dependabot
 
         dependency_set
       rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::BadAlias => e
-        Dependabot.logger.error("Failed to parse file #{file.path}: #{e.message}")
         raise Dependabot::DependencyFileNotParseable.new(file.path, e.message)
       end
 

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe Dependabot::Docker::FileParser do
       its(:length) { is_expected.to eq(0) }
     end
 
+    context "when a Dockerfile cannot be parsed" do
+      let(:error) { Dependabot::DependencyFileNotParseable.new("/Dockerfile") }
+
+      before do
+        allow(dockerfile).to receive(:content).and_raise(error)
+      end
+
+      it "raises the unparseable file error" do
+        expect { dependencies }.to raise_error(error)
+      end
+    end
+
     context "with a name" do
       let(:dockerfile_fixture_name) { "name" }
 
@@ -1168,6 +1180,80 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.name).to eq("my-repo/nginx")
           expect(dependency.version).to eq("1.14.2")
           expect(dependency.requirements).to eq(expected_requirements)
+        end
+      end
+    end
+
+    context "when a YAML file cannot be parsed" do
+      let(:unparseable_file) do
+        Dependabot::DependencyFile.new(
+          name: "unparseable.yaml",
+          directory: "/",
+          content: <<~YAML
+            metadata:
+              annotations:
+                a.b/c: "true"
+               invalid: yaml
+          YAML
+        )
+      end
+
+      before do
+        allow(Dependabot.logger).to receive(:warn)
+      end
+
+      context "with a valid Dockerfile" do
+        let(:podfiles) { [dockerfile, unparseable_file] }
+
+        it "warns and parses dependencies from the Dockerfile" do
+          expect(dependencies.length).to eq(1)
+          expect(dependencies.first.name).to eq("ubuntu")
+          expect(dependencies.first.version).to eq("17.04")
+          expect(Dependabot.logger).to have_received(:warn).with(
+            a_string_including("Failed to parse YAML file /unparseable.yaml")
+          )
+        end
+      end
+
+      context "with another valid YAML file" do
+        let(:podfiles) { [unparseable_file, valid_file] }
+        let(:valid_file) do
+          Dependabot::DependencyFile.new(
+            name: "valid.yaml",
+            directory: "/",
+            content: fixture("kubernetes", "yaml", "pod.yaml")
+          )
+        end
+
+        it "warns and parses dependencies from the valid file" do
+          expect(dependencies.length).to eq(1)
+          expect(dependencies.first.name).to eq("nginx")
+          expect(dependencies.first.version).to eq("1.14.2")
+          expect(dependencies.first.requirements).to eq(
+            [{
+              requirement: nil,
+              groups: [],
+              file: "valid.yaml",
+              source: { tag: "1.14.2" }
+            }]
+          )
+          expect(Dependabot.logger).to have_received(:warn).with(
+            a_string_including("Failed to parse YAML file /unparseable.yaml")
+          )
+        end
+      end
+
+      context "without a Dockerfile or parseable YAML file" do
+        let(:podfiles) { [unparseable_file] }
+
+        it "raises a missing dependency file error" do
+          expect { dependencies }.to raise_error(
+            Dependabot::DependencyFileNotFound,
+            "No parseable Dockerfiles or YAML files found"
+          )
+          expect(Dependabot.logger).to have_received(:warn).with(
+            a_string_including("Failed to parse YAML file /unparseable.yaml")
+          )
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Allow Docker dependency parsing to skip malformed YAML files without preventing valid Dockerfiles or other valid YAML files from being processed.

### Real world scenario

Consider a repository hosted in (or mirrored to, or has builds hosted in) Azure DevOps with some Dockerfiles and possibly Helm YAML files.  These should parse in dependabot and they currently do.  But since this repo is in Azure DevOps it also has pipeline definition YAML files.  Those files can have some syntax that the Ruby YAML parser can't handle.  Before this change if a dependabot Docker job was started with `**/*` as a directory, these YAML files would cause the entire Docker updater to fail, but now we skip those unparsable YAML files to allow the rest to continue.

### Details

Malformed YAML files now produce a warning. Dockerfile parse failures remain fatal and continue to raise `DependencyFileNotParseable`. If no Dockerfiles are present and every discovered YAML file is unparseable, parsing raises `DependencyFileNotFound`.

### Anything you want to highlight for special attention from reviewers?

The error handling is intentionally scoped to the YAML parsing loop so Dockerfile failures retain their existing behavior.

### How will you know you have accomplished your goal?

The parser specs verify that:

- an invalid YAML file alongside a valid Dockerfile logs a warning and returns the Dockerfile dependency;
- an invalid YAML file does not prevent another valid YAML file from being parsed;
- a Dockerfile parse failure still raises `DependencyFileNotParseable`; and
- all-invalid YAML input with no Dockerfile raises `DependencyFileNotFound`.

Validated locally with the Docker file parser specs (79 examples, 0 failures) and RuboCop on the changed parser and spec.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.