### PR TITLE
Update dependency regex to support multiline requirements

### DIFF
--- a/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
@@ -12,13 +12,26 @@ module Dependabot
         extend T::Sig
         extend T::Helpers
 
-        # After the version requirement there may be additional labeled arguments (e.g. `traits: []`)
-        # that can span onto following lines before the closing `)` of `.package(`, optionally with a
-        # trailing comma after the final argument.
+        # An optional `name:` label may precede the `url:` argument.
+        NAME_ARGUMENT = /(?:name:\s+"[^"]+",\s*)?/
+
+        # The `url:` argument identifies the dependency's source.
+        URL_ARGUMENT = /url:\s+"(?<url>[^"]+)",\s*/
+
+        # The version requirement (e.g. `from: "1.0.0"`, `.upToNextMajor(from: "1.0.0")`, a range).
+        REQUIREMENT_ARGUMENT = /(?<requirement>#{NativeRequirement::REGEXP})/
+
+        # A single additional labeled argument (e.g. `traits: []`) whose value may be an array, a
+        # string, or a bare token. The leading comma is optional so the final argument matches too.
+        TRAILING_ARGUMENT = /\s*,?\s*\w+\s*:\s*(?:\[[^\]]*\]|"[^"]*"|[^\s,)]+)/
+
+        # After the requirement there may be any number of trailing arguments (which can span onto
+        # following lines) before the closing `)`, optionally followed by a trailing comma.
+        TRAILING_ARGUMENTS = /(?:#{TRAILING_ARGUMENT})*\s*,?\s*/
+
         DEPENDENCY =
           /(?<declaration>\.package\(\s*
-            (?:name:\s+"[^"]+",\s*)?url:\s+"(?<url>[^"]+)",\s*(?<requirement>#{NativeRequirement::REGEXP})
-            (?:\s*,?\s*\w+\s*:\s*(?:\[[^\]]*\]|"[^"]*"|[^\s,)]+))*\s*,?\s*
+            #{NAME_ARGUMENT}#{URL_ARGUMENT}#{REQUIREMENT_ARGUMENT}#{TRAILING_ARGUMENTS}
            \))/x
 
         sig do

--- a/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
@@ -13,11 +13,12 @@ module Dependabot
         extend T::Helpers
 
         # After the version requirement there may be additional labeled arguments (e.g. `traits: []`)
-        # that can span onto following lines before the closing `)` of `.package(`.
+        # that can span onto following lines before the closing `)` of `.package(`, optionally with a
+        # trailing comma after the final argument.
         DEPENDENCY =
           /(?<declaration>\.package\(\s*
             (?:name:\s+"[^"]+",\s*)?url:\s+"(?<url>[^"]+)",\s*(?<requirement>#{NativeRequirement::REGEXP})
-            (?:\s*,?\s*\w+\s*:\s*(?:\[[^\]]*\]|"[^"]*"|[^\s,)]+))*\s*
+            (?:\s*,?\s*\w+\s*:\s*(?:\[[^\]]*\]|"[^"]*"|[^\s,)]+))*\s*,?\s*
            \))/x
 
         sig do

--- a/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
+++ b/swift/lib/dependabot/swift/file_parser/manifest_parser.rb
@@ -12,9 +12,12 @@ module Dependabot
         extend T::Sig
         extend T::Helpers
 
+        # After the version requirement there may be additional labeled arguments (e.g. `traits: []`)
+        # that can span onto following lines before the closing `)` of `.package(`.
         DEPENDENCY =
           /(?<declaration>\.package\(\s*
-            (?:name:\s+"[^"]+",\s*)?url:\s+"(?<url>[^"]+)",\s*(?<requirement>#{NativeRequirement::REGEXP})\s*
+            (?:name:\s+"[^"]+",\s*)?url:\s+"(?<url>[^"]+)",\s*(?<requirement>#{NativeRequirement::REGEXP})
+            (?:\s*,?\s*\w+\s*:\s*(?:\[[^\]]*\]|"[^"]*"|[^\s,)]+))*\s*
            \))/x
 
         sig do

--- a/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
+++ b/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
@@ -28,11 +28,23 @@ module Dependabot
         sig { returns(String) }
         def updated_content
           content.gsub(declaration) do |match|
-            match.to_s.sub(old_requirement, new_requirement)
+            match.to_s.sub(old_requirement, replacement)
           end
         end
 
         private
+
+        # The parsed requirement can include a trailing separator (e.g. a comma before a
+        # following argument on the next line). Carry it over when the replacement doesn't
+        # already have one, so multi-line declarations stay valid.
+        sig { returns(String) }
+        def replacement
+          trailing_separator = old_requirement[/,\s*\z/]
+          return new_requirement if trailing_separator.nil?
+          return new_requirement if new_requirement.match?(/,\s*\z/)
+
+          new_requirement + trailing_separator
+        end
 
         sig { returns(String) }
         attr_reader :content

--- a/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
+++ b/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
@@ -34,16 +34,15 @@ module Dependabot
 
         private
 
-        # The parsed requirement can include a trailing separator (e.g. a comma before a
-        # following argument on the next line). Carry it over when the replacement doesn't
-        # already have one, so multi-line declarations stay valid.
+        # The parsed requirement can include a trailing suffix (a comma before a following
+        # argument on the next line, and/or an inline comment). Carry it over when the
+        # replacement doesn't already have it, so multi-line declarations stay valid.
         sig { returns(String) }
         def replacement
-          trailing_separator = old_requirement[/,\s*\z/]
-          return new_requirement if trailing_separator.nil?
-          return new_requirement if new_requirement.match?(/,\s*\z/)
+          suffix = old_requirement[%r{,\s*(?://.*)?\z}] || old_requirement[%r{\s*//.*\z}]
+          return new_requirement if suffix.nil? || new_requirement.end_with?(suffix)
 
-          new_requirement + trailing_separator
+          new_requirement + suffix
         end
 
         sig { returns(String) }

--- a/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
+++ b/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
@@ -34,17 +34,15 @@ module Dependabot
 
         private
 
-        # The parsed requirement can include a trailing suffix (a comma before a following
-        # argument on the next line, and/or an inline `//` or `/* */` comment). Carry it over
-        # when the replacement doesn't already have it, so multi-line declarations stay valid.
+        # The parser captures a trailing comma separating the requirement from a following
+        # argument on the next line. Carry it over when the replacement doesn't already have
+        # one, so multi-line declarations stay valid.
         sig { returns(String) }
         def replacement
-          suffix =
-            old_requirement[%r{,\s*(?://.*|/\*.*\*/)?\z}] ||
-            old_requirement[%r{\s*(?://.*|/\*.*\*/)\z}]
-          return new_requirement if suffix.nil? || new_requirement.end_with?(suffix)
+          return new_requirement unless old_requirement.end_with?(",")
+          return new_requirement if new_requirement.end_with?(",")
 
-          new_requirement + suffix
+          "#{new_requirement},"
         end
 
         sig { returns(String) }

--- a/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
+++ b/swift/lib/dependabot/swift/file_updater/requirement_replacer.rb
@@ -35,11 +35,13 @@ module Dependabot
         private
 
         # The parsed requirement can include a trailing suffix (a comma before a following
-        # argument on the next line, and/or an inline comment). Carry it over when the
-        # replacement doesn't already have it, so multi-line declarations stay valid.
+        # argument on the next line, and/or an inline `//` or `/* */` comment). Carry it over
+        # when the replacement doesn't already have it, so multi-line declarations stay valid.
         sig { returns(String) }
         def replacement
-          suffix = old_requirement[%r{,\s*(?://.*)?\z}] || old_requirement[%r{\s*//.*\z}]
+          suffix =
+            old_requirement[%r{,\s*(?://.*|/\*.*\*/)?\z}] ||
+            old_requirement[%r{\s*(?://.*|/\*.*\*/)\z}]
           return new_requirement if suffix.nil? || new_requirement.end_with?(suffix)
 
           new_requirement + suffix

--- a/swift/spec/dependabot/swift/file_parser/manifest_parser_spec.rb
+++ b/swift/spec/dependabot/swift/file_parser/manifest_parser_spec.rb
@@ -1,0 +1,162 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/dependency_requirement"
+require "dependabot/swift/file_parser/manifest_parser"
+
+RSpec.describe Dependabot::Swift::FileParser::ManifestParser do
+  subject(:manifest_parser) { described_class.new(manifest, requirement: requirement) }
+
+  let(:manifest) do
+    Dependabot::DependencyFile.new(name: "Package.swift", content: content)
+  end
+  let(:url) { "https://github.com/example/example" }
+  let(:requirement) do
+    Dependabot::DependencyRequirement.create(
+      source: { type: "git", url: url }
+    )
+  end
+
+  describe "#requirements" do
+    subject(:requirements) { manifest_parser.requirements }
+
+    context "with a single-line declaration and additional arguments" do
+      let(:content) do
+        <<~SWIFT
+          let package = Package(
+            name: "example",
+            dependencies: [
+              .package(url: "#{url}", .upToNextMajor(from: "1.0.0"), traits: [])
+            ]
+          )
+        SWIFT
+      end
+
+      it "parses the requirement" do
+        expect(requirements.length).to eq(1)
+        expect(requirements.first[:requirement]).to eq(">= 1.0.0, < 2.0.0")
+        expect(requirements.first[:metadata][:requirement_string])
+          .to eq(".upToNextMajor(from: \"1.0.0\"), traits: []")
+        expect(requirements.first[:metadata][:declaration_string])
+          .to eq(".package(url: \"#{url}\", .upToNextMajor(from: \"1.0.0\"), traits: [])")
+      end
+    end
+
+    context "when the closing parenthesis is on a later line than the requirement" do
+      context "with an .upToNextMajor requirement followed by a trailing argument" do
+        let(:content) do
+          <<~SWIFT
+            let package = Package(
+              name: "example",
+              dependencies: [
+                .package(
+                  url: "#{url}",
+                  .upToNextMajor(from: "1.0.0"),
+                  traits: []
+                )
+              ]
+            )
+          SWIFT
+        end
+
+        it "parses the requirement" do
+          expect(requirements.length).to eq(1)
+          expect(requirements.first[:requirement]).to eq(">= 1.0.0, < 2.0.0")
+          expect(requirements.first[:metadata][:requirement_string]).to eq(".upToNextMajor(from: \"1.0.0\"),")
+        end
+      end
+
+      context "with a from: requirement followed by a trailing argument" do
+        let(:content) do
+          <<~SWIFT
+            let package = Package(
+              name: "example",
+              dependencies: [
+                .package(
+                  url: "#{url}",
+                  from: "1.0.0",
+                  traits: []
+                )
+              ]
+            )
+          SWIFT
+        end
+
+        it "parses the requirement" do
+          expect(requirements.length).to eq(1)
+          expect(requirements.first[:requirement]).to eq(">= 1.0.0, < 2.0.0")
+          expect(requirements.first[:metadata][:requirement_string]).to eq("from: \"1.0.0\",")
+        end
+      end
+
+      context "with a range requirement followed by a trailing argument" do
+        let(:content) do
+          <<~SWIFT
+            let package = Package(
+              name: "example",
+              dependencies: [
+                .package(
+                  url: "#{url}",
+                  "1.0.0"..<"2.0.0",
+                  traits: []
+                )
+              ]
+            )
+          SWIFT
+        end
+
+        it "parses the requirement" do
+          expect(requirements.length).to eq(1)
+          expect(requirements.first[:requirement]).to eq(">= 1.0.0, < 2.0.0")
+          expect(requirements.first[:metadata][:requirement_string]).to eq("\"1.0.0\"..<\"2.0.0\",")
+        end
+      end
+
+      context "with an exact: requirement followed by a trailing argument" do
+        let(:content) do
+          <<~SWIFT
+            let package = Package(
+              name: "example",
+              dependencies: [
+                .package(
+                  url: "#{url}",
+                  exact: "1.0.0",
+                  traits: []
+                )
+              ]
+            )
+          SWIFT
+        end
+
+        it "parses the requirement" do
+          expect(requirements.length).to eq(1)
+          expect(requirements.first[:requirement]).to eq("= 1.0.0")
+          expect(requirements.first[:metadata][:requirement_string]).to eq("exact: \"1.0.0\",")
+        end
+      end
+    end
+
+    context "with sibling declarations on their own lines" do
+      let(:content) do
+        <<~SWIFT
+          let package = Package(
+            name: "example",
+            dependencies: [
+              .package(url: "#{url}", "0.1.0"..<"0.1.2"),
+              .package(url: "https://github.com/other/other", from: "2.0.0")
+            ]
+          )
+        SWIFT
+      end
+
+      it "does not merge sibling declarations" do
+        expect(requirements.length).to eq(1)
+        expect(requirements.first[:metadata][:declaration_string])
+          .to eq(".package(url: \"#{url}\", \"0.1.0\"..<\"0.1.2\")")
+        expect(requirements.first[:metadata][:requirement_string]).to eq("\"0.1.0\"..<\"0.1.2\"")
+      end
+    end
+  end
+end

--- a/swift/spec/dependabot/swift/file_parser/manifest_parser_spec.rb
+++ b/swift/spec/dependabot/swift/file_parser/manifest_parser_spec.rb
@@ -136,6 +136,29 @@ RSpec.describe Dependabot::Swift::FileParser::ManifestParser do
           expect(requirements.first[:metadata][:requirement_string]).to eq("exact: \"1.0.0\",")
         end
       end
+
+      context "with a trailing comma after the final labeled argument" do
+        let(:content) do
+          <<~SWIFT
+            let package = Package(
+              name: "example",
+              dependencies: [
+                .package(
+                  url: "#{url}",
+                  .upToNextMajor(from: "1.0.0"),
+                  traits: [],
+                )
+              ]
+            )
+          SWIFT
+        end
+
+        it "parses the requirement" do
+          expect(requirements.length).to eq(1)
+          expect(requirements.first[:requirement]).to eq(">= 1.0.0, < 2.0.0")
+          expect(requirements.first[:metadata][:requirement_string]).to eq(".upToNextMajor(from: \"1.0.0\"),")
+        end
+      end
     end
 
     context "with sibling declarations on their own lines" do

--- a/swift/spec/dependabot/swift/file_updater/requirement_replacer_spec.rb
+++ b/swift/spec/dependabot/swift/file_updater/requirement_replacer_spec.rb
@@ -78,6 +78,23 @@ RSpec.describe Dependabot::Swift::FileUpdater::RequirementReplacer do
       end
     end
 
+    context "with a multi-line declaration where the requirement line ends with a block comment" do
+      let(:declaration) do
+        ".package(\n" \
+          "      url: \"#{url}\",\n" \
+          "      #{old_requirement}\n" \
+          "      traits: []\n" \
+          "    )"
+      end
+      let(:old_requirement) { ".upToNextMajor(from: \"1.30.0\"), /* keep */" }
+      let(:new_requirement) { "\"1.30.0\"...\"1.36.2\"" }
+
+      it "preserves the comma and block comment before the next argument" do
+        expect(replacer.updated_content).to include("\"1.30.0\"...\"1.36.2\", /* keep */\n")
+        expect(replacer.updated_content).to include("traits: []")
+      end
+    end
+
     context "with a single-line declaration where the requirement has no trailing separator" do
       let(:declaration) { ".package(url: \"#{url}\", from: \"1.0.0\")" }
       let(:old_requirement) { "from: \"1.0.0\"" }

--- a/swift/spec/dependabot/swift/file_updater/requirement_replacer_spec.rb
+++ b/swift/spec/dependabot/swift/file_updater/requirement_replacer_spec.rb
@@ -1,0 +1,61 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/swift/file_updater/requirement_replacer"
+
+RSpec.describe Dependabot::Swift::FileUpdater::RequirementReplacer do
+  subject(:replacer) do
+    described_class.new(
+      content: content,
+      declaration: declaration,
+      old_requirement: old_requirement,
+      new_requirement: new_requirement
+    )
+  end
+
+  let(:url) { "https://github.com/ordo-one/benchmark" }
+  let(:content) { "let package = Package(\n  dependencies: [\n    #{declaration}\n  ]\n)\n" }
+
+  describe "#updated_content" do
+    context "with a multi-line declaration where the requirement is followed by another argument" do
+      let(:declaration) do
+        ".package(\n" \
+          "      url: \"#{url}\",\n" \
+          "      #{old_requirement}\n" \
+          "      traits: []\n" \
+          "    )"
+      end
+      # The parser captures the trailing comma as part of the requirement string.
+      let(:old_requirement) { ".upToNextMajor(from: \"1.30.0\")," }
+
+      context "when the new requirement does not carry the trailing separator" do
+        let(:new_requirement) { "\"1.30.0\"...\"1.36.2\"" }
+
+        it "preserves the comma separating the requirement from the next argument" do
+          expect(replacer.updated_content).to include("\"1.30.0\"...\"1.36.2\",\n")
+          expect(replacer.updated_content).to include("traits: []")
+        end
+      end
+
+      context "when the new requirement already carries the trailing separator" do
+        let(:new_requirement) { ".upToNextMajor(from: \"1.36.2\")," }
+
+        it "does not duplicate the trailing comma" do
+          expect(replacer.updated_content).to include(".upToNextMajor(from: \"1.36.2\"),\n")
+          expect(replacer.updated_content).not_to include(",,")
+        end
+      end
+    end
+
+    context "with a single-line declaration where the requirement has no trailing separator" do
+      let(:declaration) { ".package(url: \"#{url}\", from: \"1.0.0\")" }
+      let(:old_requirement) { "from: \"1.0.0\"" }
+      let(:new_requirement) { "from: \"1.1.0\"" }
+
+      it "replaces the requirement without adding a separator" do
+        expect(replacer.updated_content).to include(".package(url: \"#{url}\", from: \"1.1.0\")")
+      end
+    end
+  end
+end

--- a/swift/spec/dependabot/swift/file_updater/requirement_replacer_spec.rb
+++ b/swift/spec/dependabot/swift/file_updater/requirement_replacer_spec.rb
@@ -48,53 +48,6 @@ RSpec.describe Dependabot::Swift::FileUpdater::RequirementReplacer do
       end
     end
 
-    context "with a multi-line declaration where the requirement line ends with an inline comment" do
-      let(:declaration) do
-        ".package(\n" \
-          "      url: \"#{url}\",\n" \
-          "      #{old_requirement}\n" \
-          "      traits: []\n" \
-          "    )"
-      end
-      # The parser captures the trailing comma and comment as part of the requirement string.
-      let(:old_requirement) { ".upToNextMajor(from: \"1.30.0\"), // keep this" }
-
-      context "when the new requirement does not carry the trailing separator" do
-        let(:new_requirement) { "\"1.30.0\"...\"1.36.2\"" }
-
-        it "preserves the comma and comment before the next argument" do
-          expect(replacer.updated_content).to include("\"1.30.0\"...\"1.36.2\", // keep this\n")
-          expect(replacer.updated_content).to include("traits: []")
-        end
-      end
-
-      context "when the new requirement already carries the trailing comma and comment" do
-        let(:new_requirement) { ".upToNextMajor(from: \"1.36.2\"), // keep this" }
-
-        it "does not duplicate the suffix" do
-          expect(replacer.updated_content).to include(".upToNextMajor(from: \"1.36.2\"), // keep this\n")
-          expect(replacer.updated_content).not_to include("// keep this // keep this")
-        end
-      end
-    end
-
-    context "with a multi-line declaration where the requirement line ends with a block comment" do
-      let(:declaration) do
-        ".package(\n" \
-          "      url: \"#{url}\",\n" \
-          "      #{old_requirement}\n" \
-          "      traits: []\n" \
-          "    )"
-      end
-      let(:old_requirement) { ".upToNextMajor(from: \"1.30.0\"), /* keep */" }
-      let(:new_requirement) { "\"1.30.0\"...\"1.36.2\"" }
-
-      it "preserves the comma and block comment before the next argument" do
-        expect(replacer.updated_content).to include("\"1.30.0\"...\"1.36.2\", /* keep */\n")
-        expect(replacer.updated_content).to include("traits: []")
-      end
-    end
-
     context "with a single-line declaration where the requirement has no trailing separator" do
       let(:declaration) { ".package(url: \"#{url}\", from: \"1.0.0\")" }
       let(:old_requirement) { "from: \"1.0.0\"" }

--- a/swift/spec/dependabot/swift/file_updater/requirement_replacer_spec.rb
+++ b/swift/spec/dependabot/swift/file_updater/requirement_replacer_spec.rb
@@ -48,6 +48,36 @@ RSpec.describe Dependabot::Swift::FileUpdater::RequirementReplacer do
       end
     end
 
+    context "with a multi-line declaration where the requirement line ends with an inline comment" do
+      let(:declaration) do
+        ".package(\n" \
+          "      url: \"#{url}\",\n" \
+          "      #{old_requirement}\n" \
+          "      traits: []\n" \
+          "    )"
+      end
+      # The parser captures the trailing comma and comment as part of the requirement string.
+      let(:old_requirement) { ".upToNextMajor(from: \"1.30.0\"), // keep this" }
+
+      context "when the new requirement does not carry the trailing separator" do
+        let(:new_requirement) { "\"1.30.0\"...\"1.36.2\"" }
+
+        it "preserves the comma and comment before the next argument" do
+          expect(replacer.updated_content).to include("\"1.30.0\"...\"1.36.2\", // keep this\n")
+          expect(replacer.updated_content).to include("traits: []")
+        end
+      end
+
+      context "when the new requirement already carries the trailing comma and comment" do
+        let(:new_requirement) { ".upToNextMajor(from: \"1.36.2\"), // keep this" }
+
+        it "does not duplicate the suffix" do
+          expect(replacer.updated_content).to include(".upToNextMajor(from: \"1.36.2\"), // keep this\n")
+          expect(replacer.updated_content).not_to include("// keep this // keep this")
+        end
+      end
+    end
+
     context "with a single-line declaration where the requirement has no trailing separator" do
       let(:declaration) { ".package(url: \"#{url}\", from: \"1.0.0\")" }
       let(:old_requirement) { "from: \"1.0.0\"" }


### PR DESCRIPTION
### What are you trying to accomplish?
Fix Swift `Package.swift` parsing **and updating** when a dependency's version requirement is followed by an additional argument (e.g. `traits: []`) and the closing `)` of `.package(` ends up on a later line than the requirement.

This is a follow-up to #15311 (which fixed #15310). That PR taught `NativeRequirement` to parse requirement strings containing trailing arguments, so the single-line form already works:

```swift
.package(url: "https://github.com/example/example", .upToNextMajor(from: "1.0.0"), traits: [])
```

But the multi-line form still failed to parse and update:

```swift
.package(
    url: "https://github.com/example/example",
    .upToNextMajor(from: "1.0.0"),
    traits: []
)
```

There were two distinct problems:

1. **Parsing** (`file_parser/manifest_parser.rb`): the `DEPENDENCY` regex expected the closing `)` immediately after the requirement. Because `NativeRequirement::REGEXP` relies on `.*` (which doesn't cross newlines), a trailing argument on a later line caused the regex to either not match at all or capture a malformed requirement like `.upToNextMajor(from: "1.0.0"` (missing its closing paren), breaking downstream parsing. Fixed by extending the `DEPENDENCY` regex to consume optional labeled arguments (which may span onto following lines) between the requirement and the closing paren.

2. **Replacement** (`file_updater/requirement_replacer.rb`): in the multi-line form the requirement's greedy `.*` captures the trailing **comma** into `requirement_string` (e.g. `.upToNextMajor(from: "1.30.0"),`). When the update checker builds an "unlocked" candidate manifest, it generates a comma-less requirement (`"1.30.0"..."1.36.2"`), and `RequirementReplacer` substituted the comma-bearing old string for the comma-less new one — dropping the separator and producing invalid Swift (`error: expected ',' separator`). Fixed by preserving a trailing separator captured with the old requirement when the replacement doesn't already carry one.

Fixes #15865
<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
- The parser's trailing-argument matcher `(?:\s*,?\s*\w+\s*:\s*(?:\[[^\]]*\]|"[^"]*"|[^\s,)]+))*` is deliberately scoped so it cannot merge sibling declarations: each trailing argument must be a `label: value` pair, and a following sibling starts with `.package` (a `.`, not a word-label), so the matcher stops before it. There's an explicit regression test for this.
- Single-line behavior is intentionally left unchanged: the requirement's greedy `.*` still captures same-line trailing arguments into `requirement_string`, so existing fixtures (`traits`, `trailing_comma`, `double_parentheses`) and their expectations are unaffected.
- The `RequirementReplacer` change only appends a separator when the old requirement ended with one **and** the new requirement doesn't — it never strips or reorders anything, keeping the parser's existing (spec-asserted) comma-in-`requirement_string` behavior intact. The `update` path already carries the comma, so a guard avoids duplicating it.
- No changes were needed in `native_requirement.rb`; the captured `requirement_string` is always single-line, which its existing regexes already handle.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- `file_parser/manifest_parser_spec.rb` — a focused unit spec (no Swift CLI required) covering the single-line declaration with an additional argument (unchanged behavior), all four multi-line requirement forms (`from:`, `exact:`, `.upToNextMajor`, and range) each followed by a trailing `traits: []`, and a sibling-declarations regression guard proving two adjacent `.package(...)` entries are not merged.
- `file_updater/requirement_replacer_spec.rb` — a new unit spec (no Swift CLI required) covering the multi-line dropped-comma case, a no-duplicate-comma case, and the single-line no-separator case.
- The original reproduction from #15865 (`.upToNextMajor(from:)` followed by `traits: []` across lines) now resolves and updates to a valid `Package.swift` instead of failing with `error: expected ',' separator`.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
