### PR TITLE
npm_and_yarn: read the last document of multi-document pnpm lockfiles in the dependency grapher

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/pnpm_relationship_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/pnpm_relationship_resolver.rb
@@ -17,7 +17,11 @@ module Dependabot
 
         sig { returns(T::Hash[String, T::Array[String]]) }
         def relationships
-          parsed = YAML.safe_load(T.must(@lockfile.content)) || {}
+          # pnpm 11+ can write pnpm-lock.yaml as a two-document YAML stream: an
+          # env document (pnpm's own binaries, with its own "packages" and
+          # "snapshots" sections) precedes the project document. The project
+          # graph is always the last document in the stream.
+          parsed = YAML.safe_load_stream(T.must(@lockfile.content)).last || {}
 
           # v9+ uses "snapshots" for resolved dependency details; v6 uses "packages"
           entries = parsed.fetch("snapshots", nil) || parsed.fetch("packages", {})

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher_spec.rb
@@ -368,6 +368,32 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher do
       end
     end
 
+    context "with a pnpm two-document lockfile (env document before the project document)" do
+      let(:dependency_files) { project_dependency_files("grapher/pnpm_multi_document") }
+
+      it "reads the project graph from the last document" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        to_regex_range = resolved_dependencies["pkg:npm/to-regex-range@5.0.1"]
+        expect(to_regex_range).not_to be_nil
+        expect(to_regex_range.direct).to be(true)
+        expect(to_regex_range.dependencies).to include("pkg:npm/is-number@7.0.0")
+
+        is_number = resolved_dependencies["pkg:npm/is-number@7.0.0"]
+        expect(is_number).not_to be_nil
+        expect(is_number.direct).to be(false)
+      end
+
+      it "does not report pnpm's own binaries from the env document" do
+        resolved_dependencies = grapher.resolved_dependencies
+
+        expect(resolved_dependencies.keys).not_to include(
+          "pkg:npm/pnpm@12.0.0",
+          "pkg:npm/%40pnpm/exe@12.0.0"
+        )
+      end
+    end
+
     context "with multiple versions of the same transitive dependency" do
       let(:dependency_files) { project_dependency_files("grapher/npm_with_multiversion_subdeps") }
 

--- a/npm_and_yarn/spec/fixtures/projects/grapher/pnpm_multi_document/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/grapher/pnpm_multi_document/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "grapher-pnpm-multi-document",
+  "version": "1.0.0",
+  "description": "Test project for pnpm grapher with a two-document lockfile",
+  "packageManager": "pnpm@12.0.0",
+  "dependencies": {
+    "to-regex-range": "5.0.1"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/grapher/pnpm_multi_document/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/grapher/pnpm_multi_document/pnpm-lock.yaml
@@ -1,0 +1,63 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0
+        version: 12.0.0
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe@12.0.0':
+    resolution: {}
+    hasBin: true
+
+  pnpm@12.0.0:
+    resolution: {}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@12.0.0': {}
+
+  pnpm@12.0.0: {}
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      to-regex-range:
+        specifier: 5.0.1
+        version: 5.0.1
+
+packages:
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifbd2qBWR5GqFQ+nbq/RqNh6cMo0tMGt2Mms/XP/4e0Nbkr09RkdSyORSvKFHxDBIF26BAhOqfWtQd0jFg==}
+    engines: {node: '>=0.12.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+snapshots:
+
+  is-number@7.0.0: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0


### PR DESCRIPTION
### What are you trying to accomplish?

Fix silent security-alert closures for pnpm 11 and 12 projects, as diagnosed in https://github.com/dependabot/dependabot-core/issues/14794#issuecomment-5251082683 (and originally in #14919).

pnpm 11+ can write `pnpm-lock.yaml` as a two-document YAML stream: an env document that lists pnpm's own binaries (with its own `packages` and `snapshots` sections) comes before the project document. pnpm 12 extends this layout to projects that pin pnpm through the `packageManager` field, so the affected population grows (see https://github.com/pnpm/pnpm/issues/13805).

`PnpmRelationshipResolver` used `YAML.safe_load`, which returns only the first document of a stream. For a two-document lockfile it got a valid, non-empty result that contains pnpm's own binaries and none of the project's dependencies. Nothing errored, so the dependency graph looked "parsed fine, no dependencies" and alerts closed as fixed. The native JS helper (`lockfile-parser.ts`) already extracts the project document since the pnpm 11 beta support change, so update PRs kept working while the graph path stayed broken. That matches the reports in #14794.

The fix follows the pnpm maintainer's recommendation: parse the full stream with `YAML.safe_load_stream` and take the last document. That is correct for single-document lockfiles and for every two-document lockfile pnpm writes, with no layout detection or version check.

### Anything you want to highlight for special attention from reviewers?

- `YAML.load_stream` is not safe-by-default even on Psych 5, so the change uses `Psych.safe_load_stream` (available since Psych 5.1; the lockfile pins 5.4.0, and the Sorbet RBI covers it).
- For an empty lockfile, `safe_load_stream` returns `[]`, so `.last || {}` keeps the previous behavior. Invalid YAML still raises `Psych::SyntaxError`, which the grapher already rescues.

### How will you know you've accomplished your goal?

New grapher spec with a two-document fixture (env document with pnpm 12 binaries first, project graph second). Without the fix, the new spec fails: the project edges are missing because the resolver reads the env document's `snapshots`. With the fix, all 91 dependency-grapher examples pass, and `rubocop` and `srb tc` are clean.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)