### PR TITLE
Add typed vulnerability audit model

### DIFF
--- a/bun/lib/dependabot/bun/update_checker.rb
+++ b/bun/lib/dependabot/bun/update_checker.rb
@@ -198,7 +198,7 @@ module Dependabot
         library? ? RequirementsUpdateStrategy::WidenRanges : RequirementsUpdateStrategy::BumpVersions
       end
 
-      sig { override.returns(T::Array[T::Hash[String, String]]) }
+      sig { override.returns(T::Array[Dependabot::UpdateCheckers::Conflict]) }
       def conflicting_dependencies
         conflicts = ConflictingDependencyResolver.new(
           dependency_files: dependency_files,

--- a/bun/lib/dependabot/bun/update_checker/conflicting_dependency_resolver.rb
+++ b/bun/lib/dependabot/bun/update_checker/conflicting_dependency_resolver.rb
@@ -37,7 +37,7 @@ module Dependabot
         #
         # @param dependency [Dependabot::Dependency] the dependency to check
         # @param target_version [String] the version to check
-        # @return [Array<Hash{String => String}]
+        # @return [Array<Hash{String => Object}]
         #   * name [String] the blocking dependencies name
         #   * version [String] the version of the blocking dependency
         #   * requirement [String] the requirement on the target_dependency
@@ -46,7 +46,7 @@ module Dependabot
             dependency: Dependabot::Dependency,
             target_version: T.nilable(T.any(String, Dependabot::Version))
           )
-            .returns(T::Array[T::Hash[String, String]])
+            .returns(T::Array[Dependabot::UpdateCheckers::Conflict])
         end
         def conflicting_dependencies(dependency:, target_version:)
           SharedHelpers.in_a_temporary_directory do
@@ -63,7 +63,7 @@ module Dependabot
                 function: "yarn:findConflictingDependencies",
                 args: [Dir.pwd, dependency.name, target_version.to_s]
               ),
-              T::Array[T::Hash[String, String]]
+              T::Array[Dependabot::UpdateCheckers::Conflict]
             )
           end
         rescue SharedHelpers::HelperSubprocessFailed

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -131,7 +131,7 @@ module Dependabot
         cooldown_options_builder.release_cooldown_options(@update_cooldown)
       end
 
-      sig { override.returns(T::Array[T::Hash[String, String]]) }
+      sig { override.returns(T::Array[Dependabot::UpdateCheckers::Conflict]) }
       def conflicting_dependencies
         ConflictingDependencyResolver.new(
           dependency_files: dependency_files,

--- a/bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
+++ b/bundler/lib/dependabot/bundler/update_checker/conflicting_dependency_resolver.rb
@@ -49,7 +49,7 @@ module Dependabot
         #
         # @param dependency [Dependabot::Dependency] the dependency to check
         # @param target_version [String] the version to check
-        # @return [Array<Hash{String => String}]
+        # @return [Array<Hash{String => Object}]
         #   * name [String] the blocking dependencies name
         #   * version [String] the version of the blocking dependency
         #   * requirement [String] the requirement on the target_dependency
@@ -58,7 +58,7 @@ module Dependabot
             dependency: Dependabot::Dependency,
             target_version: String
           )
-            .returns(T::Array[T::Hash[String, String]])
+            .returns(T::Array[Dependabot::UpdateCheckers::Conflict])
         end
         def conflicting_dependencies(dependency:, target_version:)
           return [] if lockfile.nil?

--- a/common/lib/dependabot/update_checkers/base.rb
+++ b/common/lib/dependabot/update_checkers/base.rb
@@ -9,6 +9,7 @@ require "dependabot/security_advisory"
 require "dependabot/utils"
 require "dependabot/package/release_cooldown_options"
 require "dependabot/file_filtering"
+require "dependabot/update_checkers/vulnerability_audit"
 
 module Dependabot
   module UpdateCheckers
@@ -168,11 +169,11 @@ module Dependabot
 
       # Finds any dependencies in the lockfile that have a subdependency on the
       # given dependency that do not satisfy the target_version.
-      # @return [Array<Hash{String => String}]
+      # @return [Array<Hash{String => Object}]
       #   name [String] the blocking dependencies name
       #   version [String] the version of the blocking dependency
       #   requirement [String] the requirement on the target_dependency
-      sig { overridable.returns(T::Array[T::Hash[String, String]]) }
+      sig { overridable.returns(T::Array[Dependabot::UpdateCheckers::Conflict]) }
       def conflicting_dependencies
         [] # return an empty array for ecosystems that don't support this yet
       end

--- a/common/lib/dependabot/update_checkers/vulnerability_audit.rb
+++ b/common/lib/dependabot/update_checkers/vulnerability_audit.rb
@@ -1,0 +1,282 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  module UpdateCheckers
+    Conflict = T.type_alias { T::Hash[String, Object] }
+
+    class VulnerabilityAudit < T::ImmutableStruct
+      extend T::Sig
+
+      module ValueParser
+        extend T::Sig
+
+        sig { params(value: Object, context: String).returns(T::Hash[String, Object]) }
+        def self.object_hash(value, context)
+          raise TypeError, "#{context} must be an object" unless value.is_a?(Hash)
+
+          result = T.let({}, T::Hash[String, Object])
+          value.each do |raw_key, raw_value|
+            key = T.cast(raw_key, Object)
+            raise TypeError, "#{context} keys must be strings" unless key.is_a?(String)
+
+            result[key] = T.cast(raw_value, Object)
+          end
+          result
+        end
+
+        sig { params(hash: T::Hash[String, Object], key: String, context: T.nilable(String)).returns(String) }
+        def self.string(hash, key, context: nil)
+          value = hash[key]
+          return value if value.is_a?(String)
+
+          raise TypeError, "#{field_name(context, key)} must be a string"
+        end
+
+        sig do
+          params(
+            hash: T::Hash[String, Object],
+            key: String,
+            context: T.nilable(String)
+          ).returns(T.nilable(String))
+        end
+        def self.optional_string(hash, key, context: nil)
+          value = hash[key]
+          return if value.nil?
+          return value if value.is_a?(String)
+
+          raise TypeError, "#{field_name(context, key)} must be a string or nil"
+        end
+
+        sig { params(hash: T::Hash[String, Object], key: String, context: T.nilable(String)).returns(T::Boolean) }
+        def self.boolean(hash, key, context: nil)
+          value = hash[key]
+          return value if value == true || value == false
+
+          raise TypeError, "#{field_name(context, key)} must be a boolean"
+        end
+
+        sig { params(value: Object, context: String).returns(T::Array[String]) }
+        def self.string_array(value, context)
+          raise TypeError, "#{context} must be an array" unless value.is_a?(Array)
+
+          value.map do |item|
+            item = T.cast(item, Object)
+            raise TypeError, "#{context} must contain only strings" unless item.is_a?(String)
+
+            item
+          end
+        end
+
+        sig { params(context: T.nilable(String), key: String).returns(String) }
+        def self.field_name(context, key)
+          [context, key].compact.join(" ")
+        end
+        private_class_method :field_name
+      end
+      private_constant :ValueParser
+
+      class FixUpdate < T::ImmutableStruct
+        extend T::Sig
+
+        const :dependency_name, String
+        const :current_version, String
+        const :target_version, T.nilable(String), default: nil
+        const :target_version_provided, T::Boolean, default: false
+        const :top_level_ancestors, T::Array[String], default: []
+        const :top_level_ancestors_provided, T::Boolean, default: false
+
+        sig { params(value: Object).returns(FixUpdate) }
+        def self.from_object(value)
+          hash = ValueParser.object_hash(value, "fix update")
+          target_version_provided = hash.key?("target_version")
+          top_level_ancestors_provided = hash.key?("top_level_ancestors")
+          top_level_ancestors =
+            if top_level_ancestors_provided
+              ValueParser.string_array(hash["top_level_ancestors"], "fix update top_level_ancestors")
+            else
+              []
+            end
+
+          new(
+            dependency_name: ValueParser.string(hash, "dependency_name", context: "fix update"),
+            current_version: ValueParser.string(hash, "current_version", context: "fix update"),
+            target_version: ValueParser.optional_string(hash, "target_version", context: "fix update"),
+            target_version_provided: target_version_provided,
+            top_level_ancestors: top_level_ancestors,
+            top_level_ancestors_provided: top_level_ancestors_provided
+          )
+        end
+
+        sig { returns(T::Boolean) }
+        def target_version_provided?
+          target_version_provided
+        end
+
+        sig { returns(Conflict) }
+        def to_h
+          result = T.let(
+            {
+              "dependency_name" => dependency_name,
+              "current_version" => current_version
+            },
+            Conflict
+          )
+          result["target_version"] = target_version if target_version_provided?
+          result["top_level_ancestors"] = top_level_ancestors if top_level_ancestors_provided
+          result
+        end
+      end
+
+      class BlockingDependency < T::ImmutableStruct
+        extend T::Sig
+
+        const :name, String
+        const :version, String
+        const :requirement, String
+        const :top_level_ancestor, String
+
+        sig { params(value: Object).returns(BlockingDependency) }
+        def self.from_object(value)
+          hash = ValueParser.object_hash(value, "blocking dependency")
+          new(
+            name: ValueParser.string(hash, "name", context: "blocking dependency"),
+            version: ValueParser.string(hash, "version", context: "blocking dependency"),
+            requirement: ValueParser.string(hash, "requirement", context: "blocking dependency"),
+            top_level_ancestor: ValueParser.string(hash, "top_level_ancestor", context: "blocking dependency")
+          )
+        end
+
+        sig { returns(Conflict) }
+        def to_h
+          {
+            "name" => name,
+            "version" => version,
+            "requirement" => requirement,
+            "top_level_ancestor" => top_level_ancestor
+          }
+        end
+      end
+
+      const :dependency_name, String
+      const :current_version, T.nilable(String), default: nil
+      const :current_version_provided, T::Boolean, default: false
+      const :target_version, T.nilable(String), default: nil
+      const :target_version_provided, T::Boolean, default: false
+      const :fix_available, T::Boolean
+      const :fix_updates, T::Array[FixUpdate]
+      const :top_level_ancestors, T::Array[String]
+      const :blocking_dependencies, T.nilable(T::Array[BlockingDependency]), default: nil
+      const :blocking_dependencies_provided, T::Boolean, default: false
+      const :explanation, T.nilable(String), default: nil
+
+      sig { params(value: Object).returns(VulnerabilityAudit) }
+      def self.from_object(value)
+        hash = ValueParser.object_hash(value, "audit result")
+        current_version_provided = hash.key?("current_version")
+        target_version_provided = hash.key?("target_version")
+        blocking_dependencies_provided = hash.key?("blocking_dependencies")
+
+        new(
+          dependency_name: ValueParser.string(hash, "dependency_name"),
+          current_version: ValueParser.optional_string(hash, "current_version"),
+          current_version_provided: current_version_provided,
+          target_version: ValueParser.optional_string(hash, "target_version"),
+          target_version_provided: target_version_provided,
+          fix_available: ValueParser.boolean(hash, "fix_available"),
+          fix_updates: parse_fix_updates(hash["fix_updates"]),
+          top_level_ancestors: ValueParser.string_array(hash["top_level_ancestors"], "top_level_ancestors"),
+          blocking_dependencies: parse_blocking_dependencies(hash["blocking_dependencies"]),
+          blocking_dependencies_provided: blocking_dependencies_provided
+        )
+      end
+
+      sig do
+        params(
+          dependency_name: String,
+          explanation: T.nilable(String),
+          blocking_dependencies: T.nilable(T::Array[BlockingDependency]),
+          blocking_dependencies_provided: T::Boolean
+        ).returns(VulnerabilityAudit)
+      end
+      def self.unavailable(
+        dependency_name:,
+        explanation: nil,
+        blocking_dependencies: nil,
+        blocking_dependencies_provided: false
+      )
+        new(
+          dependency_name: dependency_name,
+          fix_available: false,
+          fix_updates: [],
+          top_level_ancestors: [],
+          blocking_dependencies: blocking_dependencies,
+          blocking_dependencies_provided: blocking_dependencies_provided,
+          explanation: explanation
+        )
+      end
+
+      sig { returns(T::Boolean) }
+      def current_version_provided?
+        current_version_provided
+      end
+
+      sig { returns(T::Boolean) }
+      def target_version_provided?
+        target_version_provided
+      end
+
+      sig { returns(T::Boolean) }
+      def blocking_dependencies_provided?
+        blocking_dependencies_provided
+      end
+
+      sig { params(message: String).returns(VulnerabilityAudit) }
+      def unavailable_with_explanation(message)
+        VulnerabilityAudit.unavailable(
+          dependency_name: dependency_name,
+          explanation: message,
+          blocking_dependencies: blocking_dependencies,
+          blocking_dependencies_provided: blocking_dependencies_provided?
+        )
+      end
+
+      sig { returns(Conflict) }
+      def to_h
+        result = T.let(
+          {
+            "dependency_name" => dependency_name,
+            "fix_available" => fix_available,
+            "fix_updates" => fix_updates.map(&:to_h),
+            "top_level_ancestors" => top_level_ancestors
+          },
+          Conflict
+        )
+        result["current_version"] = current_version if current_version_provided?
+        result["target_version"] = target_version if target_version_provided?
+        result["blocking_dependencies"] = blocking_dependencies&.map(&:to_h) if blocking_dependencies_provided?
+        result["explanation"] = explanation if explanation
+        result
+      end
+
+      sig { params(value: Object).returns(T::Array[FixUpdate]) }
+      def self.parse_fix_updates(value)
+        raise TypeError, "fix_updates must be an array" unless value.is_a?(Array)
+
+        value.map { |update| FixUpdate.from_object(T.cast(update, Object)) }
+      end
+      private_class_method :parse_fix_updates
+
+      sig { params(value: Object).returns(T.nilable(T::Array[BlockingDependency])) }
+      def self.parse_blocking_dependencies(value)
+        return if value.nil?
+        raise TypeError, "blocking_dependencies must be an array or nil" unless value.is_a?(Array)
+
+        value.map { |dependency| BlockingDependency.from_object(T.cast(dependency, Object)) }
+      end
+      private_class_method :parse_blocking_dependencies
+    end
+  end
+end

--- a/common/spec/dependabot/update_checkers/vulnerability_audit_spec.rb
+++ b/common/spec/dependabot/update_checkers/vulnerability_audit_spec.rb
@@ -1,0 +1,220 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/update_checkers/vulnerability_audit"
+
+RSpec.describe Dependabot::UpdateCheckers::VulnerabilityAudit do
+  describe ".from_object" do
+    subject(:audit) { described_class.from_object(payload) }
+
+    let(:payload) do
+      {
+        "dependency_name" => "minimist",
+        "current_version" => "1.2.5",
+        "target_version" => "1.2.8",
+        "fix_available" => true,
+        "fix_updates" => [{
+          "dependency_name" => "parent",
+          "current_version" => "2.0.0",
+          "target_version" => "2.1.0",
+          "top_level_ancestors" => ["app"],
+          "dependency_location" => "node_modules/parent"
+        }],
+        "top_level_ancestors" => ["app"],
+        "blocking_dependencies" => [{
+          "name" => "parent",
+          "version" => "2.0.0",
+          "requirement" => "^1.2.5",
+          "top_level_ancestor" => "app"
+        }],
+        "ignored" => true
+      }
+    end
+
+    it "parses the supported fields and ignores unknown keys" do
+      expect(audit).to have_attributes(
+        dependency_name: "minimist",
+        current_version: "1.2.5",
+        target_version: "1.2.8",
+        fix_available: true,
+        top_level_ancestors: ["app"]
+      )
+      expect(audit.fix_updates.first).to have_attributes(
+        dependency_name: "parent",
+        current_version: "2.0.0",
+        target_version: "2.1.0",
+        top_level_ancestors: ["app"]
+      )
+      expect(audit.blocking_dependencies&.first).to have_attributes(
+        name: "parent",
+        version: "2.0.0",
+        requirement: "^1.2.5",
+        top_level_ancestor: "app"
+      )
+      expect(audit.to_h).not_to include("ignored", "dependency_location")
+    end
+
+    it "preserves the public hash shape" do
+      expect(audit.to_h).to eq(
+        {
+          "dependency_name" => "minimist",
+          "current_version" => "1.2.5",
+          "target_version" => "1.2.8",
+          "fix_available" => true,
+          "fix_updates" => [{
+            "dependency_name" => "parent",
+            "current_version" => "2.0.0",
+            "target_version" => "2.1.0",
+            "top_level_ancestors" => ["app"]
+          }],
+          "top_level_ancestors" => ["app"],
+          "blocking_dependencies" => [{
+            "name" => "parent",
+            "version" => "2.0.0",
+            "requirement" => "^1.2.5",
+            "top_level_ancestor" => "app"
+          }]
+        }
+      )
+    end
+
+    context "when target versions are absent" do
+      let(:payload) do
+        {
+          "dependency_name" => "minimist",
+          "fix_available" => true,
+          "fix_updates" => [{
+            "dependency_name" => "parent",
+            "current_version" => "2.0.0"
+          }],
+          "top_level_ancestors" => []
+        }
+      end
+
+      it "keeps the values nil and omits their keys when serialized" do
+        expect(audit.target_version).to be_nil
+        expect(audit.target_version_provided?).to be(false)
+        expect(audit.fix_updates.first.target_version).to be_nil
+        expect(audit.fix_updates.first.target_version_provided?).to be(false)
+        expect(audit.to_h).not_to have_key("target_version")
+        expect(audit.to_h.fetch("fix_updates").first).not_to have_key("target_version")
+      end
+    end
+
+    context "when blocking dependencies are absent" do
+      let(:payload) do
+        {
+          "dependency_name" => "minimist",
+          "fix_available" => false,
+          "fix_updates" => [],
+          "top_level_ancestors" => []
+        }
+      end
+
+      it "omits the key when serialized" do
+        expect(audit.blocking_dependencies).to be_nil
+        expect(audit.blocking_dependencies_provided?).to be(false)
+        expect(audit.to_h).not_to have_key("blocking_dependencies")
+      end
+    end
+
+    context "when blocking dependencies are empty" do
+      let(:payload) do
+        {
+          "dependency_name" => "minimist",
+          "fix_available" => false,
+          "fix_updates" => [],
+          "top_level_ancestors" => [],
+          "blocking_dependencies" => []
+        }
+      end
+
+      it "retains the empty array when serialized" do
+        expect(audit.blocking_dependencies).to eq([])
+        expect(audit.blocking_dependencies_provided?).to be(true)
+        expect(audit.to_h).to include("blocking_dependencies" => [])
+      end
+    end
+
+    [
+      [nil, "audit result must be an object"],
+      [{}, "dependency_name must be a string"],
+      [{
+        "dependency_name" => "minimist",
+        "fix_available" => "yes",
+        "fix_updates" => [],
+        "top_level_ancestors" => []
+      }, "fix_available must be a boolean"],
+      [{
+        "dependency_name" => "minimist",
+        "fix_available" => true,
+        "fix_updates" => [{}],
+        "top_level_ancestors" => []
+      }, "fix update dependency_name must be a string"],
+      [{
+        "dependency_name" => "minimist",
+        "fix_available" => true,
+        "fix_updates" => [],
+        "top_level_ancestors" => ["app", 1]
+      }, "top_level_ancestors must contain only strings"],
+      [{
+        "dependency_name" => "minimist",
+        "fix_available" => false,
+        "fix_updates" => [],
+        "top_level_ancestors" => [],
+        "blocking_dependencies" => [{}]
+      }, "blocking dependency name must be a string"]
+    ].each do |invalid_payload, message|
+      context "with #{message}" do
+        let(:payload) { invalid_payload }
+
+        it "raises an explicit type error" do
+          expect { audit }.to raise_error(TypeError, message)
+        end
+      end
+    end
+  end
+
+  describe ".unavailable" do
+    it "builds the existing helper-failure response" do
+      audit = described_class.unavailable(dependency_name: "minimist")
+
+      expect(audit.to_h).to eq(
+        {
+          "dependency_name" => "minimist",
+          "fix_available" => false,
+          "fix_updates" => [],
+          "top_level_ancestors" => []
+        }
+      )
+    end
+  end
+
+  describe "#unavailable_with_explanation" do
+    it "keeps an explicitly empty blocker list" do
+      audit = described_class.from_object(
+        {
+          "dependency_name" => "minimist",
+          "fix_available" => false,
+          "fix_updates" => [],
+          "top_level_ancestors" => [],
+          "blocking_dependencies" => []
+        }
+      )
+
+      unavailable = audit.unavailable_with_explanation("No fix")
+
+      expect(unavailable.to_h).to eq(
+        {
+          "dependency_name" => "minimist",
+          "fix_available" => false,
+          "fix_updates" => [],
+          "top_level_ancestors" => [],
+          "blocking_dependencies" => [],
+          "explanation" => "No fix"
+        }
+      )
+    end
+  end
+end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -199,7 +199,7 @@ module Dependabot
         library? ? RequirementsUpdateStrategy::WidenRanges : RequirementsUpdateStrategy::BumpVersions
       end
 
-      sig { override.returns(T::Array[T::Hash[String, String]]) }
+      sig { override.returns(T::Array[Dependabot::UpdateCheckers::Conflict]) }
       def conflicting_dependencies
         conflicts = ConflictingDependencyResolver.new(
           dependency_files: dependency_files,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/conflicting_dependency_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/conflicting_dependency_resolver.rb
@@ -37,7 +37,7 @@ module Dependabot
         #
         # @param dependency [Dependabot::Dependency] the dependency to check
         # @param target_version [String] the version to check
-        # @return [Array<Hash{String => String}]
+        # @return [Array<Hash{String => Object}]
         #   * name [String] the blocking dependencies name
         #   * version [String] the version of the blocking dependency
         #   * requirement [String] the requirement on the target_dependency
@@ -46,7 +46,7 @@ module Dependabot
             dependency: Dependabot::Dependency,
             target_version: T.nilable(T.any(String, Dependabot::Version))
           )
-            .returns(T::Array[T::Hash[String, String]])
+            .returns(T::Array[Dependabot::UpdateCheckers::Conflict])
         end
         def conflicting_dependencies(dependency:, target_version:)
           SharedHelpers.in_a_temporary_directory do
@@ -70,7 +70,7 @@ module Dependabot
                   function: "npm:findConflictingDependencies",
                   args: [Dir.pwd, dependency.name, target_version.to_s]
                 ),
-                T::Array[T::Hash[String, String]]
+                T::Array[Dependabot::UpdateCheckers::Conflict]
               )
             else
               T.cast(
@@ -79,7 +79,7 @@ module Dependabot
                   function: "yarn:findConflictingDependencies",
                   args: [Dir.pwd, dependency.name, target_version.to_s]
                 ),
-                T::Array[T::Hash[String, String]]
+                T::Array[Dependabot::UpdateCheckers::Conflict]
               )
             end
           end

--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -163,14 +163,14 @@ module Dependabot
         params(
           checker: Dependabot::UpdateCheckers::Base,
           latest_allowed_version: String,
-          conflicting_dependencies: T::Array[T::Hash[String, String]]
+          conflicting_dependencies: T::Array[Dependabot::UpdateCheckers::Conflict]
         )
           .returns(String)
       end
       def security_update_not_possible_message(checker, latest_allowed_version, conflicting_dependencies)
         if conflicting_dependencies.any?
           dep_messages = conflicting_dependencies.map do |dep|
-            "  #{dep['explanation']}"
+            "  #{T.cast(dep['explanation'], String)}"
           end.join("\n")
 
           dependencies_pluralized =


### PR DESCRIPTION
Add shared typed models for vulnerability-audit results and correct the `conflicting_dependencies` value type. The next two PRs wire npm and Bun into the parser.