### PR TITLE
Type npm vulnerability audits

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 790
+# Offense count: 766
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -333,7 +333,6 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/library_detector.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/version_selector.rb"
     - "opentofu/lib/dependabot/opentofu/file_parser.rb"
     - "opentofu/lib/dependabot/opentofu/package/package_details_fetcher.rb"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb
@@ -12,6 +12,9 @@ module Dependabot
     class UpdateChecker < Dependabot::UpdateCheckers::Base # rubocop:disable Metrics/ClassLength
       extend T::Sig
 
+      Audit = Dependabot::UpdateCheckers::VulnerabilityAudit
+      FixUpdate = Dependabot::UpdateCheckers::VulnerabilityAudit::FixUpdate
+
       require_relative "update_checker/requirements_updater"
       require_relative "update_checker/library_detector"
       require_relative "update_checker/latest_version_finder"
@@ -52,7 +55,7 @@ module Dependabot
         @latest_version = T.let(nil, T.nilable(T.any(String, Gem::Version)))
         @latest_resolvable_version = T.let(nil, T.nilable(T.any(String, Dependabot::Version)))
         @updated_requirements = T.let(nil, T.nilable(T::Array[Dependabot::DependencyRequirement]))
-        @vulnerability_audit = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
+        @vulnerability_audit = T.let(nil, T.nilable(Audit))
         @vulnerable_versions = T.let(nil, T.nilable(T::Array[T.any(String, Gem::Version)]))
 
         @latest_version_for_git_dependency = T.let(nil, T.nilable(T.any(String, Gem::Version)))
@@ -117,7 +120,7 @@ module Dependabot
       sig { override.returns(T.nilable(Dependabot::Version)) }
       def lowest_security_fix_version
         # This will require a full unlock to update multiple top level ancestors.
-        return if vulnerability_audit["fix_available"] && vulnerability_audit["top_level_ancestors"].count > 1
+        return if vulnerability_audit.fix_available && vulnerability_audit.top_level_ancestors.count > 1
 
         latest_version_finder.lowest_security_fix_version
       end
@@ -210,9 +213,8 @@ module Dependabot
         )
         return conflicts unless vulnerability_audit_performed?
 
-        vulnerable = [vulnerability_audit].select do |hash|
-          !hash["fix_available"] && hash["explanation"]
-        end
+        audit = vulnerability_audit
+        vulnerable = !audit.fix_available && audit.explanation ? [audit.to_h] : []
 
         conflicts + vulnerable
       end
@@ -224,7 +226,7 @@ module Dependabot
         !!defined?(@vulnerability_audit)
       end
 
-      sig { returns(T::Hash[String, T.untyped]) }
+      sig { returns(Audit) }
       def vulnerability_audit
         @vulnerability_audit ||=
           VulnerabilityAuditor.new(
@@ -257,12 +259,12 @@ module Dependabot
 
         return false unless security_advisories.any?
 
-        vulnerability_audit["fix_available"]
+        vulnerability_audit.fix_available
       end
 
       sig { override.returns(T::Array[Dependabot::Dependency]) }
       def updated_dependencies_after_full_unlock
-        return conflicting_updated_dependencies if security_advisories.any? && vulnerability_audit["fix_available"]
+        return conflicting_updated_dependencies if security_advisories.any? && vulnerability_audit.fix_available
 
         T.must(version_resolver.dependency_updates_from_full_unlock)
          .map { |update_details| build_updated_dependency(update_details.transform_keys(&:to_sym)) }
@@ -273,10 +275,10 @@ module Dependabot
       def conflicting_updated_dependencies
         top_level_dependencies = top_level_dependency_lookup
 
-        updated_deps = vulnerability_audit["fix_updates"].filter_map do |update|
-          next log_skipped_fix_update(update) if update["target_version"] == update["current_version"]
+        updated_deps = vulnerability_audit.fix_updates.filter_map do |update|
+          next log_skipped_fix_update(update) if update.target_version == update.current_version
 
-          dependency_name = update["dependency_name"]
+          dependency_name = update.dependency_name
           requirements = requirements_for_update(top_level_dependencies, update)
 
           build_updated_dependency(
@@ -285,8 +287,8 @@ module Dependabot
               package_manager: "npm_and_yarn",
               requirements: requirements
             ),
-            version: update["target_version"],
-            previous_version: update["current_version"]
+            version: update.target_version,
+            previous_version: update.current_version
           )
         end
         # rubocop:enable Metrics/AbcSize
@@ -296,7 +298,7 @@ module Dependabot
         # to include it so it's described in the PR and we'll pass validation
         # that this dependency is at a non-vulnerable version.
         if updated_deps.none? { |dep| dep.name == dependency.name }
-          target_version = vulnerability_audit["target_version"]
+          target_version = vulnerability_audit.target_version
           updated_deps << build_updated_dependency(
             dependency: dependency,
             version: target_version,
@@ -312,11 +314,11 @@ module Dependabot
           updated_deps.reject { |dep| dep.name == dependency.name }
       end
 
-      sig { params(update: T::Hash[String, T.untyped]).returns(NilClass) }
+      sig { params(update: FixUpdate).returns(NilClass) }
       def log_skipped_fix_update(update)
         Dependabot.logger.info(
-          "#{update['dependency_name']} is already at the target version " \
-          "(#{update['current_version']}), no update needed"
+          "#{update.dependency_name} is already at the target version " \
+          "(#{update.current_version}), no update needed"
         )
         nil
       end
@@ -324,12 +326,12 @@ module Dependabot
       sig do
         params(
           top_level_dependencies: T::Hash[String, Dependabot::Dependency],
-          update: T::Hash[String, T.untyped]
-        ).returns(T::Array[T::Hash[Symbol, T.untyped]])
+          update: FixUpdate
+        ).returns(T::Array[Dependabot::DependencyRequirement])
       end
       def requirements_for_update(top_level_dependencies, update)
-        dependency_name = update["dependency_name"]
-        if top_level_dependencies[dependency_name]&.version == update["current_version"]
+        dependency_name = update.dependency_name
+        if top_level_dependencies[dependency_name]&.version == update.current_version
           top_level_dependencies[dependency_name]&.requirements || []
         else
           []

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -44,20 +44,7 @@ module Dependabot
         #
         # @param dependency [Dependabot::Dependency] the dependency to check
         # @param security_advisories [Array<Dependabot::SecurityAdvisory>] advisories for the dependency
-        # @return [Hash<String, [String, Array<Hash<String, String>>]>] the audit results
-        #   * :dependency_name [String] the name of the dependency
-        #   * :fix_available [Boolean] whether a fix is available
-        #   * :current_version [String] the version of the dependency
-        #   * :target_version [String] the version of the dependency after the fix
-        #   * :fix_updates [Array<Hash<String, String>>] a list of dependencies to update in order to fix
-        #     * :dependency_name [String] the name of the blocking dependency
-        #     * :current_version [String] the current version of the blocking dependency
-        #     * :target_version [String] the target version of the blocking dependency
-        #     * :top_level_ancestors [Array<String>] the names of top-level dependencies with a transitive
-        #       dependency on the blocking dependency
-        #   * :top_level_ancestors [Array<String>] the names of all top-level dependencies with a transitive
-        #     dependency on the dependency
-        #   * :explanation [String] an explanation for why the project failed the vulnerability auditor run
+        # @return [Dependabot::UpdateCheckers::VulnerabilityAudit] the parsed audit result
         sig do
           params(
             dependency: Dependabot::Dependency,

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/vulnerability_auditor.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "stringio"
@@ -13,12 +13,17 @@ require "dependabot/npm_and_yarn/native_helpers"
 require "dependabot/npm_and_yarn/update_checker"
 require "dependabot/npm_and_yarn/update_checker/dependency_files_builder"
 require "dependabot/shared_helpers"
+require "dependabot/update_checkers/vulnerability_audit"
 
 module Dependabot
   module NpmAndYarn
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       class VulnerabilityAuditor
         extend T::Sig
+
+        Audit = Dependabot::UpdateCheckers::VulnerabilityAudit
+        FixUpdate = Dependabot::UpdateCheckers::VulnerabilityAudit::FixUpdate
+        BlockingDependency = Dependabot::UpdateCheckers::VulnerabilityAudit::BlockingDependency
 
         sig do
           params(
@@ -58,7 +63,7 @@ module Dependabot
             dependency: Dependabot::Dependency,
             security_advisories: T::Array[Dependabot::SecurityAdvisory]
           )
-            .returns(T::Hash[String, T.untyped])
+            .returns(Audit)
         end
         def audit(dependency:, security_advisories:)
           Dependabot.logger.info("VulnerabilityAuditor: starting audit")
@@ -82,22 +87,17 @@ module Dependabot
         sig { returns(T::Array[Dependabot::Credential]) }
         attr_reader :credentials
 
-        sig { params(dependency: Dependabot::Dependency).returns(T::Hash[String, T.untyped]) }
+        sig { params(dependency: Dependabot::Dependency).returns(Audit) }
         def fix_unavailable_response(dependency)
-          {
-            "dependency_name" => dependency.name,
-            "fix_available" => false,
-            "fix_updates" => [],
-            "top_level_ancestors" => []
-          }
+          Audit.unavailable(dependency_name: dependency.name)
         end
 
         sig do
           params(
             dependency: Dependabot::Dependency,
             security_advisories: T::Array[Dependabot::SecurityAdvisory],
-            fix_unavailable: T::Hash[String, T.untyped]
-          ).returns(T::Hash[String, T.untyped])
+            fix_unavailable: Audit
+          ).returns(Audit)
         end
         def run_audit(dependency:, security_advisories:, fix_unavailable:)
           SharedHelpers.in_a_temporary_directory do
@@ -137,7 +137,7 @@ module Dependabot
         end
 
         sig do
-          params(security_advisories: T::Array[Dependabot::SecurityAdvisory]).returns(T::Hash[String, T.untyped])
+          params(security_advisories: T::Array[Dependabot::SecurityAdvisory]).returns(Audit)
         end
         def run_vulnerability_auditor(security_advisories)
           vuln_versions = security_advisories.map do |advisory|
@@ -147,13 +147,12 @@ module Dependabot
             }
           end
 
-          T.cast(
+          Audit.from_object(
             SharedHelpers.run_helper_subprocess(
               command: NativeHelpers.helper_path,
               function: "npm:vulnerabilityAuditor",
               args: [Dir.pwd, vuln_versions]
-            ),
-            T::Hash[String, T.untyped]
+            )
           )
         end
 
@@ -161,9 +160,9 @@ module Dependabot
           params(
             dependency: Dependabot::Dependency,
             security_advisories: T::Array[Dependabot::SecurityAdvisory],
-            audit_result: T::Hash[String, T.untyped],
-            fix_unavailable: T::Hash[String, T.untyped]
-          ).returns(T::Hash[String, T.untyped])
+            audit_result: Audit,
+            fix_unavailable: Audit
+          ).returns(Audit)
         end
         def handle_audit_result(dependency:, security_advisories:, audit_result:, fix_unavailable:)
           validation_result = validate_audit_result(audit_result, security_advisories)
@@ -173,17 +172,19 @@ module Dependabot
           end
 
           Dependabot.logger.info("VulnerabilityAuditor: audit result not viable: #{validation_result}")
-          fix_unavailable["explanation"] = explain_fix_unavailable(validation_result, dependency, audit_result)
-          blocking_dependencies = audit_result["blocking_dependencies"]
-          fix_unavailable["blocking_dependencies"] = blocking_dependencies if blocking_dependencies
-          fix_unavailable
+          Audit.unavailable(
+            dependency_name: fix_unavailable.dependency_name,
+            explanation: explain_fix_unavailable(validation_result, dependency, audit_result),
+            blocking_dependencies: audit_result.blocking_dependencies,
+            blocking_dependencies_provided: audit_result.blocking_dependencies_provided?
+          )
         end
 
         sig do
           params(
             validation_result: Symbol,
             dependency: Dependabot::Dependency,
-            audit_result: T::Hash[String, T.untyped]
+            audit_result: Audit
           ).returns(String)
         end
         def explain_fix_unavailable(validation_result, dependency, audit_result)
@@ -193,20 +194,31 @@ module Dependabot
           when :dependency_still_vulnerable
             dependency_still_vulnerable_message(dependency, audit_result)
           when :downgrades_dependencies
-            downgraded_dependency = audit_result["fix_updates"].find do |update|
-              downgrades_version?(update["current_version"], update["target_version"])
+            downgraded_dependency = audit_result.fix_updates.find do |update|
+              downgrades_version?(update.current_version, update.target_version)
             end
 
             # When no individual `fix_updates` entry is itself a downgrade, the audited
             # dependency's own current/target versions are the ones being downgraded.
-            downgraded_dependency ||= {
-              "dependency_name" => dependency.name,
-              "current_version" => audit_result["current_version"],
-              "target_version" => audit_result["target_version"],
-              "top_level_ancestors" => audit_result["top_level_ancestors"]
-            }
-
-            downgraded_dependency_message(dependency, downgraded_dependency, audit_result)
+            if downgraded_dependency
+              downgraded_dependency_message(
+                dependency,
+                dependency_name: downgraded_dependency.dependency_name,
+                current_version: downgraded_dependency.current_version,
+                target_version: downgraded_dependency.target_version,
+                top_level_ancestors: downgraded_dependency.top_level_ancestors,
+                audit_result: audit_result
+              )
+            else
+              downgraded_dependency_message(
+                dependency,
+                dependency_name: dependency.name,
+                current_version: audit_result.current_version,
+                target_version: audit_result.target_version,
+                top_level_ancestors: audit_result.top_level_ancestors,
+                audit_result: audit_result
+              )
+            end
           when :fix_incomplete
             "The lockfile might be out of sync?"
           else
@@ -216,12 +228,12 @@ module Dependabot
 
         sig do
           params(
-            audit_result: T::Hash[String, T.untyped],
+            audit_result: Audit,
             security_advisories: T::Array[Dependabot::SecurityAdvisory]
           ).returns(Symbol)
         end
         def validate_audit_result(audit_result, security_advisories)
-          return :fix_unavailable unless audit_result["fix_available"]
+          return :fix_unavailable unless audit_result.fix_available
           return :dependency_still_vulnerable if dependency_still_vulnerable?(audit_result, security_advisories)
           return :downgrades_dependencies if downgrades_dependencies?(audit_result)
           return :fix_incomplete if fix_incomplete?(audit_result)
@@ -231,25 +243,26 @@ module Dependabot
 
         sig do
           params(
-            audit_result: T::Hash[String, T.untyped],
+            audit_result: Audit,
             security_advisories: T::Array[Dependabot::SecurityAdvisory]
           )
             .returns(T::Boolean)
         end
         def dependency_still_vulnerable?(audit_result, security_advisories)
           # vulnerable dependency is removed if the target version is nil
-          return false unless audit_result["target_version"]
+          target_version = audit_result.target_version
+          return false unless target_version
 
-          version = Version.new(audit_result["target_version"])
+          version = Version.new(target_version)
           security_advisories.any? { |a| a.vulnerable?(version) }
         end
 
-        sig { params(audit_result: T::Hash[String, T.untyped]).returns(T::Boolean) }
+        sig { params(audit_result: Audit).returns(T::Boolean) }
         def downgrades_dependencies?(audit_result)
-          return true if downgrades_version?(audit_result["current_version"], audit_result["target_version"])
+          return true if downgrades_version?(audit_result.current_version, audit_result.target_version)
 
-          audit_result["fix_updates"].any? do |update|
-            downgrades_version?(update["current_version"], update["target_version"])
+          audit_result.fix_updates.any? do |update|
+            downgrades_version?(update.current_version, update.target_version)
           end
         end
 
@@ -271,24 +284,23 @@ module Dependabot
         sig do
           params(
             dependency: Dependabot::Dependency,
-            audit_result: T::Hash[String, T.untyped]
+            audit_result: Audit
           ).returns(String)
         end
         def fix_unavailable_message(dependency, audit_result)
-          blockers = audit_result["blocking_dependencies"]
+          blockers = audit_result.blocking_dependencies
           return generic_fix_unavailable_message(dependency) if blockers.nil? || blockers.empty?
 
           # Group by the top-level dependency a customer would actually need to act on, rather than
           # listing one line per (parent, version, requirement) tuple. A single top-level package
           # (e.g. jest) commonly pulls in the vulnerable dependency via several different parents/
           # versions, and repeating each of those separately buries the actionable information.
-          grouped_by_ancestor = blockers.group_by { |blocker| blocker["top_level_ancestor"] }
+          grouped_by_ancestor = blockers.group_by(&:top_level_ancestor)
 
           ancestor_lines = grouped_by_ancestor.sort.map do |ancestor, group|
             requirements = group.map do |blocker|
-              blocker_name = blocker["name"]
-              detail = "#{dependency.name}@#{blocker['requirement']}"
-              detail += " (via #{blocker_name}@#{blocker['version']})" if blocker_name != ancestor
+              detail = "#{dependency.name}@#{blocker.requirement}"
+              detail += " (via #{blocker.name}@#{blocker.version})" if blocker.name != ancestor
               detail
             end.uniq.join(" and ")
 
@@ -318,29 +330,34 @@ module Dependabot
         sig do
           params(
             dependency: Dependabot::Dependency,
-            audit_result: T::Hash[String, T.untyped]
+            audit_result: Audit
           ).returns(String)
         end
         def dependency_still_vulnerable_message(dependency, audit_result)
           "A patched version exists for #{dependency.name}, but the available " \
-            "update path still resolves it to #{audit_result['target_version']}"
+            "update path still resolves it to #{audit_result.target_version}"
         end
 
         sig do
           params(
             dependency: Dependabot::Dependency,
-            downgraded_dependency: T::Hash[String, T.untyped],
-            audit_result: T.nilable(T::Hash[String, T.untyped])
+            dependency_name: String,
+            current_version: T.nilable(String),
+            target_version: T.nilable(String),
+            top_level_ancestors: T::Array[String],
+            audit_result: T.nilable(Audit)
           ).returns(String)
         end
-        def downgraded_dependency_message(dependency, downgraded_dependency, audit_result = nil)
-          downgraded_name = downgraded_dependency["dependency_name"]
-          current_version = downgraded_dependency["current_version"]
-          target_version = downgraded_dependency["target_version"]
-          top_level_ancestors = downgraded_dependency["top_level_ancestors"]
-
+        def downgraded_dependency_message(
+          dependency,
+          dependency_name:,
+          current_version:,
+          target_version:,
+          top_level_ancestors:,
+          audit_result: nil
+        )
           message = "A patched version exists for #{dependency.name}, but the available " \
-                    "update path would downgrade #{downgraded_name} " \
+                    "update path would downgrade #{dependency_name} " \
                     "from #{current_version} to #{target_version}"
 
           # `blocking_dependencies` covers every top-level package that still requires a
@@ -348,14 +365,16 @@ module Dependabot
           # packages unrelated to why *this particular* dependency was downgraded. Narrow it down
           # to only the edges reachable from the downgraded dependency itself so the explanation
           # stays focused on the actual cause.
-          relevant_ancestors = ([downgraded_name] + Array(top_level_ancestors)).uniq
-          blockers = audit_result&.dig("blocking_dependencies")
-          relevant_blockers = blockers&.select { |blocker| relevant_ancestors.include?(blocker["top_level_ancestor"]) }
+          relevant_ancestors = ([dependency_name] + top_level_ancestors).uniq
+          blockers = audit_result&.blocking_dependencies
+          relevant_blockers = blockers&.select do |blocker|
+            relevant_ancestors.include?(blocker.top_level_ancestor)
+          end
 
           if relevant_blockers&.any?
             details = downgrade_blocker_details(dependency.name, relevant_blockers)
             message += " because:\n#{details}"
-          elsif top_level_ancestors&.any?
+          elsif top_level_ancestors.any?
             ancestors_list = top_level_ancestors.sort.map { |ancestor| "  - #{ancestor}" }.join("\n")
             message += " because these top-level dependencies are involved in the update path:\n#{ancestors_list}"
             message += "\n\nTo resolve this, update #{top_level_ancestors.sort.join(', ')} to a release " \
@@ -369,17 +388,16 @@ module Dependabot
         sig do
           params(
             vulnerable_dependency: String,
-            blockers: T::Array[T::Hash[String, T.untyped]]
+            blockers: T::Array[BlockingDependency]
           ).returns(String)
         end
         def downgrade_blocker_details(vulnerable_dependency, blockers)
-          grouped_by_ancestor = blockers.group_by { |blocker| blocker["top_level_ancestor"] }
+          grouped_by_ancestor = blockers.group_by(&:top_level_ancestor)
 
           ancestor_lines = grouped_by_ancestor.sort.map do |ancestor, group|
             requirements = group.map do |blocker|
-              blocker_name = blocker["name"]
-              detail = "#{vulnerable_dependency}@#{blocker['requirement']}"
-              detail += " (via #{blocker_name}@#{blocker['version']})" if blocker_name != ancestor
+              detail = "#{vulnerable_dependency}@#{blocker.requirement}"
+              detail += " (via #{blocker.name}@#{blocker.version})" if blocker.name != ancestor
               detail
             end.uniq.join(" and ")
 
@@ -398,10 +416,10 @@ module Dependabot
           details
         end
 
-        sig { params(audit_result: T::Hash[String, T.untyped]).returns(T::Boolean) }
+        sig { params(audit_result: Audit).returns(T::Boolean) }
         def fix_incomplete?(audit_result)
-          audit_result["fix_updates"].any? { |update| !update.key?("target_version") } ||
-            audit_result["fix_updates"].empty?
+          audit_result.fix_updates.any? { |update| !update.target_version_provided? } ||
+            audit_result.fix_updates.empty?
         end
 
         sig do

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/vulnerability_auditor_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
         ]
 
         expect(Dependabot.logger).to receive(:info).with(/audit result viable/i)
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "dependency_name" => dependency.name,
             "current_version" => "1.0.0",
@@ -95,7 +95,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
         ]
 
         expect(Dependabot.logger).to receive(:info).with(/audit result viable/i)
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "dependency_name" => dependency.name,
             "current_version" => "1.0.0",
@@ -125,7 +125,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
           )
         ]
 
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "dependency_name" => dependency.name,
             "current_version" => "1.0.0",
@@ -167,7 +167,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
           )
         ]
 
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "dependency_name" => dependency.name,
             "current_version" => "1.0.0",
@@ -223,7 +223,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             }]
           })
 
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "fix_available" => false,
             "explanation" =>
@@ -291,7 +291,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             ]
           })
 
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "fix_available" => false,
             "explanation" =>
@@ -331,7 +331,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
             "blocking_dependencies" => []
           })
 
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "fix_available" => false,
             "explanation" =>
@@ -362,12 +362,15 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
         allow(Dependabot::SharedHelpers)
           .to receive(:run_helper_subprocess)
           .and_return({
+            "dependency_name" => dependency.name,
             "fix_available" => true,
-            "target_version" => "1.0.0"
+            "target_version" => "1.0.0",
+            "fix_updates" => [],
+            "top_level_ancestors" => []
           })
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: dependency_still_vulnerable/i)
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "fix_available" => false,
             "explanation" =>
@@ -407,7 +410,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
           })
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: downgrades_dependencies/i)
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "fix_available" => false,
             "explanation" =>
@@ -441,12 +444,12 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: downgrades_dependencies/i)
         result = vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories)
-        expect(result["fix_available"]).to be false
-        expect(result["explanation"]).to include(
+        expect(result.fix_available).to be false
+        expect(result.explanation).to include(
           "A patched version exists for #{dependency.name}, but the available " \
           "update path would downgrade #{dependency.name} from 2.0.0 to 1.5.0"
         )
-        expect(result["explanation"]).to include("- eslint-config-next")
+        expect(result.explanation).to include("- eslint-config-next")
       end
 
       it "provides detailed information when top_level_ancestors are available" do
@@ -477,17 +480,17 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: downgrades_dependencies/i)
         result = vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories)
-        expect(result["fix_available"]).to be false
-        expect(result["explanation"]).to include(
+        expect(result.fix_available).to be false
+        expect(result.explanation).to include(
           "A patched version exists for #{dependency.name}, but the available " \
           "update path would downgrade @dependabot-fixtures/npm-parent-dependency from 2.0.0 to 1.0.2"
         )
-        expect(result["explanation"]).to include(
+        expect(result.explanation).to include(
           "because these top-level dependencies are involved in the update path:"
         )
-        expect(result["explanation"]).to include("- eslint-config-next")
-        expect(result["explanation"]).to include("- jest")
-        expect(result["explanation"]).to include(
+        expect(result.explanation).to include("- eslint-config-next")
+        expect(result.explanation).to include("- jest")
+        expect(result.explanation).to include(
           "To resolve this, update eslint-config-next, jest to a release that allows #{dependency.name}"
         )
       end
@@ -540,8 +543,8 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: downgrades_dependencies/i)
         result = vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories)
-        expect(result["fix_available"]).to be false
-        explanation = result["explanation"]
+        expect(result.fix_available).to be false
+        explanation = result.explanation
         expect(explanation).to include(
           "A patched version exists for #{dependency.name}, but the available " \
           "update path would downgrade @svgr/webpack from 8.1.0 to 6.5.1"
@@ -574,7 +577,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
         ]
 
         expect(Dependabot.logger).to receive(:info).with(/audit result not viable: fix_incomplete/i)
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "fix_available" => false,
             "explanation" => "The lockfile might be out of sync?"
@@ -587,7 +590,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
 
       it "logs missing lockfile and returns fix_available => false" do
         expect(Dependabot.logger).to receive(:info).with(/missing lockfile/i)
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: []))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: []).to_h)
           .to include("fix_available" => false)
       end
     end
@@ -603,8 +606,29 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
           .to receive(:helper_path).and_return("false")
 
         expect(Dependabot.logger).to receive(:info).with(/failed/i)
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: []))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: []).to_h)
           .to include("fix_available" => false)
+      end
+    end
+
+    context "when the native helper returns a malformed result" do
+      let(:dependency_files) { project_dependency_files("npm8/simple") }
+
+      before do
+        allow(Dependabot::SharedHelpers)
+          .to receive(:run_helper_subprocess)
+          .and_return({
+            "dependency_name" => dependency.name,
+            "fix_available" => true,
+            "fix_updates" => "invalid",
+            "top_level_ancestors" => []
+          })
+      end
+
+      it "raises at the helper boundary" do
+        expect do
+          vulnerability_auditor.audit(dependency: dependency, security_advisories: [])
+        end.to raise_error(TypeError, "fix_updates must be an array")
       end
     end
 
@@ -632,7 +656,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
         expect(Dependabot.logger)
           .to have_received(:info)
           .with(a_string_including("helper.rb:1\nhelper.rb:2"))
-        expect(result).to include("fix_available" => false)
+        expect(result.to_h).to include("fix_available" => false)
       end
     end
 
@@ -649,7 +673,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::VulnerabilityAuditor do
           )
         ]
 
-        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories))
+        expect(vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories).to_h)
           .to include(
             "dependency_name" => dependency.name,
             "current_version" => "1.0.0",

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker_spec.rb
@@ -11,6 +11,17 @@ require "dependabot/requirements_update_strategy"
 require_common_spec "update_checkers/shared_examples_for_update_checkers"
 
 RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
+  def build_vulnerability_audit(attributes)
+    Dependabot::UpdateCheckers::VulnerabilityAudit.from_object(
+      {
+        "dependency_name" => dependency.name,
+        "fix_available" => false,
+        "fix_updates" => [],
+        "top_level_ancestors" => []
+      }.merge(attributes)
+    )
+  end
+
   let(:dependency_version) { "1.0.0" }
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -626,10 +637,10 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
       before do
         allow(described_class::VulnerabilityAuditor).to receive(:new).and_return(vulnerability_auditor)
         allow(vulnerability_auditor).to receive(:audit).and_return(
-          {
+          build_vulnerability_audit(
             "fix_available" => true,
             "top_level_ancestors" => %w(applause lodash)
-          }
+          )
         )
       end
 
@@ -1926,7 +1937,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
       context "when a fix_update has the same target and current version" do
         let(:vulnerability_audit_result) do
-          {
+          build_vulnerability_audit(
             "fix_available" => true,
             "target_version" => "1.0.1",
             "fix_updates" => [
@@ -1938,7 +1949,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
               }
             ],
             "top_level_ancestors" => ["@dependabot-fixtures/npm-parent-dependency"]
-          }
+          )
         end
 
         it "skips the no-op fix_update and updates the target dependency directly" do
@@ -1951,7 +1962,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
 
       context "when there are both no-op and real fix_updates" do
         let(:vulnerability_audit_result) do
-          {
+          build_vulnerability_audit(
             "fix_available" => true,
             "target_version" => "1.0.1",
             "fix_updates" => [
@@ -1969,7 +1980,7 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker do
               }
             ],
             "top_level_ancestors" => ["@dependabot-fixtures/npm-parent-dependency"]
-          }
+          )
         end
 
         it "skips the no-op and includes the real update with information_only target" do


### PR DESCRIPTION
Migrate npm vulnerability auditing and its update-checker consumers to the shared model.

`T.untyped`: 790 -> 766; excluded files: 141 -> 140.