### PR TITLE
Type Bun vulnerability audits

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 766
+# Offense count: 758
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -259,7 +259,6 @@ Sorbet/ForbidTUntyped:
     - "bun/lib/dependabot/bun/update_checker/latest_version_finder.rb"
     - "bun/lib/dependabot/bun/update_checker/library_detector.rb"
     - "bun/lib/dependabot/bun/update_checker/version_resolver.rb"
-    - "bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb"
     - "bun/lib/dependabot/bun/version_selector.rb"
     - "bundler/lib/dependabot/bundler/file_parser.rb"
     - "bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb"

--- a/bun/lib/dependabot/bun/update_checker.rb
+++ b/bun/lib/dependabot/bun/update_checker.rb
@@ -12,6 +12,8 @@ module Dependabot
     class UpdateChecker < Dependabot::UpdateCheckers::Base # rubocop:disable Metrics/ClassLength
       extend T::Sig
 
+      Audit = Dependabot::UpdateCheckers::VulnerabilityAudit
+
       require_relative "update_checker/requirements_updater"
       require_relative "update_checker/library_detector"
       require_relative "update_checker/latest_version_finder"
@@ -52,7 +54,7 @@ module Dependabot
         @latest_version = T.let(nil, T.nilable(T.any(String, Gem::Version)))
         @latest_resolvable_version = T.let(nil, T.nilable(T.any(String, Dependabot::Version)))
         @updated_requirements = T.let(nil, T.nilable(T::Array[Dependabot::DependencyRequirement]))
-        @vulnerability_audit = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
+        @vulnerability_audit = T.let(nil, T.nilable(Audit))
         @vulnerable_versions = T.let(nil, T.nilable(T::Array[T.any(String, Gem::Version)]))
 
         @latest_version_for_git_dependency = T.let(nil, T.nilable(T.any(String, Gem::Version)))
@@ -116,7 +118,7 @@ module Dependabot
       sig { override.returns(T.nilable(Dependabot::Version)) }
       def lowest_security_fix_version
         # This will require a full unlock to update multiple top level ancestors.
-        return if vulnerability_audit["fix_available"] && vulnerability_audit["top_level_ancestors"].count > 1
+        return if vulnerability_audit.fix_available && vulnerability_audit.top_level_ancestors.count > 1
 
         latest_version_finder.lowest_security_fix_version
       end
@@ -209,9 +211,8 @@ module Dependabot
         )
         return conflicts unless vulnerability_audit_performed?
 
-        vulnerable = [vulnerability_audit].select do |hash|
-          !hash["fix_available"] && hash["explanation"]
-        end
+        audit = vulnerability_audit
+        vulnerable = !audit.fix_available && audit.explanation ? [audit.to_h] : []
 
         conflicts + vulnerable
       end
@@ -223,7 +224,7 @@ module Dependabot
         !!defined?(@vulnerability_audit)
       end
 
-      sig { returns(T::Hash[String, T.untyped]) }
+      sig { returns(Audit) }
       def vulnerability_audit
         @vulnerability_audit ||=
           VulnerabilityAuditor.new(
@@ -256,12 +257,12 @@ module Dependabot
 
         return false unless security_advisories.any?
 
-        vulnerability_audit["fix_available"]
+        vulnerability_audit.fix_available
       end
 
       sig { override.returns(T::Array[Dependabot::Dependency]) }
       def updated_dependencies_after_full_unlock
-        return conflicting_updated_dependencies if security_advisories.any? && vulnerability_audit["fix_available"]
+        return conflicting_updated_dependencies if security_advisories.any? && vulnerability_audit.fix_available
 
         T.must(version_resolver.dependency_updates_from_full_unlock)
          .map { |update_details| build_updated_dependency(update_details.transform_keys(&:to_sym)) }
@@ -273,8 +274,8 @@ module Dependabot
         top_level_dependencies = top_level_dependency_lookup
 
         updated_deps = []
-        vulnerability_audit["fix_updates"].each do |update|
-          dependency_name = update["dependency_name"]
+        vulnerability_audit.fix_updates.each do |update|
+          dependency_name = update.dependency_name
           requirements = top_level_dependencies[dependency_name]&.requirements || []
 
           updated_deps << build_updated_dependency(
@@ -283,8 +284,8 @@ module Dependabot
               package_manager: "bun",
               requirements: requirements
             ),
-            version: update["target_version"],
-            previous_version: update["current_version"]
+            version: update.target_version,
+            previous_version: update.current_version
           )
         end
         # rubocop:enable Metrics/AbcSize
@@ -294,7 +295,7 @@ module Dependabot
         # to include it so it's described in the PR and we'll pass validation
         # that this dependency is at a non-vulnerable version.
         if updated_deps.none? { |dep| dep.name == dependency.name }
-          target_version = vulnerability_audit["target_version"]
+          target_version = vulnerability_audit.target_version
           updated_deps << build_updated_dependency(
             dependency: dependency,
             version: target_version,

--- a/bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
+++ b/bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
@@ -42,20 +42,7 @@ module Dependabot
         #
         # @param dependency [Dependabot::Dependency] the dependency to check
         # @param security_advisories [Array<Dependabot::SecurityAdvisory>] advisories for the dependency
-        # @return [Hash<String, [String, Array<Hash<String, String>>]>] the audit results
-        #   * :dependency_name [String] the name of the dependency
-        #   * :fix_available [Boolean] whether a fix is available
-        #   * :current_version [String] the version of the dependency
-        #   * :target_version [String] the version of the dependency after the fix
-        #   * :fix_updates [Array<Hash<String, String>>] a list of dependencies to update in order to fix
-        #     * :dependency_name [String] the name of the blocking dependency
-        #     * :current_version [String] the current version of the blocking dependency
-        #     * :target_version [String] the target version of the blocking dependency
-        #     * :top_level_ancestors [Array<String>] the names of top-level dependencies with a transitive
-        #       dependency on the blocking dependency
-        #   * :top_level_ancestors [Array<String>] the names of all top-level dependencies with a transitive
-        #     dependency on the dependency
-        #   * :explanation [String] an explanation for why the project failed the vulnerability auditor run
+        # @return [Dependabot::UpdateCheckers::VulnerabilityAudit] the parsed audit result
         sig do
           params(
             dependency: Dependabot::Dependency,

--- a/bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
+++ b/bun/lib/dependabot/bun/update_checker/vulnerability_auditor.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -13,12 +13,15 @@ require "dependabot/bun/native_helpers"
 require "dependabot/bun/update_checker"
 require "dependabot/bun/update_checker/dependency_files_builder"
 require "dependabot/shared_helpers"
+require "dependabot/update_checkers/vulnerability_audit"
 
 module Dependabot
   module Bun
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       class VulnerabilityAuditor
         extend T::Sig
+
+        Audit = Dependabot::UpdateCheckers::VulnerabilityAudit
 
         sig do
           params(
@@ -32,7 +35,6 @@ module Dependabot
           @credentials = credentials
         end
 
-        # rubocop:disable Metrics/MethodLength
         # Finds any dependencies in the `package-lock.json` or `npm-shrinkwrap.json` that have
         # a subdependency on the given dependency that is locked to a vuln version range.
         #
@@ -59,17 +61,12 @@ module Dependabot
             dependency: Dependabot::Dependency,
             security_advisories: T::Array[Dependabot::SecurityAdvisory]
           )
-            .returns(T::Hash[String, T.untyped])
+            .returns(Audit)
         end
         def audit(dependency:, security_advisories:)
           Dependabot.logger.info("VulnerabilityAuditor: starting audit")
 
-          fix_unavailable = {
-            "dependency_name" => dependency.name,
-            "fix_available" => false,
-            "fix_updates" => [],
-            "top_level_ancestors" => []
-          }
+          fix_unavailable = Audit.unavailable(dependency_name: dependency.name)
 
           SharedHelpers.in_a_temporary_directory do
             dependency_files_builder = DependencyFilesBuilder.new(
@@ -86,20 +83,20 @@ module Dependabot
               }
             end
 
-            audit_result = T.cast(
+            audit_result = Audit.from_object(
               SharedHelpers.run_helper_subprocess(
                 command: NativeHelpers.helper_path,
                 function: "npm:vulnerabilityAuditor",
                 args: [Dir.pwd, vuln_versions]
-              ),
-              T::Hash[String, T.untyped]
+              )
             )
 
             validation_result = validate_audit_result(audit_result, security_advisories)
             if validation_result != :viable
               Dependabot.logger.info("VulnerabilityAuditor: audit result not viable: #{validation_result}")
-              fix_unavailable["explanation"] = explain_fix_unavailable(validation_result, dependency)
-              return fix_unavailable
+              return fix_unavailable.unavailable_with_explanation(
+                explain_fix_unavailable(validation_result, dependency)
+              )
             end
 
             Dependabot.logger.info("VulnerabilityAuditor: audit result viable")
@@ -109,7 +106,6 @@ module Dependabot
           log_helper_subprocess_failure(dependency, e)
           T.must(fix_unavailable)
         end
-        # rubocop:enable Metrics/MethodLength
 
         private
 
@@ -133,12 +129,12 @@ module Dependabot
 
         sig do
           params(
-            audit_result: T::Hash[String, T.untyped],
+            audit_result: Audit,
             security_advisories: T::Array[Dependabot::SecurityAdvisory]
           ).returns(Symbol)
         end
         def validate_audit_result(audit_result, security_advisories)
-          return :fix_unavailable unless audit_result["fix_available"]
+          return :fix_unavailable unless audit_result.fix_available
           return :dependency_still_vulnerable if dependency_still_vulnerable?(audit_result, security_advisories)
           return :downgrades_dependencies if downgrades_dependencies?(audit_result)
           return :fix_incomplete if fix_incomplete?(audit_result)
@@ -148,25 +144,26 @@ module Dependabot
 
         sig do
           params(
-            audit_result: T::Hash[String, T.untyped],
+            audit_result: Audit,
             security_advisories: T::Array[Dependabot::SecurityAdvisory]
           )
             .returns(T::Boolean)
         end
         def dependency_still_vulnerable?(audit_result, security_advisories)
           # vulnerable dependency is removed if the target version is nil
-          return false unless audit_result["target_version"]
+          target_version = audit_result.target_version
+          return false unless target_version
 
-          version = Version.new(audit_result["target_version"])
+          version = Version.new(target_version)
           security_advisories.any? { |a| a.vulnerable?(version) }
         end
 
-        sig { params(audit_result: T::Hash[String, T.untyped]).returns(T::Boolean) }
+        sig { params(audit_result: Audit).returns(T::Boolean) }
         def downgrades_dependencies?(audit_result)
-          return true if downgrades_version?(audit_result["current_version"], audit_result["target_version"])
+          return true if downgrades_version?(audit_result.current_version, audit_result.target_version)
 
-          audit_result["fix_updates"].any? do |update|
-            downgrades_version?(update["current_version"], update["target_version"])
+          audit_result.fix_updates.any? do |update|
+            downgrades_version?(update.current_version, update.target_version)
           end
         end
 
@@ -185,10 +182,10 @@ module Dependabot
           current > target
         end
 
-        sig { params(audit_result: T::Hash[String, T.untyped]).returns(T::Boolean) }
+        sig { params(audit_result: Audit).returns(T::Boolean) }
         def fix_incomplete?(audit_result)
-          audit_result["fix_updates"].any? { |update| !update.key?("target_version") } ||
-            audit_result["fix_updates"].empty?
+          audit_result.fix_updates.any? { |update| !update.target_version_provided? } ||
+            audit_result.fix_updates.empty?
         end
 
         sig do

--- a/bun/spec/dependabot/bun/update_checker/vulnerability_auditor_spec.rb
+++ b/bun/spec/dependabot/bun/update_checker/vulnerability_auditor_spec.rb
@@ -4,6 +4,7 @@
 require "spec_helper"
 require "dependabot/bun/update_checker/vulnerability_auditor"
 require "dependabot/dependency"
+require "dependabot/security_advisory"
 
 RSpec.describe Dependabot::Bun::UpdateChecker::VulnerabilityAuditor do
   subject(:vulnerability_auditor) do
@@ -35,18 +36,111 @@ RSpec.describe Dependabot::Bun::UpdateChecker::VulnerabilityAuditor do
     )
   end
 
-  before do
-    allow(Dependabot.logger).to receive(:info)
-    allow(Dependabot::SharedHelpers)
-      .to receive(:run_helper_subprocess).and_raise(helper_error)
+  before { allow(Dependabot.logger).to receive(:info) }
+
+  context "when the helper returns a viable fix" do
+    let(:security_advisories) do
+      [Dependabot::SecurityAdvisory.new(
+        dependency_name: dependency.name,
+        package_manager: "bun",
+        vulnerable_versions: ["<1.0.1"],
+        safe_versions: ["1.0.1"]
+      )]
+    end
+
+    before do
+      allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess).and_return(
+        {
+          "dependency_name" => dependency.name,
+          "current_version" => "1.0.0",
+          "target_version" => "1.0.1",
+          "fix_available" => true,
+          "fix_updates" => [{
+            "dependency_name" => "parent",
+            "current_version" => "2.0.0",
+            "target_version" => "2.1.0",
+            "top_level_ancestors" => ["app"]
+          }],
+          "top_level_ancestors" => ["app"]
+        }
+      )
+    end
+
+    it "returns a typed audit result" do
+      result = vulnerability_auditor.audit(dependency: dependency, security_advisories: security_advisories)
+
+      expect(result).to have_attributes(
+        dependency_name: dependency.name,
+        current_version: "1.0.0",
+        target_version: "1.0.1",
+        fix_available: true,
+        top_level_ancestors: ["app"]
+      )
+      expect(result.fix_updates.first).to have_attributes(
+        dependency_name: "parent",
+        current_version: "2.0.0",
+        target_version: "2.1.0"
+      )
+    end
   end
 
-  it "logs helper traces and returns an unavailable fix" do
-    result = vulnerability_auditor.audit(dependency: dependency, security_advisories: [])
+  context "when the fix removes the vulnerable dependency" do
+    before do
+      allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess).and_return(
+        {
+          "dependency_name" => dependency.name,
+          "current_version" => "1.0.0",
+          "fix_available" => true,
+          "fix_updates" => [{
+            "dependency_name" => "parent",
+            "current_version" => "2.0.0",
+            "target_version" => "2.1.0"
+          }],
+          "top_level_ancestors" => ["app"]
+        }
+      )
+    end
 
-    expect(Dependabot.logger)
-      .to have_received(:info)
-      .with(a_string_including("helper.rb:1\nhelper.rb:2"))
-    expect(result).to include("fix_available" => false)
+    it "keeps the target version absent" do
+      result = vulnerability_auditor.audit(dependency: dependency, security_advisories: [])
+
+      expect(result.target_version).to be_nil
+      expect(result.to_h).not_to have_key("target_version")
+    end
+  end
+
+  context "when the helper returns malformed data" do
+    before do
+      allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess).and_return(
+        {
+          "dependency_name" => dependency.name,
+          "fix_available" => true,
+          "fix_updates" => "invalid",
+          "top_level_ancestors" => []
+        }
+      )
+    end
+
+    it "raises at the helper boundary" do
+      expect do
+        vulnerability_auditor.audit(dependency: dependency, security_advisories: [])
+      end.to raise_error(TypeError, "fix_updates must be an array")
+    end
+  end
+
+  context "when the helper raises" do
+    before do
+      allow(Dependabot::SharedHelpers)
+        .to receive(:run_helper_subprocess).and_raise(helper_error)
+    end
+
+    it "logs helper traces and returns an unavailable fix" do
+      result = vulnerability_auditor.audit(dependency: dependency, security_advisories: [])
+
+      expect(Dependabot.logger)
+        .to have_received(:info)
+        .with(a_string_including("helper.rb:1\nhelper.rb:2"))
+      expect(result.to_h).to include("fix_available" => false)
+    end
   end
 end

--- a/bun/spec/dependabot/bun/update_checker_spec.rb
+++ b/bun/spec/dependabot/bun/update_checker_spec.rb
@@ -546,10 +546,14 @@ RSpec.describe Dependabot::Bun::UpdateChecker do
       before do
         allow(described_class::VulnerabilityAuditor).to receive(:new).and_return(vulnerability_auditor)
         allow(vulnerability_auditor).to receive(:audit).and_return(
-          {
-            "fix_available" => true,
-            "top_level_ancestors" => %w(applause lodash)
-          }
+          Dependabot::UpdateCheckers::VulnerabilityAudit.from_object(
+            {
+              "dependency_name" => dependency.name,
+              "fix_available" => true,
+              "fix_updates" => [],
+              "top_level_ancestors" => %w(applause lodash)
+            }
+          )
         )
       end
 


### PR DESCRIPTION
Migrate Bun vulnerability auditing and its update-checker consumers to the shared model.

`T.untyped`: 766 -> 758; excluded files: 140 -> 139.