### PR TITLE
Bump default Bazel version to 8.5.1

### DIFF
--- a/bazel/lib/dependabot/bazel/package_manager.rb
+++ b/bazel/lib/dependabot/bazel/package_manager.rb
@@ -10,7 +10,7 @@ module Dependabot
   module Bazel
     ECOSYSTEM = "bazel"
     PACKAGE_MANAGER = "bazel"
-    DEFAULT_BAZEL_VERSION = "8.4.2"
+    DEFAULT_BAZEL_VERSION = "8.5.1"
 
     # Keep versions in ascending order
     SUPPORTED_BAZEL_VERSIONS = T.let([Version.new("6"), Version.new("7")].freeze, T::Array[Dependabot::Version])

--- a/bazel/spec/dependabot/bazel/file_parser_spec.rb
+++ b/bazel/spec/dependabot/bazel/file_parser_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe Dependabot::Bazel::FileParser do
       it "uses the default version for detected_version" do
         ecosystem = parser.ecosystem
 
-        expect(ecosystem.package_manager.detected_version.to_s).to eq("8.4.2")
+        expect(ecosystem.package_manager.detected_version.to_s).to eq("8.5.1")
         expect(ecosystem.package_manager.version).to be_nil
-        expect(ecosystem.language.version.to_s).to eq("8.4.2")
+        expect(ecosystem.language.version.to_s).to eq("8.5.1")
       end
     end
   end

--- a/bazel/spec/dependabot/bazel/file_updater/lockfile_updater_spec.rb
+++ b/bazel/spec/dependabot/bazel/file_updater/lockfile_updater_spec.rb
@@ -169,9 +169,8 @@ RSpec.describe Dependabot::Bazel::FileUpdater::LockfileUpdater do
     context "when .bazelversion file does not exist" do
       let(:dependency_files) { bazel_project_dependency_files("simple_module_with_lockfile") }
 
-      it "returns DEFAULT_BAZEL_VERSION" do
-        expect(lockfile_updater.determine_bazel_version)
-          .to eq(Dependabot::Bazel::DEFAULT_BAZEL_VERSION)
+      it "returns Bazel 8.5.1" do
+        expect(lockfile_updater.determine_bazel_version).to eq("8.5.1")
       end
     end
 
@@ -186,9 +185,8 @@ RSpec.describe Dependabot::Bazel::FileUpdater::LockfileUpdater do
         files
       end
 
-      it "returns DEFAULT_BAZEL_VERSION" do
-        expect(lockfile_updater.determine_bazel_version)
-          .to eq(Dependabot::Bazel::DEFAULT_BAZEL_VERSION)
+      it "returns Bazel 8.5.1" do
+        expect(lockfile_updater.determine_bazel_version).to eq("8.5.1")
       end
     end
 
@@ -203,9 +201,8 @@ RSpec.describe Dependabot::Bazel::FileUpdater::LockfileUpdater do
         files
       end
 
-      it "returns DEFAULT_BAZEL_VERSION" do
-        expect(lockfile_updater.determine_bazel_version)
-          .to eq(Dependabot::Bazel::DEFAULT_BAZEL_VERSION)
+      it "returns Bazel 8.5.1" do
+        expect(lockfile_updater.determine_bazel_version).to eq("8.5.1")
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Update the Bazel fallback used when a repository does not include `.bazelversion` from 8.4.2 to 8.5.1.

`rules_python` 2.3.x uses `flag_alias` in its BCR `MODULE.bazel`, which Bazel 8.4.2 cannot parse. Dependabot therefore fails while regenerating `MODULE.bazel.lock` before it can create an update PR. Bazel 8.5.1 supports this declaration.

This affects [update job 1535385032](https://github.com/dsp-testing/dependabot-all-updates-test-staging/network/updates/1535385032) and its [failed Actions job](https://github.com/dsp-testing/dependabot-all-updates-test-staging/actions/runs/32488533302/job/96790509589).

### Anything you want to highlight for special attention from reviewers?

This keeps the existing behavior of using a known fallback when `.bazelversion` is absent and advances that fallback to the first compatible Bazel patch release. Repositories that declare `.bazelversion` continue to use their requested version.

The parser and lockfile-updater specs now assert the concrete fallback version so a future stale default is visible in review.

### How will you know you've accomplished your goal?

A `rules_python` 2.3.1 lockfile update that fails with `name 'flag_alias' is not defined` under Bazel 8.4.2 completes under Bazel 8.5.1.

Validation completed:

- Focused Bazel specs: 30 examples, 0 failures
- RuboCop: no offenses
- Sorbet: no errors

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.