### PR TITLE
Nix: lock the selected revision

### DIFF
--- a/nix/lib/dependabot/nix/file_parser.rb
+++ b/nix/lib/dependabot/nix/file_parser.rb
@@ -159,7 +159,7 @@ module Dependabot
           "https://#{host}/#{locked['owner']}/#{locked['repo']}"
         when "sourcehut"
           host = locked["host"] || DEFAULT_HOSTS["sourcehut"]
-          "https://#{host}/~#{locked['owner']}/#{locked['repo']}"
+          "https://#{host}/#{locked['owner']}/#{locked['repo']}"
         when "git"
           locked["url"]
         end

--- a/nix/lib/dependabot/nix/file_parser.rb
+++ b/nix/lib/dependabot/nix/file_parser.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "json"
 require "sorbet-runtime"
 
 require "dependabot/dependency"
@@ -9,6 +8,7 @@ require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/shared_helpers"
 require "dependabot/nix/channel"
+require "dependabot/nix/lockfile"
 require "dependabot/nix/package_manager"
 
 module Dependabot
@@ -32,22 +32,17 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::Dependency]) }
       def parse
-        lock_content = JSON.parse(T.must(flake_lock.content))
+        lockfile = Lockfile.new(T.must(flake_lock.content))
 
-        lock_version = lock_content["version"]
+        lock_version = lockfile.version
         if lock_version != SUPPORTED_LOCK_VERSION
           Dependabot.logger.warn(
             "flake.lock version #{lock_version.inspect} differs from expected #{SUPPORTED_LOCK_VERSION}"
           )
         end
 
-        root_name = lock_content.fetch("root", "root")
-        nodes = lock_content.fetch("nodes", {})
-        root_node = nodes.fetch(root_name, {})
-        root_inputs = root_node.fetch("inputs", {})
-
-        root_inputs.filter_map do |input_name, node_label|
-          node = resolve_node(node_label, nodes)
+        lockfile.root_input_names.filter_map do |input_name|
+          node = lockfile.input_node(input_name)
           next unless node
 
           build_dependency(input_name, node)
@@ -66,60 +61,6 @@ module Dependabot
       end
 
       private
-
-      # Resolves a node_label to its node in the lock file.
-      # node_label is either a string (direct reference) or an array ("follows" path
-      # that must be walked through nested inputs maps).
-      sig do
-        params(
-          node_label: T.any(String, T::Array[String]),
-          nodes: T::Hash[String, T.untyped]
-        ).returns(T.nilable(T::Hash[String, T.untyped]))
-      end
-      def resolve_node(node_label, nodes)
-        return nodes[node_label] unless node_label.is_a?(Array)
-        return nil if node_label.empty?
-
-        # Walk the "follows" path: e.g. ["nixpkgs", "flake-utils"] means
-        # follow root -> nixpkgs node -> its inputs -> flake-utils
-        resolved_label = resolve_follows_path(node_label, nodes)
-        resolved_label ? nodes[resolved_label] : nil
-      end
-
-      # Walks a "follows" path through nested inputs to find the final node label.
-      sig do
-        params(
-          path: T::Array[String],
-          nodes: T::Hash[String, T.untyped]
-        ).returns(T.nilable(String))
-      end
-      def resolve_follows_path(path, nodes)
-        current_node_label = T.let(nil, T.nilable(String))
-
-        path.each_with_index do |segment, index|
-          # For the first segment, look up in the root's inputs via nodes directly
-          target = if index.zero?
-                     # The first segment references a top-level node by name
-                     segment
-                   else
-                     # Subsequent segments look up inputs within the current node
-                     node = nodes[T.must(current_node_label)]
-                     return nil unless node.is_a?(Hash)
-
-                     inputs = node.fetch("inputs", nil)
-                     return nil unless inputs.is_a?(Hash)
-
-                     label = inputs[segment]
-                     return nil unless label.is_a?(String)
-
-                     label
-                   end
-
-          current_node_label = target
-        end
-
-        current_node_label
-      end
 
       sig do
         params(

--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -110,7 +110,14 @@ module Dependabot
 
       sig { params(lockfile: Lockfile).returns(T.nilable(T::Hash[String, Object])) }
       def updated_git_source(lockfile)
-        source = lockfile.original_source(dependency.name)
+        original_source = lockfile.original_source(dependency.name)
+        return unless original_source
+
+        source = if original_source["type"] == "indirect"
+                   lockfile.locked_source(dependency.name)
+                 else
+                   original_source
+                 end
         return unless source
 
         ref = new_source_ref

--- a/nix/lib/dependabot/nix/file_updater.rb
+++ b/nix/lib/dependabot/nix/file_updater.rb
@@ -1,6 +1,7 @@
 # typed: strong
 # frozen_string_literal: true
 
+require "json"
 require "sorbet-runtime"
 
 require "dependabot/errors"
@@ -8,11 +9,14 @@ require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 require "dependabot/shared_helpers"
 require "dependabot/nix/flake_nix_parser"
+require "dependabot/nix/lockfile"
 
 module Dependabot
   module Nix
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
+
+      require_relative "file_updater/flake_ref_builder"
 
       # Nix's CLI restricts flake input attribute path elements to this regex.
       # see `flakeIdRegex` in nix/src/libflake/include/nix/flake/flakeref.hh
@@ -26,6 +30,7 @@ module Dependabot
         updated_files << updated_file(file: flake_nix, content: updated_flake_nix_content) if updated_flake_nix_content
 
         updated_lockfile_content = update_flake_lock(updated_flake_nix_content)
+        validate_updated_revision(updated_lockfile_content)
 
         if updated_lockfile_content == flake_lock.content
           raise Dependabot::DependencyFileContentNotChanged,
@@ -53,18 +58,17 @@ module Dependabot
         return unless old_ref
         return if old_ref == new_ref
 
-        FlakeNixParser.update_input_ref(T.must(flake_nix.content), dependency.name, new_ref)
+        updated_content = FlakeNixParser.update_input_ref(T.must(flake_nix.content), dependency.name, new_ref)
+        return updated_content if updated_content
+
+        raise Dependabot::DependencyFileNotResolvable,
+              "Cannot update the ref for flake input '#{dependency.name}' in flake.nix"
       end
 
       sig { params(updated_nix_content: T.nilable(String)).returns(String) }
       def update_flake_lock(updated_nix_content)
-        unless dependency.name.match?(FLAKE_ID_REGEX)
-          raise Dependabot::DependencyFileNotResolvable,
-                "Cannot update flake input '#{dependency.name}': Nix requires input names to start " \
-                "with a letter and contain only letters, digits, underscores, or hyphens " \
-                "(pattern: [a-zA-Z][a-zA-Z0-9_-]*). " \
-                "Rename the input in flake.nix to update it via Dependabot."
-        end
+        lockfile = Lockfile.new(T.must(flake_lock.content))
+        input_path = validated_input_path(lockfile)
 
         SharedHelpers.in_a_temporary_repo_directory(
           flake_lock.directory,
@@ -74,12 +78,96 @@ module Dependabot
           File.write("flake.lock", T.must(flake_lock.content))
 
           SharedHelpers.run_shell_command(
-            "nix flake update #{dependency.name}",
-            fingerprint: "nix flake update <input_name>"
+            update_command(lockfile, input_path),
+            fingerprint: command_fingerprint
           )
 
           File.read("flake.lock")
         end
+      end
+
+      sig { params(lockfile: Lockfile, input_path: String).returns(SharedHelpers::Command) }
+      def update_command(lockfile, input_path)
+        if git_dependency?
+          source = updated_git_source(lockfile)
+          revision = dependency.version
+          unless source && revision
+            raise Dependabot::DependencyFileNotResolvable,
+                  "Cannot update flake input '#{dependency.name}' because its source metadata " \
+                  "or target revision is missing"
+          end
+
+          exact_ref = build_exact_flake_ref(source, revision)
+          # `nix flake lock` writes the override but keeps the input's original branch or tag.
+          ["nix", "flake", "lock", "--override-input", input_path, exact_ref]
+        elsif tarball_dependency?
+          ["nix", "flake", "update", input_path]
+        else
+          raise Dependabot::DependencyFileNotResolvable,
+                "Cannot update flake input '#{dependency.name}' because its dependency source type is not supported"
+        end
+      end
+
+      sig { params(lockfile: Lockfile).returns(T.nilable(T::Hash[String, Object])) }
+      def updated_git_source(lockfile)
+        source = lockfile.original_source(dependency.name)
+        return unless source
+
+        ref = new_source_ref
+        ref ? source.merge("ref" => ref) : source
+      end
+
+      sig { returns(String) }
+      def command_fingerprint
+        if git_dependency?
+          "nix flake lock --override-input <input_path> <flake_ref>"
+        else
+          "nix flake update <input_name>"
+        end
+      end
+
+      sig { params(source: T::Hash[String, Object], revision: String).returns(String) }
+      def build_exact_flake_ref(source, revision)
+        FlakeRefBuilder.new(source: source, revision: revision).to_s
+      rescue ArgumentError, URI::InvalidURIError => e
+        raise Dependabot::DependencyFileNotResolvable,
+              "Cannot update flake input '#{dependency.name}': #{e.message}"
+      end
+
+      sig { params(lockfile: Lockfile).returns(String) }
+      def validated_input_path(lockfile)
+        path = lockfile.input_path(dependency.name)
+        unless path&.all? { |segment| segment.match?(FLAKE_ID_REGEX) }
+          raise Dependabot::DependencyFileNotResolvable,
+                "Cannot update flake input '#{dependency.name}': each Nix input path segment must match " \
+                "[a-zA-Z][a-zA-Z0-9_-]*"
+        end
+
+        path.join("/")
+      end
+
+      sig { params(content: String).void }
+      def validate_updated_revision(content)
+        expected_revision = dependency.version
+        actual_revision = Lockfile.new(content).locked_revision(dependency.name)
+        return if expected_revision && actual_revision == expected_revision
+
+        raise Dependabot::DependencyFileNotResolvable,
+              "Expected flake input '#{dependency.name}' to lock revision " \
+              "#{expected_revision.inspect}, but Nix generated #{actual_revision.inspect}"
+      rescue JSON::ParserError => e
+        raise Dependabot::DependencyFileNotResolvable,
+              "Nix generated an invalid flake.lock for '#{dependency.name}': #{e.message}"
+      end
+
+      sig { returns(T::Boolean) }
+      def git_dependency?
+        dependency.requirements.first&.source_string("type") == "git"
+      end
+
+      sig { returns(T::Boolean) }
+      def tarball_dependency?
+        dependency.requirements.first&.source_string("type") == "tarball"
       end
 
       sig { returns(T.nilable(String)) }

--- a/nix/lib/dependabot/nix/file_updater/flake_ref_builder.rb
+++ b/nix/lib/dependabot/nix/file_updater/flake_ref_builder.rb
@@ -1,0 +1,132 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "uri"
+require "sorbet-runtime"
+
+require "dependabot/nix/file_updater"
+
+module Dependabot
+  module Nix
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class FlakeRefBuilder
+        extend T::Sig
+
+        ARCHIVE_TYPES = %w(github gitlab sourcehut).freeze
+        ARCHIVE_PATH_KEYS = %w(type owner repo ref rev).freeze
+        GIT_URL_KEYS = %w(type url rev).freeze
+        LOCKED_ONLY_KEYS = %w(lastModified narHash revCount).freeze
+        SCP_STYLE_URL = /\A(?<user>[^@]+)@(?<host>[^:]+):(?<path>.+)\z/
+
+        sig { params(source: T::Hash[String, Object], revision: String).void }
+        def initialize(source:, revision:)
+          @source = source
+          @revision = revision
+        end
+
+        sig { returns(String) }
+        def to_s
+          source_type = required_string("type")
+
+          if ARCHIVE_TYPES.include?(source_type)
+            archive_reference(source_type)
+          elsif source_type == "git"
+            git_reference
+          else
+            raise ArgumentError, "Nix flake source type #{source_type.inspect} is not supported"
+          end
+        end
+
+        private
+
+        sig { returns(T::Hash[String, Object]) }
+        attr_reader :source
+
+        sig { returns(String) }
+        attr_reader :revision
+
+        sig { params(source_type: String).returns(String) }
+        def archive_reference(source_type)
+          owner = encode_path_segment(required_string("owner"))
+          repo = encode_path_segment(required_string("repo"))
+          base = "#{source_type}:#{owner}/#{repo}/#{encode_path_segment(revision)}"
+
+          append_query(base, query_attributes(excluding: ARCHIVE_PATH_KEYS))
+        end
+
+        sig { returns(String) }
+        def git_reference
+          uri = URI.parse(normalized_git_url(required_string("url")))
+          query = URI.decode_www_form(uri.query || "").to_h
+          query.merge!(query_attributes(excluding: GIT_URL_KEYS))
+          query["rev"] = revision
+          uri.query = encoded_query(query)
+          uri.to_s
+        end
+
+        sig { params(url: String).returns(String) }
+        def normalized_git_url(url)
+          return url if url.match?(/\Agit(?:\+[^:]+)?:/)
+
+          if (match = SCP_STYLE_URL.match(url))
+            return "git+ssh://#{match[:user]}@#{match[:host]}/#{match[:path]}"
+          end
+
+          uri = URI.parse(url)
+          raise ArgumentError, "git source URL #{url.inspect} must include a scheme" unless uri.scheme
+
+          "git+#{url}"
+        end
+
+        sig { params(excluding: T::Array[String]).returns(T::Hash[String, String]) }
+        def query_attributes(excluding:)
+          attributes = T.let({}, T::Hash[String, String])
+          source.each do |key, value|
+            next if excluding.include?(key) || LOCKED_ONLY_KEYS.include?(key) || value.nil?
+
+            attributes[key] = query_value(value)
+          end
+          attributes
+        end
+
+        sig { params(base: String, query: T::Hash[String, String]).returns(String) }
+        def append_query(base, query)
+          return base if query.empty?
+
+          "#{base}?#{encoded_query(query)}"
+        end
+
+        sig { params(query: T::Hash[String, String]).returns(String) }
+        def encoded_query(query)
+          URI.encode_www_form(query.sort)
+        end
+
+        sig { params(value: Object).returns(String) }
+        def query_value(value)
+          case value
+          when true then "1"
+          when false then "0"
+          when String, Integer then value.to_s
+          else
+            raise ArgumentError, "Nix flake source attribute value #{value.inspect} is not supported"
+          end
+        end
+
+        sig { params(value: String).returns(String) }
+        def encode_path_segment(value)
+          URI.encode_www_form_component(value)
+             .gsub("+", "%20")
+             .gsub("%7E", "~")
+        end
+
+        sig { params(key: String).returns(String) }
+        def required_string(key)
+          value = source[key]
+          return value if value.is_a?(String) && !value.empty?
+
+          raise ArgumentError, "Nix flake source is missing attribute #{key.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/nix/lib/dependabot/nix/flake_nix_parser.rb
+++ b/nix/lib/dependabot/nix/flake_nix_parser.rb
@@ -1,16 +1,14 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "uri"
 require "sorbet-runtime"
 
 require "dependabot/nix/channel"
 
 module Dependabot
   module Nix
-    # Parses flake.nix content to locate input URL declarations and extract
-    # their components (scheme, owner, repo, ref). Only handles the shorthand
-    # URL schemes (github:, gitlab:, sourcehut:) since those are the ones
-    # where the ref appears inline in the URL string.
+    # Parses flake.nix input URL declarations and updates their refs.
     class FlakeNixParser
       extend T::Sig
 
@@ -32,6 +30,9 @@ module Dependabot
         /(?<ref>[a-zA-Z0-9_\-\./]+)\z
       }x
       private_constant :INDIRECT_URL_PATTERN
+
+      GENERIC_GIT_SCHEME = /\Agit(?:\+[a-zA-Z][a-zA-Z0-9+.-]*)?\z/
+      private_constant :GENERIC_GIT_SCHEME
 
       # Matches an input URL assignment tied to a specific input name.
       # Covers the common syntactic forms:
@@ -66,7 +67,29 @@ module Dependabot
 
         build_shorthand_input(url_str, match) ||
           build_tarball_input(url_str, match) ||
+          build_git_input(url_str, match) ||
           build_indirect_input(url_str, match)
+      end
+
+      sig { params(url_str: String, match: T::Hash[Symbol, T.untyped]).returns(T.nilable(InputUrl)) }
+      def build_git_input(url_str, match)
+        uri = URI.parse(url_str)
+        return unless uri.scheme&.match?(GENERIC_GIT_SCHEME)
+
+        ref = URI.decode_www_form(uri.query || "").find { |key, _value| key == "ref" }&.last
+
+        InputUrl.new(
+          full_url: url_str,
+          scheme: "git",
+          owner: "",
+          repo: "",
+          ref: ref,
+          query: uri.query,
+          match_start: match[:url_start],
+          match_end: match[:url_end]
+        )
+      rescue URI::InvalidURIError
+        nil
       end
 
       sig { params(new_ref: String).returns(T.nilable(String)) }
@@ -216,10 +239,21 @@ module Dependabot
         when "tarball"
           old_channel = T.must(input_url.ref)
           input_url.full_url.sub("/#{old_channel}/", "/#{new_ref}/")
+        when "git"
+          update_git_ref(input_url.full_url, new_ref)
         else
           base = "#{input_url.scheme}:#{input_url.owner}/#{input_url.repo}/#{new_ref}"
           input_url.query ? "#{base}?#{input_url.query}" : base
         end
+      end
+
+      sig { params(url: String, new_ref: String).returns(String) }
+      def update_git_ref(url, new_ref)
+        uri = URI.parse(url)
+        query = URI.decode_www_form(uri.query || "")
+        query.each { |parameter| parameter[1] = new_ref if parameter.first == "ref" }
+        uri.query = URI.encode_www_form(query)
+        uri.to_s
       end
 
       # Represents a parsed flake input URL from flake.nix

--- a/nix/lib/dependabot/nix/lockfile.rb
+++ b/nix/lib/dependabot/nix/lockfile.rb
@@ -1,0 +1,128 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "json"
+require "sorbet-runtime"
+
+module Dependabot
+  module Nix
+    class Lockfile
+      extend T::Sig
+
+      Node = T.type_alias { T::Hash[String, Object] }
+
+      sig { params(content: String).void }
+      def initialize(content)
+        @data = T.let(T.cast(JSON.parse(content), Node), Node)
+      end
+
+      sig { returns(T.nilable(Integer)) }
+      def version
+        value = @data["version"]
+        value if value.is_a?(Integer)
+      end
+
+      sig { returns(T::Array[String]) }
+      def root_input_names
+        root_inputs.keys
+      end
+
+      sig { params(input_name: String).returns(T.nilable(T::Array[String])) }
+      def input_path(input_name)
+        reference = root_inputs[input_name]
+        return [input_name] if reference.is_a?(String)
+        return unless string_array?(reference)
+
+        T.cast(reference, T::Array[String])
+      end
+
+      sig { params(input_name: String).returns(T.nilable(Node)) }
+      def input_node(input_name)
+        label = resolve_reference(root_inputs[input_name], T.let(Set.new, T::Set[String]))
+        return unless label
+
+        node = nodes[label]
+        node if node.is_a?(Hash)
+      end
+
+      sig { params(input_name: String).returns(T.nilable(Node)) }
+      def original_source(input_name)
+        original = input_node(input_name)&.fetch("original", nil)
+        original if original.is_a?(Hash)
+      end
+
+      sig { params(input_name: String).returns(T.nilable(String)) }
+      def locked_revision(input_name)
+        locked = input_node(input_name)&.fetch("locked", nil)
+        return unless locked.is_a?(Hash)
+
+        revision = locked["rev"]
+        revision if revision.is_a?(String)
+      end
+
+      private
+
+      sig { returns(Node) }
+      def nodes
+        value = @data["nodes"]
+        value.is_a?(Hash) ? value : {}
+      end
+
+      sig { returns(Node) }
+      def root_inputs
+        root_name = @data["root"]
+        root_name = "root" unless root_name.is_a?(String)
+
+        root_node = nodes[root_name]
+        return {} unless root_node.is_a?(Hash)
+
+        inputs = root_node["inputs"]
+        inputs.is_a?(Hash) ? inputs : {}
+      end
+
+      sig { params(reference: Object, visited_paths: T::Set[String]).returns(T.nilable(String)) }
+      def resolve_reference(reference, visited_paths)
+        return reference if reference.is_a?(String)
+        return unless string_array?(reference)
+
+        path = T.cast(reference, T::Array[String])
+        path_key = path.join("\0")
+        return if visited_paths.include?(path_key)
+
+        visited_paths.add(path_key)
+        resolve_path(path, visited_paths)
+      end
+
+      sig { params(path: T::Array[String], visited_paths: T::Set[String]).returns(T.nilable(String)) }
+      def resolve_path(path, visited_paths)
+        first_segment = path.first
+        return unless first_segment
+
+        reference = T.let(root_inputs[first_segment], Object)
+
+        index = T.let(1, Integer)
+        while index < path.length
+          segment = path.fetch(index)
+          label = resolve_reference(reference, visited_paths)
+          return unless label
+
+          node = nodes[label]
+          return unless node.is_a?(Hash)
+
+          inputs = node["inputs"]
+          return unless inputs.is_a?(Hash)
+
+          reference = T.let(inputs[segment], Object)
+          index += 1
+        end
+
+        resolve_reference(reference, visited_paths)
+      end
+
+      sig { params(value: Object).returns(T::Boolean) }
+      def string_array?(value)
+        value.is_a?(Array) && !value.empty? && value.all?(String)
+      end
+    end
+  end
+end

--- a/nix/lib/dependabot/nix/lockfile.rb
+++ b/nix/lib/dependabot/nix/lockfile.rb
@@ -51,10 +51,16 @@ module Dependabot
         original if original.is_a?(Hash)
       end
 
+      sig { params(input_name: String).returns(T.nilable(Node)) }
+      def locked_source(input_name)
+        locked = input_node(input_name)&.fetch("locked", nil)
+        locked if locked.is_a?(Hash)
+      end
+
       sig { params(input_name: String).returns(T.nilable(String)) }
       def locked_revision(input_name)
-        locked = input_node(input_name)&.fetch("locked", nil)
-        return unless locked.is_a?(Hash)
+        locked = locked_source(input_name)
+        return unless locked
 
         revision = locked["rev"]
         revision if revision.is_a?(String)

--- a/nix/spec/dependabot/nix/file_parser_spec.rb
+++ b/nix/spec/dependabot/nix/file_parser_spec.rb
@@ -132,6 +132,47 @@ RSpec.describe Dependabot::Nix::FileParser do
       end
     end
 
+    context "with a SourceHut input" do
+      let(:flake_lock_content) do
+        <<~JSON
+          {
+            "nodes": {
+              "sourcehut-dep": {
+                "locked": {
+                  "lastModified": 1654847660,
+                  "narHash": "sha256-Mjdh3ackWoxkNBIcfXyqPlAc4mNe0EtZvb1cmgcyd+I=",
+                  "owner": "~user",
+                  "repo": "myrepo",
+                  "rev": "old_sha_abc123",
+                  "type": "sourcehut"
+                },
+                "original": {
+                  "owner": "~user",
+                  "ref": "main",
+                  "repo": "myrepo",
+                  "type": "sourcehut"
+                }
+              },
+              "root": {
+                "inputs": {
+                  "sourcehut-dep": "sourcehut-dep"
+                }
+              }
+            },
+            "root": "root",
+            "version": 7
+          }
+        JSON
+      end
+
+      it "uses the owner from the lockfile" do
+        dependency = dependencies.find { |item| item.name == "sourcehut-dep" }
+
+        expect(dependency.requirements.first[:source][:url])
+          .to eq("https://git.sr.ht/~user/myrepo")
+      end
+    end
+
     context "with follows inputs" do
       let(:flake_lock_content) { fixture("flake_with_follows.lock") }
 

--- a/nix/spec/dependabot/nix/file_parser_spec.rb
+++ b/nix/spec/dependabot/nix/file_parser_spec.rb
@@ -148,6 +148,67 @@ RSpec.describe Dependabot::Nix::FileParser do
       end
     end
 
+    context "with a root input that follows a nested input path" do
+      let(:flake_lock_content) do
+        <<~JSON
+          {
+            "nodes": {
+              "parent-node": {
+                "inputs": {
+                  "nested": "target-node"
+                },
+                "locked": {
+                  "rev": "parent-revision",
+                  "type": "github",
+                  "owner": "example",
+                  "repo": "parent"
+                },
+                "original": {
+                  "type": "github",
+                  "owner": "example",
+                  "repo": "parent"
+                }
+              },
+              "target-node": {
+                "locked": {
+                  "rev": "target-revision",
+                  "type": "gitlab",
+                  "owner": "example",
+                  "repo": "target"
+                },
+                "original": {
+                  "type": "gitlab",
+                  "owner": "example",
+                  "repo": "target",
+                  "ref": "main"
+                }
+              },
+              "root": {
+                "inputs": {
+                  "alias": ["parent", "nested"],
+                  "parent": "parent-node"
+                }
+              }
+            },
+            "root": "root",
+            "version": 7
+          }
+        JSON
+      end
+
+      it "parses the followed node as the root dependency" do
+        dependency = dependencies.find { |item| item.name == "alias" }
+
+        expect(dependency.version).to eq("target-revision")
+        expect(dependency.requirements.first[:source])
+          .to include(
+            type: "git",
+            url: "https://gitlab.com/example/target",
+            ref: "main"
+          )
+      end
+    end
+
     context "with a custom host (self-hosted GitHub Enterprise)" do
       let(:flake_lock_content) { fixture("flake_with_custom_host.lock") }
 

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -1,6 +1,11 @@
 # typed: false
 # frozen_string_literal: true
 
+require "json"
+require "fileutils"
+require "open3"
+require "tmpdir"
+
 require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
@@ -108,11 +113,99 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         expect(updated_files.first.name).to eq("flake.lock")
       end
 
-      it "calls nix flake update with the input name" do
+      it "locks the input to the selected revision" do
         updated_files
         expect(Dependabot::SharedHelpers)
           .to have_received(:run_shell_command)
-          .with("nix flake update nixpkgs", fingerprint: "nix flake update <input_name>")
+          .with(
+            [
+              "nix", "flake", "lock", "--override-input",
+              "nixpkgs", "github:NixOS/nixpkgs/new_sha_abc123"
+            ],
+            fingerprint: "nix flake lock --override-input <input_path> <flake_ref>"
+          )
+      end
+
+      context "when Nix writes a different revision" do
+        let(:updated_lock_content) do
+          flake_lock_content.gsub(
+            "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+            "unexpected_sha_def456"
+          )
+        end
+
+        it "reports the requested and generated revisions" do
+          expect { updated_files }
+            .to raise_error(
+              Dependabot::DependencyFileNotResolvable,
+              /new_sha_abc123.*unexpected_sha_def456/
+            )
+        end
+      end
+
+      context "when Nix omits the locked revision" do
+        let(:updated_lock_content) do
+          content = JSON.parse(flake_lock_content)
+          content.fetch("nodes").fetch("nixpkgs").fetch("locked").delete("rev")
+          JSON.pretty_generate(content)
+        end
+
+        it "reports the missing revision" do
+          expect { updated_files }
+            .to raise_error(Dependabot::DependencyFileNotResolvable, /new_sha_abc123.*nil/)
+        end
+      end
+    end
+
+    context "with a generic Git ref change" do
+      let(:flake_nix_content) do
+        <<~NIX
+          {
+            inputs.generic-git.url = "git+https://example.com/myorg/repo.git?ref=v1.0.0&dir=nix";
+            outputs = { self, generic-git }: { };
+          }
+        NIX
+      end
+      let(:dependency) do
+        git_dependency(
+          name: "generic-git",
+          version: "new_sha_abc123",
+          previous_version: "old_sha_abc123",
+          url: "https://example.com/myorg/repo.git",
+          ref: "v2.0.0",
+          previous_ref: "v1.0.0"
+        )
+      end
+      let(:flake_lock_content) do
+        git_lock_content(
+          name: "generic-git",
+          revision: "old_sha_abc123",
+          source: {
+            "type" => "git",
+            "url" => "https://example.com/myorg/repo.git",
+            "ref" => "v1.0.0",
+            "dir" => "nix"
+          }
+        )
+      end
+      let(:updated_lock_content) do
+        flake_lock_content.gsub("old_sha_abc123", "new_sha_abc123")
+      end
+
+      it "updates flake.nix and uses the new ref for the lock override" do
+        expect(updated_files.map(&:name)).to contain_exactly("flake.nix", "flake.lock")
+        expect(updated_files.find { |file| file.name == "flake.nix" }.content)
+          .to include("ref=v2.0.0&dir=nix")
+        expect(Dependabot::SharedHelpers)
+          .to have_received(:run_shell_command)
+          .with(
+            lock_command(
+              input_path: "generic-git",
+              ref: "git+https://example.com/myorg/repo.git" \
+                   "?dir=nix&ref=v2.0.0&rev=new_sha_abc123"
+            ),
+            fingerprint: "nix flake lock --override-input <input_path> <flake_ref>"
+          )
       end
     end
 
@@ -148,15 +241,224 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         )
       end
 
-      it "raises DependencyFileNotResolvable with a clear message" do
+      it "includes the invalid input name in the error" do
         expect { updated_files }
           .to raise_error(Dependabot::DependencyFileNotResolvable, /_1password-shell-plugins/)
         expect(Dependabot::SharedHelpers).not_to have_received(:run_shell_command)
       end
     end
 
+    [
+      {
+        description: "GitHub Enterprise input",
+        name: "internal-lib",
+        url: "https://github.corp.example.com/myteam/internal-lib",
+        source: {
+          "type" => "github",
+          "owner" => "myteam",
+          "repo" => "internal-lib",
+          "ref" => "main",
+          "host" => "github.corp.example.com",
+          "dir" => "nix"
+        },
+        expected_ref: "github:myteam/internal-lib/new_sha_abc123?dir=nix&host=github.corp.example.com"
+      },
+      {
+        description: "GitLab subgroup input",
+        name: "gitlab-dep",
+        url: "https://gitlab.com/myorg/subgroup/myrepo",
+        source: {
+          "type" => "gitlab",
+          "owner" => "myorg/subgroup",
+          "repo" => "myrepo",
+          "ref" => "main"
+        },
+        expected_ref: "gitlab:myorg%2Fsubgroup/myrepo/new_sha_abc123"
+      },
+      {
+        description: "SourceHut input",
+        name: "sourcehut-dep",
+        url: "https://git.sr.ht/~user/myrepo",
+        source: {
+          "type" => "sourcehut",
+          "owner" => "~user",
+          "repo" => "myrepo",
+          "ref" => "main"
+        },
+        expected_ref: "sourcehut:~user/myrepo/new_sha_abc123"
+      },
+      {
+        description: "generic HTTPS Git input",
+        name: "generic-git",
+        url: "https://example.com/myorg/repo.git",
+        source: {
+          "type" => "git",
+          "url" => "https://example.com/myorg/repo.git",
+          "ref" => "main",
+          "dir" => "nix",
+          "submodules" => true
+        },
+        expected_ref: "git+https://example.com/myorg/repo.git" \
+                      "?dir=nix&ref=main&rev=new_sha_abc123&submodules=1"
+      },
+      {
+        description: "SCP-style Git input",
+        name: "ssh-git",
+        url: "git@example.com:myorg/repo.git",
+        source: {
+          "type" => "git",
+          "url" => "git@example.com:myorg/repo.git",
+          "ref" => "main"
+        },
+        expected_ref: "git+ssh://git@example.com/myorg/repo.git?ref=main&rev=new_sha_abc123"
+      }
+    ].each do |test_case|
+      context "with a #{test_case.fetch(:description)}" do
+        let(:dependency) do
+          git_dependency(
+            name: test_case.fetch(:name),
+            version: "new_sha_abc123",
+            previous_version: "old_sha_abc123",
+            url: test_case.fetch(:url),
+            ref: "main"
+          )
+        end
+        let(:flake_lock_content) do
+          git_lock_content(
+            name: test_case.fetch(:name),
+            revision: "old_sha_abc123",
+            source: test_case.fetch(:source)
+          )
+        end
+        let(:updated_lock_content) do
+          flake_lock_content.gsub("old_sha_abc123", "new_sha_abc123")
+        end
+
+        it "builds an exact reference without changing the source type" do
+          updated_files
+          expect(Dependabot::SharedHelpers)
+            .to have_received(:run_shell_command)
+            .with(
+              lock_command(
+                input_path: test_case.fetch(:name),
+                ref: test_case.fetch(:expected_ref)
+              ),
+              fingerprint: "nix flake lock --override-input <input_path> <flake_ref>"
+            )
+        end
+      end
+    end
+
+    context "with a root input that follows a nested input" do
+      let(:dependency) do
+        git_dependency(
+          name: "alias",
+          version: "new_sha_abc123",
+          previous_version: "old_sha_abc123",
+          url: "https://github.com/example/target",
+          ref: "main"
+        )
+      end
+      let(:flake_lock_content) do
+        JSON.pretty_generate(
+          "nodes" => {
+            "parent-node" => {
+              "inputs" => {
+                "nested" => "target-node"
+              },
+              "locked" => {
+                "rev" => "parent-revision"
+              },
+              "original" => {
+                "type" => "github",
+                "owner" => "example",
+                "repo" => "parent"
+              }
+            },
+            "target-node" => {
+              "locked" => {
+                "rev" => "old_sha_abc123"
+              },
+              "original" => {
+                "type" => "github",
+                "owner" => "example",
+                "repo" => "target",
+                "ref" => "main"
+              }
+            },
+            "root" => {
+              "inputs" => {
+                "alias" => %w(parent nested),
+                "parent" => "parent-node"
+              }
+            }
+          },
+          "root" => "root",
+          "version" => 7
+        )
+      end
+      let(:updated_lock_content) do
+        flake_lock_content.gsub("old_sha_abc123", "new_sha_abc123")
+      end
+
+      it "uses the path followed by the root input" do
+        expect(JSON.parse(updated_files.fetch(0).content).dig("nodes", "root", "inputs", "alias"))
+          .to eq(%w(parent nested))
+        expect(Dependabot::SharedHelpers)
+          .to have_received(:run_shell_command)
+          .with(
+            lock_command(
+              input_path: "parent/nested",
+              ref: "github:example/target/new_sha_abc123"
+            ),
+            fingerprint: "nix flake lock --override-input <input_path> <flake_ref>"
+          )
+      end
+    end
+
+    context "with unsupported lockfile source metadata" do
+      let(:dependency) do
+        git_dependency(
+          name: "unsupported",
+          version: "new_sha_abc123",
+          previous_version: "old_sha_abc123",
+          url: "https://example.com/repo",
+          ref: "main"
+        )
+      end
+      let(:flake_lock_content) do
+        git_lock_content(
+          name: "unsupported",
+          revision: "old_sha_abc123",
+          source: {
+            "type" => "mercurial",
+            "url" => "https://example.com/repo",
+            "ref" => "main"
+          }
+        )
+      end
+
+      it "rejects the source before running Nix" do
+        expect { updated_files }
+          .to raise_error(Dependabot::DependencyFileNotResolvable, /source type "mercurial" is not supported/)
+        expect(Dependabot::SharedHelpers).not_to have_received(:run_shell_command)
+      end
+    end
+
     context "with a tag-pinned input (ref changed)" do
       let(:flake_nix_content) { fixture("flake_with_tag.nix") }
+      let(:flake_lock_content) do
+        git_lock_content(
+          name: "devenv",
+          revision: "old_sha_abc123",
+          source: {
+            "type" => "github",
+            "owner" => "cachix",
+            "repo" => "devenv",
+            "ref" => "v0.5"
+          }
+        )
+      end
 
       let(:dependency) do
         Dependabot::Dependency.new(
@@ -189,7 +491,9 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         )
       end
 
-      let(:updated_lock_content) { '{"updated": true}' }
+      let(:updated_lock_content) do
+        flake_lock_content.gsub("old_sha_abc123", "new_sha_def456")
+      end
 
       it "returns both flake.nix and flake.lock" do
         expect(updated_files.length).to eq(2)
@@ -213,10 +517,35 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         expect(File).to have_received(:write)
           .with("flake.nix", a_string_including("github:cachix/devenv/v0.6.2"))
       end
+
+      it "locks the input to the selected tag commit" do
+        updated_files
+        expect(Dependabot::SharedHelpers)
+          .to have_received(:run_shell_command)
+          .with(
+            lock_command(
+              input_path: "devenv",
+              ref: "github:cachix/devenv/new_sha_def456"
+            ),
+            fingerprint: "nix flake lock --override-input <input_path> <flake_ref>"
+          )
+      end
     end
 
     context "with a versioned branch input (ref changed)" do
       let(:flake_nix_content) { fixture("flake_with_versioned_branch.nix") }
+      let(:flake_lock_content) do
+        git_lock_content(
+          name: "nixpkgs",
+          revision: "old_sha_abc123",
+          source: {
+            "type" => "github",
+            "owner" => "NixOS",
+            "repo" => "nixpkgs",
+            "ref" => "nixos-24.11"
+          }
+        )
+      end
 
       let(:dependency) do
         Dependabot::Dependency.new(
@@ -249,7 +578,9 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         )
       end
 
-      let(:updated_lock_content) { '{"updated": true}' }
+      let(:updated_lock_content) do
+        flake_lock_content.gsub("old_sha_abc123", "new_sha_def456")
+      end
 
       it "returns both flake.nix and flake.lock" do
         expect(updated_files.length).to eq(2)
@@ -260,6 +591,19 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         nix_file = updated_files.find { |f| f.name == "flake.nix" }
         expect(nix_file.content).to include('"github:NixOS/nixpkgs/nixos-25.05"')
         expect(nix_file.content).not_to include("nixos-24.11")
+      end
+
+      it "locks the input to the selected branch commit" do
+        updated_files
+        expect(Dependabot::SharedHelpers)
+          .to have_received(:run_shell_command)
+          .with(
+            lock_command(
+              input_path: "nixpkgs",
+              ref: "github:NixOS/nixpkgs/new_sha_def456"
+            ),
+            fingerprint: "nix flake lock --override-input <input_path> <flake_ref>"
+          )
       end
     end
 
@@ -273,6 +617,12 @@ RSpec.describe Dependabot::Nix::FileUpdater do
             outputs = { self, nixpkgs }: { };
           }
         NIX
+      end
+      let(:flake_lock_content) do
+        tarball_lock_content(
+          revision: "old_rev_aaa",
+          url: "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz"
+        )
       end
 
       let(:dependency) do
@@ -306,7 +656,9 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         )
       end
 
-      let(:updated_lock_content) { '{"updated": true}' }
+      let(:updated_lock_content) do
+        flake_lock_content.gsub("old_rev_aaa", "new_rev_bbb")
+      end
 
       it "returns both flake.nix and flake.lock" do
         expect(updated_files.length).to eq(2)
@@ -323,7 +675,10 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         updated_files
         expect(Dependabot::SharedHelpers)
           .to have_received(:run_shell_command)
-          .with("nix flake update nixpkgs", fingerprint: "nix flake update <input_name>")
+          .with(
+            %w(nix flake update nixpkgs),
+            fingerprint: "nix flake update <input_name>"
+          )
       end
     end
 
@@ -337,6 +692,12 @@ RSpec.describe Dependabot::Nix::FileUpdater do
             outputs = { self, nixpkgs }: { };
           }
         NIX
+      end
+      let(:flake_lock_content) do
+        tarball_lock_content(
+          revision: "old_rev_aaa",
+          url: "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
+        )
       end
 
       let(:dependency) do
@@ -370,12 +731,209 @@ RSpec.describe Dependabot::Nix::FileUpdater do
         )
       end
 
-      let(:updated_lock_content) { '{"updated": true}' }
+      let(:updated_lock_content) do
+        flake_lock_content.gsub("old_rev_aaa", "new_rev_bbb")
+      end
 
       it "returns only the updated flake.lock" do
         expect(updated_files.length).to eq(1)
         expect(updated_files.first.name).to eq("flake.lock")
       end
     end
+  end
+
+  describe "with the real Nix command" do
+    let(:input_repo) { Dir.mktmpdir("dependabot-nix-input") }
+    let(:flake_project) { Dir.mktmpdir("dependabot-nix-project") }
+
+    after do
+      FileUtils.rm_rf(input_repo)
+      FileUtils.rm_rf(flake_project)
+    end
+
+    it "locks the selected commit, not the current branch tip" do
+      initialize_git_flake(input_repo)
+      existing_revision = commit_input_version(input_repo, "existing")
+      selected_revision = commit_input_version(input_repo, "selected")
+      live_revision = commit_input_version(input_repo, "live")
+
+      run_command("git", "reset", "--hard", existing_revision, chdir: input_repo)
+      write_flake_project(flake_project, input_repo)
+      run_command("nix", "flake", "lock", chdir: flake_project)
+      original_lock_content = File.read(File.join(flake_project, "flake.lock"))
+      run_command("git", "reset", "--hard", live_revision, chdir: input_repo)
+
+      dependency = Dependabot::Dependency.new(
+        name: "local_input",
+        version: selected_revision,
+        previous_version: existing_revision,
+        requirements: [{
+          file: "flake.lock",
+          requirement: nil,
+          source: {
+            type: "git",
+            url: "file://#{input_repo}",
+            branch: nil,
+            ref: "main"
+          },
+          groups: []
+        }],
+        previous_requirements: [{
+          file: "flake.lock",
+          requirement: nil,
+          source: {
+            type: "git",
+            url: "file://#{input_repo}",
+            branch: nil,
+            ref: "main"
+          },
+          groups: []
+        }],
+        package_manager: "nix"
+      )
+
+      updater = described_class.new(
+        dependency_files: [
+          Dependabot::DependencyFile.new(
+            name: "flake.nix",
+            content: File.read(File.join(flake_project, "flake.nix"))
+          ),
+          Dependabot::DependencyFile.new(
+            name: "flake.lock",
+            content: original_lock_content
+          )
+        ],
+        dependencies: [dependency],
+        credentials: []
+      )
+
+      updated_lock = JSON.parse(updater.updated_dependency_files.fetch(0).content)
+      node_name = updated_lock.fetch("nodes").fetch("root").fetch("inputs").fetch("local_input")
+      input_node = updated_lock.fetch("nodes").fetch(node_name)
+
+      expect(input_node.fetch("locked").fetch("rev")).to eq(selected_revision)
+      expect(input_node.fetch("locked").fetch("rev")).not_to eq(live_revision)
+      expect(input_node.fetch("original").fetch("ref")).to eq("main")
+    end
+  end
+
+  def git_lock_content(name:, revision:, source:)
+    JSON.pretty_generate(
+      "nodes" => {
+        name => {
+          "locked" => source.merge(
+            "lastModified" => 1_700_000_000,
+            "narHash" => "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            "rev" => revision
+          ).except("ref"),
+          "original" => source
+        },
+        "root" => {
+          "inputs" => {
+            name => name
+          }
+        }
+      },
+      "root" => "root",
+      "version" => 7
+    )
+  end
+
+  def git_dependency(name:, version:, previous_version:, url:, ref:, previous_ref: ref)
+    Dependabot::Dependency.new(
+      name: name,
+      version: version,
+      previous_version: previous_version,
+      requirements: [{
+        file: "flake.lock",
+        requirement: nil,
+        source: {
+          type: "git",
+          url: url,
+          branch: nil,
+          ref: ref
+        },
+        groups: []
+      }],
+      previous_requirements: [{
+        file: "flake.lock",
+        requirement: nil,
+        source: {
+          type: "git",
+          url: url,
+          branch: nil,
+          ref: previous_ref
+        },
+        groups: []
+      }],
+      package_manager: "nix"
+    )
+  end
+
+  def lock_command(input_path:, ref:)
+    ["nix", "flake", "lock", "--override-input", input_path, ref]
+  end
+
+  def tarball_lock_content(revision:, url:)
+    JSON.pretty_generate(
+      "nodes" => {
+        "nixpkgs" => {
+          "locked" => {
+            "lastModified" => 1_700_000_000,
+            "narHash" => "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            "rev" => revision,
+            "type" => "tarball",
+            "url" => "https://releases.nixos.org/#{revision}/nixexprs.tar.xz"
+          },
+          "original" => {
+            "type" => "tarball",
+            "url" => url
+          }
+        },
+        "root" => {
+          "inputs" => {
+            "nixpkgs" => "nixpkgs"
+          }
+        }
+      },
+      "root" => "root",
+      "version" => 7
+    )
+  end
+
+  def initialize_git_flake(path)
+    run_command("git", "init", "--initial-branch", "main", chdir: path)
+    run_command("git", "config", "user.email", "dependabot@example.com", chdir: path)
+    run_command("git", "config", "user.name", "Dependabot Test", chdir: path)
+    File.write(
+      File.join(path, "flake.nix"),
+      "{ outputs = { self }: { }; }\n"
+    )
+  end
+
+  def commit_input_version(path, version)
+    File.write(File.join(path, "version.txt"), "#{version}\n")
+    run_command("git", "add", ".", chdir: path)
+    run_command("git", "commit", "-m", version, chdir: path)
+    run_command("git", "rev-parse", "HEAD", chdir: path).strip
+  end
+
+  def write_flake_project(path, input_repo)
+    File.write(
+      File.join(path, "flake.nix"),
+      <<~NIX
+        {
+          inputs.local_input.url = "git+file://#{input_repo}?ref=main";
+          outputs = { self, local_input }: { };
+        }
+      NIX
+    )
+  end
+
+  def run_command(*command, chdir:)
+    output, status = Open3.capture2e(*command, chdir: chdir)
+    raise "Command failed: #{command.join(' ')}\n#{output}" unless status.success?
+
+    output
   end
 end

--- a/nix/spec/dependabot/nix/file_updater_spec.rb
+++ b/nix/spec/dependabot/nix/file_updater_spec.rb
@@ -349,6 +349,70 @@ RSpec.describe Dependabot::Nix::FileUpdater do
       end
     end
 
+    context "with an indirect registry input" do
+      let(:flake_nix_content) do
+        <<~NIX
+          {
+            inputs.nixpkgs.url = "nixpkgs/nixos-24.11";
+            outputs = { self, nixpkgs }: { };
+          }
+        NIX
+      end
+      let(:dependency) do
+        git_dependency(
+          name: "nixpkgs",
+          version: "new_sha_abc123",
+          previous_version: "old_sha_abc123",
+          url: "https://github.com/NixOS/nixpkgs",
+          ref: "nixos-24.11"
+        )
+      end
+      let(:flake_lock_content) do
+        JSON.pretty_generate(
+          "nodes" => {
+            "nixpkgs" => {
+              "locked" => {
+                "lastModified" => 1_700_000_000,
+                "narHash" => "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                "owner" => "NixOS",
+                "repo" => "nixpkgs",
+                "rev" => "old_sha_abc123",
+                "type" => "github"
+              },
+              "original" => {
+                "id" => "nixpkgs",
+                "ref" => "nixos-24.11",
+                "type" => "indirect"
+              }
+            },
+            "root" => {
+              "inputs" => {
+                "nixpkgs" => "nixpkgs"
+              }
+            }
+          },
+          "root" => "root",
+          "version" => 7
+        )
+      end
+      let(:updated_lock_content) do
+        flake_lock_content.gsub("old_sha_abc123", "new_sha_abc123")
+      end
+
+      it "uses the resolved source for the lock override" do
+        expect(updated_files.map(&:name)).to eq(["flake.lock"])
+        expect(Dependabot::SharedHelpers)
+          .to have_received(:run_shell_command)
+          .with(
+            lock_command(
+              input_path: "nixpkgs",
+              ref: "github:NixOS/nixpkgs/new_sha_abc123"
+            ),
+            fingerprint: "nix flake lock --override-input <input_path> <flake_ref>"
+          )
+      end
+    end
+
     context "with a root input that follows a nested input" do
       let(:dependency) do
         git_dependency(

--- a/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
+++ b/nix/spec/dependabot/nix/flake_nix_parser_spec.rb
@@ -138,19 +138,23 @@ RSpec.describe Dependabot::Nix::FlakeNixParser do
       end
     end
 
-    context "with non-shorthand URL" do
+    context "with a generic Git URL" do
       let(:content) do
         <<~NIX
           {
-            inputs.mylib.url = "git+https://example.com/repo.git?ref=main";
+            inputs.mylib.url = "git+https://example.com/repo.git?ref=main&dir=nix";
             outputs = { self, mylib }: { };
           }
         NIX
       end
 
-      it "returns nil for non-shorthand URLs" do
+      it "parses the ref and query" do
         result = described_class.find_input_url(content, "mylib")
-        expect(result).to be_nil
+
+        expect(result).not_to be_nil
+        expect(result.scheme).to eq("git")
+        expect(result.ref).to eq("main")
+        expect(result.query).to eq("ref=main&dir=nix")
       end
     end
 
@@ -303,6 +307,25 @@ RSpec.describe Dependabot::Nix::FlakeNixParser do
         updated = described_class.update_input_ref(content, "nixpkgs", "nixos-25.05")
 
         expect(updated).to include('"github:NixOS/nixpkgs/nixos-25.05?host=github.corp.example.com"')
+      end
+    end
+
+    context "with a generic Git URL" do
+      let(:content) do
+        <<~NIX
+          {
+            inputs.mylib.url = "git+https://example.com/repo.git?ref=v1.0.0&dir=nix";
+            outputs = { self, mylib }: { };
+          }
+        NIX
+      end
+
+      it "rewrites the ref and preserves other query parameters" do
+        updated = described_class.update_input_ref(content, "mylib", "v2.0.0")
+
+        expect(updated).to include(
+          '"git+https://example.com/repo.git?ref=v2.0.0&dir=nix"'
+        )
       end
     end
 

--- a/nix/spec/dependabot/nix/lockfile_spec.rb
+++ b/nix/spec/dependabot/nix/lockfile_spec.rb
@@ -1,0 +1,102 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/nix/lockfile"
+
+RSpec.describe Dependabot::Nix::Lockfile do
+  describe "root input resolution" do
+    subject(:lockfile) { described_class.new(content) }
+
+    let(:content) do
+      File.read(File.join(__dir__, "fixtures", "flake.lock"))
+    end
+
+    it "returns the lockfile version and root input names" do
+      expect(lockfile.version).to eq(7)
+      expect(lockfile.root_input_names).to contain_exactly("flake-utils", "nixpkgs")
+    end
+
+    it "resolves a direct input path and node" do
+      expect(lockfile.input_path("nixpkgs")).to eq(["nixpkgs"])
+      expect(lockfile.locked_revision("nixpkgs"))
+        .to eq("3030f185ba6a4bf4f18b87f345f104e6a6961f34")
+      expect(lockfile.original_source("nixpkgs"))
+        .to include("type" => "github", "ref" => "nixos-unstable")
+    end
+
+    context "when a root input follows a nested input path" do
+      let(:content) do
+        <<~JSON
+          {
+            "nodes": {
+              "parent-node": {
+                "inputs": {
+                  "nested": "target-node"
+                },
+                "locked": {
+                  "rev": "parent-revision"
+                },
+                "original": {
+                  "type": "github",
+                  "owner": "example",
+                  "repo": "parent"
+                }
+              },
+              "target-node": {
+                "locked": {
+                  "rev": "target-revision"
+                },
+                "original": {
+                  "type": "gitlab",
+                  "owner": "example",
+                  "repo": "target",
+                  "ref": "main"
+                }
+              },
+              "root": {
+                "inputs": {
+                  "alias": ["parent", "nested"],
+                  "parent": "parent-node"
+                }
+              }
+            },
+            "root": "root",
+            "version": 7
+          }
+        JSON
+      end
+
+      it "returns the followed path and target node" do
+        expect(lockfile.input_path("alias")).to eq(%w(parent nested))
+        expect(lockfile.locked_revision("alias")).to eq("target-revision")
+        expect(lockfile.original_source("alias"))
+          .to include("type" => "gitlab", "ref" => "main")
+      end
+    end
+
+    context "when a follows path is cyclic" do
+      let(:content) do
+        <<~JSON
+          {
+            "nodes": {
+              "root": {
+                "inputs": {
+                  "first": ["second"],
+                  "second": ["first"]
+                }
+              }
+            },
+            "root": "root",
+            "version": 7
+          }
+        JSON
+      end
+
+      it "returns nil for the cycle" do
+        expect(lockfile.input_node("first")).to be_nil
+        expect(lockfile.locked_revision("first")).to be_nil
+      end
+    end
+  end
+end

--- a/nix/spec/dependabot/nix/lockfile_spec.rb
+++ b/nix/spec/dependabot/nix/lockfile_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Dependabot::Nix::Lockfile do
         .to eq("3030f185ba6a4bf4f18b87f345f104e6a6961f34")
       expect(lockfile.original_source("nixpkgs"))
         .to include("type" => "github", "ref" => "nixos-unstable")
+      expect(lockfile.locked_source("nixpkgs"))
+        .to include(
+          "type" => "github",
+          "rev" => "3030f185ba6a4bf4f18b87f345f104e6a6961f34"
+        )
     end
 
     context "when a root input follows a nested input path" do


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #15960.

Dependabot can select a cooldown-qualified commit for a moving Nix input, then resolve the branch again while updating `flake.lock`. This makes the PR metadata and lockfile disagree.

Use `nix flake lock --override-input` to lock the selected SHA, then check that Nix wrote the expected revision. The change also handles root inputs that use `follows` and updates refs in generic Git URLs.

### Anything you want to highlight for special attention from reviewers?

The exact flake reference comes from the source metadata in `flake.lock`. This covers GitHub, GitLab, SourceHut, custom hosts, and generic Git URLs without changing the original branch or tag stored by Nix.

### How will you know you've accomplished your goal?

A local Git regression test creates an old locked commit, a selected commit, and a newer branch tip. The updated lockfile must contain the selected commit.

The Nix test suite, RuboCop, and scoped Sorbet check pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
