### PR TITLE
Align vendored NuGet assemblies with the .NET SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -213,6 +213,9 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    ignore:
+      # This revision must remain aligned with the SDK and assembly versions used by NuGetUpdater.
+      - dependency-name: "nuget/helpers/lib/NuGet.Client"
   - package-ecosystem: "maven"
     directory: "/maven/lib/dependabot/maven/"
     schedule:

--- a/.github/instructions/nuget-projects.instructions.md
+++ b/.github/instructions/nuget-projects.instructions.md
@@ -8,6 +8,17 @@ applyTo: "nuget/helpers/lib/NuGetUpdater/NuGetProjects/**"
 
 When the `NuGet.Client` submodule is updated, all `*.cs` files under `NuGetProjects/` must be re-checked against their original files in the submodule to ensure they remain largely in line with the upstream content.
 
+The NuGet version must also remain synchronized across:
+
+- The NuGet assemblies bundled with the SDK selected by `NuGetUpdater/global.json`.
+- The `release/*` branch and pinned revision for the `NuGet.Client` submodule.
+- The `<Version>` in `NuGetProjects/Directory.Build.props`.
+- The `Microsoft.Build` package version in `NuGetUpdater/Directory.Packages.props`.
+
+The locally compiled NuGet assemblies and the SDK's NuGet assemblies share an assembly load context. Their assembly versions and NuGet public-key identity must match, or SDK tasks can fail at runtime with an assembly load error. `NuGetProjects/Directory.Build.targets` enforces the version relationship during builds.
+
+Dependabot embeds `NuGet.CommandLine` in a .NET process and registers the selected SDK's MSBuild with `MSBuildLocator`. This differs from standalone NuGet.exe, which runs on .NET Framework and rejects SDK MSBuild paths. The maintained `UpdateCommand.cs` override intentionally accepts the registered SDK path so packages.config updates continue to work in the Linux updater image.
+
 ## Rules for modified files
 
 1. **No references to `NuGet.Core`.** Remove all `extern alias CoreV2` usages and any other references to the legacy `NuGet.Core` (v2) package.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,8 @@
 [submodule "nuget/helpers/lib/NuGet.Client"]
 	path = nuget/helpers/lib/NuGet.Client
 	url = https://github.com/NuGet/NuGet.Client
-	branch = release/7.6.x
+	# Keep this branch aligned with the NuGet assemblies bundled by the SDK in NuGetUpdater/global.json.
+	branch = release/7.9.x
 [submodule "nuget/helpers/lib/dotnet-core"]
 	path = nuget/helpers/lib/dotnet-core
 	url = https://github.com/dotnet/core

--- a/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
+++ b/nuget/helpers/lib/NuGetUpdater/Directory.Packages.props
@@ -3,7 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
-    <MSBuildPackageVersion>18.3.3</MSBuildPackageVersion>
+    <!-- Match the MSBuild assemblies supplied by the SDK selected in global.json. -->
+    <MSBuildPackageVersion>18.9.6</MSBuildPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="DiffPlex" Version="1.9.0" />
@@ -34,8 +35,8 @@
     <PackageVersion Include="System.ComponentModel.Composition" Version="10.0.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.3" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="9.0.11" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.10" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.8" />
     <PackageVersion Include="System.Text.Json" Version="10.0.3" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="10.0.3" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.props
@@ -11,7 +11,15 @@
     <SharedDirectory>$(NuGetSourceLocation)\build\Shared</SharedDirectory>
     <NoWarn>$(NoWarn);CA1416</NoWarn><!-- platform compatibility in vendored NuGet.Client code -->
     <NoWarn>$(NoWarn);CS0436</NoWarn><!-- type conflicts with imported types in vendored NuGet.Client code -->
-    <Version>6.8.0</Version>
+    <!--
+      These assemblies share the default load context with the copies bundled in the selected .NET SDK.
+      Keep this version aligned with both NuGet.Client/build/config.props and the SDK in ../global.json.
+    -->
+    <Version>7.9.0</Version>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign>true</PublicSign>
+    <!-- NuGet.Core assemblies use Microsoft's public key, as do the copies bundled with the SDK. -->
+    <AssemblyOriginatorKeyFile>$(NuGetSourceLocation)\keys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <Import Project="..\Directory.Common.props" />

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.targets
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/Directory.Build.targets
@@ -1,7 +1,63 @@
 <Project>
 
   <ItemGroup>
-    <Compile Include="$(SharedDirectory)\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+    <!-- NuGetFeatureFlags depends on NuGet.Common and is included only by projects that use it upstream. -->
+    <Compile Include="$(SharedDirectory)\*.cs"
+             Exclude="bin\**;obj\**;**\*.xproj;packages\**;$(SharedDirectory)\NuGetFeatureFlags.cs" />
   </ItemGroup>
+
+  <!--
+    MSBuild and the updater load NuGet assemblies into the same process. Fail the build before a
+    mismatched assembly identity can become a runtime FileNotFoundException.
+  -->
+  <Target Name="ValidateNuGetAssemblyVersion"
+          BeforeTargets="CoreCompile"
+          Condition="'$(MSBuildProjectName)' == 'NuGet.Frameworks'">
+    <XmlPeek XmlInputPath="$(NuGetSourceLocation)\build\config.props"
+             Query="/Project/PropertyGroup/MajorNuGetVersion/text()">
+      <Output TaskParameter="Result" PropertyName="_VendoredNuGetMajorVersion" />
+    </XmlPeek>
+    <XmlPeek XmlInputPath="$(NuGetSourceLocation)\build\config.props"
+             Query="/Project/PropertyGroup/MinorNuGetVersion/text()">
+      <Output TaskParameter="Result" PropertyName="_VendoredNuGetMinorVersion" />
+    </XmlPeek>
+    <XmlPeek XmlInputPath="$(NuGetSourceLocation)\build\config.props"
+             Query="/Project/PropertyGroup/PatchNuGetVersion/text()">
+      <Output TaskParameter="Result" PropertyName="_VendoredNuGetPatchVersion" />
+    </XmlPeek>
+
+    <PropertyGroup>
+      <_VendoredNuGetVersion>$(_VendoredNuGetMajorVersion).$(_VendoredNuGetMinorVersion).$(_VendoredNuGetPatchVersion)</_VendoredNuGetVersion>
+      <_SdkNuGetFrameworksPath>$(MSBuildSDKsPath)\..\NuGet.Frameworks.dll</_SdkNuGetFrameworksPath>
+    </PropertyGroup>
+
+    <Error Condition="'$(_VendoredNuGetVersion)' != '$(Version)'"
+           Text="The NuGetProjects version ($(Version)) must match the vendored NuGet.Client version ($(_VendoredNuGetVersion)). Update the submodule and Directory.Build.props together." />
+    <Error Condition="!Exists('$(_SdkNuGetFrameworksPath)')"
+           Text="NuGet.Frameworks.dll was not found beside the selected SDK at '$(_SdkNuGetFrameworksPath)'." />
+
+    <GetAssemblyIdentity AssemblyFiles="$(_SdkNuGetFrameworksPath)"
+                         Condition="Exists('$(_SdkNuGetFrameworksPath)')">
+      <Output TaskParameter="Assemblies" ItemName="_SdkNuGetFrameworksAssembly" />
+    </GetAssemblyIdentity>
+
+    <Error Condition="'%(_SdkNuGetFrameworksAssembly.Version)' != '$(Version).0'"
+           Text="The selected SDK contains NuGet.Frameworks version %(_SdkNuGetFrameworksAssembly.Version), but NuGetProjects builds version $(Version).0. Keep global.json, the NuGet.Client submodule, and Directory.Build.props aligned." />
+  </Target>
+
+  <Target Name="ValidateNuGetAssemblyIdentity"
+          AfterTargets="CopyFilesToOutputDirectory"
+          DependsOnTargets="ValidateNuGetAssemblyVersion"
+          Condition="'$(MSBuildProjectName)' == 'NuGet.Frameworks'">
+    <GetAssemblyIdentity AssemblyFiles="$(TargetPath)">
+      <Output TaskParameter="Assemblies" ItemName="_BuiltNuGetFrameworksAssembly" />
+    </GetAssemblyIdentity>
+    <GetAssemblyIdentity AssemblyFiles="$(_SdkNuGetFrameworksPath)">
+      <Output TaskParameter="Assemblies" ItemName="_SdkNuGetFrameworksAssemblyForIdentity" />
+    </GetAssemblyIdentity>
+
+    <Error Condition="'@(_BuiltNuGetFrameworksAssembly)' != '@(_SdkNuGetFrameworksAssemblyForIdentity)'"
+           Text="The built NuGet.Frameworks identity '@(_BuiltNuGetFrameworksAssembly)' must match the selected SDK copy '@(_SdkNuGetFrameworksAssemblyForIdentity)'." />
+  </Target>
 
 </Project>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -38,6 +38,9 @@ namespace NuGet.CommandLine
 
         private IEnvironmentVariableReader _environmentVariableReader;
 
+        private bool _deterministic;
+        private string _deterministicTimestamp;
+
         // Files we want to always exclude from the resulting package
         private static readonly HashSet<string> ExcludeFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             NuGetConstants.PackageReferenceFile,
@@ -71,6 +74,8 @@ namespace NuGet.CommandLine
         {
             return new ProjectFactory(packArgs.MsBuildDirectory.Value, path, packArgs.Properties)
             {
+                _deterministic = packArgs.Deterministic,
+                _deterministicTimestamp = packArgs.DeterministicTimestamp,
                 IsTool = packArgs.Tool,
                 LogLevel = packArgs.LogLevel,
                 Logger = packArgs.Logger,
@@ -234,7 +239,10 @@ namespace NuGet.CommandLine
                 }
             }
 
-            builder = new PackageBuilder(false, Logger);
+            builder = new PackageBuilder(_deterministic, Logger)
+            {
+                DeterministicTimestamp = _deterministicTimestamp,
+            };
 
             try
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -84,7 +84,12 @@ namespace NuGet.CommandLine
                 throw new CommandException(NuGetResources.InvalidFile);
             }
 
-            _msbuildDirectory = MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(MSBuildPath, MSBuildVersion, Console).Value.Path;
+            // Upstream rejects SDK MSBuild paths because standalone NuGet.exe runs on .NET Framework and cannot load
+            // .NET SDK assemblies. Dependabot embeds this command in .NET and pre-registers the matching SDK with
+            // MSBuildLocator, so the supplied SDK path is both supported and required on Linux.
+            _msbuildDirectory = string.IsNullOrEmpty(MSBuildPath)
+                ? MsBuildUtility.GetMsBuildDirectoryFromMsBuildPath(MSBuildPath, MSBuildVersion, Console).Value.Path
+                : MSBuildPath;
             var context = new UpdateConsoleProjectContext(Console, FileConflictAction);
 
             var logger = new LoggerAdapter(context);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/PackageFolderReader.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Packaging/PackageFolderReader.cs
@@ -237,7 +237,7 @@ namespace NuGet.Packaging
             // do nothing here
         }
 
-        public override Task<PrimarySignature> GetPrimarySignatureAsync(CancellationToken token)
+        public override Task<PrimarySignature?> GetPrimarySignatureAsync(CancellationToken token)
         {
             return TaskResult.Null<PrimarySignature>();
         }
@@ -262,7 +262,7 @@ namespace NuGet.Packaging
             return false;
         }
 
-        public override string GetContentHash(CancellationToken token, Func<string> GetUnsignedPackageHash = null)
+        public override string GetContentHash(CancellationToken token, Func<string>? GetUnsignedPackageHash = null)
         {
             throw new NotImplementedException();
         }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetProjects/NuGet.Protocol/NuGet.Protocol.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="$(NuGetSourceLocation)\src\NuGet.Core\NuGet.Protocol\**\*.cs" />
+    <Compile Include="$(SharedDirectory)\NuGetFeatureFlags.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -2,6 +2,12 @@ using System.Text;
 using System.Text.Json;
 
 using NuGet;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 
 using NuGetUpdater.Core.Analyze;
 using NuGetUpdater.Core.Run.ApiModel;
@@ -1503,5 +1509,132 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
         var context = new NuGetContext(tempDir.DirectoryPath);
         var infoUrl = await context.GetPackageInfoUrlAsync("some.package", "1.0.0", CancellationToken.None);
         Assert.Null(infoUrl);
+    }
+
+    [Fact]
+    public async Task GetPackageInfoUrlAsyncFallsBackToMetadataWhenDownloadResourceIsNull()
+    {
+        var expectedUrl = new Uri("https://example.com/package");
+        using var context = await CreateNuGetContextAsync(downloadResource: null, expectedUrl);
+
+        var infoUrl = await context.GetPackageInfoUrlAsync("some.package", "1.0.0", CancellationToken.None);
+
+        Assert.Equal(expectedUrl.ToString(), infoUrl);
+    }
+
+    [Fact]
+    public async Task GetPackageInfoUrlAsyncFallsBackToMetadataWhenAvailableDownloadHasNoPackageReader()
+    {
+        var expectedUrl = new Uri("https://example.com/package");
+        var downloadResource = new TestDownloadResource(
+            new DownloadResourceResult(new MemoryStream(), packageReader: null, source: "test"));
+        using var context = await CreateNuGetContextAsync(downloadResource, expectedUrl);
+
+        var infoUrl = await context.GetPackageInfoUrlAsync("some.package", "1.0.0", CancellationToken.None);
+
+        Assert.Equal(expectedUrl.ToString(), infoUrl);
+    }
+
+    private static async Task<NuGetContext> CreateNuGetContextAsync(DownloadResource? downloadResource, Uri projectUrl)
+    {
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(
+            ("NuGet.Config", """
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="test" value="https://example.com/v3/index.json" />
+                  </packageSources>
+                </configuration>
+                """)
+        );
+
+        return new NuGetContext(
+            tempDir.DirectoryPath,
+            sourceRepositoryFactory: source => new SourceRepository(
+                source,
+                [
+                    new TestResourceProvider<MetadataResource>(new TestMetadataResource()),
+                    new TestResourceProvider<DownloadResource>(downloadResource),
+                    new TestResourceProvider<PackageMetadataResource>(new TestPackageMetadataResource(projectUrl)),
+                ]));
+    }
+
+    private sealed class TestResourceProvider<TResource>(TResource? resource) : INuGetResourceProvider
+        where TResource : class, INuGetResource
+    {
+        public Type ResourceType => typeof(TResource);
+        public string Name => typeof(TResource).Name;
+        public IEnumerable<string> Before => [];
+        public IEnumerable<string> After => [];
+
+        public Task<Tuple<bool, INuGetResource?>> TryCreate(SourceRepository source, CancellationToken token) =>
+            Task.FromResult(Tuple.Create(true, (INuGetResource?)resource));
+    }
+
+    private sealed class TestMetadataResource : MetadataResource
+    {
+        public override Task<bool> Exists(
+            PackageIdentity identity,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            NuGet.Common.ILogger log,
+            CancellationToken token) => Task.FromResult(true);
+
+        public override Task<bool> Exists(
+            string packageId,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            NuGet.Common.ILogger log,
+            CancellationToken token) => Task.FromResult(true);
+
+        public override Task<IEnumerable<NuGetVersion>> GetVersions(
+            string packageId,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            NuGet.Common.ILogger log,
+            CancellationToken token) => Task.FromResult<IEnumerable<NuGetVersion>>([]);
+
+        public override Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(
+            IEnumerable<string> packageIds,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            NuGet.Common.ILogger log,
+            CancellationToken token) => Task.FromResult<IEnumerable<KeyValuePair<string, NuGetVersion>>>([]);
+    }
+
+    private sealed class TestDownloadResource(DownloadResourceResult result) : DownloadResource
+    {
+        public override Task<DownloadResourceResult> GetDownloadResourceResultAsync(
+            PackageIdentity identity,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
+            NuGet.Common.ILogger logger,
+            CancellationToken token) => Task.FromResult(result);
+    }
+
+    private sealed class TestPackageMetadataResource(Uri projectUrl) : PackageMetadataResource
+    {
+        public override Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(
+            string packageId,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            NuGet.Common.ILogger log,
+            CancellationToken token) => Task.FromResult<IEnumerable<IPackageSearchMetadata>>([]);
+
+        public override Task<IPackageSearchMetadata> GetMetadataAsync(
+            PackageIdentity package,
+            SourceCacheContext sourceCacheContext,
+            NuGet.Common.ILogger log,
+            CancellationToken token) =>
+            Task.FromResult<IPackageSearchMetadata>(
+                new PackageSearchMetadataBuilder.ClonedPackageSearchMetadata
+                {
+                    Identity = package,
+                    ProjectUrl = projectUrl,
+                });
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/NuGetContext.cs
@@ -20,8 +20,12 @@ internal record NuGetContext : IDisposable
     public IMachineWideSettings MachineWideSettings { get; }
     public ImmutableArray<PackageSource> PackageSources { get; }
     public NuGet.Common.ILogger Logger { get; }
+    private readonly Func<PackageSource, SourceRepository> _sourceRepositoryFactory;
 
-    public NuGetContext(string? currentDirectory = null, NuGet.Common.ILogger? logger = null)
+    public NuGetContext(
+        string? currentDirectory = null,
+        NuGet.Common.ILogger? logger = null,
+        Func<PackageSource, SourceRepository>? sourceRepositoryFactory = null)
     {
         SourceCacheContext = new SourceCacheContext();
         PackageDownloadContext = new PackageDownloadContext(SourceCacheContext);
@@ -36,6 +40,7 @@ internal record NuGetContext : IDisposable
             .Where(p => p.IsEnabled)
             .ToImmutableArray();
         Logger = logger ?? NullLogger.Instance;
+        _sourceRepositoryFactory = sourceRepositoryFactory ?? Repository.Factory.GetCoreV3;
     }
 
     public void Dispose()
@@ -83,7 +88,7 @@ internal record NuGetContext : IDisposable
         foreach (var source in sources)
         {
             message.AppendLine($"  checking {source.Name}");
-            var sourceRepository = Repository.Factory.GetCoreV3(source);
+            var sourceRepository = _sourceRepositoryFactory(source);
             var feed = await sourceRepository.GetResourceAsync<MetadataResource>(cancellationToken);
             if (feed is null)
             {
@@ -118,21 +123,24 @@ internal record NuGetContext : IDisposable
             }
 
             var downloadResource = await sourceRepository.GetResourceAsync<DownloadResource>(cancellationToken);
-            using var downloadResult = await downloadResource.GetDownloadResourceResultAsync(packageIdentity, PackageDownloadContext, globalPackagesFolder, Logger, cancellationToken);
-            if (downloadResult.Status == DownloadResourceResultStatus.Available)
+            if (downloadResource is not null)
             {
-                var repositoryMetadata = downloadResult.PackageReader.NuspecReader.GetRepositoryMetadata();
-                message.AppendLine($"    repometadata: type=[{repositoryMetadata.Type}], url=[{repositoryMetadata.Url}], branch=[{repositoryMetadata.Branch}], commit=[{repositoryMetadata.Commit}]");
-                if (!string.IsNullOrEmpty(repositoryMetadata.Url))
+                using var downloadResult = await downloadResource.GetDownloadResourceResultAsync(packageIdentity, PackageDownloadContext, globalPackagesFolder, Logger, cancellationToken);
+                if (downloadResult.Status == DownloadResourceResultStatus.Available &&
+                    downloadResult.PackageReader is not null)
                 {
-                    return repositoryMetadata.Url;
+                    var repositoryMetadata = downloadResult.PackageReader.NuspecReader.GetRepositoryMetadata();
+                    message.AppendLine($"    repometadata: type=[{repositoryMetadata.Type}], url=[{repositoryMetadata.Url}], branch=[{repositoryMetadata.Branch}], commit=[{repositoryMetadata.Commit}]");
+                    if (!string.IsNullOrEmpty(repositoryMetadata.Url))
+                    {
+                        return repositoryMetadata.Url;
+                    }
+                }
+                else
+                {
+                    message.AppendLine($"    download result status: {downloadResult.Status}");
                 }
             }
-            else
-            {
-                message.AppendLine($"    download result status: {downloadResult.Status}");
-            }
-
             var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
             if (metadataResource is not null)
             {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Updater/PackagesConfigUpdater.cs
@@ -57,7 +57,7 @@ internal static partial class PackagesConfigUpdater
         var restoreArgs = new List<string>
         {
             "restore",
-            projectPath,
+            packagesConfigPath,
             "-PackagesDirectory",
             packagesDirectory,
             "-NonInteractive",
@@ -80,11 +80,10 @@ internal static partial class PackagesConfigUpdater
         var msbuildDirectory = MSBuildHelper.MSBuildPath;
         if (msbuildDirectory is not null)
         {
-            foreach (var args in new[] { restoreArgs, updateArgs })
-            {
-                args.Add("-MSBuildPath");
-                args.Add(msbuildDirectory); // e.g., /usr/share/dotnet/sdk/7.0.203
-            }
+            // Restoring packages.config directly does not require MSBuild. The update command does, and our embedded
+            // NuGet.CommandLine override supports the SDK MSBuild instance already registered by MSBuildLocator.
+            updateArgs.Add("-MSBuildPath");
+            updateArgs.Add(msbuildDirectory); // e.g., /usr/share/dotnet/sdk/10.0.400
         }
 
         using (new SpecialImportsConditionPatcher(projectPath))

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/DependencyConflictResolver.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/DependencyConflictResolver.cs
@@ -114,6 +114,11 @@ public class PackageManager
             }
 
             var metadataResource = await sourceRepository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
+            if (metadataResource is null)
+            {
+                continue;
+            }
+
             var metadata = await metadataResource.GetMetadataAsync(packageIdentity, SourceCacheContext, Logger, cancellationToken);
             return metadata;
         }


### PR DESCRIPTION
### What are you trying to accomplish?

Align the NuGet assemblies compiled into `NuGetUpdater` with the NuGet assemblies supplied by the .NET SDK that hosts MSBuild.

The updater currently has three different NuGet identities in one process:

| Component | Version before this change |
| --- | --- |
| SDK selected by `NuGetUpdater/global.json` | .NET SDK 10.0.400 |
| NuGet assemblies bundled with that SDK | `7.9.0.0`, public key token `31bf3856ad364e35` |
| Vendored `NuGet.Client` source | `release/7.6.x` |
| Version forced onto the locally compiled NuGet projects | `6.8.0.0` |

`NuGetUpdater` registers MSBuild and then loads both its locally compiled NuGet assemblies and SDK components into the same process. When an MSBuild SDK resolver causes SDK targets to request the SDK's `NuGet.Frameworks` identity, the runtime can find the updater's incompatible assembly first. The request then fails because the located manifest does not match `NuGet.Frameworks, Version=7.9.0.0, PublicKeyToken=31bf3856ad364e35`.

This is not safely solved with a binding redirect or a custom assembly resolver. Those approaches would mask a split NuGet object graph in which SDK tasks and the updater were compiled against different contracts. The assemblies need to have coherent source, version, and strong-name identities.

This change:

1. Keeps the selected .NET SDK at 10.0.400.
2. Moves the `NuGet.Client` submodule from `release/7.6.x` to `release/7.9.x`, pinned at `626dc64e95d6f5bc366cbbe191a15751ccbfb097`.
3. Changes the locally compiled NuGet assembly version from 6.8.0 to 7.9.0.
4. Public-signs the locally compiled NuGet.Core assemblies with `35MSSharedLib1024.snk`, matching the SDK's `31bf3856ad364e35` public key token.
5. Aligns the compile-time Microsoft.Build packages with MSBuild 18.9.6 from SDK 10.0.400, including the transitive cryptography package versions required by that package family.
6. Adds build-time checks that compare:
   - the semantic version declared by the vendored NuGet source;
   - the version assigned to the local wrapper projects;
   - the `NuGet.Frameworks` version supplied by the selected SDK; and
   - the complete built and SDK assembly identities.
7. Excludes `NuGetFeatureFlags.cs` from the blanket shared-source import and includes it only in `NuGet.Protocol`, matching upstream's dependency layering. The file depends on `NuGet.Common`, so including it in foundational assemblies such as `NuGet.Frameworks` creates an invalid dependency.
8. Reconciles Dependabot's maintained `ProjectFactory.cs` override with NuGet 7.9's deterministic packing behavior.
9. Handles nullable NuGet 7.9 resource and package-reader contracts explicitly rather than suppressing the warnings.
10. Documents the SDK, NuGet.Client, assembly-version, signing, and Microsoft.Build coupling in the NuGet project maintenance instructions.
11. Prevents the repository's generic git-submodule Dependabot configuration from updating `NuGet.Client` independently of the SDK and assembly settings.

### Anything you want to highlight for special attention from reviewers?

The assembly's public key token is as important as its version. Initially changing only the version produced:

```text
NuGet.Frameworks, Version=7.9.0.0, PublicKeyToken=b03f5f7f11d50a3a
```

The SDK expects:

```text
NuGet.Frameworks, Version=7.9.0.0, PublicKeyToken=31bf3856ad364e35
```

NuGet.Core projects are signed with Microsoft's public key upstream. This PR uses NuGet.Client's checked-in `35MSSharedLib1024.snk` public-signing key so the updater produces the same identity as the SDK. The new `ValidateNuGetAssemblyIdentity` target prevents a future version-only fix from overlooking this distinction.

The C# changes fall into two categories:

- `NuGetProjects/NuGet.CommandLine/Commands/ProjectFactory.cs` is a Dependabot-maintained copy because the upstream file depends on legacy `NuGet.Core` v2 APIs. It therefore needs to be reconciled manually with every submodule update. The added deterministic fields, `PackArgs` propagation, and `PackageBuilder` initialization are copied from the upstream 7.9 delta.
- `NuGetContext.cs` and `DependencyConflictResolver.cs` now honor nullable NuGet 7.9 contracts. A repository may not provide a requested download or metadata resource, and an available download result may not contain a package reader. These are genuine nullable states, so using null-forgiving operators would retain possible runtime failures. The updated code records diagnostics and continues through the existing fallback/next-source behavior.

The `NuGet.Client` submodule is intentionally ignored by the generic `gitsubmodule` Dependabot job. Future updates need to be coordinated with the selected SDK, local assembly version, signing identity, Microsoft.Build packages, and any changes to the maintained source overrides.

### How will you know you've accomplished your goal?

#### Build validation

The complete solution was built in the same SDK selected by `global.json`:

```console
docker run --rm \
  --volume "$PWD:/repo" \
  --workdir /repo/nuget/helpers/lib/NuGetUpdater \
  mcr.microsoft.com/dotnet/sdk:10.0.400 \
  dotnet build NuGetUpdater.slnx --configuration Release
```

Result:

```text
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

The generated and SDK assembly identities were also compared directly. Both are now:

```text
NuGet.Frameworks, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
```

The built CLI starts successfully and reports version `1.0.0`.

#### End-to-end failure reproduction

A local fixture was created with:

- `global.json` selecting SDK 10.0.303 with `rollForward: latestMinor`;
- `Microsoft.Build.Traversal` 4.1.0 declared under `msbuild-sdks`;
- a `dirs.proj` using `Microsoft.Build.Traversal`;
- a `net10.0` child project; and
- an outdated `Newtonsoft.Json` 13.0.1 reference.

Dependabot CLI v1.92.0 was run with `--local` against the currently published NuGet updater image, pinned by digest:

```text
ghcr.io/dependabot/dependabot-updater-nuget@sha256:4ea46a85cbb7fed98ed042a5601f7befd029f31b3972f95350483e08ca377235
```

The published image failed while expanding `dirs.proj`:

```text
The expression "[MSBuild]::GetTargetFrameworkIdentifier(net45)" cannot be evaluated.
Could not load file or assembly 'NuGet.Frameworks, Version=7.9.0.0,
Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The located assembly's
manifest definition does not match the assembly reference. (0x80131040)
```

Discovery consequently returned an empty project list and did not discover the child project's `Newtonsoft.Json` dependency.

#### End-to-end fix verification

The local NuGet updater image was rebuilt from this branch using:

```console
script/build nuget
```

The resulting image ID was:

```text
sha256:42d7c06b318c4fe5812265250656bcd4908e00e133fea3b78f364f40858817eb
```

Dependabot CLI was then run again with the same arguments and unchanged fixture, changing only the updater image. The fixed image:

- expanded `dirs.proj` without an assembly-load error;
- discovered `Repro.csproj`;
- reported both `Microsoft.Build.Traversal` and `Newtonsoft.Json`;
- updated `Microsoft.Build.Traversal` from 4.1.0 to 4.1.82;
- updated `Newtonsoft.Json` from 13.0.1 to 13.0.4; and
- completed repeated post-update discovery successfully.

This exercises the exact MSBuild traversal path that fails in the published image and demonstrates that aligning the NuGet source, version, and public-key identity removes the failure.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
