### PR TITLE
Add typed pyproject wire models

### DIFF
--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -21,6 +21,9 @@ module Dependabot
     class FileParser < Dependabot::FileParsers::Base # rubocop:disable Metrics/ClassLength
       extend T::Sig
 
+      require_relative "file_parser/pyproject_document"
+      require_relative "file_parser/poetry_lock"
+      require_relative "file_parser/pep_dependency"
       require_relative "file_parser/pipfile_files_parser"
       require_relative "file_parser/pyproject_files_parser"
       require_relative "file_parser/setup_file_parser"

--- a/python/lib/dependabot/python/file_parser/pep_dependency.rb
+++ b/python/lib/dependabot/python/file_parser/pep_dependency.rb
@@ -1,0 +1,53 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/python/file_parser"
+
+module Dependabot
+  module Python
+    class FileParser < Dependabot::FileParsers::Base
+      class PepDependency < T::ImmutableStruct
+        extend T::Sig
+
+        const :name, String
+        const :version, T.nilable(String), default: nil
+        const :markers, T.nilable(String), default: nil
+        const :file, String
+        const :requirement, T.nilable(String), default: nil
+        const :source_requirement, T.nilable(String), default: nil
+        const :extras, T::Array[String]
+        const :requirement_type, T.nilable(String), default: nil
+
+        sig { params(result: Object).returns(T::Array[PepDependency]) }
+        def self.from_helper_result(result)
+          PyprojectValueParser.array(result, "PEP dependency result").map do |value|
+            from_object(value)
+          end
+        end
+
+        sig { params(value: Object).returns(PepDependency) }
+        def self.from_object(value)
+          hash = PyprojectValueParser.object_hash(value, "PEP dependency")
+          new(
+            name: PyprojectValueParser.string(hash["name"], "PEP dependency name"),
+            version: PyprojectValueParser.optional_string(hash["version"], "PEP dependency version"),
+            markers: PyprojectValueParser.optional_string(hash["markers"], "PEP dependency markers"),
+            file: PyprojectValueParser.string(hash["file"], "PEP dependency file"),
+            requirement: PyprojectValueParser.optional_string(hash["requirement"], "PEP dependency requirement"),
+            source_requirement: PyprojectValueParser.optional_string(
+              hash["source_requirement"],
+              "PEP dependency source_requirement"
+            ),
+            extras: PyprojectValueParser.string_array(hash["extras"], "PEP dependency extras"),
+            requirement_type: PyprojectValueParser.optional_string(
+              hash["requirement_type"],
+              "PEP dependency requirement_type"
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/python/lib/dependabot/python/file_parser/poetry_lock.rb
+++ b/python/lib/dependabot/python/file_parser/poetry_lock.rb
@@ -81,11 +81,11 @@ module Dependabot
         sig do
           params(
             name: String,
-            normalizer: T.proc.params(name: String).returns(String)
+            _normalizer: T.proc.params(name: String).returns(String)
           )
             .returns(T.nilable(String))
         end
-        def version_for(name, &normalizer)
+        def version_for(name, &_normalizer)
           normalized_name = yield(name)
           packages.find { |package| yield(package.name) == normalized_name }&.version
         end

--- a/python/lib/dependabot/python/file_parser/poetry_lock.rb
+++ b/python/lib/dependabot/python/file_parser/poetry_lock.rb
@@ -1,0 +1,95 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "toml-rb"
+require "sorbet-runtime"
+
+require "dependabot/dependency_file"
+require "dependabot/errors"
+require "dependabot/python/file_parser"
+
+module Dependabot
+  module Python
+    class FileParser < Dependabot::FileParsers::Base
+      class PoetryLock
+        extend T::Sig
+
+        class Package < T::ImmutableStruct
+          extend T::Sig
+
+          const :name, String
+          const :version, String
+          const :source_type, T.nilable(String), default: nil
+
+          sig { params(value: Object).returns(Package) }
+          def self.from_object(value)
+            hash = PyprojectValueParser.object_hash(value, "Poetry lock package")
+            source = hash["source"]
+            source_hash =
+              if source.nil?
+                nil
+              else
+                PyprojectValueParser.object_hash(source, "Poetry lock package source")
+              end
+
+            new(
+              name: PyprojectValueParser.string(hash["name"], "Poetry lock package name"),
+              version: PyprojectValueParser.string(hash["version"], "Poetry lock package version"),
+              source_type: PyprojectValueParser.optional_string(
+                source_hash&.[]("type"),
+                "Poetry lock package source type"
+              )
+            )
+          end
+
+          sig { returns(T::Hash[Symbol, T.nilable(String)]) }
+          def to_h
+            {
+              name: name,
+              version: version,
+              source_type: source_type
+            }
+          end
+        end
+
+        sig { returns(T::Array[Package]) }
+        attr_reader :packages
+
+        sig { params(packages: T::Array[Package]).void }
+        def initialize(packages)
+          @packages = packages
+        end
+
+        sig { params(file: Dependabot::DependencyFile).returns(PoetryLock) }
+        def self.from_file(file)
+          parsed = T.cast(TomlRB.parse(T.must(file.content)), Object)
+          document = PyprojectValueParser.object_hash(parsed, "poetry.lock")
+          value = document["package"]
+          packages =
+            if value.nil?
+              []
+            else
+              PyprojectValueParser.array(value, "poetry.lock package").map do |package|
+                Package.from_object(package)
+              end
+            end
+          new(packages)
+        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
+          raise Dependabot::DependencyFileNotParseable, file.path
+        end
+
+        sig do
+          params(
+            name: String,
+            normalizer: T.proc.params(name: String).returns(String)
+          )
+            .returns(T.nilable(String))
+        end
+        def version_for(name, &normalizer)
+          normalized_name = yield(name)
+          packages.find { |package| yield(package.name) == normalized_name }&.version
+        end
+      end
+    end
+  end
+end

--- a/python/lib/dependabot/python/file_parser/pyproject_document.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_document.rb
@@ -1,0 +1,242 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "toml-rb"
+require "sorbet-runtime"
+
+require "dependabot/dependency_file"
+require "dependabot/errors"
+require "dependabot/python/file_parser"
+
+module Dependabot
+  module Python
+    class FileParser < Dependabot::FileParsers::Base
+      module PyprojectValueParser
+        extend T::Sig
+
+        ObjectHash = T.type_alias { T::Hash[String, Object] }
+        PoetryRequirement = T.type_alias { T.any(String, ObjectHash) }
+        PoetryDependencyMap = T.type_alias { T::Hash[String, T::Array[PoetryRequirement]] }
+
+        sig { params(value: Object, context: String).returns(ObjectHash) }
+        def self.object_hash(value, context)
+          raise TypeError, "#{context} must be an object" unless value.is_a?(Hash)
+
+          result = T.let({}, ObjectHash)
+          value.each do |raw_key, raw_value|
+            key = T.cast(raw_key, Object)
+            raise TypeError, "#{context} keys must be strings" unless key.is_a?(String)
+
+            result[key] = T.cast(raw_value, Object)
+          end
+          result
+        end
+
+        sig { params(value: Object, context: String).returns(T::Array[Object]) }
+        def self.array(value, context)
+          raise TypeError, "#{context} must be an array" unless value.is_a?(Array)
+
+          value.map { |item| T.cast(item, Object) }
+        end
+
+        sig { params(value: Object, context: String).returns(String) }
+        def self.string(value, context)
+          return value if value.is_a?(String)
+
+          raise TypeError, "#{context} must be a string"
+        end
+
+        sig { params(value: T.nilable(Object), context: String).returns(T.nilable(String)) }
+        def self.optional_string(value, context)
+          return if value.nil?
+
+          string(value, context)
+        end
+
+        sig { params(value: Object, context: String).returns(T::Array[String]) }
+        def self.string_array(value, context)
+          array(value, context).map do |item|
+            raise TypeError, "#{context} must contain only strings" unless item.is_a?(String)
+
+            item
+          end
+        end
+
+        sig { params(value: Object, name: String).returns(T::Array[PoetryRequirement]) }
+        def self.poetry_requirements(value, name)
+          flattened = value.is_a?(Array) ? value.flatten : [value]
+          flattened.compact.map do |item|
+            item = T.cast(item, Object)
+            case item
+            when String
+              item
+            when Hash
+              object_hash(item, "Poetry dependency #{name}")
+            else
+              raise TypeError, "Poetry dependency #{name} must be a string, object, or array"
+            end
+          end
+        end
+
+        sig { params(value: Object, context: String).returns(PoetryDependencyMap) }
+        def self.poetry_dependency_map(value, context)
+          object_hash(value, context).to_h do |name, requirement|
+            [name, poetry_requirements(requirement, name)]
+          end
+        end
+      end
+      private_constant :PyprojectValueParser
+
+      class PyprojectDocument
+        extend T::Sig
+
+        PoetryRequirement = T.type_alias { PyprojectValueParser::PoetryRequirement }
+        PoetryDependencyMap = T.type_alias { PyprojectValueParser::PoetryDependencyMap }
+
+        class PoetrySource < T::ImmutableStruct
+          const :name, String
+          const :url, String
+        end
+
+        sig { params(data: PyprojectValueParser::ObjectHash).void }
+        def initialize(data)
+          @data = data
+        end
+
+        sig { params(file: Dependabot::DependencyFile).returns(PyprojectDocument) }
+        def self.from_file(file)
+          content = T.must(file.content)
+          parsed = T.cast(TomlRB.parse(content), Object)
+          new(PyprojectValueParser.object_hash(parsed, "pyproject.toml"))
+        rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
+          raise Dependabot::DependencyFileNotParseable, file.path
+        end
+
+        sig { returns(T::Boolean) }
+        def poetry?
+          !poetry_root.nil?
+        end
+
+        sig { returns(T::Boolean) }
+        def pep621?
+          project = section(@data, "project", "project")
+          build_system = section(@data, "build-system", "build-system")
+
+          !project&.[]("dependencies").nil? ||
+            !project&.[]("optional-dependencies").nil? ||
+            !build_system&.[]("requires").nil?
+        end
+
+        sig { returns(T::Boolean) }
+        def pep735?
+          @data.key?("dependency-groups")
+        end
+
+        sig { params(type: String).returns(PoetryDependencyMap) }
+        def poetry_dependencies(type)
+          root = poetry_root
+          return {} unless root
+
+          value = root[type]
+          return {} if value.nil?
+
+          PyprojectValueParser.poetry_dependency_map(value, "tool.poetry.#{type}")
+        end
+
+        sig { returns(T::Hash[String, PoetryDependencyMap]) }
+        def poetry_groups
+          root = poetry_root
+          return {} unless root
+
+          raw_groups = root["group"]
+          return {} if raw_groups.nil?
+
+          parsed_groups = PyprojectValueParser.object_hash(raw_groups, "tool.poetry.group")
+          parsed_groups.each_with_object({}) do |(name, value), groups|
+            group = PyprojectValueParser.object_hash(value, "tool.poetry.group.#{name}")
+            dependencies = group["dependencies"]
+            next if dependencies.nil?
+
+            groups[name] = PyprojectValueParser.poetry_dependency_map(
+              dependencies,
+              "tool.poetry.group.#{name}.dependencies"
+            )
+          end
+        end
+
+        sig { returns(T::Array[String]) }
+        def dynamic_fields
+          project = section(@data, "project", "project")
+          value = project&.[]("dynamic")
+          return [] if value.nil?
+
+          PyprojectValueParser.string_array(value, "project.dynamic")
+        end
+
+        sig { params(name: String).returns(T::Boolean) }
+        def optional_dependency_group?(name)
+          project = section(@data, "project", "project")
+          value = project&.[]("optional-dependencies")
+          return false if value.nil?
+
+          PyprojectValueParser.object_hash(value, "project.optional-dependencies").key?(name)
+        end
+
+        sig { params(name: String).returns(T.nilable(PoetrySource)) }
+        def poetry_source(name)
+          poetry_sources.find { |source| source.name == name }
+        end
+
+        sig { params(key: String).returns(T::Array[String]) }
+        def workspace_globs(key)
+          tool = section(@data, "tool", "tool")
+          uv = tool && section(tool, "uv", "tool.uv")
+          workspace = uv && section(uv, "workspace", "tool.uv.workspace")
+          value = workspace&.[](key)
+          return [] if value.nil?
+
+          PyprojectValueParser.string_array(value, "tool.uv.workspace.#{key}")
+        end
+
+        private
+
+        sig { returns(T.nilable(PyprojectValueParser::ObjectHash)) }
+        def poetry_root
+          tool = section(@data, "tool", "tool")
+          tool && section(tool, "poetry", "tool.poetry")
+        end
+
+        sig { returns(T::Array[PoetrySource]) }
+        def poetry_sources
+          root = poetry_root
+          return [] unless root
+
+          value = root["source"]
+          return [] if value.nil?
+
+          PyprojectValueParser.array(value, "tool.poetry.source").map do |source|
+            source = PyprojectValueParser.object_hash(source, "tool.poetry.source entry")
+            PoetrySource.new(
+              name: PyprojectValueParser.string(source["name"], "Poetry source name"),
+              url: PyprojectValueParser.string(source["url"], "Poetry source url")
+            )
+          end
+        end
+
+        sig do
+          params(
+            hash: PyprojectValueParser::ObjectHash,
+            key: String,
+            context: String
+          ).returns(T.nilable(PyprojectValueParser::ObjectHash))
+        end
+        def section(hash, key, context)
+          value = hash[key]
+          return if value.nil?
+
+          PyprojectValueParser.object_hash(value, context)
+        end
+      end
+    end
+  end
+end

--- a/python/lib/dependabot/python/file_parser/pyproject_document.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_document.rb
@@ -95,7 +95,7 @@ module Dependabot
 
         class PoetrySource < T::ImmutableStruct
           const :name, String
-          const :url, String
+          const :url, T.nilable(String), default: nil
         end
 
         sig { params(data: PyprojectValueParser::ObjectHash).void }
@@ -218,7 +218,7 @@ module Dependabot
             source = PyprojectValueParser.object_hash(source, "tool.poetry.source entry")
             PoetrySource.new(
               name: PyprojectValueParser.string(source["name"], "Poetry source name"),
-              url: PyprojectValueParser.string(source["url"], "Poetry source url")
+              url: PyprojectValueParser.optional_string(source["url"], "Poetry source url")
             )
           end
         end

--- a/python/spec/dependabot/python/file_parser/pep_dependency_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pep_dependency_spec.rb
@@ -1,0 +1,80 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/python/file_parser/pep_dependency"
+
+RSpec.describe Dependabot::Python::FileParser::PepDependency do
+  describe ".from_helper_result" do
+    subject(:dependencies) { described_class.from_helper_result(result) }
+
+    let(:result) do
+      [{
+        "name" => "cachecontrol",
+        "version" => nil,
+        "markers" => "python_version >= \"3.9\"",
+        "file" => "pyproject.toml",
+        "requirement" => ">=0.14.0",
+        "source_requirement" => ">= 0.14.0",
+        "extras" => ["filecache"],
+        "requirement_type" => "dependencies",
+        "unknown" => true
+      }]
+    end
+
+    it "parses supported fields and ignores unknown keys" do
+      expect(dependencies.first).to have_attributes(
+        name: "cachecontrol",
+        version: nil,
+        markers: "python_version >= \"3.9\"",
+        file: "pyproject.toml",
+        requirement: ">=0.14.0",
+        source_requirement: ">= 0.14.0",
+        extras: ["filecache"],
+        requirement_type: "dependencies"
+      )
+    end
+
+    context "with a UV path dependency" do
+      let(:result) do
+        [{
+          "name" => "local-package",
+          "version" => nil,
+          "markers" => nil,
+          "file" => "pyproject.toml",
+          "requirement" => nil,
+          "extras" => [],
+          "path_dependency" => true,
+          "path" => "../local-package"
+        }]
+      end
+
+      it "allows a nil requirement" do
+        expect(dependencies.first).to have_attributes(
+          name: "local-package",
+          requirement: nil,
+          extras: []
+        )
+      end
+    end
+
+    [
+      [nil, "PEP dependency result must be an array"],
+      [[{}], "PEP dependency name must be a string"],
+      [[{
+        "name" => "requests",
+        "file" => "pyproject.toml",
+        "requirement" => ">=2",
+        "extras" => [1]
+      }], "PEP dependency extras must contain only strings"]
+    ].each do |invalid_result, message|
+      context "with #{message}" do
+        let(:result) { invalid_result }
+
+        it "raises an explicit type error" do
+          expect { dependencies }.to raise_error(TypeError, message)
+        end
+      end
+    end
+  end
+end

--- a/python/spec/dependabot/python/file_parser/poetry_lock_spec.rb
+++ b/python/spec/dependabot/python/file_parser/poetry_lock_spec.rb
@@ -1,0 +1,65 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/python/file_parser/poetry_lock"
+
+RSpec.describe Dependabot::Python::FileParser::PoetryLock do
+  subject(:lock) { described_class.from_file(file) }
+
+  let(:file) do
+    Dependabot::DependencyFile.new(
+      name: "poetry.lock",
+      content: content
+    )
+  end
+  let(:content) do
+    <<~TOML
+      [[package]]
+      name = "requests"
+      version = "2.32.0"
+
+      [[package]]
+      name = "local"
+      version = "1.0.0"
+
+      [package.source]
+      type = "directory"
+    TOML
+  end
+
+  it "parses packages and source types" do
+    expect(lock.packages.map(&:to_h)).to eq(
+      [
+        { name: "requests", version: "2.32.0", source_type: nil },
+        { name: "local", version: "1.0.0", source_type: "directory" }
+      ]
+    )
+  end
+
+  it "finds a package version by normalized name" do
+    expect(lock.version_for("Requests", &:downcase)).to eq("2.32.0")
+  end
+
+  context "with no packages" do
+    let(:content) { "lock-version = \"2.0\"\n" }
+
+    it "returns an empty package list" do
+      expect(lock.packages).to eq([])
+    end
+  end
+
+  context "with a malformed package" do
+    let(:content) do
+      <<~TOML
+        [[package]]
+        name = "requests"
+        version = 2
+      TOML
+    end
+
+    it "raises an explicit type error" do
+      expect { lock }.to raise_error(TypeError, "Poetry lock package version must be a string")
+    end
+  end
+end

--- a/python/spec/dependabot/python/file_parser/pyproject_document_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_document_spec.rb
@@ -68,6 +68,28 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectDocument do
     expect(document.workspace_globs("exclude")).to eq(["packages/ignored"])
   end
 
+  context "with Poetry's reserved PyPI source" do
+    let(:content) do
+      <<~TOML
+        [[tool.poetry.source]]
+        name = "pypi"
+        priority = "explicit"
+
+        [[tool.poetry.source]]
+        name = "private"
+        url = "https://example.com/simple"
+      TOML
+    end
+
+    it "allows the reserved source to omit its URL" do
+      expect(document.poetry_source("pypi")).to have_attributes(name: "pypi", url: nil)
+      expect(document.poetry_source("private")).to have_attributes(
+        name: "private",
+        url: "https://example.com/simple"
+      )
+    end
+  end
+
   it "ignores unknown keys" do
     file.content = "#{content}\n[tool.unknown]\nvalue = 1\n"
 

--- a/python/spec/dependabot/python/file_parser/pyproject_document_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_document_spec.rb
@@ -1,0 +1,112 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/python/file_parser/pyproject_document"
+
+RSpec.describe Dependabot::Python::FileParser::PyprojectDocument do
+  subject(:document) { described_class.from_file(file) }
+
+  let(:file) do
+    Dependabot::DependencyFile.new(
+      name: "pyproject.toml",
+      content: content
+    )
+  end
+  let(:content) do
+    <<~TOML
+      [project]
+      dependencies = ["requests>=2"]
+      dynamic = ["optional-dependencies"]
+
+      [project.optional-dependencies]
+      test = ["pytest"]
+
+      [tool.poetry.dependencies]
+      python = "^3.12"
+      requests = "^2.0"
+      attrs = [{ version = "^24.0" }]
+
+      [tool.poetry.group.dev.dependencies]
+      rspec = "^3.0"
+
+      [[tool.poetry.source]]
+      name = "private"
+      url = "https://example.com/simple"
+
+      [tool.uv.workspace]
+      members = ["packages/*"]
+      exclude = ["packages/ignored"]
+
+      [dependency-groups]
+      lint = ["ruff"]
+    TOML
+  end
+
+  it "exposes typed project and Poetry values" do
+    expect(document).to be_poetry
+    expect(document).to be_pep621
+    expect(document).to be_pep735
+    expect(document.dynamic_fields).to eq(["optional-dependencies"])
+    expect(document.optional_dependency_group?("test")).to be(true)
+    expect(document.poetry_dependencies("dependencies")).to eq(
+      "python" => ["^3.12"],
+      "requests" => ["^2.0"],
+      "attrs" => [{ "version" => "^24.0" }]
+    )
+    expect(document.poetry_groups).to eq(
+      "dev" => { "rspec" => ["^3.0"] }
+    )
+  end
+
+  it "resolves Poetry sources and UV workspace globs" do
+    expect(document.poetry_source("private")).to have_attributes(
+      name: "private",
+      url: "https://example.com/simple"
+    )
+    expect(document.workspace_globs("members")).to eq(["packages/*"])
+    expect(document.workspace_globs("exclude")).to eq(["packages/ignored"])
+  end
+
+  it "ignores unknown keys" do
+    file.content = "#{content}\n[tool.unknown]\nvalue = 1\n"
+
+    expect(document.poetry_dependencies("dependencies")).to include("requests" => ["^2.0"])
+  end
+
+  context "with invalid TOML" do
+    let(:content) { "[project\n" }
+
+    it "raises the existing parse error" do
+      expect { document }.to raise_error(Dependabot::DependencyFileNotParseable)
+    end
+  end
+
+  context "with a malformed Poetry dependency value" do
+    let(:content) do
+      <<~TOML
+        [tool.poetry.dependencies]
+        requests = 123
+      TOML
+    end
+
+    it "raises an explicit type error" do
+      expect { document.poetry_dependencies("dependencies") }
+        .to raise_error(TypeError, "Poetry dependency requests must be a string, object, or array")
+    end
+  end
+
+  context "with malformed workspace globs" do
+    let(:content) do
+      <<~TOML
+        [tool.uv.workspace]
+        members = ["packages/*", 1]
+      TOML
+    end
+
+    it "raises an explicit type error" do
+      expect { document.workspace_globs("members") }
+        .to raise_error(TypeError, "tool.uv.workspace.members must contain only strings")
+    end
+  end
+end


### PR DESCRIPTION
Add shared typed models for `pyproject.toml`, Poetry lock packages, and PEP 621/735 helper rows. #15987 wires them into Python, and #15988 wires them into UV.