### PR TITLE
Consolidate Dependabot update jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      per-dependency:
+        group-by: "dependency-name"
 
   # Watch the per-ecosystem native helpers
   - package-ecosystem: "composer"
@@ -64,12 +66,26 @@ updates:
   - package-ecosystem: "docker"
     directories:
       - "/"
-      - "/go_modules"
       - "/cargo"
+      - "/docker"
+      - "/go_modules"
+      - "/gradle"
+      - "/helm"
+      - "/maven"
+      - "/nix"
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    groups:
+      container-tools:
+        patterns:
+          - "alpine/helm"
+          - "oras-project/oras"
+          - "regclient/regctl*"
+          - "sigstore/cosign/cosign*"
+      per-image:
+        group-by: "dependency-name"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -80,11 +96,27 @@ updates:
       all-actions:
         patterns: [ "*" ]
   - package-ecosystem: "gomod"
-    directory: "/go_modules/helpers"
+    directories:
+      - "/go_modules/helpers"
+      - "/silent/tests"
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    groups:
+      per-dependency:
+        group-by: "dependency-name"
+  - package-ecosystem: "julia"
+    directories:
+      - "/julia/helpers"
+      - "/julia/helpers/DependabotHelper.jl"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
+    groups:
+      per-dependency:
+        group-by: "dependency-name"
   - package-ecosystem: "mix"
     directory: "/hex/helpers"
     schedule:
@@ -92,7 +124,9 @@ updates:
       day: "sunday"
       time: "16:00"
   - package-ecosystem: "npm"
-    directory: "/npm_and_yarn/helpers"
+    directories:
+      - "/bun/helpers"
+      - "/npm_and_yarn/helpers"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -118,6 +152,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      per-dependency:
+        group-by: "dependency-name"
     ignore:
       - dependency-name: "npm"
         update-types: [ "version-update:semver-major" ]
@@ -161,6 +197,10 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "16:00"
+    groups:
+      microsoft-build:
+        patterns:
+          - "Microsoft.Build*"
   - package-ecosystem: "dotnet-sdk"
     directory: "/nuget/helpers/lib/NuGetUpdater"
     schedule:
@@ -180,12 +220,6 @@ updates:
       day: "sunday"
       time: "16:00"
   - package-ecosystem: "docker"
-    directory: "/maven"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "16:00"
-  - package-ecosystem: "docker"
     directory: "/uv"
     multi-ecosystem-group: "uv-ecosystem"
     patterns: ["*"]
@@ -197,30 +231,3 @@ updates:
       # Ignore major updates as most major updates will need manual intervention
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
-  - package-ecosystem: "docker"
-    directory: "/docker"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "16:00"
-    groups:
-      regclient:
-        patterns:
-          - "regclient/regctl*"
-          - "sigstore/cosign/cosign*"
-  - package-ecosystem: "docker"
-    directory: "/gradle"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "16:00"
-  - package-ecosystem: "docker"
-    directory: "/helm"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "16:00"
-    groups:
-      helm:
-        patterns:
-          - "*"


### PR DESCRIPTION
### What are you trying to accomplish?

Reduce duplicate Dependabot PRs and cover helper manifests that are currently missed.

This combines the npm jobs for `/npm_and_yarn/helpers` and `/bun/helpers`, and combines the Docker jobs except for UV, which remains in its multi-ecosystem group. It also adds Julia, `/silent/tests`, and Nix coverage. Shared dependencies are grouped by name, while Microsoft.Build packages are kept in one NuGet group.

### Anything you want to highlight for special attention from reviewers?

The Docker job uses explicit patterns for Helm, ORAS, regctl, and cosign. Other images are grouped by dependency name, so unrelated image updates stay separate.

### How will you know you've accomplished your goal?

Future update runs should create one PR when the same dependency appears in several configured directories, and should detect updates in the newly added Bun, Julia, silent, and Nix paths.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
