### PR TITLE
NuGet: fix inverted caseSensitive flag in PathHelper.GetMatchingDirectoriesUnder

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/PathHelperTests.cs
@@ -42,17 +42,41 @@ public class PathHelperTests
         // arrange
         using var tempDir = await TemporaryDirectory.CreateWithContentsAsync([.. directoriesOnDisk.Select(d => (Path.Combine(d, "file.txt"), "contents irrelevant"))]);
 
-        // test both rooted and unrooted patterns
+        // test both rooted and unrooted patterns; the casing of the patterns and the directories on disk
+        // always agrees here, so the results are the same whether or not matching is case-sensitive
         var unrootedSearchPattern = rawSearchPattern.TrimStart('/');
         var rootedSearchPattern = rawSearchPattern.EnsurePrefix("/");
         foreach (var searchPattern in new[] { unrootedSearchPattern, rootedSearchPattern })
         {
-            // act
-            var actualDirectories = PathHelper.GetMatchingDirectoriesUnder(tempDir.DirectoryPath, searchPattern, caseSensitive: true).ToArray();
+            foreach (var caseSensitive in new[] { true, false })
+            {
+                // act
+                var actualDirectories = PathHelper.GetMatchingDirectoriesUnder(tempDir.DirectoryPath, searchPattern, caseSensitive).ToArray();
 
-            // assert
-            AssertEx.Equal(expectedDirectories, actualDirectories);
+                // assert
+                AssertEx.Equal(expectedDirectories, actualDirectories);
+            }
         }
+    }
+
+    [Theory]
+    // a pattern that differs only in casing matches when case-sensitivity is off...
+    [InlineData("/src/client/android", false, new[] { "/Src/Client/Android" })]
+    // ...and doesn't when it's on
+    [InlineData("/src/client/android", true, new string[] { })]
+    // an exactly cased pattern matches either way
+    [InlineData("/Src/Client/Android", false, new[] { "/Src/Client/Android" })]
+    [InlineData("/Src/Client/Android", true, new[] { "/Src/Client/Android" })]
+    public async Task DirectoryPatternMatchHonorsCaseSensitivity(string searchPattern, bool caseSensitive, string[] expectedDirectories)
+    {
+        // arrange
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(("Src/Client/Android/file.txt", "contents irrelevant"));
+
+        // act
+        var actualDirectories = PathHelper.GetMatchingDirectoriesUnder(tempDir.DirectoryPath, searchPattern, caseSensitive).ToArray();
+
+        // assert
+        AssertEx.Equal(expectedDirectories, actualDirectories);
     }
 
     public static IEnumerable<object[]> DirectoryPatternMatchTestData()

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/PathHelper.cs
@@ -328,7 +328,7 @@ internal static class PathHelper
             pb.Append('$');
         }
 
-        var pattern = new Regex(pb.ToString(), caseSensitive ? RegexOptions.IgnoreCase : RegexOptions.None);
+        var pattern = new Regex(pb.ToString(), caseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase);
 
         // find all directories
         var allDirectories = Directory.EnumerateDirectories(rootDirectory, "*", SearchOption.AllDirectories)


### PR DESCRIPTION
## Summary

Fixes #16017.

`PathHelper.GetMatchingDirectoriesUnder`'s `caseSensitive` parameter was wired backwards when building the matching `Regex`:

```csharp
var pattern = new Regex(pb.ToString(), caseSensitive ? RegexOptions.IgnoreCase : RegexOptions.None);
```

`caseSensitive: true` produced `IgnoreCase`, and `caseSensitive: false` produced `None` — the opposite of what the flag name promises. Nine lines later in the same method, the `OrderBy` correctly uses `caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase`.

The only production caller, `Job.GetAllDirectories`, passes `caseSensitive: false`, so `directories` glob matching was actually case-*sensitive*: a config whose glob casing differs from the on-disk casing (e.g. `directories: ["/Test/**/*"]` against an on-disk `test/`) silently expands to zero directories, and the run completes having found nothing to update.

The existing test suite didn't catch this because its one call site always passes `caseSensitive: true`, which — due to the inversion — exercised the case-*insensitive* branch and passed.

## Changes

- `PathHelper.cs`: swap the ternary branches so `caseSensitive: true` maps to `RegexOptions.None` and `caseSensitive: false` maps to `RegexOptions.IgnoreCase`, matching the `OrderBy` polarity below it.
- `PathHelperTests.cs`:
  - `DirectoryPatternMatch` now exercises both `caseSensitive: true` and `caseSensitive: false` (all existing fixture data is lowercase-only, so results are unaffected by the flag, but this exercises the previously-untested branch).
  - New `DirectoryPatternMatchHonorsCaseSensitivity` theory with mixed-case directories on disk, directly asserting that a differently-cased pattern matches only when `caseSensitive: false`.

## Test plan

- [x] `dotnet test NuGetUpdater.Core.Test --filter "FullyQualifiedName~PathHelperTests"` — 28/28 pass with the fix.
- [x] Verified the new tests fail against the pre-fix code (2 failures, both in the new case-sensitivity theory) before applying the fix, confirming they catch the regression.