### PR TITLE
Return `base_commit_sha` in fetch container as job result

### DIFF
--- a/updater/lib/dependabot/environment.rb
+++ b/updater/lib/dependabot/environment.rb
@@ -48,6 +48,14 @@ module Dependabot
       @repo_contents_path ||= T.let(environment_variable("DEPENDABOT_REPO_CONTENTS_PATH", nil), T.nilable(String))
     end
 
+    # The base commit SHA handed off from the fetch container. In the split-container flow the
+    # update container has no clone to resolve it from, so the orchestrator captures the value the
+    # fetch container prints and passes it in via this environment variable.
+    sig { returns(T.nilable(String)) }
+    def self.base_commit_sha
+      @base_commit_sha ||= T.let(environment_variable("DEPENDABOT_BASE_COMMIT_SHA", nil), T.nilable(String))
+    end
+
     sig { returns(T::Boolean) }
     def self.github_actions?
       b = T.cast(environment_variable("GITHUB_ACTIONS", false), T::Boolean)

--- a/updater/lib/dependabot/file_fetcher_command.rb
+++ b/updater/lib/dependabot/file_fetcher_command.rb
@@ -9,11 +9,12 @@ require "dependabot/opentelemetry"
 require "dependabot/updater"
 require "dependabot/file_fetcher_command_connectivity"
 require "dependabot/file_fetcher_command_local_checkout"
+require "json"
 require "octokit"
 require "sorbet-runtime"
 
 module Dependabot
-  class FileFetcherCommand < BaseCommand
+  class FileFetcherCommand < BaseCommand # rubocop:disable Metrics/ClassLength
     extend T::Sig
     include FileFetcherCommandConnectivity
     include FileFetcherCommandLocalCheckout
@@ -75,6 +76,7 @@ module Dependabot
         end
 
         Dependabot.logger.info("Base commit SHA: #{@base_commit_sha}")
+        emit_base_commit_sha
       end
     end
 
@@ -146,6 +148,16 @@ module Dependabot
     sig { returns(T::Hash[String, Dependabot::DependabotError]) }
     def directory_fetch_errors
       @directory_fetch_errors ||= T.let({}, T.nilable(T::Hash[String, Dependabot::DependabotError]))
+    end
+
+    # In the split-container flow the update container has no clone to resolve the base commit SHA
+    # from, so the fetch container prints it as a JSON line on stdout for the orchestrator to
+    # capture and hand to the update container.
+    sig { void }
+    def emit_base_commit_sha
+      return unless Experiments.enabled?(:isolate_fetch_update)
+
+      puts(JSON.generate({ base_commit_sha: @base_commit_sha }))
     end
 
     sig { params(directory: T.nilable(String)).returns(Dependabot::FileFetchers::Base) }

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -89,6 +89,13 @@ module Dependabot
 
     sig { override.returns(T.nilable(String)) }
     def base_commit_sha
+      # In the split-container flow the base commit SHA is handed off from the fetch container
+      # instead of being resolved from a local clone. Fall back to the fetched files otherwise.
+      if Experiments.enabled?(:isolate_fetch_update)
+        handed_off_sha = Environment.base_commit_sha
+        return handed_off_sha if handed_off_sha
+      end
+
       @fetched_files.base_commit_sha
     end
 

--- a/updater/spec/dependabot/file_fetcher_command_spec.rb
+++ b/updater/spec/dependabot/file_fetcher_command_spec.rb
@@ -76,6 +76,26 @@ RSpec.describe Dependabot::FileFetcherCommand do
       end
     end
 
+    context "when the isolate_fetch_update experiment is enabled" do
+      let(:job_definition) do
+        definition = JSON.parse(fixture("jobs/job_without_credentials.json"))
+        definition["job"]["experiments"]["isolate_fetch_update"] = true
+        definition
+      end
+
+      it "prints the base commit SHA as a JSON line on stdout",
+         vcr: { cassette_name: "Dependabot_FileFetcherCommand/_perform_job/fetches_the_files" } do
+        expect { perform_job }.to output(/\{"base_commit_sha":"[0-9a-f]{40}"\}/).to_stdout_from_any_process
+      end
+    end
+
+    context "when the isolate_fetch_update experiment is disabled" do
+      it "does not print the base commit SHA to stdout",
+         vcr: { cassette_name: "Dependabot_FileFetcherCommand/_perform_job/fetches_the_files" } do
+        expect { perform_job }.not_to output(/"base_commit_sha"/).to_stdout_from_any_process
+      end
+    end
+
     context "when only a local checkout may be used" do
       let(:repo_contents_path) { Dir.mktmpdir }
 

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -82,6 +82,36 @@ RSpec.describe Dependabot::UpdateFilesCommand do
     end
   end
 
+  describe "#base_commit_sha" do
+    after { Dependabot::Experiments.reset! }
+
+    context "when the isolate_fetch_update experiment is disabled" do
+      it "returns the base commit SHA from the fetched files" do
+        expect(job.base_commit_sha).to eq("1c6331732c41e4557a16dacb82534f1d1c831848")
+      end
+    end
+
+    context "when the isolate_fetch_update experiment is enabled" do
+      before { Dependabot::Experiments.register(:isolate_fetch_update, true) }
+
+      context "when a handed-off base commit SHA is present" do
+        before { allow(Dependabot::Environment).to receive(:base_commit_sha).and_return("handed-off-sha") }
+
+        it "returns the handed-off base commit SHA" do
+          expect(job.base_commit_sha).to eq("handed-off-sha")
+        end
+      end
+
+      context "when no handed-off base commit SHA is present" do
+        before { allow(Dependabot::Environment).to receive(:base_commit_sha).and_return(nil) }
+
+        it "falls back to the fetched files base commit SHA" do
+          expect(job.base_commit_sha).to eq("1c6331732c41e4557a16dacb82534f1d1c831848")
+        end
+      end
+    end
+  end
+
   describe "#perform_job when there is an error parsing the dependency files" do
     subject(:perform_job) { job.perform_job }
 


### PR DESCRIPTION
### What are you trying to accomplish?
Part of the epic to split Dependabot's fetch and update phases into separate, isolated containers, which remediates the repo-exfiltration finding by removing the repo-read token/network from the update container.

In the split-container flow the update container has no clone to resolve the base commit SHA from. This PR has the **fetch** container return the `base_commit_sha` so the orchestrator can hand it to the **update** container:

- `FileFetcherCommand` prints the resolved base commit SHA as a single JSON line on stdout (`{"base_commit_sha":"<sha>"}`) once fetching succeeds, gated behind the `isolate_fetch_update` experiment.
- `Dependabot::Environment.base_commit_sha` reads the value the orchestrator passes back in via the `DEPENDABOT_BASE_COMMIT_SHA` environment variable.
- `UpdateFilesCommand#base_commit_sha` consumes that handed-off value when the experiment is enabled, falling back to `@fetched_files.base_commit_sha` when it isn't present (so the combined/non-split flow is unchanged).


<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?
- The behavior is fully gated behind the `isolate_fetch_update` experiment, so the existing combined fetch+update path is unaffected: the emit is a no-op and the consume side falls back to the fetched files' SHA.
- The emit uses `Kernel#puts` (rather than `$stdout.puts`) so it stays valid under `# typed: strong`, and avoids an `IO`/`StringIO` cast that would break the RSpec `to_stdout` matcher at runtime.
- The value is emitted as structured JSON on stdout rather than written to a file, so the orchestrator can capture it without a shared writable path. The orchestrator side that reads stdout and sets `DEPENDABOT_BASE_COMMIT_SHA` is handled separately; this PR only implements the core emit/consume.
<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?
- New specs:
  - `file_fetcher_command_spec.rb` asserts the `{"base_commit_sha":"<40-hex>"}` line is printed to stdout when `isolate_fetch_update` is enabled, and is absent when it is disabled.
  - `update_files_command_spec.rb` covers `#base_commit_sha` for the three cases: experiment disabled → fetched-files SHA; enabled with a handed-off value → that value; enabled with none → falls back to the fetched-files SHA.
- Verified end-to-end locally with the dependabot cli against a go_modules repo: the fetch step logs the emitted SHA (`{"base_commit_sha":"160300187fedba9292e56b0277db8fffa369b560"}`) and the resulting PR is created with the matching `base-commit-sha`.
<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
