### PR TITLE
Prefer SHA pins for GitHub Actions

### DIFF
--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/github_actions/lib/dependabot/github_actions/file_parser.rb
+++ b/github_actions/lib/dependabot/github_actions/file_parser.rb
@@ -11,6 +11,7 @@ require "dependabot/file_parsers/base"
 require "dependabot/github_actions/constants"
 require "dependabot/github_actions/version"
 require "dependabot/github_actions/package_manager"
+require "dependabot/github_actions/workflow_file"
 
 # For docs, see
 # https://help.github.com/en/articles/configuring-a-workflow#referencing-actions-in-your-workflow
@@ -54,62 +55,106 @@ module Dependabot
       sig { params(file: Dependabot::DependencyFile).returns(Dependabot::FileParsers::Base::DependencySet) }
       def workfile_file_dependencies(file)
         dependency_set = DependencySet.new
-
-        json = YAML.safe_load(T.must(file.content), aliases: true, permitted_classes: [Date, Time, Symbol])
-        return dependency_set if json.nil?
-
-        uses_strings = deep_fetch_uses(json.fetch("jobs", json.fetch("runs", nil))).uniq
-
-        uses_strings.each do |string|
-          # TODO: Support Docker references and path references
-          next if string.start_with?(".", "docker://")
-          next unless string.match?(GITHUB_REPO_REFERENCE)
-
-          dep = build_github_dependency(file, string)
-          git_checker = Dependabot::GitCommitChecker.new(
-            dependency: dep,
-            credentials: credentials,
-            consider_version_branches_pinned: true
-          )
-          if git_checker.git_repo_reachable?
-            next unless git_checker.pinned?
-
-            # If dep does not have an assigned (semver) version, look for a commit that references a semver tag
-            unless dep.version
-              resolved = git_checker.version_for_pinned_sha
-
-              if resolved
-                dep = Dependency.new(
-                  name: dep.name,
-                  version: resolved.to_s,
-                  requirements: dep.requirements,
-                  package_manager: dep.package_manager
-                )
-              end
-            end
-          end
+        workflow_file = WorkflowFile.new(T.must(file.content))
+        workflow_file.uses_declarations.group_by(&:value).each do |string, declarations|
+          dep = dependency_for_declarations(file, workflow_file, string, declarations)
+          next unless dep
 
           dependency_set << dep
         end
-
         dependency_set
       rescue Psych::SyntaxError, Psych::DisallowedClass, Psych::BadAlias
         raise Dependabot::DependencyFileNotParseable, file.path
       end
 
-      sig { params(file: Dependabot::DependencyFile, string: String).returns(Dependabot::Dependency) }
-      def build_github_dependency(file, string)
+      sig do
+        params(
+          file: Dependabot::DependencyFile,
+          workflow_file: WorkflowFile,
+          string: String,
+          declarations: T::Array[WorkflowFile::UsesDeclaration]
+        ).returns(T.nilable(Dependabot::Dependency))
+      end
+      def dependency_for_declarations(file, workflow_file, string, declarations)
+        # TODO: Support Docker references and path references
+        return if string.start_with?(".", "docker://")
+        return unless string.match?(GITHUB_REPO_REFERENCE)
+
+        metadata = declarations.map do |declaration|
+          declaration_metadata(workflow_file, declaration)
+        end
+        dep = build_github_dependency(file, string, metadata)
+        git_checker = Dependabot::GitCommitChecker.new(
+          dependency: dep,
+          credentials: credentials,
+          consider_version_branches_pinned: true
+        )
+        return dep unless git_checker.git_repo_reachable?
+        return unless git_checker.pinned?
+
+        dependency_with_resolved_version(dep, git_checker) || dep
+      end
+
+      sig do
+        params(
+          workflow_file: WorkflowFile,
+          declaration: WorkflowFile::UsesDeclaration
+        ).returns(T::Hash[Symbol, Object])
+      end
+      def declaration_metadata(workflow_file, declaration)
+        metadata = T.let({ declaration_string: declaration.value }, T::Hash[Symbol, Object])
+        if workflow_file.source_metadata_required?(declaration)
+          metadata[:yaml_source] = workflow_file.source_metadata(declaration)
+        end
+        metadata
+      end
+
+      sig do
+        params(
+          dep: Dependabot::Dependency,
+          git_checker: Dependabot::GitCommitChecker
+        ).returns(T.nilable(Dependabot::Dependency))
+      end
+      def dependency_with_resolved_version(dep, git_checker)
+        return if dep.version
+
+        resolved = git_checker.version_for_pinned_sha
+        return unless resolved
+
+        Dependency.new(
+          name: dep.name,
+          version: resolved.to_s,
+          requirements: dep.requirements,
+          package_manager: dep.package_manager
+        )
+      end
+
+      sig do
+        params(
+          file: Dependabot::DependencyFile,
+          string: String,
+          metadata: T::Array[T::Hash[Symbol, Object]]
+        ).returns(Dependabot::Dependency)
+      end
+      def build_github_dependency(file, string, metadata)
         unless source&.hostname == GITHUB_COM
-          dep = github_dependency(file, string, T.must(source).hostname)
+          dep = github_dependency(file, string, T.must(source).hostname, metadata)
           git_checker = Dependabot::GitCommitChecker.new(dependency: dep, credentials: credentials)
           return dep if git_checker.git_repo_reachable?
         end
 
-        github_dependency(file, string, GITHUB_COM)
+        github_dependency(file, string, GITHUB_COM, metadata)
       end
 
-      sig { params(file: Dependabot::DependencyFile, string: String, hostname: String).returns(Dependabot::Dependency) }
-      def github_dependency(file, string, hostname)
+      sig do
+        params(
+          file: Dependabot::DependencyFile,
+          string: String,
+          hostname: String,
+          metadata: T::Array[T::Hash[Symbol, Object]]
+        ).returns(Dependabot::Dependency)
+      end
+      def github_dependency(file, string, hostname, metadata)
         details = T.must(string.match(GITHUB_REPO_REFERENCE)).named_captures
         repo_name = "#{details.fetch(OWNER_KEY)}/#{details.fetch(REPO_KEY)}"
         path = details[PATH_KEY]
@@ -130,43 +175,22 @@ module Dependabot
         Dependency.new(
           name: name,
           version: version,
-          requirements: [{
-            requirement: nil,
-            groups: [],
-            source: {
-              type: "git",
-              url: "https://#{hostname}/#{repo_name}".downcase,
-              ref: ref,
-              branch: nil
-            },
-            file: file.name,
-            metadata: { declaration_string: string }
-          }],
+          requirements: metadata.map do |details|
+            {
+              requirement: nil,
+              groups: [],
+              source: {
+                type: "git",
+                url: "https://#{hostname}/#{repo_name}".downcase,
+                ref: ref,
+                branch: nil
+              },
+              file: file.name,
+              metadata: details
+            }
+          end,
           package_manager: PackageManager::NAME
         )
-      end
-
-      sig { params(json_obj: T.untyped, found_uses: T::Array[String]).returns(T::Array[String]) }
-      def deep_fetch_uses(json_obj, found_uses = [])
-        case json_obj
-        when Hash then deep_fetch_uses_from_hash(json_obj, found_uses)
-        when Array then json_obj.flat_map { |o| deep_fetch_uses(o, found_uses) }
-        else []
-        end
-      end
-
-      sig { params(json_object: T::Hash[String, T.untyped], found_uses: T::Array[String]).returns(T::Array[String]) }
-      def deep_fetch_uses_from_hash(json_object, found_uses)
-        if json_object.key?(USES_KEY)
-          found_uses << json_object[USES_KEY]
-        elsif json_object.key?(STEPS_KEY)
-          # Bypass other fields as uses are under steps if they exist
-          deep_fetch_uses(json_object[STEPS_KEY], found_uses)
-        else
-          json_object.values.flat_map { |obj| deep_fetch_uses(obj, found_uses) }
-        end
-
-        found_uses
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -138,7 +138,6 @@ module Dependabot
         file.path.delete_prefix("/")
       end
 
-      # rubocop:disable Metrics/AbcSize
       sig { params(file: Dependabot::DependencyFile).returns(String) }
       def updated_workflow_file_content(file)
         updated_requirement_pairs =
@@ -162,29 +161,135 @@ module Dependabot
           new_declaration =
             old_declaration
             .gsub(/@.*+/, "@#{new_ref}")
+          declaration_pattern = uses_declaration_pattern(old_declaration)
 
           # Include the rest of the line so a new comment is appended after any
           # flow-style mapping syntax, rather than inside the mapping.
           updated_content =
             updated_content
             .gsub(
-              /(?<=[^a-zA-Z_-]|"|')#{Regexp.escape(old_declaration)}["']?(?=\s|$|[,}])(?<suffix>[^\r\n]*)/
+              /#{declaration_pattern}(?<suffix>[^\r\n]*)/
             ) do |match|
-              suffix = T.must(Regexp.last_match(:suffix))
-              comment = suffix[/\s+#.*\z/]
-              match.gsub!(old_declaration, new_declaration)
-              if comment && (updated_comment = updated_version_comment(comment, old_ref, new_ref))
-                match.gsub!(comment, updated_comment)
-              elsif !comment && (new_comment = new_version_comment(old_ref, new_ref))
-                match << new_comment
-              end
-              match
+              updated_workflow_line(
+                match: match,
+                comment: trailing_yaml_comment(T.must(Regexp.last_match(:suffix))),
+                declaration_pattern: declaration_pattern,
+                old_declaration: old_declaration,
+                new_declaration: new_declaration,
+                old_ref: old_ref,
+                new_ref: new_ref
+              )
             end
         end
-
         updated_content
       end
-      # rubocop:enable Metrics/AbcSize
+
+      sig { params(declaration: String).returns(Regexp) }
+      def uses_declaration_pattern(declaration)
+        escaped_declaration = Regexp.escape(declaration)
+
+        /
+          (?:^|[ \t{,])
+          (?:"uses"|'uses'|uses)[ \t]*:[ \t]*
+          (?:"#{escaped_declaration}"|'#{escaped_declaration}'|#{escaped_declaration})
+          (?=[ \t]|$|[,}\]])
+        /x
+      end
+
+      sig do
+        params(
+          match: String,
+          comment: T.nilable(String),
+          declaration_pattern: Regexp,
+          old_declaration: String,
+          new_declaration: String,
+          old_ref: String,
+          new_ref: String
+        ).returns(String)
+      end
+      def updated_workflow_line(
+        match:,
+        comment:,
+        declaration_pattern:,
+        old_declaration:,
+        new_declaration:,
+        old_ref:,
+        new_ref:
+      )
+        line_without_comment = comment ? match.delete_suffix(comment) : match
+        updated_match = line_without_comment.gsub(declaration_pattern) do |declaration|
+          declaration.sub(old_declaration, new_declaration)
+        end
+
+        if comment
+          updated_match << (updated_version_comment(comment, old_ref, new_ref) || comment)
+        elsif (new_comment = new_version_comment(old_ref, new_ref))
+          updated_match << new_comment
+        end
+        updated_match
+      end
+
+      sig { params(suffix: String).returns(T.nilable(String)) }
+      def trailing_yaml_comment(suffix)
+        previous_non_whitespace = T.let(nil, T.nilable(String))
+        index = 0
+
+        while index < suffix.length
+          character = T.must(suffix[index])
+
+          if quoted_scalar_start?(character, previous_non_whitespace)
+            previous_non_whitespace = character
+            index = quoted_scalar_end(suffix, index)
+            next
+          end
+          return comment_with_leading_whitespace(suffix, index) if yaml_comment_start?(suffix, index)
+
+          previous_non_whitespace = character unless character.match?(/\s/)
+          index += 1
+        end
+
+        nil
+      end
+
+      sig { params(character: String, previous_non_whitespace: T.nilable(String)).returns(T::Boolean) }
+      def quoted_scalar_start?(character, previous_non_whitespace)
+        return false unless character == "'" || character == '"'
+
+        previous_non_whitespace.nil? || ":,[{?-".include?(previous_non_whitespace)
+      end
+
+      sig { params(suffix: String, quote_index: Integer).returns(Integer) }
+      def quoted_scalar_end(suffix, quote_index)
+        quote = T.must(suffix[quote_index])
+        index = quote_index + 1
+
+        while index < suffix.length
+          character = T.must(suffix[index])
+          if quote == "'" && character == "'" && suffix[index + 1] == "'"
+            index += 2
+          elsif quote == '"' && character == "\\"
+            index += 2
+          elsif character == quote
+            return index + 1
+          else
+            index += 1
+          end
+        end
+
+        suffix.length
+      end
+
+      sig { params(suffix: String, index: Integer).returns(T::Boolean) }
+      def yaml_comment_start?(suffix, index)
+        suffix[index] == "#" && index.positive? && T.must(suffix[index - 1]).match?(/\s/)
+      end
+
+      sig { params(suffix: String, hash_index: Integer).returns(String) }
+      def comment_with_leading_whitespace(suffix, hash_index)
+        comment_start = hash_index
+        comment_start -= 1 while comment_start.positive? && T.must(suffix[comment_start - 1]).match?(/\s/)
+        T.must(suffix[comment_start..])
+      end
 
       sig { params(comment: T.nilable(String), old_ref: String, new_ref: String).returns(T.nilable(String)) }
       def updated_version_comment(comment, old_ref, new_ref)

--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -163,22 +163,20 @@ module Dependabot
             old_declaration
             .gsub(/@.*+/, "@#{new_ref}")
 
-          # Replace the old declaration that's preceded by a non-word character (unless it's a hyphen)
-          # and followed by a whitespace character (comments) or EOL.
-          # If the declaration is followed by a comment that lists the version associated
-          # with the SHA source ref, then update the comment to the human-readable new version.
-          # However, if the comment includes additional text beyond the version, for safety
-          # we skip updating the comment in case it's a custom note, todo, warning etc of some kind.
-          # See the related unit tests for examples.
+          # Include the rest of the line so a new comment is appended after any
+          # flow-style mapping syntax, rather than inside the mapping.
           updated_content =
             updated_content
             .gsub(
-              /(?<=[^a-zA-Z_-]|"|')#{Regexp.escape(old_declaration)}["']?(?<comment>\s+#.*)?(?=\s|$)/
+              /(?<=[^a-zA-Z_-]|"|')#{Regexp.escape(old_declaration)}["']?(?=\s|$|[,}])(?<suffix>[^\r\n]*)/
             ) do |match|
-              comment = Regexp.last_match(:comment)
+              suffix = T.must(Regexp.last_match(:suffix))
+              comment = suffix[/\s+#.*\z/]
               match.gsub!(old_declaration, new_declaration)
               if comment && (updated_comment = updated_version_comment(comment, old_ref, new_ref))
                 match.gsub!(comment, updated_comment)
+              elsif !comment && (new_comment = new_version_comment(old_ref, new_ref))
+                match << new_comment
               end
               match
             end
@@ -193,18 +191,7 @@ module Dependabot
         raise "No comment!" unless comment
 
         comment = comment.rstrip
-        git_checker = Dependabot::GitCommitChecker.new(dependency: dependency, credentials: credentials)
-        return unless git_checker.ref_looks_like_commit_sha?(old_ref)
-
-        previous_version_tags = git_checker.most_specific_version_tags_for_sha(old_ref)
-        return unless previous_version_tags.any? # There's no tag for this commit
-
-        # Use the most specific (longest) matching version to avoid partial replacements.
-        # Tags are sorted ascending, so ["v1", "v1.0", "v1.0.1"] maps to ["1", "1.0", "1.0.1"].
-        # Without this, "1" could match the end of "v1.0.1", causing gsub("1", "1.1") => "v1.1.0.1.1".
-        previous_version = previous_version_tags.map { |tag| version_class.new(tag).to_s }
-                                                .select { |version| comment.end_with?(version) }
-                                                .max_by(&:length)
+        previous_version = previous_version_from_comment(comment, old_ref, new_ref)
         return unless previous_version
 
         new_version_tag = git_checker.most_specific_version_tag_for_sha(new_ref)
@@ -212,6 +199,54 @@ module Dependabot
 
         new_version = version_class.new(new_version_tag).to_s
         comment.gsub(previous_version, new_version)
+      end
+
+      sig { params(comment: String, old_ref: String, new_ref: String).returns(T.nilable(String)) }
+      def previous_version_from_comment(comment, old_ref, new_ref)
+        version_tags = if git_checker.ref_looks_like_commit_sha?(old_ref)
+                         git_checker.most_specific_version_tags_for_sha(old_ref)
+                       elsif tag_to_sha?(old_ref, new_ref)
+                         version_tags_for_ref(old_ref)
+                       else
+                         []
+                       end
+
+        # Prefer the longest matching version so "1" does not partially replace "1.0.1".
+        version_tags
+          .filter_map { |tag| version_class.new(tag).to_s if version_class.correct?(tag) }
+          .select { |version| comment.end_with?(version) }
+          .max_by(&:length)
+      end
+
+      sig { params(ref: String).returns(T::Array[String]) }
+      def version_tags_for_ref(ref)
+        tags = [ref]
+        commit_sha = git_checker.head_commit_for_local_branch(ref)
+        tags.concat(git_checker.most_specific_version_tags_for_sha(commit_sha)) if commit_sha
+        tags.uniq
+      end
+
+      sig { params(old_ref: String, new_ref: String).returns(T.nilable(String)) }
+      def new_version_comment(old_ref, new_ref)
+        return unless tag_to_sha?(old_ref, new_ref)
+
+        new_version_tag = git_checker.most_specific_version_tag_for_sha(new_ref)
+        return unless new_version_tag
+
+        " # #{new_version_tag}"
+      end
+
+      sig { params(old_ref: String, new_ref: String).returns(T::Boolean) }
+      def tag_to_sha?(old_ref, new_ref)
+        version_class.correct?(old_ref) && git_checker.ref_looks_like_commit_sha?(new_ref)
+      end
+
+      sig { returns(Dependabot::GitCommitChecker) }
+      def git_checker
+        @git_checker ||= T.let(
+          Dependabot::GitCommitChecker.new(dependency: dependency, credentials: credentials),
+          T.nilable(Dependabot::GitCommitChecker)
+        )
       end
 
       sig { returns(T.class_of(Dependabot::GithubActions::Version)) }

--- a/github_actions/lib/dependabot/github_actions/file_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater.rb
@@ -8,11 +8,14 @@ require "dependabot/file_updaters"
 require "dependabot/file_updaters/base"
 require "dependabot/github_actions/constants"
 require "dependabot/github_actions/lockfile"
+require "dependabot/github_actions/workflow_file"
 
 module Dependabot
   module GithubActions
     class FileUpdater < Dependabot::FileUpdaters::Base
       extend T::Sig
+
+      require_relative "file_updater/workflow_updater"
 
       sig { override.returns(T::Array[Dependabot::DependencyFile]) }
       def updated_dependency_files
@@ -140,223 +143,22 @@ module Dependabot
 
       sig { params(file: Dependabot::DependencyFile).returns(String) }
       def updated_workflow_file_content(file)
-        updated_requirement_pairs =
-          dependency.requirements.zip(T.must(dependency.previous_requirements))
-                    .reject do |new_req, old_req|
-            next true if new_req.file != file.name
-
-            new_req.source == T.must(old_req).source
-          end
-
-        updated_content = T.must(file.content)
-
-        updated_requirement_pairs.each do |new_req, old_req|
-          # TODO: Support updating Docker sources
-          next unless new_req.source_string("type") == "git"
-
-          old_ref = T.must(T.must(old_req).source_string("ref"))
-          new_ref = T.must(new_req.source_string("ref"))
-
-          old_declaration = T.must(T.must(old_req).metadata_string("declaration_string"))
-          new_declaration =
-            old_declaration
-            .gsub(/@.*+/, "@#{new_ref}")
-          declaration_pattern = uses_declaration_pattern(old_declaration)
-
-          # Include the rest of the line so a new comment is appended after any
-          # flow-style mapping syntax, rather than inside the mapping.
-          updated_content =
-            updated_content
-            .gsub(
-              /#{declaration_pattern}(?<suffix>[^\r\n]*)/
-            ) do |match|
-              updated_workflow_line(
-                match: match,
-                comment: trailing_yaml_comment(T.must(Regexp.last_match(:suffix))),
-                declaration_pattern: declaration_pattern,
-                old_declaration: old_declaration,
-                new_declaration: new_declaration,
-                old_ref: old_ref,
-                new_ref: new_ref
-              )
-            end
-        end
-        updated_content
+        WorkflowUpdater.new(
+          file: file,
+          dependency: dependency,
+          commenter: version_commenter
+        ).updated_content
       end
 
-      sig { params(declaration: String).returns(Regexp) }
-      def uses_declaration_pattern(declaration)
-        escaped_declaration = Regexp.escape(declaration)
-
-        /
-          (?:^|[ \t{,])
-          (?:"uses"|'uses'|uses)[ \t]*:[ \t]*
-          (?:"#{escaped_declaration}"|'#{escaped_declaration}'|#{escaped_declaration})
-          (?=[ \t]|$|[,}\]])
-        /x
-      end
-
-      sig do
-        params(
-          match: String,
-          comment: T.nilable(String),
-          declaration_pattern: Regexp,
-          old_declaration: String,
-          new_declaration: String,
-          old_ref: String,
-          new_ref: String
-        ).returns(String)
-      end
-      def updated_workflow_line(
-        match:,
-        comment:,
-        declaration_pattern:,
-        old_declaration:,
-        new_declaration:,
-        old_ref:,
-        new_ref:
-      )
-        line_without_comment = comment ? match.delete_suffix(comment) : match
-        updated_match = line_without_comment.gsub(declaration_pattern) do |declaration|
-          declaration.sub(old_declaration, new_declaration)
-        end
-
-        if comment
-          updated_match << (updated_version_comment(comment, old_ref, new_ref) || comment)
-        elsif (new_comment = new_version_comment(old_ref, new_ref))
-          updated_match << new_comment
-        end
-        updated_match
-      end
-
-      sig { params(suffix: String).returns(T.nilable(String)) }
-      def trailing_yaml_comment(suffix)
-        previous_non_whitespace = T.let(nil, T.nilable(String))
-        index = 0
-
-        while index < suffix.length
-          character = T.must(suffix[index])
-
-          if quoted_scalar_start?(character, previous_non_whitespace)
-            previous_non_whitespace = character
-            index = quoted_scalar_end(suffix, index)
-            next
-          end
-          return comment_with_leading_whitespace(suffix, index) if yaml_comment_start?(suffix, index)
-
-          previous_non_whitespace = character unless character.match?(/\s/)
-          index += 1
-        end
-
-        nil
-      end
-
-      sig { params(character: String, previous_non_whitespace: T.nilable(String)).returns(T::Boolean) }
-      def quoted_scalar_start?(character, previous_non_whitespace)
-        return false unless character == "'" || character == '"'
-
-        previous_non_whitespace.nil? || ":,[{?-".include?(previous_non_whitespace)
-      end
-
-      sig { params(suffix: String, quote_index: Integer).returns(Integer) }
-      def quoted_scalar_end(suffix, quote_index)
-        quote = T.must(suffix[quote_index])
-        index = quote_index + 1
-
-        while index < suffix.length
-          character = T.must(suffix[index])
-          if quote == "'" && character == "'" && suffix[index + 1] == "'"
-            index += 2
-          elsif quote == '"' && character == "\\"
-            index += 2
-          elsif character == quote
-            return index + 1
-          else
-            index += 1
-          end
-        end
-
-        suffix.length
-      end
-
-      sig { params(suffix: String, index: Integer).returns(T::Boolean) }
-      def yaml_comment_start?(suffix, index)
-        suffix[index] == "#" && index.positive? && T.must(suffix[index - 1]).match?(/\s/)
-      end
-
-      sig { params(suffix: String, hash_index: Integer).returns(String) }
-      def comment_with_leading_whitespace(suffix, hash_index)
-        comment_start = hash_index
-        comment_start -= 1 while comment_start.positive? && T.must(suffix[comment_start - 1]).match?(/\s/)
-        T.must(suffix[comment_start..])
-      end
-
-      sig { params(comment: T.nilable(String), old_ref: String, new_ref: String).returns(T.nilable(String)) }
-      def updated_version_comment(comment, old_ref, new_ref)
-        raise "No comment!" unless comment
-
-        comment = comment.rstrip
-        previous_version = previous_version_from_comment(comment, old_ref, new_ref)
-        return unless previous_version
-
-        new_version_tag = git_checker.most_specific_version_tag_for_sha(new_ref)
-        return unless new_version_tag
-
-        new_version = version_class.new(new_version_tag).to_s
-        comment.gsub(previous_version, new_version)
-      end
-
-      sig { params(comment: String, old_ref: String, new_ref: String).returns(T.nilable(String)) }
-      def previous_version_from_comment(comment, old_ref, new_ref)
-        version_tags = if git_checker.ref_looks_like_commit_sha?(old_ref)
-                         git_checker.most_specific_version_tags_for_sha(old_ref)
-                       elsif tag_to_sha?(old_ref, new_ref)
-                         version_tags_for_ref(old_ref)
-                       else
-                         []
-                       end
-
-        # Prefer the longest matching version so "1" does not partially replace "1.0.1".
-        version_tags
-          .filter_map { |tag| version_class.new(tag).to_s if version_class.correct?(tag) }
-          .select { |version| comment.end_with?(version) }
-          .max_by(&:length)
-      end
-
-      sig { params(ref: String).returns(T::Array[String]) }
-      def version_tags_for_ref(ref)
-        tags = [ref]
-        commit_sha = git_checker.head_commit_for_local_branch(ref)
-        tags.concat(git_checker.most_specific_version_tags_for_sha(commit_sha)) if commit_sha
-        tags.uniq
-      end
-
-      sig { params(old_ref: String, new_ref: String).returns(T.nilable(String)) }
-      def new_version_comment(old_ref, new_ref)
-        return unless tag_to_sha?(old_ref, new_ref)
-
-        new_version_tag = git_checker.most_specific_version_tag_for_sha(new_ref)
-        return unless new_version_tag
-
-        " # #{new_version_tag}"
-      end
-
-      sig { params(old_ref: String, new_ref: String).returns(T::Boolean) }
-      def tag_to_sha?(old_ref, new_ref)
-        version_class.correct?(old_ref) && git_checker.ref_looks_like_commit_sha?(new_ref)
-      end
-
-      sig { returns(Dependabot::GitCommitChecker) }
-      def git_checker
-        @git_checker ||= T.let(
-          Dependabot::GitCommitChecker.new(dependency: dependency, credentials: credentials),
-          T.nilable(Dependabot::GitCommitChecker)
+      sig { returns(WorkflowUpdater::VersionCommenter) }
+      def version_commenter
+        @version_commenter ||= T.let(
+          WorkflowUpdater::VersionCommenter.new(
+            dependency: dependency,
+            credentials: credentials
+          ),
+          T.nilable(WorkflowUpdater::VersionCommenter)
         )
-      end
-
-      sig { returns(T.class_of(Dependabot::GithubActions::Version)) }
-      def version_class
-        GithubActions::Version
       end
     end
   end

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater.rb
@@ -17,8 +17,15 @@ module Dependabot
           const :new_ref, String
         end
 
+        class ContentEdit < T::Struct
+          const :start_offset, Integer
+          const :end_offset, Integer
+          const :replacement, String
+        end
+
         require_relative "workflow_updater/version_commenter"
         require_relative "workflow_updater/yaml_comment_finder"
+        require_relative "workflow_updater/flow_sequence_comments"
         require_relative "workflow_updater/source_updater"
 
         sig do

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater.rb
@@ -25,6 +25,8 @@ module Dependabot
 
         require_relative "workflow_updater/version_commenter"
         require_relative "workflow_updater/yaml_comment_finder"
+        require_relative "workflow_updater/source_comment_locator"
+        require_relative "workflow_updater/source_comment_updater"
         require_relative "workflow_updater/flow_sequence_comments"
         require_relative "workflow_updater/source_updater"
 

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater.rb
@@ -1,0 +1,213 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/github_actions/file_updater"
+
+module Dependabot
+  module GithubActions
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class WorkflowUpdater
+        extend T::Sig
+
+        class SourceUpdate < T::Struct
+          const :declaration, WorkflowFile::UsesDeclaration
+          const :old_declaration, String
+          const :new_declaration, String
+          const :old_ref, String
+          const :new_ref, String
+        end
+
+        require_relative "workflow_updater/version_commenter"
+        require_relative "workflow_updater/yaml_comment_finder"
+        require_relative "workflow_updater/source_updater"
+
+        sig do
+          params(
+            file: Dependabot::DependencyFile,
+            dependency: Dependabot::Dependency,
+            commenter: VersionCommenter
+          ).void
+        end
+        def initialize(file:, dependency:, commenter:)
+          @file = file
+          @dependency = dependency
+          @commenter = commenter
+          @comment_finder = T.let(YamlCommentFinder.new, YamlCommentFinder)
+        end
+
+        sig { returns(String) }
+        def updated_content
+          workflow_file = WorkflowFile.new(T.must(file.content))
+          source_updates, fallback_pairs = requirement_updates(workflow_file)
+
+          content = SourceUpdater.new(
+            workflow_file: workflow_file,
+            updates: source_updates,
+            commenter: commenter,
+            comment_finder: comment_finder
+          ).updated_content
+          fallback_pairs.each do |new_req, old_req|
+            content = apply_text_update(content, new_req, old_req)
+          end
+          content
+        end
+
+        private
+
+        sig { returns(Dependabot::DependencyFile) }
+        attr_reader :file
+
+        sig { returns(Dependabot::Dependency) }
+        attr_reader :dependency
+
+        sig { returns(VersionCommenter) }
+        attr_reader :commenter
+
+        sig { returns(YamlCommentFinder) }
+        attr_reader :comment_finder
+
+        sig do
+          params(workflow_file: WorkflowFile).returns(
+            [
+              T::Array[SourceUpdate],
+              T::Array[[Dependabot::DependencyRequirement, Dependabot::DependencyRequirement]]
+            ]
+          )
+        end
+        def requirement_updates(workflow_file)
+          source_updates = T.let([], T::Array[SourceUpdate])
+          fallback_pairs = T.let(
+            [],
+            T::Array[[Dependabot::DependencyRequirement, Dependabot::DependencyRequirement]]
+          )
+
+          dependency.requirements.zip(T.must(dependency.previous_requirements)).each do |new_req, old_req|
+            previous_requirement = T.must(old_req)
+            next if new_req.file != file.name || new_req.source == previous_requirement.source
+            next unless new_req.source_string("type") == "git"
+
+            source_update = source_update_for(workflow_file, new_req, previous_requirement)
+            source_update ? source_updates << source_update : fallback_pairs << [new_req, previous_requirement]
+          end
+
+          [source_updates, fallback_pairs]
+        end
+
+        sig do
+          params(
+            workflow_file: WorkflowFile,
+            new_req: Dependabot::DependencyRequirement,
+            old_req: Dependabot::DependencyRequirement
+          ).returns(T.nilable(SourceUpdate))
+        end
+        def source_update_for(workflow_file, new_req, old_req)
+          path = yaml_source_path(old_req)
+          return unless path
+
+          declaration = workflow_file.declaration_at(path)
+          return unless declaration
+          return unless declaration.value_node && declaration.source_node && declaration.mapping_node
+
+          old_declaration = T.must(old_req.metadata_string("declaration_string"))
+          new_ref = T.must(new_req.source_string("ref"))
+          SourceUpdate.new(
+            declaration: declaration,
+            old_declaration: old_declaration,
+            new_declaration: old_declaration.gsub(/@.*+/, "@#{new_ref}"),
+            old_ref: T.must(old_req.source_string("ref")),
+            new_ref: new_ref
+          )
+        end
+
+        sig { params(requirement: Dependabot::DependencyRequirement).returns(T.nilable(WorkflowFile::Path)) }
+        def yaml_source_path(requirement)
+          metadata = requirement.metadata
+          return unless metadata
+
+          raw_source = metadata[:yaml_source] || metadata["yaml_source"]
+          return unless raw_source.is_a?(Hash)
+
+          raw_path = raw_source[:path] || raw_source["path"]
+          return unless raw_path.is_a?(Array)
+          return unless raw_path.all? { |part| part.is_a?(String) || part.is_a?(Integer) }
+
+          path = T.let([], WorkflowFile::Path)
+          raw_path.each { |part| path << part }
+          path
+        end
+
+        sig do
+          params(
+            content: String,
+            new_req: Dependabot::DependencyRequirement,
+            old_req: Dependabot::DependencyRequirement
+          ).returns(String)
+        end
+        def apply_text_update(content, new_req, old_req)
+          old_ref = T.must(old_req.source_string("ref"))
+          new_ref = T.must(new_req.source_string("ref"))
+          old_declaration = T.must(old_req.metadata_string("declaration_string"))
+          new_declaration = old_declaration.gsub(/@.*+/, "@#{new_ref}")
+          declaration_pattern = uses_declaration_pattern(old_declaration)
+
+          content.gsub(/#{declaration_pattern}(?<suffix>[^\r\n]*)/) do |match|
+            updated_workflow_line(
+              match: match,
+              comment: comment_finder.find(T.must(Regexp.last_match(:suffix))),
+              declaration_pattern: declaration_pattern,
+              old_declaration: old_declaration,
+              new_declaration: new_declaration,
+              old_ref: old_ref,
+              new_ref: new_ref
+            )
+          end
+        end
+
+        sig { params(declaration: String).returns(Regexp) }
+        def uses_declaration_pattern(declaration)
+          escaped_declaration = Regexp.escape(declaration)
+
+          /
+            (?:^|[ \t{,])
+            (?:"uses"|'uses'|uses)[ \t]*:[ \t]*
+            (?:"#{escaped_declaration}"|'#{escaped_declaration}'|#{escaped_declaration})
+            (?=[ \t]|$|[,}\]])
+          /x
+        end
+
+        sig do
+          params(
+            match: String,
+            comment: T.nilable(String),
+            declaration_pattern: Regexp,
+            old_declaration: String,
+            new_declaration: String,
+            old_ref: String,
+            new_ref: String
+          ).returns(String)
+        end
+        def updated_workflow_line(
+          match:,
+          comment:,
+          declaration_pattern:,
+          old_declaration:,
+          new_declaration:,
+          old_ref:,
+          new_ref:
+        )
+          line_without_comment = comment ? match.delete_suffix(comment) : match
+          updated_match = line_without_comment.gsub(declaration_pattern) do |declaration|
+            declaration.sub(old_declaration, new_declaration)
+          end
+
+          if comment
+            updated_match << (commenter.updated_comment(comment, old_ref, new_ref) || comment)
+          elsif (new_comment = commenter.new_comment(old_ref, new_ref))
+            updated_match << new_comment
+          end
+          updated_match
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/flow_sequence_comments.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/flow_sequence_comments.rb
@@ -27,16 +27,17 @@ module Dependabot
               workflow_file: WorkflowFile,
               sequence: Psych::Nodes::Sequence,
               commenter: VersionCommenter,
-              comment_finder: YamlCommentFinder,
+              comment_locator: SourceCommentLocator,
               item_indent: String
             ).void
           end
-          def initialize(workflow_file:, sequence:, commenter:, comment_finder:, item_indent:)
+          def initialize(workflow_file:, sequence:, commenter:, comment_locator:, item_indent:)
             @workflow_file = workflow_file
             @sequence = sequence
             @commenter = commenter
-            @comment_finder = comment_finder
+            @comment_locator = comment_locator
             @item_indent = item_indent
+            @leading_comments = T.let(build_leading_comments, T::Array[String])
             @source_comments = T.let(build_source_comments, T::Hash[Integer, ItemComments])
           end
 
@@ -69,22 +70,30 @@ module Dependabot
             ([line] + standalone).join(workflow_file.newline)
           end
 
-          sig { params(updates: T::Array[SourceUpdate]).returns(T.nilable(ContentEdit)) }
-          def trailing_comment_edit(updates)
-            line = workflow_file.node_end_line(sequence)
-            column = workflow_file.node_end_column(sequence)
-            suffix = workflow_file.line_body(line).byteslice(workflow_file.byte_column(line, column)..) || ""
-            comment = comment_finder.find(suffix)
-            return unless comment
-            return unless updates.any? do |update|
-              commenter.recognized_comment?(comment, update.old_ref, update.new_ref)
-            end
+          sig { returns(T::Array[String]) }
+          def leading_lines
+            @leading_comments.map { |comment| "#{item_indent}#{comment}" }
+          end
 
-            relative_start = T.must(suffix.b.index(comment.b))
-            start_offset = workflow_file.offset(line, column) + relative_start
+          sig { params(updates: T::Array[SourceUpdate]).returns(T.nilable(ContentEdit)) }
+          def claim_trailing_comment(updates)
+            located_comment = comment_locator.for_sequence(sequence)
+            return unless located_comment
+
+            update = updates.find do |candidate|
+              commenter.recognized_comment?(
+                located_comment.comment,
+                candidate.old_ref,
+                candidate.new_ref
+              )
+            end
+            return unless update
+            return unless update.declaration.sequence_item_index
+
+            add_source_comment(T.must(update.declaration.sequence_item_index), located_comment.comment)
             ContentEdit.new(
-              start_offset: start_offset,
-              end_offset: start_offset + comment.bytesize,
+              start_offset: located_comment.start_offset,
+              end_offset: located_comment.end_offset,
               replacement: ""
             )
           end
@@ -100,8 +109,8 @@ module Dependabot
           sig { returns(VersionCommenter) }
           attr_reader :commenter
 
-          sig { returns(YamlCommentFinder) }
-          attr_reader :comment_finder
+          sig { returns(SourceCommentLocator) }
+          attr_reader :comment_locator
 
           sig { returns(String) }
           attr_reader :item_indent
@@ -118,6 +127,15 @@ module Dependabot
             end
           end
 
+          sig { returns(T::Array[String]) }
+          def build_leading_comments
+            first_child = workflow_file.node_children(sequence).first
+            return [] unless first_child
+
+            gap = workflow_file.content.byteslice((opening_bracket_offset + 1)...node_start_offset(first_child)) || ""
+            gap.lines.filter_map { |line| find_comment(line, trailing: false) }
+          end
+
           sig { params(gap: String).returns(ItemComments) }
           def comments_from_gap(gap)
             lines = gap.lines
@@ -131,10 +149,27 @@ module Dependabot
           sig { params(line: String, trailing: T::Boolean).returns(T.nilable(String)) }
           def find_comment(line, trailing:)
             body = line.delete_suffix("\n").delete_suffix("\r")
-            comment = comment_finder.find(body)
+            comment = comment_locator.find_line(body)
             return unless comment
 
             trailing ? " #{comment.lstrip}" : comment.lstrip
+          end
+
+          sig { params(index: Integer, comment: String).void }
+          def add_source_comment(index, comment)
+            existing = @source_comments.fetch(index, ItemComments.new(trailing: nil, standalone: []))
+            @source_comments[index] =
+              if existing.trailing
+                ItemComments.new(
+                  trailing: existing.trailing,
+                  standalone: existing.standalone + [comment.lstrip]
+                )
+              else
+                ItemComments.new(
+                  trailing: " #{comment.lstrip}",
+                  standalone: existing.standalone
+                )
+              end
           end
 
           sig do
@@ -167,10 +202,17 @@ module Dependabot
 
           sig { params(updates: T::Array[SourceUpdate]).returns(ItemComments) }
           def generated_comments(updates)
-            comments = updates.filter_map { |update| commenter.comment_for_ref(update.new_ref) }.uniq
+            comments = updates.filter_map { |update| commenter.new_comment(update.old_ref, update.new_ref) }.uniq
             raise "Conflicting version comments for one workflow step" if comments.length > 1
 
             ItemComments.new(trailing: comments.first, standalone: [])
+          end
+
+          sig { returns(Integer) }
+          def opening_bracket_offset
+            source = workflow_file.node_source(sequence)
+            opening_bracket = T.must(source.b.index("["))
+            node_start_offset(sequence) + opening_bracket
           end
 
           sig { returns(Integer) }

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/flow_sequence_comments.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/flow_sequence_comments.rb
@@ -1,0 +1,202 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/github_actions/file_updater/workflow_updater"
+
+module Dependabot
+  module GithubActions
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class WorkflowUpdater
+        class FlowSequenceComments
+          extend T::Sig
+
+          class ItemComments < T::Struct
+            extend T::Sig
+
+            const :trailing, T.nilable(String)
+            const :standalone, T::Array[String]
+
+            sig { returns(T::Boolean) }
+            def any?
+              !trailing.nil? || standalone.any?
+            end
+          end
+
+          sig do
+            params(
+              workflow_file: WorkflowFile,
+              sequence: Psych::Nodes::Sequence,
+              commenter: VersionCommenter,
+              comment_finder: YamlCommentFinder,
+              item_indent: String
+            ).void
+          end
+          def initialize(workflow_file:, sequence:, commenter:, comment_finder:, item_indent:)
+            @workflow_file = workflow_file
+            @sequence = sequence
+            @commenter = commenter
+            @comment_finder = comment_finder
+            @item_indent = item_indent
+            @source_comments = T.let(build_source_comments, T::Hash[Integer, ItemComments])
+          end
+
+          sig { params(index: Integer, updates: T::Array[SourceUpdate]).returns(ItemComments) }
+          def rendered_for(index, updates)
+            source_comments = @source_comments.fetch(index, ItemComments.new(trailing: nil, standalone: []))
+            return generated_comments(updates) unless source_comments.any?
+
+            ItemComments.new(
+              trailing: process_comment(source_comments.trailing, updates, trailing: true),
+              standalone: source_comments.standalone.filter_map do |comment|
+                process_comment(comment, updates, trailing: false)
+              end
+            )
+          end
+
+          sig do
+            params(
+              index: Integer,
+              item_count: Integer,
+              source: String,
+              updates: T::Array[SourceUpdate]
+            ).returns(String)
+          end
+          def render_item(index:, item_count:, source:, updates:)
+            comments = rendered_for(index, updates)
+            comma = index == item_count - 1 ? "" : ","
+            line = "#{item_indent}#{source}#{comma}#{comments.trailing}"
+            standalone = comments.standalone.map { |comment| "#{item_indent}#{comment}" }
+            ([line] + standalone).join(workflow_file.newline)
+          end
+
+          sig { params(updates: T::Array[SourceUpdate]).returns(T.nilable(ContentEdit)) }
+          def trailing_comment_edit(updates)
+            line = workflow_file.node_end_line(sequence)
+            column = workflow_file.node_end_column(sequence)
+            suffix = workflow_file.line_body(line).byteslice(workflow_file.byte_column(line, column)..) || ""
+            comment = comment_finder.find(suffix)
+            return unless comment
+            return unless updates.any? do |update|
+              commenter.recognized_comment?(comment, update.old_ref, update.new_ref)
+            end
+
+            relative_start = T.must(suffix.b.index(comment.b))
+            start_offset = workflow_file.offset(line, column) + relative_start
+            ContentEdit.new(
+              start_offset: start_offset,
+              end_offset: start_offset + comment.bytesize,
+              replacement: ""
+            )
+          end
+
+          private
+
+          sig { returns(WorkflowFile) }
+          attr_reader :workflow_file
+
+          sig { returns(Psych::Nodes::Sequence) }
+          attr_reader :sequence
+
+          sig { returns(VersionCommenter) }
+          attr_reader :commenter
+
+          sig { returns(YamlCommentFinder) }
+          attr_reader :comment_finder
+
+          sig { returns(String) }
+          attr_reader :item_indent
+
+          sig { returns(T::Hash[Integer, ItemComments]) }
+          def build_source_comments
+            children = workflow_file.node_children(sequence)
+            closing_offset = closing_bracket_offset
+
+            children.each_with_index.to_h do |child, index|
+              gap_end = children[index + 1] ? node_start_offset(T.must(children[index + 1])) : closing_offset
+              gap = workflow_file.content.byteslice(node_end_offset(child)...gap_end) || ""
+              [index, comments_from_gap(gap)]
+            end
+          end
+
+          sig { params(gap: String).returns(ItemComments) }
+          def comments_from_gap(gap)
+            lines = gap.lines
+            first_line = lines.shift || gap
+            trailing = find_comment(first_line, trailing: true)
+            standalone = lines.filter_map { |line| find_comment(line, trailing: false) }
+
+            ItemComments.new(trailing: trailing, standalone: standalone)
+          end
+
+          sig { params(line: String, trailing: T::Boolean).returns(T.nilable(String)) }
+          def find_comment(line, trailing:)
+            body = line.delete_suffix("\n").delete_suffix("\r")
+            comment = comment_finder.find(body)
+            return unless comment
+
+            trailing ? " #{comment.lstrip}" : comment.lstrip
+          end
+
+          sig do
+            params(
+              comment: T.nilable(String),
+              updates: T::Array[SourceUpdate],
+              trailing: T::Boolean
+            ).returns(T.nilable(String))
+          end
+          def process_comment(comment, updates, trailing:)
+            return unless comment
+
+            index = 0
+            while index < updates.length
+              update = T.must(updates[index])
+              updated = commenter.updated_comment(comment, update.old_ref, update.new_ref)
+              return normalize_comment(updated, trailing: trailing) if updated
+              return if commenter.recognized_comment?(comment, update.old_ref, update.new_ref)
+
+              index += 1
+            end
+
+            normalize_comment(comment, trailing: trailing)
+          end
+
+          sig { params(comment: String, trailing: T::Boolean).returns(String) }
+          def normalize_comment(comment, trailing:)
+            trailing ? " #{comment.lstrip}" : comment.lstrip
+          end
+
+          sig { params(updates: T::Array[SourceUpdate]).returns(ItemComments) }
+          def generated_comments(updates)
+            comments = updates.filter_map { |update| commenter.comment_for_ref(update.new_ref) }.uniq
+            raise "Conflicting version comments for one workflow step" if comments.length > 1
+
+            ItemComments.new(trailing: comments.first, standalone: [])
+          end
+
+          sig { returns(Integer) }
+          def closing_bracket_offset
+            source = workflow_file.node_source(sequence)
+            closing_bracket = T.must(source.b.rindex("]"))
+            node_start_offset(sequence) + closing_bracket
+          end
+
+          sig { params(node: Psych::Nodes::Node).returns(Integer) }
+          def node_start_offset(node)
+            workflow_file.offset(
+              workflow_file.node_start_line(node),
+              workflow_file.node_start_column(node)
+            )
+          end
+
+          sig { params(node: Psych::Nodes::Node).returns(Integer) }
+          def node_end_offset(node)
+            workflow_file.offset(
+              workflow_file.node_end_line(node),
+              workflow_file.node_end_column(node)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/flow_sequence_comments.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/flow_sequence_comments.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/github_actions/file_updater/workflow_updater"

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_comment_locator.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_comment_locator.rb
@@ -1,0 +1,147 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "dependabot/github_actions/file_updater/workflow_updater"
+
+module Dependabot
+  module GithubActions
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class WorkflowUpdater
+        class SourceCommentLocator
+          extend T::Sig
+
+          class LocatedComment < T::Struct
+            const :comment, String
+            const :start_offset, Integer
+            const :end_offset, Integer
+            const :syntax_adjacent, T::Boolean
+          end
+
+          sig do
+            params(
+              workflow_file: WorkflowFile,
+              comment_finder: YamlCommentFinder,
+              metadata_builder: WorkflowFile::MetadataBuilder
+            ).void
+          end
+          def initialize(workflow_file:, comment_finder:, metadata_builder:)
+            @workflow_file = workflow_file
+            @comment_finder = comment_finder
+            @metadata_builder = metadata_builder
+          end
+
+          sig { params(declaration: WorkflowFile::UsesDeclaration).returns(T.nilable(LocatedComment)) }
+          def for_declaration(declaration)
+            anchor = metadata_builder.comment_anchor(declaration)
+            return unless anchor
+
+            locate(
+              line: anchor.first,
+              column: anchor.last,
+              owner_sequence: declaration.steps_sequence,
+              block_scalar: block_scalar?(declaration.source_node)
+            )
+          end
+
+          sig { params(sequence: Psych::Nodes::Sequence).returns(T.nilable(LocatedComment)) }
+          def for_sequence(sequence)
+            locate(
+              line: workflow_file.node_end_line(sequence),
+              column: workflow_file.node_end_column(sequence),
+              owner_sequence: sequence,
+              block_scalar: false
+            )
+          end
+
+          sig { params(source: String).returns(T.nilable(String)) }
+          def find_line(source)
+            comment_finder.find_line(source)
+          end
+
+          private
+
+          sig { returns(WorkflowFile) }
+          attr_reader :workflow_file
+
+          sig { returns(YamlCommentFinder) }
+          attr_reader :comment_finder
+
+          sig { returns(WorkflowFile::MetadataBuilder) }
+          attr_reader :metadata_builder
+
+          sig do
+            params(
+              line: Integer,
+              column: Integer,
+              owner_sequence: T.nilable(Psych::Nodes::Sequence),
+              block_scalar: T::Boolean
+            ).returns(T.nilable(LocatedComment))
+          end
+          def locate(line:, column:, owner_sequence:, block_scalar:)
+            suffix = workflow_file.line_body(line).byteslice(workflow_file.byte_column(line, column)..) || ""
+            comment = comment_finder.find(suffix)
+            return unless comment
+
+            relative_start = T.must(suffix.b.index(comment.b))
+            start_offset = workflow_file.offset(line, column) + relative_start
+            return if inside_other_sequence?(start_offset, owner_sequence)
+
+            prefix = suffix.byteslice(0...relative_start) || ""
+            LocatedComment.new(
+              comment: comment,
+              start_offset: start_offset,
+              end_offset: start_offset + comment.bytesize,
+              syntax_adjacent: adjacent_prefix?(prefix, block_scalar)
+            )
+          end
+
+          sig do
+            params(
+              offset: Integer,
+              owner_sequence: T.nilable(Psych::Nodes::Sequence)
+            ).returns(T::Boolean)
+          end
+          def inside_other_sequence?(offset, owner_sequence)
+            workflow_file.sequences.any? do |sequence|
+              next false if owner_sequence.equal?(sequence)
+
+              node_start_offset(sequence) <= offset && offset < node_end_offset(sequence)
+            end
+          end
+
+          sig { params(prefix: String, block_scalar: T::Boolean).returns(T::Boolean) }
+          def adjacent_prefix?(prefix, block_scalar)
+            return true if prefix.match?(/\A[ \t,\]\}]*\z/)
+            return false unless block_scalar
+
+            prefix.match?(/\A[>|0-9+-]+[ \t]*\z/)
+          end
+
+          sig { params(node: T.nilable(Psych::Nodes::Node)).returns(T::Boolean) }
+          def block_scalar?(node)
+            return false unless node.is_a?(Psych::Nodes::Scalar)
+
+            style = workflow_file.scalar_node_style(node)
+            [Psych::Nodes::Scalar::LITERAL, Psych::Nodes::Scalar::FOLDED].include?(style)
+          end
+
+          sig { params(node: Psych::Nodes::Node).returns(Integer) }
+          def node_start_offset(node)
+            workflow_file.offset(
+              workflow_file.node_start_line(node),
+              workflow_file.node_start_column(node)
+            )
+          end
+
+          sig { params(node: Psych::Nodes::Node).returns(Integer) }
+          def node_end_offset(node)
+            workflow_file.offset(
+              workflow_file.node_end_line(node),
+              workflow_file.node_end_column(node)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_comment_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_comment_updater.rb
@@ -1,0 +1,191 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "dependabot/github_actions/file_updater/workflow_updater"
+
+module Dependabot
+  module GithubActions
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class WorkflowUpdater
+        class SourceCommentUpdater
+          extend T::Sig
+
+          sig do
+            params(
+              workflow_file: WorkflowFile,
+              commenter: VersionCommenter,
+              metadata_builder: WorkflowFile::MetadataBuilder,
+              comment_locator: SourceCommentLocator
+            ).void
+          end
+          def initialize(workflow_file:, commenter:, metadata_builder:, comment_locator:)
+            @workflow_file = workflow_file
+            @commenter = commenter
+            @metadata_builder = metadata_builder
+            @comment_locator = comment_locator
+          end
+
+          sig { params(update: SourceUpdate).returns(T::Array[ContentEdit]) }
+          def edits_for(update)
+            located_comment = located_comment_for(update)
+            if located_comment
+              recognized = commenter.recognized_comment?(
+                located_comment.comment,
+                update.old_ref,
+                update.new_ref
+              )
+              if located_comment.syntax_adjacent || recognized
+                return edits_for_existing_comment(update, located_comment, recognized)
+              end
+            end
+
+            edits_for_new_comment(update)
+          end
+
+          private
+
+          sig { returns(WorkflowFile) }
+          attr_reader :workflow_file
+
+          sig { returns(VersionCommenter) }
+          attr_reader :commenter
+
+          sig { returns(WorkflowFile::MetadataBuilder) }
+          attr_reader :metadata_builder
+
+          sig { returns(SourceCommentLocator) }
+          attr_reader :comment_locator
+
+          sig do
+            params(
+              update: SourceUpdate,
+              located_comment: SourceCommentLocator::LocatedComment,
+              recognized: T::Boolean
+            ).returns(T::Array[ContentEdit])
+          end
+          def edits_for_existing_comment(update, located_comment, recognized)
+            updated_comment = commenter.updated_comment(
+              located_comment.comment,
+              update.old_ref,
+              update.new_ref
+            )
+            mapping = colliding_flow_mapping(update)
+            if recognized && !located_comment.syntax_adjacent && mapping
+              return relocated_mapping_comment_edits(mapping, located_comment, updated_comment)
+            end
+
+            replacement = updated_comment || (recognized ? "" : nil)
+            return [] unless replacement
+
+            [
+              ContentEdit.new(
+                start_offset: located_comment.start_offset,
+                end_offset: located_comment.end_offset,
+                replacement: replacement
+              )
+            ]
+          end
+
+          sig { params(update: SourceUpdate).returns(T::Array[ContentEdit]) }
+          def edits_for_new_comment(update)
+            new_comment = commenter.new_comment(update.old_ref, update.new_ref)
+            return [] unless new_comment
+
+            mapping_edit = colliding_flow_mapping_comment_edit(update, new_comment)
+            return [mapping_edit] if mapping_edit
+
+            line = T.must(metadata_builder.comment_anchor(update.declaration)).first
+            line_end = workflow_file.line_end_offset(line)
+            [ContentEdit.new(start_offset: line_end, end_offset: line_end, replacement: new_comment)]
+          end
+
+          sig { params(update: SourceUpdate).returns(T.nilable(SourceCommentLocator::LocatedComment)) }
+          def located_comment_for(update)
+            declaration_comment = comment_locator.for_declaration(update.declaration)
+            if declaration_comment
+              recognized = commenter.recognized_comment?(
+                declaration_comment.comment,
+                update.old_ref,
+                update.new_ref
+              )
+              return declaration_comment if declaration_comment.syntax_adjacent || recognized
+            end
+
+            sequence = update.declaration.steps_sequence
+            return unless sequence
+
+            sequence_comment = comment_locator.for_sequence(sequence)
+            return unless sequence_comment
+
+            recognized = commenter.recognized_comment?(sequence_comment.comment, update.old_ref, update.new_ref)
+            return unless sequence_comment.syntax_adjacent || recognized
+
+            sequence_comment
+          end
+
+          sig do
+            params(
+              mapping: Psych::Nodes::Mapping,
+              located_comment: SourceCommentLocator::LocatedComment,
+              updated_comment: T.nilable(String)
+            ).returns(T::Array[ContentEdit])
+          end
+          def relocated_mapping_comment_edits(mapping, located_comment, updated_comment)
+            deletion = ContentEdit.new(
+              start_offset: located_comment.start_offset,
+              end_offset: located_comment.end_offset,
+              replacement: ""
+            )
+            return [deletion] unless updated_comment
+
+            end_offset = node_end_offset(mapping)
+            indentation = " " * workflow_file.node_start_column(mapping)
+            insertion = ContentEdit.new(
+              start_offset: end_offset,
+              end_offset: end_offset,
+              replacement: "#{updated_comment}#{workflow_file.newline}#{indentation}"
+            )
+            [insertion, deletion]
+          end
+
+          sig { params(update: SourceUpdate, comment: String).returns(T.nilable(ContentEdit)) }
+          def colliding_flow_mapping_comment_edit(update, comment)
+            mapping = colliding_flow_mapping(update)
+            return unless mapping
+
+            end_offset = node_end_offset(mapping)
+            indentation = " " * workflow_file.node_start_column(mapping)
+            ContentEdit.new(
+              start_offset: end_offset,
+              end_offset: end_offset,
+              replacement: "#{comment}#{workflow_file.newline}#{indentation}"
+            )
+          end
+
+          sig { params(update: SourceUpdate).returns(T.nilable(Psych::Nodes::Mapping)) }
+          def colliding_flow_mapping(update)
+            declaration = update.declaration
+            return if declaration.steps_sequence
+            return unless metadata_builder.comment_line_collision?(declaration)
+
+            mapping = declaration.mapping_node
+            return unless mapping
+
+            flow_style = T.cast(Psych::Nodes::Mapping::FLOW, Integer)
+            return unless workflow_file.mapping_node_style(mapping) == flow_style
+
+            mapping
+          end
+
+          sig { params(node: Psych::Nodes::Node).returns(Integer) }
+          def node_end_offset(node)
+            workflow_file.offset(
+              workflow_file.node_end_line(node),
+              workflow_file.node_end_column(node)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_updater.rb
@@ -1,0 +1,421 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/github_actions/file_updater/workflow_updater"
+
+module Dependabot
+  module GithubActions
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class WorkflowUpdater
+        class SourceUpdater
+          extend T::Sig
+
+          class ContentEdit < T::Struct
+            const :start_offset, Integer
+            const :end_offset, Integer
+            const :replacement, String
+          end
+
+          sig do
+            params(
+              workflow_file: WorkflowFile,
+              updates: T::Array[SourceUpdate],
+              commenter: VersionCommenter,
+              comment_finder: YamlCommentFinder
+            ).void
+          end
+          def initialize(workflow_file:, updates:, commenter:, comment_finder:)
+            @workflow_file = workflow_file
+            @updates = updates
+            @commenter = commenter
+            @comment_finder = comment_finder
+          end
+
+          sig { returns(String) }
+          def updated_content
+            return workflow_file.content if updates.empty?
+
+            sequence_updates = grouped_flow_sequence_updates
+            edits = sequence_updates.flat_map do |sequence, grouped_updates|
+              expanded_flow_sequence_edits(sequence, grouped_updates)
+            end
+
+            updates.each do |update|
+              sequence = expanded_sequence_for_update(sequence_updates, update)
+              source_node = T.must(update.declaration.source_node)
+              source_in_expanded_sequence = sequence_updates.keys.any? do |expanded_sequence|
+                node_within?(source_node, expanded_sequence)
+              end
+              edits << source_value_edit(update) unless source_in_expanded_sequence
+
+              next if sequence
+
+              edit = comment_edit(update)
+              edits << edit if edit
+            end
+
+            apply_content_edits(edits)
+          end
+
+          private
+
+          sig { returns(WorkflowFile) }
+          attr_reader :workflow_file
+
+          sig { returns(T::Array[SourceUpdate]) }
+          attr_reader :updates
+
+          sig { returns(VersionCommenter) }
+          attr_reader :commenter
+
+          sig { returns(YamlCommentFinder) }
+          attr_reader :comment_finder
+
+          sig { returns(T::Hash[Psych::Nodes::Sequence, T::Array[SourceUpdate]]) }
+          def grouped_flow_sequence_updates
+            groups = T.let({}, T::Hash[Psych::Nodes::Sequence, T::Array[SourceUpdate]])
+            updates.each do |update|
+              sequence = update.declaration.steps_sequence
+              next unless sequence
+              next unless expand_flow_sequence?(sequence, update)
+
+              groups[sequence] ||= []
+              T.must(groups[sequence]) << update
+            end
+            groups
+          end
+
+          sig { params(sequence: Psych::Nodes::Sequence, update: SourceUpdate).returns(T::Boolean) }
+          def expand_flow_sequence?(sequence, update)
+            workflow_file.sequence_node_style(sequence) == Psych::Nodes::Sequence::FLOW &&
+              workflow_file.node_start_line(sequence) == workflow_file.node_end_line(sequence) &&
+              workflow_file.declarations_in_sequence(sequence).length > 1 &&
+              commenter.sha?(update.new_ref)
+          end
+
+          sig do
+            params(
+              sequence_updates: T::Hash[Psych::Nodes::Sequence, T::Array[SourceUpdate]],
+              update: SourceUpdate
+            ).returns(T.nilable(Psych::Nodes::Sequence))
+          end
+          def expanded_sequence_for_update(sequence_updates, update)
+            sequence_updates.each do |sequence, grouped_updates|
+              return sequence if grouped_updates.include?(update)
+            end
+            nil
+          end
+
+          sig do
+            params(
+              sequence: Psych::Nodes::Sequence,
+              grouped_updates: T::Array[SourceUpdate]
+            ).returns(T::Array[ContentEdit])
+          end
+          def expanded_flow_sequence_edits(sequence, grouped_updates)
+            declaration = T.must(grouped_updates.first).declaration
+            key_node = T.must(declaration.steps_key_node)
+            children = workflow_file.node_children(sequence)
+            item_indent = " " * (workflow_file.node_start_column(key_node) + 2)
+            closing_indent = " " * workflow_file.node_start_column(key_node)
+
+            lines = children.each_with_index.map do |child, index|
+              render_flow_sequence_child(
+                child,
+                index,
+                children.length,
+                grouped_updates,
+                item_indent
+              )
+            end
+
+            edits = [
+              ContentEdit.new(
+                start_offset: node_start_offset(sequence),
+                end_offset: node_end_offset(sequence),
+                replacement: flow_sequence_replacement(sequence, lines, closing_indent)
+              )
+            ]
+            trailing_comment_edit = sequence_trailing_comment_edit(sequence, grouped_updates)
+            edits << trailing_comment_edit if trailing_comment_edit
+            edits
+          end
+
+          sig do
+            params(
+              child: Psych::Nodes::Node,
+              index: Integer,
+              item_count: Integer,
+              grouped_updates: T::Array[SourceUpdate],
+              item_indent: String
+            ).returns(String)
+          end
+          def render_flow_sequence_child(child, index, item_count, grouped_updates, item_indent)
+            source_updates = updates.select do |update|
+              source_node = T.must(update.declaration.source_node)
+              node_within?(source_node, child)
+            end
+            source_updates = source_updates.uniq { |update| T.must(update.declaration.source_node) }
+            comment_updates = grouped_updates.select do |update|
+              update.declaration.sequence_item_index == index
+            end
+            child_source = workflow_file.node_source(child).strip
+            child_source = replace_declarations_in_node_source(child, child_source, source_updates)
+
+            comments = comment_updates.filter_map { |update| commenter.comment_for_ref(update.new_ref) }.uniq
+            raise "Conflicting version comments for one workflow step" if comments.length > 1
+
+            comma = index == item_count - 1 ? "" : ","
+            "#{item_indent}#{child_source}#{comma}#{comments.first}"
+          end
+
+          sig do
+            params(
+              sequence: Psych::Nodes::Sequence,
+              lines: T::Array[String],
+              closing_indent: String
+            ).returns(String)
+          end
+          def flow_sequence_replacement(sequence, lines, closing_indent)
+            source = workflow_file.node_source(sequence)
+            opening_bracket = T.must(source.b.index("["))
+            closing_bracket = T.must(source.b.rindex("]"))
+            prefix = source.byteslice(0...opening_bracket) || ""
+            suffix = source.byteslice((closing_bracket + 1)..) || ""
+            expanded = [
+              "[",
+              lines.join(workflow_file.newline),
+              "#{closing_indent}]"
+            ].join(workflow_file.newline)
+            prefix + expanded + suffix
+          end
+
+          sig do
+            params(
+              sequence: Psych::Nodes::Sequence,
+              grouped_updates: T::Array[SourceUpdate]
+            ).returns(T.nilable(ContentEdit))
+          end
+          def sequence_trailing_comment_edit(sequence, grouped_updates)
+            line = workflow_file.node_end_line(sequence)
+            column = workflow_file.node_end_column(sequence)
+            byte_column = workflow_file.byte_column(line, column)
+            suffix = workflow_file.line_body(line).byteslice(byte_column..) || ""
+            comment = comment_finder.find(suffix)
+            return unless comment
+            return unless grouped_updates.any? do |update|
+              commenter.recognized_comment?(comment, update.old_ref, update.new_ref)
+            end
+
+            relative_start = T.must(suffix.b.index(comment.b))
+            start_offset = workflow_file.offset(line, column) + relative_start
+            ContentEdit.new(
+              start_offset: start_offset,
+              end_offset: start_offset + comment.bytesize,
+              replacement: ""
+            )
+          end
+
+          sig do
+            params(
+              container_node: Psych::Nodes::Node,
+              container_source: String,
+              source_updates: T::Array[SourceUpdate]
+            ).returns(String)
+          end
+          def replace_declarations_in_node_source(container_node, container_source, source_updates)
+            container_start = node_start_offset(container_node)
+            changes = unique_edits(source_updates.map { |update| source_value_change(update) })
+            changes.sort_by(&:start_offset).reverse_each.reduce(container_source) do |source, change|
+              replace_bytes(
+                source,
+                change.start_offset - container_start,
+                change.end_offset - container_start,
+                change.replacement
+              )
+            end
+          end
+
+          sig { params(update: SourceUpdate).returns(ContentEdit) }
+          def source_value_edit(update)
+            source_value_change(update)
+          end
+
+          sig { params(update: SourceUpdate).returns(ContentEdit) }
+          def source_value_change(update)
+            source_node = T.must(update.declaration.source_node)
+            node_start = node_start_offset(source_node)
+            source = workflow_file.node_source(source_node)
+            declaration = update.old_declaration.strip
+            relative_start = source.b.index(declaration.b)
+            if relative_start
+              return ContentEdit.new(
+                start_offset: node_start + relative_start,
+                end_offset: node_start + relative_start + declaration.bytesize,
+                replacement: update.new_declaration.strip
+              )
+            end
+
+            quoted_scalar_change(source_node, source, node_start, update)
+          end
+
+          sig do
+            params(
+              source_node: Psych::Nodes::Node,
+              source: String,
+              node_start: Integer,
+              update: SourceUpdate
+            ).returns(ContentEdit)
+          end
+          def quoted_scalar_change(source_node, source, node_start, update)
+            raise "Expected workflow source to include #{update.old_declaration}" unless
+              source_node.is_a?(Psych::Nodes::Scalar)
+
+            style = workflow_file.scalar_node_style(source_node)
+            quote = case style
+                    when Psych::Nodes::Scalar::SINGLE_QUOTED then "'"
+                    when Psych::Nodes::Scalar::DOUBLE_QUOTED then '"'
+                    end
+            raise "Expected workflow source to include #{update.old_declaration}" unless quote
+
+            value_start = T.must(source.b.index(quote.b))
+            value_end = T.must(source.b.rindex(quote.b))
+            replacement = escaped_quoted_value(update.new_declaration.strip, quote)
+            ContentEdit.new(
+              start_offset: node_start + value_start + 1,
+              end_offset: node_start + value_end,
+              replacement: replacement
+            )
+          end
+
+          sig { params(value: String, quote: String).returns(String) }
+          def escaped_quoted_value(value, quote)
+            return value.gsub("'", "''") if quote == "'"
+
+            value.gsub("\\", "\\\\").gsub('"', '\\"')
+          end
+
+          sig { params(update: SourceUpdate).returns(T.nilable(ContentEdit)) }
+          def comment_edit(update)
+            line, column = comment_anchor(update)
+            line_body = workflow_file.line_body(line)
+            suffix = line_body.byteslice(workflow_file.byte_column(line, column)..) || ""
+            comment = comment_finder.find(suffix)
+
+            if comment
+              updated_comment = commenter.updated_comment(comment, update.old_ref, update.new_ref)
+              return unless updated_comment
+
+              relative_start = T.must(suffix.b.index(comment.b))
+              start_offset = workflow_file.offset(line, column) + relative_start
+              return ContentEdit.new(
+                start_offset: start_offset,
+                end_offset: start_offset + comment.bytesize,
+                replacement: updated_comment
+              )
+            end
+
+            new_comment = commenter.comment_for_ref(update.new_ref)
+            return unless new_comment
+
+            line_end = workflow_file.line_end_offset(line)
+            ContentEdit.new(start_offset: line_end, end_offset: line_end, replacement: new_comment)
+          end
+
+          sig { params(update: SourceUpdate).returns([Integer, Integer]) }
+          def comment_anchor(update)
+            declaration = update.declaration
+            source_node = T.must(declaration.source_node)
+            return block_scalar_comment_anchor(source_node) if block_scalar?(source_node)
+
+            mapping = declaration.mapping_node
+            if mapping && workflow_file.mapping_node_style(mapping) == Psych::Nodes::Mapping::FLOW
+              return [workflow_file.node_end_line(mapping), workflow_file.node_end_column(mapping)]
+            end
+
+            value_node = T.must(declaration.value_node)
+            [workflow_file.node_end_line(value_node), workflow_file.node_end_column(value_node)]
+          end
+
+          sig { params(node: Psych::Nodes::Node).returns([Integer, Integer]) }
+          def block_scalar_comment_anchor(node)
+            [workflow_file.node_start_line(node), workflow_file.node_start_column(node)]
+          end
+
+          sig { params(node: Psych::Nodes::Node).returns(T::Boolean) }
+          def block_scalar?(node)
+            return false unless node.is_a?(Psych::Nodes::Scalar)
+
+            style = workflow_file.scalar_node_style(node)
+            [Psych::Nodes::Scalar::LITERAL, Psych::Nodes::Scalar::FOLDED].include?(style)
+          end
+
+          sig { params(child: Psych::Nodes::Node, parent: Psych::Nodes::Node).returns(T::Boolean) }
+          def node_within?(child, parent)
+            node_start_offset(child) >= node_start_offset(parent) &&
+              node_end_offset(child) <= node_end_offset(parent)
+          end
+
+          sig { params(node: Psych::Nodes::Node).returns(Integer) }
+          def node_start_offset(node)
+            workflow_file.offset(
+              workflow_file.node_start_line(node),
+              workflow_file.node_start_column(node)
+            )
+          end
+
+          sig { params(node: Psych::Nodes::Node).returns(Integer) }
+          def node_end_offset(node)
+            workflow_file.offset(
+              workflow_file.node_end_line(node),
+              workflow_file.node_end_column(node)
+            )
+          end
+
+          sig { params(edits: T::Array[ContentEdit]).returns(String) }
+          def apply_content_edits(edits)
+            ordered_edits = unique_edits(edits).sort_by(&:start_offset)
+            (0...(ordered_edits.length - 1)).each do |index|
+              left = T.must(ordered_edits[index])
+              right = T.must(ordered_edits[index + 1])
+              raise "Overlapping workflow edits" if left.end_offset > right.start_offset
+            end
+
+            ordered_edits.reverse_each.reduce(workflow_file.content) do |content, edit|
+              replace_bytes(content, edit.start_offset, edit.end_offset, edit.replacement)
+            end
+          end
+
+          sig { params(edits: T::Array[ContentEdit]).returns(T::Array[ContentEdit]) }
+          def unique_edits(edits)
+            edits_by_range = T.let({}, T::Hash[[Integer, Integer], ContentEdit])
+            edits.each do |edit|
+              key = [edit.start_offset, edit.end_offset]
+              existing = edits_by_range[key]
+              if existing && existing.replacement != edit.replacement
+                raise "Conflicting workflow edits at #{edit.start_offset}"
+              end
+
+              edits_by_range[key] = edit
+            end
+            edits_by_range.values
+          end
+
+          sig do
+            params(
+              content: String,
+              start_offset: Integer,
+              end_offset: Integer,
+              replacement: String
+            ).returns(String)
+          end
+          def replace_bytes(content, start_offset, end_offset, replacement)
+            prefix = content.byteslice(0...start_offset) || ""
+            suffix = content.byteslice(end_offset..) || ""
+            prefix + replacement + suffix
+          end
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_updater.rb
@@ -88,8 +88,7 @@ module Dependabot
           sig { params(sequence: Psych::Nodes::Sequence, update: SourceUpdate).returns(T::Boolean) }
           def expand_flow_sequence?(sequence, update)
             workflow_file.sequence_node_style(sequence) == Psych::Nodes::Sequence::FLOW &&
-              workflow_file.node_start_line(sequence) == workflow_file.node_end_line(sequence) &&
-              workflow_file.declarations_in_sequence(sequence).length > 1 &&
+              workflow_file.declarations_share_comment_line?(sequence) &&
               commenter.sha?(update.new_ref)
           end
 
@@ -324,7 +323,11 @@ module Dependabot
 
           sig { params(update: SourceUpdate).returns([Integer, Integer]) }
           def comment_anchor(update)
-            declaration = update.declaration
+            declaration_comment_anchor(update.declaration)
+          end
+
+          sig { params(declaration: WorkflowFile::UsesDeclaration).returns([Integer, Integer]) }
+          def declaration_comment_anchor(declaration)
             source_node = T.must(declaration.source_node)
             return block_scalar_comment_anchor(source_node) if block_scalar?(source_node)
 

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_updater.rb
@@ -22,7 +22,24 @@ module Dependabot
             @workflow_file = workflow_file
             @updates = updates
             @commenter = commenter
-            @comment_finder = comment_finder
+            @metadata_builder = T.let(WorkflowFile::MetadataBuilder.new(workflow_file), WorkflowFile::MetadataBuilder)
+            @comment_locator = T.let(
+              SourceCommentLocator.new(
+                workflow_file: workflow_file,
+                comment_finder: comment_finder,
+                metadata_builder: @metadata_builder
+              ),
+              SourceCommentLocator
+            )
+            @comment_updater = T.let(
+              SourceCommentUpdater.new(
+                workflow_file: workflow_file,
+                commenter: commenter,
+                metadata_builder: @metadata_builder,
+                comment_locator: @comment_locator
+              ),
+              SourceCommentUpdater
+            )
           end
 
           sig { returns(String) }
@@ -44,8 +61,7 @@ module Dependabot
 
               next if sequence
 
-              edit = comment_edit(update)
-              edits << edit if edit
+              edits.concat(comment_updater.edits_for(update))
             end
 
             apply_content_edits(edits)
@@ -62,28 +78,53 @@ module Dependabot
           sig { returns(VersionCommenter) }
           attr_reader :commenter
 
-          sig { returns(YamlCommentFinder) }
-          attr_reader :comment_finder
+          sig { returns(WorkflowFile::MetadataBuilder) }
+          attr_reader :metadata_builder
+
+          sig { returns(SourceCommentLocator) }
+          attr_reader :comment_locator
+
+          sig { returns(SourceCommentUpdater) }
+          attr_reader :comment_updater
 
           sig { returns(T::Hash[Psych::Nodes::Sequence, T::Array[SourceUpdate]]) }
           def grouped_flow_sequence_updates
+            sequences = updates.flat_map { |update| sequences_to_expand(update) }
             groups = T.let({}, T::Hash[Psych::Nodes::Sequence, T::Array[SourceUpdate]])
+            sequences.uniq.each { |sequence| groups[sequence] = [] }
+
             updates.each do |update|
               sequence = update.declaration.steps_sequence
-              next unless sequence
-              next unless expand_flow_sequence?(sequence, update)
-
-              groups[sequence] ||= []
-              T.must(groups[sequence]) << update
+              T.must(groups[sequence]) << update if sequence && groups.key?(sequence)
             end
             groups
           end
 
-          sig { params(sequence: Psych::Nodes::Sequence, update: SourceUpdate).returns(T::Boolean) }
-          def expand_flow_sequence?(sequence, update)
-            workflow_file.sequence_node_style(sequence) == Psych::Nodes::Sequence::FLOW &&
-              workflow_file.declarations_share_comment_line?(sequence) &&
-              commenter.sha?(update.new_ref)
+          sig { params(update: SourceUpdate).returns(T::Array[Psych::Nodes::Sequence]) }
+          def sequences_to_expand(update)
+            return [] unless commenter.sha?(update.new_ref)
+
+            sequences = metadata_builder.collision_sequences_for(update.declaration)
+            collision = metadata_builder.comment_line_collision?(update.declaration)
+            own_sequence = update.declaration.steps_sequence
+            sequence_comment = sequence_comment_requires_expansion?(update)
+            sequences << own_sequence if own_sequence && sequence_comment
+            return [] unless collision || sequence_comment
+
+            sequences.uniq.select do |sequence|
+              workflow_file.sequence_node_style(sequence) == Psych::Nodes::Sequence::FLOW
+            end
+          end
+
+          sig { params(update: SourceUpdate).returns(T::Boolean) }
+          def sequence_comment_requires_expansion?(update)
+            sequence = update.declaration.steps_sequence
+            return false unless sequence
+
+            located_comment = comment_locator.for_sequence(sequence)
+            return false unless located_comment
+
+            commenter.recognized_comment?(located_comment.comment, update.old_ref, update.new_ref)
           end
 
           sig do
@@ -106,8 +147,7 @@ module Dependabot
             ).returns(T::Array[ContentEdit])
           end
           def expanded_flow_sequence_edits(sequence, grouped_updates)
-            declaration = T.must(grouped_updates.first).declaration
-            key_node = T.must(declaration.steps_key_node)
+            key_node = T.must(workflow_file.steps_key_node_for(sequence))
             children = workflow_file.node_children(sequence)
             item_indent = " " * (workflow_file.node_start_column(key_node) + 2)
             closing_indent = " " * workflow_file.node_start_column(key_node)
@@ -115,11 +155,12 @@ module Dependabot
               workflow_file: workflow_file,
               sequence: sequence,
               commenter: commenter,
-              comment_finder: comment_finder,
+              comment_locator: comment_locator,
               item_indent: item_indent
             )
+            trailing_comment_edit = sequence_comments.claim_trailing_comment(grouped_updates)
 
-            lines = children.each_with_index.map do |child, index|
+            lines = sequence_comments.leading_lines + children.each_with_index.map do |child, index|
               render_flow_sequence_child(
                 child,
                 index,
@@ -136,7 +177,6 @@ module Dependabot
                 replacement: flow_sequence_replacement(sequence, lines, closing_indent)
               )
             ]
-            trailing_comment_edit = sequence_comments.trailing_comment_edit(grouped_updates)
             edits << trailing_comment_edit if trailing_comment_edit
             edits
           end
@@ -274,65 +314,6 @@ module Dependabot
             return value.gsub("'", "''") if quote == "'"
 
             value.gsub("\\", "\\\\").gsub('"', '\\"')
-          end
-
-          sig { params(update: SourceUpdate).returns(T.nilable(ContentEdit)) }
-          def comment_edit(update)
-            line, column = comment_anchor(update)
-            line_body = workflow_file.line_body(line)
-            suffix = line_body.byteslice(workflow_file.byte_column(line, column)..) || ""
-            comment = comment_finder.find(suffix)
-
-            if comment
-              updated_comment = commenter.updated_comment(comment, update.old_ref, update.new_ref)
-              return unless updated_comment
-
-              relative_start = T.must(suffix.b.index(comment.b))
-              start_offset = workflow_file.offset(line, column) + relative_start
-              return ContentEdit.new(
-                start_offset: start_offset,
-                end_offset: start_offset + comment.bytesize,
-                replacement: updated_comment
-              )
-            end
-
-            new_comment = commenter.comment_for_ref(update.new_ref)
-            return unless new_comment
-
-            line_end = workflow_file.line_end_offset(line)
-            ContentEdit.new(start_offset: line_end, end_offset: line_end, replacement: new_comment)
-          end
-
-          sig { params(update: SourceUpdate).returns([Integer, Integer]) }
-          def comment_anchor(update)
-            declaration_comment_anchor(update.declaration)
-          end
-
-          sig { params(declaration: WorkflowFile::UsesDeclaration).returns([Integer, Integer]) }
-          def declaration_comment_anchor(declaration)
-            source_node = T.must(declaration.source_node)
-            return block_scalar_comment_anchor(source_node) if block_scalar?(source_node)
-
-            mapping = declaration.mapping_node
-            if mapping && workflow_file.mapping_node_style(mapping) == Psych::Nodes::Mapping::FLOW
-              return [workflow_file.node_end_line(mapping), workflow_file.node_end_column(mapping)]
-            end
-
-            value_node = T.must(declaration.value_node)
-            [workflow_file.node_end_line(value_node), workflow_file.node_end_column(value_node)]
-          end
-
-          sig { params(node: Psych::Nodes::Node).returns([Integer, Integer]) }
-          def block_scalar_comment_anchor(node)
-            [workflow_file.node_start_line(node), workflow_file.node_start_column(node)]
-          end
-
-          sig { params(node: Psych::Nodes::Node).returns(T::Boolean) }
-          def block_scalar?(node)
-            return false unless node.is_a?(Psych::Nodes::Scalar)
-
-            style = workflow_file.scalar_node_style(node)
-            [Psych::Nodes::Scalar::LITERAL, Psych::Nodes::Scalar::FOLDED].include?(style)
           end
 
           sig { params(child: Psych::Nodes::Node, parent: Psych::Nodes::Node).returns(T::Boolean) }

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_updater.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/source_updater.rb
@@ -10,12 +10,6 @@ module Dependabot
         class SourceUpdater
           extend T::Sig
 
-          class ContentEdit < T::Struct
-            const :start_offset, Integer
-            const :end_offset, Integer
-            const :replacement, String
-          end
-
           sig do
             params(
               workflow_file: WorkflowFile,
@@ -117,6 +111,13 @@ module Dependabot
             children = workflow_file.node_children(sequence)
             item_indent = " " * (workflow_file.node_start_column(key_node) + 2)
             closing_indent = " " * workflow_file.node_start_column(key_node)
+            sequence_comments = FlowSequenceComments.new(
+              workflow_file: workflow_file,
+              sequence: sequence,
+              commenter: commenter,
+              comment_finder: comment_finder,
+              item_indent: item_indent
+            )
 
             lines = children.each_with_index.map do |child, index|
               render_flow_sequence_child(
@@ -124,7 +125,7 @@ module Dependabot
                 index,
                 children.length,
                 grouped_updates,
-                item_indent
+                sequence_comments
               )
             end
 
@@ -135,7 +136,7 @@ module Dependabot
                 replacement: flow_sequence_replacement(sequence, lines, closing_indent)
               )
             ]
-            trailing_comment_edit = sequence_trailing_comment_edit(sequence, grouped_updates)
+            trailing_comment_edit = sequence_comments.trailing_comment_edit(grouped_updates)
             edits << trailing_comment_edit if trailing_comment_edit
             edits
           end
@@ -146,10 +147,16 @@ module Dependabot
               index: Integer,
               item_count: Integer,
               grouped_updates: T::Array[SourceUpdate],
-              item_indent: String
+              sequence_comments: FlowSequenceComments
             ).returns(String)
           end
-          def render_flow_sequence_child(child, index, item_count, grouped_updates, item_indent)
+          def render_flow_sequence_child(
+            child,
+            index,
+            item_count,
+            grouped_updates,
+            sequence_comments
+          )
             source_updates = updates.select do |update|
               source_node = T.must(update.declaration.source_node)
               node_within?(source_node, child)
@@ -161,11 +168,12 @@ module Dependabot
             child_source = workflow_file.node_source(child).strip
             child_source = replace_declarations_in_node_source(child, child_source, source_updates)
 
-            comments = comment_updates.filter_map { |update| commenter.comment_for_ref(update.new_ref) }.uniq
-            raise "Conflicting version comments for one workflow step" if comments.length > 1
-
-            comma = index == item_count - 1 ? "" : ","
-            "#{item_indent}#{child_source}#{comma}#{comments.first}"
+            sequence_comments.render_item(
+              index: index,
+              item_count: item_count,
+              source: child_source,
+              updates: comment_updates
+            )
           end
 
           sig do
@@ -187,32 +195,6 @@ module Dependabot
               "#{closing_indent}]"
             ].join(workflow_file.newline)
             prefix + expanded + suffix
-          end
-
-          sig do
-            params(
-              sequence: Psych::Nodes::Sequence,
-              grouped_updates: T::Array[SourceUpdate]
-            ).returns(T.nilable(ContentEdit))
-          end
-          def sequence_trailing_comment_edit(sequence, grouped_updates)
-            line = workflow_file.node_end_line(sequence)
-            column = workflow_file.node_end_column(sequence)
-            byte_column = workflow_file.byte_column(line, column)
-            suffix = workflow_file.line_body(line).byteslice(byte_column..) || ""
-            comment = comment_finder.find(suffix)
-            return unless comment
-            return unless grouped_updates.any? do |update|
-              commenter.recognized_comment?(comment, update.old_ref, update.new_ref)
-            end
-
-            relative_start = T.must(suffix.b.index(comment.b))
-            start_offset = workflow_file.offset(line, column) + relative_start
-            ContentEdit.new(
-              start_offset: start_offset,
-              end_offset: start_offset + comment.bytesize,
-              replacement: ""
-            )
           end
 
           sig do

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/version_commenter.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/version_commenter.rb
@@ -1,0 +1,117 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/github_actions/file_updater/workflow_updater"
+
+module Dependabot
+  module GithubActions
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class WorkflowUpdater
+        class VersionCommenter
+          extend T::Sig
+
+          sig do
+            params(
+              dependency: Dependabot::Dependency,
+              credentials: T::Array[Dependabot::Credential]
+            ).void
+          end
+          def initialize(dependency:, credentials:)
+            @dependency = dependency
+            @credentials = credentials
+          end
+
+          sig { params(comment: String, old_ref: String, new_ref: String).returns(T.nilable(String)) }
+          def updated_comment(comment, old_ref, new_ref)
+            comment = comment.rstrip
+            previous_version = previous_version_from_comment(comment, old_ref, new_ref)
+            return unless previous_version
+
+            new_version_tag = git_checker.most_specific_version_tag_for_sha(new_ref)
+            return unless new_version_tag
+
+            new_version = version_class.new(new_version_tag).to_s
+            comment.gsub(previous_version, new_version)
+          end
+
+          sig { params(comment: String, old_ref: String, new_ref: String).returns(T::Boolean) }
+          def recognized_comment?(comment, old_ref, new_ref)
+            !previous_version_from_comment(comment.rstrip, old_ref, new_ref).nil?
+          end
+
+          sig { params(old_ref: String, new_ref: String).returns(T.nilable(String)) }
+          def new_comment(old_ref, new_ref)
+            return unless tag_to_sha?(old_ref, new_ref)
+
+            comment_for_ref(new_ref)
+          end
+
+          sig { params(ref: String).returns(T.nilable(String)) }
+          def comment_for_ref(ref)
+            return unless sha?(ref)
+
+            version_tag = git_checker.most_specific_version_tag_for_sha(ref)
+            return unless version_tag
+
+            " # #{version_tag}"
+          end
+
+          sig { params(ref: String).returns(T::Boolean) }
+          def sha?(ref)
+            git_checker.ref_looks_like_commit_sha?(ref)
+          end
+
+          private
+
+          sig { returns(Dependabot::Dependency) }
+          attr_reader :dependency
+
+          sig { returns(T::Array[Dependabot::Credential]) }
+          attr_reader :credentials
+
+          sig { params(comment: String, old_ref: String, new_ref: String).returns(T.nilable(String)) }
+          def previous_version_from_comment(comment, old_ref, new_ref)
+            version_tags = if sha?(old_ref)
+                             git_checker.most_specific_version_tags_for_sha(old_ref)
+                           elsif tag_to_sha?(old_ref, new_ref)
+                             version_tags_for_ref(old_ref)
+                           else
+                             []
+                           end
+
+            version_tags
+              .filter_map { |tag| version_class.new(tag).to_s if version_class.correct?(tag) }
+              .select { |version| comment.end_with?(version) }
+              .max_by(&:length)
+          end
+
+          sig { params(ref: String).returns(T::Array[String]) }
+          def version_tags_for_ref(ref)
+            tags = [ref]
+            commit_sha = git_checker.head_commit_for_local_branch(ref)
+            tags.concat(git_checker.most_specific_version_tags_for_sha(commit_sha)) if commit_sha
+            tags.uniq
+          end
+
+          sig { params(old_ref: String, new_ref: String).returns(T::Boolean) }
+          def tag_to_sha?(old_ref, new_ref)
+            version_class.correct?(old_ref) && sha?(new_ref)
+          end
+
+          sig { returns(Dependabot::GitCommitChecker) }
+          def git_checker
+            @git_checker ||= T.let(
+              Dependabot::GitCommitChecker.new(dependency: dependency, credentials: credentials),
+              T.nilable(Dependabot::GitCommitChecker)
+            )
+          end
+
+          sig { returns(T.class_of(Dependabot::GithubActions::Version)) }
+          def version_class
+            GithubActions::Version
+          end
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/version_commenter.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/version_commenter.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/github_actions/file_updater/workflow_updater"

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/yaml_comment_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/yaml_comment_finder.rb
@@ -31,6 +31,24 @@ module Dependabot
             nil
           end
 
+          sig { params(suffix: String).returns(T.nilable(String)) }
+          def find_immediate(suffix)
+            comment = find(suffix)
+            return unless comment
+
+            comment_start = T.must(suffix.b.index(comment.b))
+            prefix = suffix.byteslice(0...comment_start) || ""
+            comment if prefix.match?(/\A[ \t]*,?[ \t]*\z/)
+          end
+
+          sig { params(line: String).returns(T.nilable(String)) }
+          def find_line(line)
+            stripped = line.lstrip
+            return stripped if stripped.start_with?("#")
+
+            find(line)
+          end
+
           private
 
           sig { params(character: String, previous_non_whitespace: T.nilable(String)).returns(T::Boolean) }

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/yaml_comment_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/yaml_comment_finder.rb
@@ -1,0 +1,78 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/github_actions/file_updater/workflow_updater"
+
+module Dependabot
+  module GithubActions
+    class FileUpdater < Dependabot::FileUpdaters::Base
+      class WorkflowUpdater
+        class YamlCommentFinder
+          extend T::Sig
+
+          sig { params(suffix: String).returns(T.nilable(String)) }
+          def find(suffix)
+            previous_non_whitespace = T.let(nil, T.nilable(String))
+            index = 0
+
+            while index < suffix.length
+              character = T.must(suffix[index])
+              if quoted_scalar_start?(character, previous_non_whitespace)
+                previous_non_whitespace = character
+                index = quoted_scalar_end(suffix, index)
+                next
+              end
+
+              return comment_with_leading_whitespace(suffix, index) if comment_start?(suffix, index)
+
+              previous_non_whitespace = character unless character.match?(/\s/)
+              index += 1
+            end
+            nil
+          end
+
+          private
+
+          sig { params(character: String, previous_non_whitespace: T.nilable(String)).returns(T::Boolean) }
+          def quoted_scalar_start?(character, previous_non_whitespace)
+            return false unless character == "'" || character == '"'
+
+            previous_non_whitespace.nil? || ":,[{?-".include?(previous_non_whitespace)
+          end
+
+          sig { params(suffix: String, quote_index: Integer).returns(Integer) }
+          def quoted_scalar_end(suffix, quote_index)
+            quote = T.must(suffix[quote_index])
+            index = quote_index + 1
+
+            while index < suffix.length
+              character = T.must(suffix[index])
+              if quote == "'" && character == "'" && suffix[index + 1] == "'"
+                index += 2
+              elsif quote == '"' && character == "\\"
+                index += 2
+              elsif character == quote
+                return index + 1
+              else
+                index += 1
+              end
+            end
+            suffix.length
+          end
+
+          sig { params(suffix: String, index: Integer).returns(T::Boolean) }
+          def comment_start?(suffix, index)
+            suffix[index] == "#" && index.positive? && T.must(suffix[index - 1]).match?(/\s/)
+          end
+
+          sig { params(suffix: String, hash_index: Integer).returns(String) }
+          def comment_with_leading_whitespace(suffix, hash_index)
+            comment_start = hash_index
+            comment_start -= 1 while comment_start.positive? && T.must(suffix[comment_start - 1]).match?(/\s/)
+            T.must(suffix[comment_start..])
+          end
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/yaml_comment_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/file_updater/workflow_updater/yaml_comment_finder.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/github_actions/file_updater/workflow_updater"

--- a/github_actions/lib/dependabot/github_actions/update_checker.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker.rb
@@ -59,7 +59,7 @@ module Dependabot
 
       sig { override.returns(T::Boolean) }
       def up_to_date?
-        super && !onboarded_requirements_changed?
+        super && !relevant_requirements_changed?
       end
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
@@ -82,14 +82,34 @@ module Dependabot
         return true if super
         return false unless requirements_to_unlock == :own
 
-        onboarded_requirements_changed?
+        relevant_requirements_changed?
       end
 
       sig { returns(T::Boolean) }
-      def onboarded_requirements_changed?
+      def relevant_requirements_changed?
         dependency.requirements.zip(updated_requirements).any? do |current, updated|
-          onboarded_requirement?(current) && current != updated
+          next false unless updated
+
+          current != updated && (onboarded_requirement?(current) || tag_to_sha_requirement?(current, updated))
         end
+      end
+
+      sig do
+        params(
+          current: Dependabot::DependencyRequirement,
+          updated: Dependabot::DependencyRequirement
+        ).returns(T::Boolean)
+      end
+      def tag_to_sha_requirement?(current, updated)
+        return false unless pin_to_sha?
+
+        current_ref = current.source_string("ref")
+        updated_ref = updated.source_string("ref")
+        return false unless current_ref && updated_ref
+        return false unless version_class.correct?(current_ref)
+        return false if Dependabot::GithubActions::Version.path_based?(current_ref)
+
+        git_commit_checker.ref_looks_like_commit_sha?(updated_ref)
       end
 
       # A requirement is "onboarded" when the repo carries an `actions.lock` that is
@@ -246,11 +266,12 @@ module Dependabot
         # TODO: Support Docker sources
         return unless git_commit_checker.git_dependency?
 
-        git_source = source && symbolize_source(source)
+        git_source = git_source_for(source)
+        current_ref = git_source&.fetch(:ref, nil)
         finder = onboarded ? latest_version_finder_for(git_source) : T.must(latest_version_finder)
 
         if vulnerable? && (new_tag = finder.lowest_security_fix_release)
-          return new_tag.fetch(:tag)
+          return ref_for_release(new_tag, current_ref: current_ref)
         end
 
         source_git_commit_checker = git_helper.git_commit_checker_for(git_source)
@@ -258,7 +279,7 @@ module Dependabot
         # Return the git tag if updating a pinned version
         if source_git_commit_checker.pinned_ref_looks_like_version? &&
            (new_tag = finder.latest_version_tag_respecting_cooldown)
-          return new_tag.fetch(:tag)
+          return ref_for_release(new_tag, current_ref: current_ref)
         end
 
         # Return the pinned git commit if one is available
@@ -269,6 +290,34 @@ module Dependabot
 
         # Otherwise we can't update the ref
         nil
+      end
+
+      sig { returns(T::Boolean) }
+      def pin_to_sha?
+        T.cast(options.fetch(:github_actions_pin_to_sha, false), T::Boolean)
+      end
+
+      sig do
+        params(
+          release: T::Hash[Symbol, Object],
+          current_ref: T.nilable(String)
+        ).returns(String)
+      end
+      def ref_for_release(release, current_ref:)
+        return T.cast(release.fetch(:tag), String) unless pin_to_sha?
+        if current_ref && Dependabot::GithubActions::Version.path_based?(current_ref)
+          return T.cast(release.fetch(:tag), String)
+        end
+
+        T.cast(release.fetch(:commit_sha), String)
+      end
+
+      sig do
+        params(source: T.nilable(Dependabot::DependencyRequirement::ObjectHash))
+          .returns(T.nilable(GitSource))
+      end
+      def git_source_for(source)
+        source && symbolize_source(source)
       end
 
       sig do

--- a/github_actions/lib/dependabot/github_actions/workflow_file.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file.rb
@@ -59,6 +59,11 @@ module Dependabot
         uses_declarations.select { |declaration| declaration.steps_sequence.equal?(sequence) }
       end
 
+      sig { params(sequence: Psych::Nodes::Sequence).returns(T::Boolean) }
+      def declarations_share_comment_line?(sequence)
+        MetadataBuilder.new(self).declarations_share_comment_line?(sequence)
+      end
+
       sig { params(declaration: UsesDeclaration).returns(T::Boolean) }
       def source_metadata_required?(declaration)
         return true if declaration.value_node.is_a?(Psych::Nodes::Alias)

--- a/github_actions/lib/dependabot/github_actions/workflow_file.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file.rb
@@ -1,0 +1,408 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "date"
+require "sorbet-runtime"
+require "yaml"
+
+require "dependabot/github_actions/constants"
+
+module Dependabot
+  module GithubActions
+    class WorkflowFile
+      extend T::Sig
+
+      Path = T.type_alias { T::Array[T.any(String, Integer)] }
+      Metadata = T.type_alias { T::Hash[Symbol, Object] }
+
+      require_relative "workflow_file/node_context"
+      require_relative "workflow_file/uses_declaration"
+      require_relative "workflow_file/uses_collector"
+      require_relative "workflow_file/metadata_builder"
+
+      sig { params(content: String).void }
+      def initialize(content)
+        @content = content
+        @data = T.let(
+          T.cast(
+            YAML.safe_load(content, aliases: true, permitted_classes: [Date, Time, Symbol]),
+            T.nilable(Object)
+          ),
+          T.nilable(Object)
+        )
+        @contexts = T.let({}, T::Hash[Path, NodeContext])
+        @anchors = T.let({}, T::Hash[String, Psych::Nodes::Node])
+        @alias_targets = T.let({}, T::Hash[Path, Psych::Nodes::Node])
+        @lines = T.let(content.lines, T::Array[String])
+        @line_offsets = T.let(line_offsets(content), T::Array[Integer])
+
+        index_stream(YAML.parse_stream(content))
+        @uses_declarations = T.let(build_uses_declarations, T::Array[UsesDeclaration])
+      end
+
+      sig { returns(T.nilable(Object)) }
+      attr_reader :data
+
+      sig { returns(T::Array[UsesDeclaration]) }
+      attr_reader :uses_declarations
+
+      sig { returns(String) }
+      attr_reader :content
+
+      sig { params(path: Path).returns(T.nilable(UsesDeclaration)) }
+      def declaration_at(path)
+        uses_declarations.find { |declaration| declaration.path == path }
+      end
+
+      sig { params(sequence: Psych::Nodes::Sequence).returns(T::Array[UsesDeclaration]) }
+      def declarations_in_sequence(sequence)
+        uses_declarations.select { |declaration| declaration.steps_sequence.equal?(sequence) }
+      end
+
+      sig { params(declaration: UsesDeclaration).returns(T::Boolean) }
+      def source_metadata_required?(declaration)
+        return true if declaration.value_node.is_a?(Psych::Nodes::Alias)
+
+        source_node = declaration.source_node
+        if source_node.is_a?(Psych::Nodes::Scalar)
+          return true if block_scalar_style?(scalar_node_style(source_node))
+          return true unless node_source(source_node).include?(declaration.value.strip)
+        end
+
+        sequence = declaration.steps_sequence
+        return false unless sequence
+
+        sequence_node_style(sequence) == Psych::Nodes::Sequence::FLOW &&
+          declarations_in_sequence(sequence).length > 1
+      end
+
+      sig { params(declaration: UsesDeclaration).returns(Metadata) }
+      def source_metadata(declaration)
+        MetadataBuilder.new(self).build(declaration)
+      end
+
+      sig { params(node: Psych::Nodes::Node).returns(String) }
+      def node_source(node)
+        start_offset = offset(node_start_line(node), node_start_column(node))
+        end_offset = offset(node_end_line(node), node_end_column(node))
+        T.must(content.byteslice(start_offset...end_offset))
+      end
+
+      sig { params(node: Psych::Nodes::Node).returns(Integer) }
+      def node_start_line(node)
+        T.cast(node.start_line, Integer)
+      end
+
+      sig { params(node: Psych::Nodes::Node).returns(Integer) }
+      def node_start_column(node)
+        T.cast(node.start_column, Integer)
+      end
+
+      sig { params(node: Psych::Nodes::Node).returns(Integer) }
+      def node_end_line(node)
+        T.cast(node.end_line, Integer)
+      end
+
+      sig { params(node: Psych::Nodes::Node).returns(Integer) }
+      def node_end_column(node)
+        T.cast(node.end_column, Integer)
+      end
+
+      sig { params(node: Psych::Nodes::Sequence).returns(Integer) }
+      def sequence_node_style(node)
+        T.cast(node.style, Integer)
+      end
+
+      sig { params(node: Psych::Nodes::Mapping).returns(Integer) }
+      def mapping_node_style(node)
+        T.cast(node.style, Integer)
+      end
+
+      sig { params(node: Psych::Nodes::Scalar).returns(Integer) }
+      def scalar_node_style(node)
+        T.cast(node.style, Integer)
+      end
+
+      sig { params(node: Psych::Nodes::Node).returns(T::Array[Psych::Nodes::Node]) }
+      def node_children(node)
+        children = node.children
+        return [] unless children.is_a?(Array)
+
+        children
+      end
+
+      sig { params(line: Integer, column: Integer).returns(Integer) }
+      def offset(line, column)
+        line_start = T.must(@line_offsets[line])
+        line_content = @lines[line] || ""
+        prefix = line_content[0, column] || ""
+        line_start + prefix.bytesize
+      end
+
+      sig { params(line: Integer, column: Integer).returns(Integer) }
+      def byte_column(line, column)
+        offset(line, column) - T.must(@line_offsets[line])
+      end
+
+      sig { params(line: Integer).returns(String) }
+      def line_body(line)
+        start_offset = T.must(@line_offsets[line])
+        end_offset = @line_offsets[line + 1] || content.bytesize
+        value = T.must(content.byteslice(start_offset...end_offset))
+        value = value.delete_suffix("\n")
+        value.delete_suffix("\r")
+      end
+
+      sig { params(line: Integer).returns(Integer) }
+      def line_end_offset(line)
+        T.must(@line_offsets[line]) + line_body(line).bytesize
+      end
+
+      sig { returns(String) }
+      def newline
+        content.include?("\r\n") ? "\r\n" : "\n"
+      end
+
+      private
+
+      sig { params(stream: Psych::Nodes::Stream).void }
+      def index_stream(stream)
+        document = node_children(stream).first
+        return unless document.is_a?(Psych::Nodes::Document)
+
+        root = node_children(document).first
+        return unless root
+
+        index_node(
+          root,
+          [],
+          mapping_node: nil,
+          key_node: nil,
+          steps_sequence: nil,
+          steps_key_node: nil,
+          sequence_item: nil,
+          sequence_item_index: nil
+        )
+      end
+
+      sig do
+        params(
+          node: Psych::Nodes::Node,
+          path: Path,
+          mapping_node: T.nilable(Psych::Nodes::Mapping),
+          key_node: T.nilable(Psych::Nodes::Scalar),
+          steps_sequence: T.nilable(Psych::Nodes::Sequence),
+          steps_key_node: T.nilable(Psych::Nodes::Scalar),
+          sequence_item: T.nilable(Psych::Nodes::Node),
+          sequence_item_index: T.nilable(Integer)
+        ).void
+      end
+      def index_node(
+        node,
+        path,
+        mapping_node:,
+        key_node:,
+        steps_sequence:,
+        steps_key_node:,
+        sequence_item:,
+        sequence_item_index:
+      )
+        record_node(
+          node,
+          path,
+          mapping_node: mapping_node,
+          key_node: key_node,
+          steps_sequence: steps_sequence,
+          steps_key_node: steps_key_node,
+          sequence_item: sequence_item,
+          sequence_item_index: sequence_item_index
+        )
+
+        index_node_children(
+          node,
+          path,
+          steps_sequence: steps_sequence,
+          steps_key_node: steps_key_node,
+          sequence_item: sequence_item,
+          sequence_item_index: sequence_item_index
+        )
+      end
+
+      sig do
+        params(
+          node: Psych::Nodes::Node,
+          path: Path,
+          mapping_node: T.nilable(Psych::Nodes::Mapping),
+          key_node: T.nilable(Psych::Nodes::Scalar),
+          steps_sequence: T.nilable(Psych::Nodes::Sequence),
+          steps_key_node: T.nilable(Psych::Nodes::Scalar),
+          sequence_item: T.nilable(Psych::Nodes::Node),
+          sequence_item_index: T.nilable(Integer)
+        ).void
+      end
+      def record_node(
+        node,
+        path,
+        mapping_node:,
+        key_node:,
+        steps_sequence:,
+        steps_key_node:,
+        sequence_item:,
+        sequence_item_index:
+      )
+        @contexts[path] = NodeContext.new(
+          node: node,
+          mapping_node: mapping_node,
+          key_node: key_node,
+          steps_sequence: steps_sequence,
+          steps_key_node: steps_key_node,
+          sequence_item: sequence_item,
+          sequence_item_index: sequence_item_index
+        )
+        if node.is_a?(Psych::Nodes::Alias)
+          target = @anchors[node.anchor]
+          @alias_targets[path] = target if target
+        end
+
+        anchor = node_anchor(node)
+        @anchors[anchor] = node if anchor
+      end
+
+      sig do
+        params(
+          node: Psych::Nodes::Node,
+          path: Path,
+          steps_sequence: T.nilable(Psych::Nodes::Sequence),
+          steps_key_node: T.nilable(Psych::Nodes::Scalar),
+          sequence_item: T.nilable(Psych::Nodes::Node),
+          sequence_item_index: T.nilable(Integer)
+        ).void
+      end
+      def index_node_children(
+        node,
+        path,
+        steps_sequence:,
+        steps_key_node:,
+        sequence_item:,
+        sequence_item_index:
+      )
+        case node
+        when Psych::Nodes::Mapping
+          index_mapping(
+            node,
+            path,
+            steps_sequence: steps_sequence,
+            steps_key_node: steps_key_node,
+            sequence_item: sequence_item,
+            sequence_item_index: sequence_item_index
+          )
+        when Psych::Nodes::Sequence
+          node_children(node).each_with_index do |child, index|
+            index_node(
+              child,
+              path + [index],
+              mapping_node: nil,
+              key_node: nil,
+              steps_sequence: steps_sequence,
+              steps_key_node: steps_key_node,
+              sequence_item: child,
+              sequence_item_index: index
+            )
+          end
+        end
+      end
+
+      sig do
+        params(
+          node: Psych::Nodes::Mapping,
+          path: Path,
+          steps_sequence: T.nilable(Psych::Nodes::Sequence),
+          steps_key_node: T.nilable(Psych::Nodes::Scalar),
+          sequence_item: T.nilable(Psych::Nodes::Node),
+          sequence_item_index: T.nilable(Integer)
+        ).void
+      end
+      def index_mapping(
+        node,
+        path,
+        steps_sequence:,
+        steps_key_node:,
+        sequence_item:,
+        sequence_item_index:
+      )
+        node_children(node).each_slice(2) do |raw_key_node, value_node|
+          next unless raw_key_node.is_a?(Psych::Nodes::Scalar) && value_node
+
+          child_steps_sequence = steps_sequence
+          child_steps_key_node = steps_key_node
+          if raw_key_node.value == STEPS_KEY && value_node.is_a?(Psych::Nodes::Sequence)
+            child_steps_sequence = value_node
+            child_steps_key_node = raw_key_node
+          end
+
+          index_node(
+            value_node,
+            path + [raw_key_node.value],
+            mapping_node: node,
+            key_node: raw_key_node,
+            steps_sequence: child_steps_sequence,
+            steps_key_node: child_steps_key_node,
+            sequence_item: sequence_item,
+            sequence_item_index: sequence_item_index
+          )
+        end
+      end
+
+      sig { returns(T::Array[UsesDeclaration]) }
+      def build_uses_declarations
+        UsesCollector.new(data).uses.map do |resolved_use|
+          build_declaration(resolved_use.value, resolved_use.path)
+        end
+      end
+
+      sig { params(value: String, path: Path).returns(UsesDeclaration) }
+      def build_declaration(value, path)
+        context = @contexts[path]
+        value_node = context&.node
+        source_node =
+          if value_node.is_a?(Psych::Nodes::Alias)
+            @alias_targets[path]
+          else
+            value_node
+          end
+
+        UsesDeclaration.new(
+          value: value,
+          path: path,
+          value_node: value_node,
+          source_node: source_node,
+          mapping_node: context&.mapping_node,
+          steps_sequence: context&.steps_sequence,
+          steps_key_node: context&.steps_key_node,
+          sequence_item: context&.sequence_item,
+          sequence_item_index: context&.sequence_item_index
+        )
+      end
+
+      sig { params(style: Integer).returns(T::Boolean) }
+      def block_scalar_style?(style)
+        [Psych::Nodes::Scalar::LITERAL, Psych::Nodes::Scalar::FOLDED].include?(style)
+      end
+
+      sig { params(node: Psych::Nodes::Node).returns(T.nilable(String)) }
+      def node_anchor(node)
+        case node
+        when Psych::Nodes::Scalar, Psych::Nodes::Mapping, Psych::Nodes::Sequence
+          node.anchor
+        end
+      end
+
+      sig { params(value: String).returns(T::Array[Integer]) }
+      def line_offsets(value)
+        offsets = [0]
+        value.each_line { |line| offsets << (offsets.last + line.bytesize) }
+        offsets
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/workflow_file.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file.rb
@@ -33,6 +33,8 @@ module Dependabot
         @contexts = T.let({}, T::Hash[Path, NodeContext])
         @anchors = T.let({}, T::Hash[String, Psych::Nodes::Node])
         @alias_targets = T.let({}, T::Hash[Path, Psych::Nodes::Node])
+        @sequences = T.let([], T::Array[Psych::Nodes::Sequence])
+        @steps_key_nodes = T.let({}, T::Hash[Psych::Nodes::Sequence, Psych::Nodes::Scalar])
         @lines = T.let(content.lines, T::Array[String])
         @line_offsets = T.let(line_offsets(content), T::Array[Integer])
 
@@ -49,20 +51,20 @@ module Dependabot
       sig { returns(String) }
       attr_reader :content
 
+      sig { returns(T::Array[Psych::Nodes::Sequence]) }
+      attr_reader :sequences
+
+      sig { returns(T::Array[Psych::Nodes::Sequence]) }
+      def steps_sequences = @steps_key_nodes.keys
+
+      sig { params(sequence: Psych::Nodes::Sequence).returns(T.nilable(Psych::Nodes::Scalar)) }
+      def steps_key_node_for(sequence) = @steps_key_nodes[sequence]
+
       sig { params(path: Path).returns(T.nilable(UsesDeclaration)) }
-      def declaration_at(path)
-        uses_declarations.find { |declaration| declaration.path == path }
-      end
+      def declaration_at(path) = uses_declarations.find { |declaration| declaration.path == path }
 
       sig { params(sequence: Psych::Nodes::Sequence).returns(T::Array[UsesDeclaration]) }
-      def declarations_in_sequence(sequence)
-        uses_declarations.select { |declaration| declaration.steps_sequence.equal?(sequence) }
-      end
-
-      sig { params(sequence: Psych::Nodes::Sequence).returns(T::Boolean) }
-      def declarations_share_comment_line?(sequence)
-        MetadataBuilder.new(self).declarations_share_comment_line?(sequence)
-      end
+      def declarations_in_sequence(sequence) = uses_declarations.select { |item| item.steps_sequence.equal?(sequence) }
 
       sig { params(declaration: UsesDeclaration).returns(T::Boolean) }
       def source_metadata_required?(declaration)
@@ -75,16 +77,13 @@ module Dependabot
         end
 
         sequence = declaration.steps_sequence
-        return false unless sequence
+        return true if sequence && sequence_node_style(sequence) == Psych::Nodes::Sequence::FLOW
 
-        sequence_node_style(sequence) == Psych::Nodes::Sequence::FLOW &&
-          declarations_in_sequence(sequence).length > 1
+        MetadataBuilder.new(self).comment_line_collision?(declaration)
       end
 
       sig { params(declaration: UsesDeclaration).returns(Metadata) }
-      def source_metadata(declaration)
-        MetadataBuilder.new(self).build(declaration)
-      end
+      def source_metadata(declaration) = MetadataBuilder.new(self).build(declaration)
 
       sig { params(node: Psych::Nodes::Node).returns(String) }
       def node_source(node)
@@ -271,6 +270,7 @@ module Dependabot
 
         anchor = node_anchor(node)
         @anchors[anchor] = node if anchor
+        @sequences << node if node.is_a?(Psych::Nodes::Sequence)
       end
 
       sig do
@@ -343,6 +343,7 @@ module Dependabot
           if raw_key_node.value == STEPS_KEY && value_node.is_a?(Psych::Nodes::Sequence)
             child_steps_sequence = value_node
             child_steps_key_node = raw_key_node
+            @steps_key_nodes[value_node] = raw_key_node
           end
 
           index_node(

--- a/github_actions/lib/dependabot/github_actions/workflow_file/metadata_builder.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file/metadata_builder.rb
@@ -38,19 +38,110 @@ module Dependabot
           metadata
         end
 
-        sig { params(sequence: Psych::Nodes::Sequence).returns(T::Boolean) }
-        def declarations_share_comment_line?(sequence)
-          nodes = workflow_file.declarations_in_sequence(sequence).filter_map do |item|
-            item.mapping_node || item.value_node
+        sig { params(declaration: UsesDeclaration).returns(T::Array[UsesDeclaration]) }
+        def collision_declarations_for(declaration)
+          anchor = comment_anchor(declaration)
+          return [] unless anchor
+
+          workflow_file.uses_declarations.select do |item|
+            item_anchor = comment_anchor(item)
+            item_anchor && item_anchor.first == anchor.first
           end
-          lines = nodes.map { |node| workflow_file.node_end_line(node) }
-          lines.length != lines.uniq.length
+        end
+
+        sig { params(declaration: UsesDeclaration).returns(T::Boolean) }
+        def comment_line_collision?(declaration)
+          anchor = comment_anchor(declaration)
+          return false unless anchor
+          return true if collision_declarations_for(declaration).length > 1
+
+          line = anchor.first
+          anchor_offset = workflow_file.offset(anchor.first, anchor.last)
+          workflow_file.steps_sequences.any? do |sequence|
+            sequence_starts_after_anchor?(sequence, line, anchor_offset) ||
+              child_starts_after_anchor?(sequence, line, anchor_offset)
+          end
+        end
+
+        sig { params(declaration: UsesDeclaration).returns(T::Array[Psych::Nodes::Sequence]) }
+        def collision_sequences_for(declaration)
+          anchor = comment_anchor(declaration)
+          return [] unless anchor
+
+          line = anchor.first
+          workflow_file.steps_sequences.select do |sequence|
+            line.between?(
+              workflow_file.node_start_line(sequence),
+              workflow_file.node_end_line(sequence)
+            )
+          end
+        end
+
+        sig { params(declaration: UsesDeclaration).returns(T.nilable([Integer, Integer])) }
+        def comment_anchor(declaration)
+          source_node = declaration.source_node
+          return unless source_node
+
+          if source_node.is_a?(Psych::Nodes::Scalar) && block_scalar?(source_node)
+            return [
+              workflow_file.node_start_line(source_node),
+              workflow_file.node_start_column(source_node)
+            ]
+          end
+
+          mapping = declaration.mapping_node
+          if mapping && workflow_file.mapping_node_style(mapping) == Psych::Nodes::Mapping::FLOW
+            return [workflow_file.node_end_line(mapping), workflow_file.node_end_column(mapping)]
+          end
+
+          value_node = declaration.value_node
+          return unless value_node
+
+          [workflow_file.node_end_line(value_node), workflow_file.node_end_column(value_node)]
         end
 
         private
 
         sig { returns(WorkflowFile) }
         attr_reader :workflow_file
+
+        sig do
+          params(
+            sequence: Psych::Nodes::Sequence,
+            line: Integer,
+            anchor_offset: Integer
+          ).returns(T::Boolean)
+        end
+        def sequence_starts_after_anchor?(sequence, line, anchor_offset)
+          workflow_file.node_start_line(sequence) == line && node_start_offset(sequence) > anchor_offset
+        end
+
+        sig do
+          params(
+            sequence: Psych::Nodes::Sequence,
+            line: Integer,
+            anchor_offset: Integer
+          ).returns(T::Boolean)
+        end
+        def child_starts_after_anchor?(sequence, line, anchor_offset)
+          workflow_file.node_children(sequence).any? do |child|
+            workflow_file.node_start_line(child) == line && node_start_offset(child) > anchor_offset
+          end
+        end
+
+        sig { params(node: Psych::Nodes::Node).returns(Integer) }
+        def node_start_offset(node)
+          workflow_file.offset(
+            workflow_file.node_start_line(node),
+            workflow_file.node_start_column(node)
+          )
+        end
+
+        sig { params(node: Psych::Nodes::Scalar).returns(T::Boolean) }
+        def block_scalar?(node)
+          style = workflow_file.scalar_node_style(node)
+          [Psych::Nodes::Scalar::LITERAL, Psych::Nodes::Scalar::FOLDED].include?(style)
+        end
 
         sig { params(node: T.nilable(Psych::Nodes::Node)).returns(Metadata) }
         def node_metadata(node)

--- a/github_actions/lib/dependabot/github_actions/workflow_file/metadata_builder.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file/metadata_builder.rb
@@ -1,0 +1,112 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/github_actions/workflow_file"
+
+module Dependabot
+  module GithubActions
+    class WorkflowFile
+      class MetadataBuilder
+        extend T::Sig
+
+        sig { params(workflow_file: WorkflowFile).void }
+        def initialize(workflow_file)
+          @workflow_file = workflow_file
+        end
+
+        sig { params(declaration: UsesDeclaration).returns(Metadata) }
+        def build(declaration)
+          metadata = T.let(
+            {
+              path: declaration.path,
+              value: node_metadata(declaration.value_node),
+              target: node_metadata(declaration.source_node),
+              mapping: node_metadata(declaration.mapping_node)
+            },
+            Metadata
+          )
+
+          sequence = declaration.steps_sequence
+          if sequence
+            metadata[:sequence] = sequence_metadata(
+              sequence,
+              declaration.steps_key_node,
+              declaration.sequence_item_index
+            )
+          end
+
+          metadata
+        end
+
+        private
+
+        sig { returns(WorkflowFile) }
+        attr_reader :workflow_file
+
+        sig { params(node: T.nilable(Psych::Nodes::Node)).returns(Metadata) }
+        def node_metadata(node)
+          return {} unless node
+
+          metadata = T.let(
+            {
+              kind: node_kind(node),
+              start_line: workflow_file.node_start_line(node),
+              start_column: workflow_file.node_start_column(node),
+              end_line: workflow_file.node_end_line(node),
+              end_column: workflow_file.node_end_column(node)
+            },
+            Metadata
+          )
+
+          if node.is_a?(Psych::Nodes::Scalar)
+            metadata[:style] = scalar_style(workflow_file.scalar_node_style(node))
+            metadata[:anchor] = node.anchor if node.anchor
+          elsif node.is_a?(Psych::Nodes::Alias)
+            metadata[:anchor] = node.anchor
+          end
+
+          metadata
+        end
+
+        sig do
+          params(
+            sequence: Psych::Nodes::Sequence,
+            key_node: T.nilable(Psych::Nodes::Scalar),
+            item_index: T.nilable(Integer)
+          ).returns(Metadata)
+        end
+        def sequence_metadata(sequence, key_node, item_index)
+          metadata = node_metadata(sequence)
+          metadata[:style] =
+            workflow_file.sequence_node_style(sequence) == Psych::Nodes::Sequence::FLOW ? "flow" : "block"
+          metadata[:item_index] = item_index if item_index
+          metadata[:item_count] = workflow_file.node_children(sequence).length
+          metadata[:key_start_column] = workflow_file.node_start_column(key_node) if key_node
+          metadata
+        end
+
+        sig { params(node: Psych::Nodes::Node).returns(String) }
+        def node_kind(node)
+          case node
+          when Psych::Nodes::Alias then "alias"
+          when Psych::Nodes::Scalar then "scalar"
+          when Psych::Nodes::Mapping then "mapping"
+          when Psych::Nodes::Sequence then "sequence"
+          else "node"
+          end
+        end
+
+        sig { params(style: Integer).returns(String) }
+        def scalar_style(style)
+          case style
+          when Psych::Nodes::Scalar::SINGLE_QUOTED then "single_quoted"
+          when Psych::Nodes::Scalar::DOUBLE_QUOTED then "double_quoted"
+          when Psych::Nodes::Scalar::LITERAL then "literal"
+          when Psych::Nodes::Scalar::FOLDED then "folded"
+          else "plain"
+          end
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/workflow_file/metadata_builder.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file/metadata_builder.rb
@@ -38,6 +38,15 @@ module Dependabot
           metadata
         end
 
+        sig { params(sequence: Psych::Nodes::Sequence).returns(T::Boolean) }
+        def declarations_share_comment_line?(sequence)
+          nodes = workflow_file.declarations_in_sequence(sequence).filter_map do |item|
+            item.mapping_node || item.value_node
+          end
+          lines = nodes.map { |node| workflow_file.node_end_line(node) }
+          lines.length != lines.uniq.length
+        end
+
         private
 
         sig { returns(WorkflowFile) }

--- a/github_actions/lib/dependabot/github_actions/workflow_file/node_context.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file/node_context.rb
@@ -1,0 +1,64 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/github_actions/workflow_file"
+
+module Dependabot
+  module GithubActions
+    class WorkflowFile
+      class NodeContext
+        extend T::Sig
+
+        sig do
+          params(
+            node: Psych::Nodes::Node,
+            mapping_node: T.nilable(Psych::Nodes::Mapping),
+            key_node: T.nilable(Psych::Nodes::Scalar),
+            steps_sequence: T.nilable(Psych::Nodes::Sequence),
+            steps_key_node: T.nilable(Psych::Nodes::Scalar),
+            sequence_item: T.nilable(Psych::Nodes::Node),
+            sequence_item_index: T.nilable(Integer)
+          ).void
+        end
+        def initialize(
+          node:,
+          mapping_node:,
+          key_node:,
+          steps_sequence:,
+          steps_key_node:,
+          sequence_item:,
+          sequence_item_index:
+        )
+          @node = node
+          @mapping_node = mapping_node
+          @key_node = key_node
+          @steps_sequence = steps_sequence
+          @steps_key_node = steps_key_node
+          @sequence_item = sequence_item
+          @sequence_item_index = sequence_item_index
+        end
+
+        sig { returns(Psych::Nodes::Node) }
+        attr_reader :node
+
+        sig { returns(T.nilable(Psych::Nodes::Mapping)) }
+        attr_reader :mapping_node
+
+        sig { returns(T.nilable(Psych::Nodes::Scalar)) }
+        attr_reader :key_node
+
+        sig { returns(T.nilable(Psych::Nodes::Sequence)) }
+        attr_reader :steps_sequence
+
+        sig { returns(T.nilable(Psych::Nodes::Scalar)) }
+        attr_reader :steps_key_node
+
+        sig { returns(T.nilable(Psych::Nodes::Node)) }
+        attr_reader :sequence_item
+
+        sig { returns(T.nilable(Integer)) }
+        attr_reader :sequence_item_index
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/workflow_file/node_context.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file/node_context.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/github_actions/workflow_file"

--- a/github_actions/lib/dependabot/github_actions/workflow_file/uses_collector.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file/uses_collector.rb
@@ -1,0 +1,78 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/github_actions/workflow_file"
+
+module Dependabot
+  module GithubActions
+    class WorkflowFile
+      class UsesCollector
+        extend T::Sig
+
+        class ResolvedUse < T::Struct
+          const :value, String
+          const :path, Path
+        end
+
+        sig { params(data: T.nilable(Object)).void }
+        def initialize(data)
+          @data = data
+        end
+
+        sig { returns(T::Array[ResolvedUse]) }
+        def uses
+          root, path = workflow_root
+          return [] unless root && path
+
+          collect_uses(root, path)
+        end
+
+        private
+
+        sig { returns(T.nilable(Object)) }
+        attr_reader :data
+
+        sig { returns([T.nilable(Object), T.nilable(Path)]) }
+        def workflow_root
+          return [nil, nil] unless data.is_a?(Hash)
+
+          workflow_data = T.cast(data, T::Hash[Object, Object])
+          if workflow_data.key?("jobs")
+            [workflow_data["jobs"], ["jobs"]]
+          elsif workflow_data.key?("runs")
+            [workflow_data["runs"], ["runs"]]
+          else
+            [nil, nil]
+          end
+        end
+
+        sig { params(value: Object, path: Path).returns(T::Array[ResolvedUse]) }
+        def collect_uses(value, path)
+          case value
+          when Hash then collect_uses_from_hash(value, path)
+          when Array
+            value.each_with_index.flat_map do |child, index|
+              collect_uses(child, path + [index])
+            end
+          else
+            []
+          end
+        end
+
+        sig { params(value: T::Hash[Object, Object], path: Path).returns(T::Array[ResolvedUse]) }
+        def collect_uses_from_hash(value, path)
+          if value.key?(USES_KEY)
+            declaration_value = value[USES_KEY]
+            return [] unless declaration_value.is_a?(String)
+
+            [ResolvedUse.new(value: declaration_value, path: path + [USES_KEY])]
+          elsif value.key?(STEPS_KEY)
+            collect_uses(value[STEPS_KEY], path + [STEPS_KEY])
+          else
+            value.flat_map { |key, child| collect_uses(child, path + [key.to_s]) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/workflow_file/uses_declaration.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file/uses_declaration.rb
@@ -1,0 +1,76 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "dependabot/github_actions/workflow_file"
+
+module Dependabot
+  module GithubActions
+    class WorkflowFile
+      class UsesDeclaration
+        extend T::Sig
+
+        sig do
+          params(
+            value: String,
+            path: Path,
+            value_node: T.nilable(Psych::Nodes::Node),
+            source_node: T.nilable(Psych::Nodes::Node),
+            mapping_node: T.nilable(Psych::Nodes::Mapping),
+            steps_sequence: T.nilable(Psych::Nodes::Sequence),
+            steps_key_node: T.nilable(Psych::Nodes::Scalar),
+            sequence_item: T.nilable(Psych::Nodes::Node),
+            sequence_item_index: T.nilable(Integer)
+          ).void
+        end
+        def initialize(
+          value:,
+          path:,
+          value_node:,
+          source_node:,
+          mapping_node:,
+          steps_sequence:,
+          steps_key_node:,
+          sequence_item:,
+          sequence_item_index:
+        )
+          @value = value
+          @path = path
+          @value_node = value_node
+          @source_node = source_node
+          @mapping_node = mapping_node
+          @steps_sequence = steps_sequence
+          @steps_key_node = steps_key_node
+          @sequence_item = sequence_item
+          @sequence_item_index = sequence_item_index
+        end
+
+        sig { returns(String) }
+        attr_reader :value
+
+        sig { returns(Path) }
+        attr_reader :path
+
+        sig { returns(T.nilable(Psych::Nodes::Node)) }
+        attr_reader :value_node
+
+        sig { returns(T.nilable(Psych::Nodes::Node)) }
+        attr_reader :source_node
+
+        sig { returns(T.nilable(Psych::Nodes::Mapping)) }
+        attr_reader :mapping_node
+
+        sig { returns(T.nilable(Psych::Nodes::Sequence)) }
+        attr_reader :steps_sequence
+
+        sig { returns(T.nilable(Psych::Nodes::Scalar)) }
+        attr_reader :steps_key_node
+
+        sig { returns(T.nilable(Psych::Nodes::Node)) }
+        attr_reader :sequence_item
+
+        sig { returns(T.nilable(Integer)) }
+        attr_reader :sequence_item_index
+      end
+    end
+  end
+end

--- a/github_actions/lib/dependabot/github_actions/workflow_file/uses_declaration.rb
+++ b/github_actions/lib/dependabot/github_actions/workflow_file/uses_declaration.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/github_actions/workflow_file"

--- a/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
@@ -209,6 +209,30 @@ RSpec.describe Dependabot::GithubActions::FileParser do
       end
     end
 
+    context "with separate flow sequences sharing one line" do
+      let(:workflow_file_fixture_name) { "workflow_cross_sequence_collision.yml" }
+
+      it "records source metadata for both declarations" do
+        checkout = dependencies.find { |dependency| dependency.name == "actions/checkout" }
+        setup_node = dependencies.find { |dependency| dependency.name == "actions/setup-node" }
+        checkout_source = checkout&.requirements&.first&.metadata&.fetch(:yaml_source)
+        setup_node_source = setup_node&.requirements&.first&.metadata&.fetch(:yaml_source)
+
+        expect(checkout_source&.dig(:sequence, :style)).to eq("flow")
+        expect(setup_node_source&.dig(:sequence, :style)).to eq("flow")
+        expect(checkout_source&.dig(:mapping, :end_line)).to eq(setup_node_source&.dig(:mapping, :end_line))
+      end
+    end
+
+    context "with an aliased whole step" do
+      let(:workflow_file_fixture_name) { "workflow_step_alias.yml" }
+
+      it "parses without requiring a physical uses node for the alias" do
+        expect { dependencies }.not_to raise_error
+        expect(dependencies.map(&:name)).to include("actions/checkout")
+      end
+    end
+
     context "with repeated actions in one flow sequence" do
       subject(:requirements) { dependencies.first.requirements }
 

--- a/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_parser_spec.rb
@@ -166,6 +166,79 @@ RSpec.describe Dependabot::GithubActions::FileParser do
       end
     end
 
+    context "with aliases and block scalars" do
+      subject(:requirements) { dependencies.first.requirements }
+
+      let(:workflow_file_fixture_name) { "workflow_source_forms.yml" }
+
+      it "records each source form separately" do
+        expect(requirements.length).to eq(4)
+
+        alias_source = requirements.find do |requirement|
+          requirement.metadata&.dig(:yaml_source, :path) == ["jobs", "alias", "steps", 0, "uses"]
+        end
+        block_source = requirements.find do |requirement|
+          requirement.metadata&.dig(:yaml_source, :path) == ["jobs", "block", "steps", 0, "uses"]
+        end
+        literal_source = requirements.find do |requirement|
+          requirement.metadata&.dig(:yaml_source, :path) == ["jobs", "literal", "steps", 0, "uses"]
+        end
+        escaped_source = requirements.find do |requirement|
+          requirement.metadata&.dig(:yaml_source, :path) == ["jobs", "escaped", "steps", 0, "uses"]
+        end
+
+        expect(alias_source&.metadata&.dig(:yaml_source, :value, :kind)).to eq("alias")
+        expect(alias_source&.metadata&.dig(:yaml_source, :target, :anchor)).to eq("checkout")
+        expect(block_source&.metadata&.dig(:yaml_source, :target, :style)).to eq("folded")
+        expect(literal_source&.metadata&.dig(:yaml_source, :target, :style)).to eq("literal")
+        expect(escaped_source&.metadata&.dig(:yaml_source, :target, :style)).to eq("double_quoted")
+      end
+    end
+
+    context "with different actions in one flow sequence" do
+      let(:workflow_file_fixture_name) { "workflow_multiple_actions_flow.yml" }
+
+      it "records the enclosing sequence and item index" do
+        checkout = dependencies.find { |dependency| dependency.name == "actions/checkout" }
+        setup_node = dependencies.find { |dependency| dependency.name == "actions/setup-node" }
+
+        checkout_sources = checkout&.requirements&.map { |requirement| requirement.metadata&.fetch(:yaml_source) }
+        expect(checkout_sources&.map { |source| source&.dig(:sequence, :style) }).to eq(%w(flow flow))
+        expect(checkout_sources&.map { |source| source&.dig(:sequence, :item_index) }).to eq([1, 2])
+        expect(setup_node&.requirements&.first&.metadata&.dig(:yaml_source, :sequence, :item_index)).to eq(3)
+      end
+    end
+
+    context "with repeated actions in one flow sequence" do
+      subject(:requirements) { dependencies.first.requirements }
+
+      let(:workflow_file_fixture_name) { "workflow_repeated_actions_flow.yml" }
+
+      it "keeps one requirement per YAML path" do
+        expect(requirements.map { |requirement| requirement.metadata&.dig(:yaml_source, :path) }).to eq(
+          [
+            ["jobs", "update", "steps", 0, "uses"],
+            ["jobs", "update", "steps", 1, "uses"]
+          ]
+        )
+        expect(
+          a_request(:get, "https://github.com/actions/checkout.git/info/refs?service=git-upload-pack")
+        ).to have_been_made.once
+      end
+    end
+
+    context "with a reused anchor name" do
+      let(:workflow_file_fixture_name) { "workflow_reused_anchors.yml" }
+
+      it "links each alias to the preceding anchor definition" do
+        checkout = dependencies.find { |dependency| dependency.name == "actions/checkout" }
+        setup_node = dependencies.find { |dependency| dependency.name == "actions/setup-node" }
+
+        expect(checkout&.requirements&.first&.metadata&.dig(:yaml_source, :target, :start_line)).to eq(6)
+        expect(setup_node&.requirements&.first&.metadata&.dig(:yaml_source, :target, :start_line)).to eq(10)
+      end
+    end
+
     describe "with multiple sources pinned to different refs, and newest ref parsed first" do
       subject(:dependency) { dependencies.first }
 

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -7,6 +7,7 @@ require "dependabot/dependency_file"
 require "dependabot/source"
 require "dependabot/github_actions/file_updater"
 require "dependabot/github_actions/version"
+require "yaml"
 require_common_spec "file_updaters/shared_examples_for_file_updaters"
 
 RSpec.describe Dependabot::GithubActions::FileUpdater do
@@ -800,6 +801,175 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
           expect(updated_workflow_file.content).not_to include("# get-vault-secrets/v0.2.2")
         end
       end
+
+      context "when transitioning from a version tag to a SHA pin" do
+        let(:service_pack_url) do
+          "https://github.com/actions/checkout.git/info/refs" \
+            "?service=git-upload-pack"
+        end
+        let(:workflow_file_body) { fixture("workflow_files", "pin_to_sha.yml") }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/checkout",
+                ref: "v2.1.0",
+                branch: nil
+              },
+              metadata: { declaration_string: "actions/checkout@v2.1.0" }
+            }],
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/checkout",
+                ref: "aabbfeb2ce60b5bd82389903509092c4648a9713",
+                branch: nil
+              },
+              metadata: {
+                declaration_string: "actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713"
+              }
+            }]
+          )
+        end
+
+        before do
+          stub_request(:get, service_pack_url)
+            .to_return(
+              status: 200,
+              body: fixture("git", "upload_packs", "checkout"),
+              headers: {
+                "content-type" => "application/x-git-upload-pack-advertisement"
+              }
+            )
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_call_original
+        end
+
+        it "adds the concrete version after block-style declarations" do
+          expect(updated_workflow_file.content).to include(
+            "uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 # v2.2.0"
+          )
+          expect(updated_workflow_file.content).to include(
+            'uses: "actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713" # v2.2.0'
+          )
+          expect(updated_workflow_file.content).to include(
+            "uses: 'actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713' # v2.2.0"
+          )
+        end
+
+        it "updates an existing version comment without duplicating it" do
+          expect(updated_workflow_file.content).not_to include("# v2.1.0")
+          expect(updated_workflow_file.content).not_to include("# v2.1.0 # v2.2.0")
+        end
+
+        it "preserves custom comments without appending a version" do
+          expect(updated_workflow_file.content).to include(
+            "actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 # keep this custom note"
+          )
+          expect(updated_workflow_file.content).not_to include("# keep this custom note # v2.2.0")
+        end
+
+        it "places comments after flow-style mappings" do
+          expect(updated_workflow_file.content).to include(
+            "- { uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 } # v2.2.0"
+          )
+          expect(updated_workflow_file.content).to include(
+            '- { name: Checkout, uses: "actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713" } # v2.2.0'
+          )
+        end
+
+        it "keeps the rewritten workflow valid YAML" do
+          expect { YAML.safe_load(T.must(updated_workflow_file.content), aliases: true) }.not_to raise_error
+        end
+
+        it "reuses one git checker for all declarations" do
+          updated_workflow_file
+
+          expect(Dependabot::GitCommitChecker).to have_received(:new).once
+        end
+
+        context "when the old ref is a floating tag" do
+          let(:dependency) do
+            Dependabot::Dependency.new(
+              name: "actions/checkout",
+              version: "3.5.2",
+              previous_version: "2",
+              package_manager: "github_actions",
+              previous_requirements: [{
+                requirement: nil,
+                groups: [],
+                file: ".github/workflows/workflow.yml",
+                source: {
+                  type: "git",
+                  url: "https://github.com/actions/checkout",
+                  ref: "v2",
+                  branch: nil
+                },
+                metadata: { declaration_string: "actions/checkout@v2" }
+              }],
+              requirements: [{
+                requirement: nil,
+                groups: [],
+                file: ".github/workflows/workflow.yml",
+                source: {
+                  type: "git",
+                  url: "https://github.com/actions/checkout",
+                  ref: "8e5e7e5ab8b370d6c329ec480221332ada57f0ab",
+                  branch: nil
+                },
+                metadata: {
+                  declaration_string: "actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab"
+                }
+              }]
+            )
+          end
+
+          it "replaces the concrete version represented by the floating tag" do
+            expect(updated_workflow_file.content).to include(
+              "actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2"
+            )
+            expect(updated_workflow_file.content).not_to include("# v2.7.0")
+          end
+        end
+
+        context "when the new SHA has no matching version tag" do
+          let(:workflow_file_body) do
+            <<~YAML
+              on: [push]
+              jobs:
+                pin:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: actions/checkout@v2.1.0
+            YAML
+          end
+          let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+          before do
+            allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+            allow(git_checker).to receive_messages(
+              ref_looks_like_commit_sha?: true,
+              most_specific_version_tag_for_sha: nil
+            )
+          end
+
+          it "updates the ref without inventing a comment" do
+            expect(updated_workflow_file.content).to include(
+              "uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713\n"
+            )
+          end
+        end
+      end
     end
 
     # Stub the CLI boundary so the wiring stays hermetic. When an actions.lock
@@ -884,6 +1054,105 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
 
         expect(fake_engine).to have_received(:relock) do |workflow_files:, **|
           expect(workflow_files.find { |file| file.name == workflow.name }).to equal(workflow)
+        end
+      end
+
+      context "when the workflow is converted from a tag to a SHA" do
+        let(:sha) { "5273d0df9c603edc4284ac8402cf650b4f1f6686" }
+        let(:workflow_file_body) do
+          <<~YAML
+            on: [push]
+            jobs:
+              pin:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/setup-node@v1
+          YAML
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/setup-node",
+            version: "1.1.0",
+            previous_version: "1",
+            package_manager: "github_actions",
+            previous_requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/setup-node",
+                ref: "v1",
+                branch: nil
+              },
+              metadata: { declaration_string: "actions/setup-node@v1" }
+            }],
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/setup-node",
+                ref: sha,
+                branch: nil
+              },
+              metadata: { declaration_string: "actions/setup-node@#{sha}" }
+            }]
+          )
+        end
+        let(:lockfile) do
+          Dependabot::DependencyFile.new(
+            name: ".github/workflows/actions.lock",
+            content: <<~LOCK
+              version: v0.0.2
+              workflows:
+                ".github/workflows/workflow.yml":
+                  - "actions/setup-node@v1"
+              dependencies:
+                "actions/setup-node@v1":
+                  ref: v1
+                  commit: sha1-#{sha}
+                  owner_id: 44036562
+                  repo_id: 167274481
+            LOCK
+          )
+        end
+        let(:relocked_lock_content) do
+          <<~LOCK
+            version: v0.0.2
+            workflows:
+              ".github/workflows/workflow.yml":
+                - "actions/setup-node@#{sha}"
+            dependencies:
+              "actions/setup-node@#{sha}":
+                ref: #{sha}
+                commit: sha1-#{sha}
+                owner_id: 44036562
+                repo_id: 167274481
+          LOCK
+        end
+
+        before do
+          stub_request(
+            :get,
+            "https://github.com/actions/setup-node.git/info/refs?service=git-upload-pack"
+          ).to_return(
+            status: 200,
+            body: fixture("git", "upload_packs", "setup-node"),
+            headers: {
+              "content-type" => "application/x-git-upload-pack-advertisement"
+            }
+          )
+        end
+
+        it "passes the SHA-rewritten workflow to the relock engine" do
+          updated_files
+
+          expect(fake_engine).to have_received(:relock) do |workflow_files:, **|
+            workflow = workflow_files.find { |file| file.name == ".github/workflows/workflow.yml" }
+            expect(workflow.content).to include("actions/setup-node@#{sha} # v1.1.0")
+          end
         end
       end
 

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -67,6 +67,24 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
     )
   end
 
+  def flow_requirement(name, ref, path)
+    {
+      requirement: nil,
+      groups: [],
+      file: ".github/workflows/workflow.yml",
+      source: {
+        type: "git",
+        url: "https://github.com/#{name}",
+        ref: ref,
+        branch: nil
+      },
+      metadata: {
+        declaration_string: "#{name}@#{ref}",
+        yaml_source: { path: path }
+      }
+    }
+  end
+
   it_behaves_like "a dependency file updater"
 
   describe "#updated_dependency_files" do
@@ -1008,6 +1026,302 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
               "uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713\n"
             )
           end
+        end
+      end
+
+      context "with aliases and block scalars" do
+        let(:workflow_file_body) do
+          fixture("workflow_files", "workflow_source_forms.yml").gsub("\n", "\r\n")
+        end
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          previous_requirements = [
+            ["jobs", "alias", "steps", 0, "uses"],
+            ["jobs", "block", "steps", 0, "uses"],
+            ["jobs", "literal", "steps", 0, "uses"],
+            ["jobs", "escaped", "steps", 0, "uses"]
+          ].map do |path|
+            declaration = path[1] == "literal" ? "actions/checkout@v2.1.0\n" : "actions/checkout@v2.1.0"
+            {
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/checkout",
+                ref: "v2.1.0",
+                branch: nil
+              },
+              metadata: {
+                declaration_string: declaration,
+                yaml_source: { path: path }
+              }
+            }
+          end
+          requirements = previous_requirements.map do |requirement|
+            requirement.merge(source: requirement.fetch(:source).merge(ref: sha))
+          end
+
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: previous_requirements,
+            requirements: requirements
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "updates the original scalar or anchor and comments each uses entry" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("CHECKOUT_ACTION: &checkout \"actions/checkout@#{sha}\"")
+          expect(content).to include("- uses: *checkout # v2.2.0")
+          expect(content).to include("- uses: >- # v2.2.0")
+          expect(content).to include("- uses: | # v2.2.0")
+          expect(content).to include("- uses: \"actions/checkout@#{sha}\" # v2.2.0")
+          expect(content).to include("    actions/checkout@#{sha}")
+          expect(content).to include("\r\n")
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+        end
+      end
+
+      context "with different actions in one flow sequence" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_multiple_actions_flow.yml") }
+        let(:checkout_sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:setup_node_sha) { "5273d0df9c603edc4284ac8402cf650b4f1f6686" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "inline", "steps", 1, "uses"]),
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "inline", "steps", 2, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", checkout_sha, ["jobs", "inline", "steps", 1, "uses"]),
+              flow_requirement("actions/checkout", checkout_sha, ["jobs", "inline", "steps", 2, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) do |ref|
+            [checkout_sha, setup_node_sha].include?(ref)
+          end
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha) do |ref|
+            ref == checkout_sha ? "v2.2.0" : "v3.1.0"
+          end
+        end
+
+        it "gives each action its own version comment across successive updates" do
+          first_content = T.must(updated_workflow_file.content)
+
+          expect(first_content).to include(
+            "steps: &shared [\n" \
+            "      { name: \"🚀\", run: echo, env: { ACTION: &checkout actions/checkout@#{checkout_sha}, " \
+            "SECOND: &checkout2 actions/checkout@#{checkout_sha} } },\n" \
+            "      { uses: *checkout }, # v2.2.0\n" \
+            "      { uses: *checkout2 }, # v2.2.0\n" \
+            "      { name: \"Node 🚀\", uses: actions/setup-node@v3.0.0 }\n" \
+            "    ]"
+          )
+          expect(first_content).not_to include("# v2.1.0")
+
+          second_file = Dependabot::DependencyFile.new(
+            content: first_content,
+            name: ".github/workflows/workflow.yml"
+          )
+          second_dependency = Dependabot::Dependency.new(
+            name: "actions/setup-node",
+            version: "3.1.0",
+            previous_version: "3.0.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/setup-node", "v3.0.0", ["jobs", "inline", "steps", 3, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/setup-node", setup_node_sha, ["jobs", "inline", "steps", 3, "uses"])
+            ]
+          )
+          second_updater = described_class.new(
+            dependency_files: [second_file],
+            dependencies: [second_dependency],
+            credentials: credentials
+          )
+          second_content = T.must(second_updater.updated_dependency_files.first.content)
+
+          expect(second_content).to include(
+            "{ uses: *checkout }, # v2.2.0"
+          )
+          expect(second_content).to include(
+            "{ uses: *checkout2 }, # v2.2.0"
+          )
+          expect(second_content).to include(
+            "{ name: \"Node 🚀\", uses: actions/setup-node@#{setup_node_sha} } # v3.1.0"
+          )
+          expect { YAML.safe_load(second_content, aliases: true) }.not_to raise_error
+        end
+
+        context "when the new SHA has no version tag" do
+          before do
+            allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(checkout_sha).and_return(nil)
+          end
+
+          it "removes the stale sequence comment" do
+            content = T.must(updated_workflow_file.content)
+
+            expect(content).to include("actions/checkout@#{checkout_sha}")
+            expect(content).not_to include("# v2.1.0")
+            expect(content).not_to include("# v2.2.0")
+          end
+        end
+      end
+
+      context "with a reused anchor name" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_reused_anchors.yml") }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "first", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", sha, ["jobs", "first", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "updates the anchor that precedes the matching alias" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("ACTION: &pin actions/checkout@#{sha}")
+          expect(content).to include("ACTION: &pin actions/setup-node@v3.0.0")
+          expect(content).to include("steps: [{ uses: *pin }] # v2.2.0")
+        end
+      end
+
+      context "with one anchor shared across flow sequences" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_shared_anchor_sequences.yml") }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "first", "steps", 0, "uses"]),
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "second", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", sha, ["jobs", "first", "steps", 0, "uses"]),
+              flow_requirement("actions/checkout", sha, ["jobs", "second", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "updates the anchor once and comments both aliases" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("{ uses: &pin actions/checkout@#{sha} }, # v2.2.0")
+          expect(content).to include("{ uses: *pin }, # v2.2.0")
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+        end
+      end
+
+      context "when pinning the same action across workflow files" do
+        let(:workflow_file_body) do
+          <<~YAML
+            on: [push]
+            jobs:
+              build:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v2.1.0
+          YAML
+        end
+        let(:second_workflow_file) do
+          Dependabot::DependencyFile.new(
+            content: workflow_file_body,
+            name: ".github/workflows/second.yml"
+          )
+        end
+        let(:files) { [workflow_file, second_workflow_file] }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          previous_requirements = [workflow_file.name, second_workflow_file.name].map do |file_name|
+            {
+              requirement: nil,
+              groups: [],
+              file: file_name,
+              source: {
+                type: "git",
+                url: "https://github.com/actions/checkout",
+                ref: "v2.1.0",
+                branch: nil
+              },
+              metadata: { declaration_string: "actions/checkout@v2.1.0" }
+            }
+          end
+          requirements = previous_requirements.map do |requirement|
+            requirement.merge(source: requirement.fetch(:source).merge(ref: sha))
+          end
+
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: previous_requirements,
+            requirements: requirements
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "reuses one git checker" do
+          expect(updated_files.length).to eq(2)
+          expect(Dependabot::GitCommitChecker).to have_received(:new).once
         end
       end
     end

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -100,6 +100,17 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
 
       its(:content) { is_expected.to include "actions/checkout@master\n" }
 
+      context "with multiple matching declarations on one line" do
+        let(:workflow_file_body) { fixture("workflow_files", "multiple_uses_same_line.yml") }
+
+        it "updates every uses value without changing unrelated matching text" do
+          expect(updated_workflow_file.content).to include(
+            "steps: [{ uses: actions/setup-node@v1.1.0 }, " \
+            "{ uses: actions/setup-node@v1.1.0, with: { source: actions/setup-node@master } }]"
+          )
+        end
+      end
+
       context "with a path" do
         let(:workflow_file_body) do
           fixture("workflow_files", "workflow_monorepo.yml")
@@ -885,6 +896,35 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
           )
           expect(updated_workflow_file.content).to include(
             '- { name: Checkout, uses: "actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713" } # v2.2.0'
+          )
+        end
+
+        it "ignores hashes inside quoted flow-style values when detecting comments" do
+          expect(updated_workflow_file.content).to include(
+            '- { uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713, name: "Checkout #1" } # v2.2.0'
+          )
+          expect(updated_workflow_file.content).to include(
+            "- { uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713, " \
+            'name: "Checkout \"#1\"" } # v2.2.0'
+          )
+          expect(updated_workflow_file.content).to include(
+            "- { uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713, " \
+            "name: 'Checkout #1' } # v2.2.0"
+          )
+        end
+
+        it "only rewrites the matched declaration in a flow-style mapping" do
+          expect(updated_workflow_file.content).to include(
+            "- { uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713, " \
+            "with: { source: actions/checkout@v2.1.0 } } # v2.2.0"
+          )
+        end
+
+        it "updates every uses declaration on a flow-style line" do
+          expect(updated_workflow_file.content).to include(
+            "steps: [{ uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713 }, " \
+            "{ uses: actions/checkout@aabbfeb2ce60b5bd82389903509092c4648a9713, " \
+            "with: { source: actions/checkout@v2.1.0 } }] # v2.2.0"
           )
         end
 

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -1191,6 +1191,120 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
         end
       end
 
+      context "with actions sharing a line in a multiline flow sequence" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_multiline_flow_collision.yml") }
+        let(:checkout_sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:setup_node_sha) { "5273d0df9c603edc4284ac8402cf650b4f1f6686" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "inline", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", checkout_sha, ["jobs", "inline", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) do |ref|
+            [checkout_sha, setup_node_sha].include?(ref)
+          end
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha) do |ref|
+            ref == checkout_sha ? "v2.2.0" : "v3.1.0"
+          end
+        end
+
+        it "expands the sequence and preserves comments across successive updates" do
+          first_content = T.must(updated_workflow_file.content)
+
+          expect(first_content).to include(
+            "steps: [\n" \
+            "      { uses: actions/checkout@#{checkout_sha} }, # v2.2.0\n" \
+            "      { uses: actions/setup-node@v3.0.0 },\n" \
+            "      { run: echo done }\n" \
+            "    ]"
+          )
+
+          second_file = Dependabot::DependencyFile.new(
+            content: first_content,
+            name: ".github/workflows/workflow.yml"
+          )
+          second_dependency = Dependabot::Dependency.new(
+            name: "actions/setup-node",
+            version: "3.1.0",
+            previous_version: "3.0.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/setup-node", "v3.0.0", ["jobs", "inline", "steps", 1, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/setup-node", setup_node_sha, ["jobs", "inline", "steps", 1, "uses"])
+            ]
+          )
+          second_updater = described_class.new(
+            dependency_files: [second_file],
+            dependencies: [second_dependency],
+            credentials: credentials
+          )
+          second_content = T.must(second_updater.updated_dependency_files.first.content)
+
+          expect(second_content).to include(
+            "{ uses: actions/checkout@#{checkout_sha} }, # v2.2.0"
+          )
+          expect(second_content).to include(
+            "{ uses: actions/setup-node@#{setup_node_sha} }, # v3.1.0"
+          )
+          expect { YAML.safe_load(second_content, aliases: true) }.not_to raise_error
+        end
+      end
+
+      context "with actions on separate lines in a multiline flow sequence" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_multiline_flow_separate.yml") }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "inline", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", sha, ["jobs", "inline", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "keeps the existing multiline flow layout" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include(
+            "steps: [\n" \
+            "      { uses: actions/checkout@#{sha} }, # v2.2.0\n" \
+            "      { uses: actions/setup-node@v3.0.0 }\n" \
+            "    ]"
+          )
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+        end
+      end
+
       context "with a reused anchor name" do
         let(:workflow_file_body) { fixture("workflow_files", "workflow_reused_anchors.yml") }
         let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -1341,10 +1341,12 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
 
           expect(content).to include(
             "steps: [\n" \
+            "      # keep this leading note\n" \
             "      { uses: actions/checkout@#{sha} }, # v2.2.0\n" \
             "      { uses: actions/setup-node@v3.0.0 }, # keep this note\n" \
             "      # keep this standalone note\n" \
             "      { run: echo done } # keep this final note\n" \
+            "      # keep this closing note\n" \
             "    ]"
           )
           expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
@@ -1426,6 +1428,500 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
             expect(content).not_to include("# v2.1.0")
             expect(content).not_to include("# v2.2.0")
           end
+        end
+      end
+
+      context "when a flow sequence is updated from SHA to SHA without a comment" do
+        let(:old_sha) { "01aecccf739ca6ff86c0539fbc67a7a5007bbc81" }
+        let(:new_sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:workflow_file_body) do
+          fixture("workflow_files", "workflow_multiline_flow_collision.yml")
+            .sub("actions/checkout@v2.1.0", "actions/checkout@#{old_sha}")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", old_sha, ["jobs", "inline", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", new_sha, ["jobs", "inline", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?).and_return(true)
+          allow(git_checker).to receive(:most_specific_version_tags_for_sha).with(old_sha).and_return(["v2.1.0"])
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(new_sha).and_return("v2.2.0")
+        end
+
+        it "does not invent a version comment" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("actions/checkout@#{new_sha}")
+          expect(content).not_to include("# v2.2.0")
+        end
+
+        context "with an existing sequence-level version comment" do
+          let(:workflow_file_body) do
+            super().sub("    ]\n", "    ] # v2.1.0\n")
+          end
+
+          it "moves and updates the existing comment" do
+            content = T.must(updated_workflow_file.content)
+
+            expect(content).to include("actions/checkout@#{new_sha} }, # v2.2.0")
+            expect(content).not_to include("# v2.1.0")
+          end
+        end
+      end
+
+      context "with a sequence-level comment and no declaration collision" do
+        let(:old_sha) { "01aecccf739ca6ff86c0539fbc67a7a5007bbc81" }
+        let(:new_sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_noncolliding_sequence_comment.yml") }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", old_sha, ["jobs", "inline", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", new_sha, ["jobs", "inline", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?).and_return(true)
+          allow(git_checker).to receive(:most_specific_version_tags_for_sha).with(old_sha).and_return(["v2.1.0"])
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(new_sha).and_return("v2.2.0")
+        end
+
+        it "moves the updated comment beside the matching action" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("actions/checkout@#{new_sha} }, # v2.2.0")
+          expect(content).not_to include("] # v2.1.0")
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+        end
+      end
+
+      context "when an alias is updated from SHA to SHA without a comment" do
+        let(:old_sha) { "01aecccf739ca6ff86c0539fbc67a7a5007bbc81" }
+        let(:new_sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:workflow_file_body) do
+          fixture("workflow_files", "workflow_source_forms.yml")
+            .gsub("actions\\x2Fcheckout@v2.1.0", "actions\\x2Fcheckout@#{old_sha}")
+            .gsub("actions/checkout@v2.1.0", "actions/checkout@#{old_sha}")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/checkout",
+                ref: old_sha,
+                branch: nil
+              },
+              metadata: {
+                declaration_string: "actions/checkout@#{old_sha}",
+                yaml_source: { path: ["jobs", "alias", "steps", 0, "uses"] }
+              }
+            }],
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/checkout",
+                ref: new_sha,
+                branch: nil
+              },
+              metadata: {
+                declaration_string: "actions/checkout@#{old_sha}",
+                yaml_source: { path: ["jobs", "alias", "steps", 0, "uses"] }
+              }
+            }]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?).and_return(true)
+          allow(git_checker).to receive(:most_specific_version_tags_for_sha).with(old_sha).and_return(["v2.1.0"])
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(new_sha).and_return("v2.2.0")
+        end
+
+        it "does not invent a version comment" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("CHECKOUT_ACTION: &checkout \"actions/checkout@#{new_sha}\"")
+          expect(content).not_to include("*checkout # v2.2.0")
+        end
+
+        context "with an existing alias version comment" do
+          let(:workflow_file_body) do
+            super().sub("- uses: *checkout", "- uses: *checkout # v2.1.0")
+          end
+
+          it "updates the existing comment" do
+            content = T.must(updated_workflow_file.content)
+
+            expect(content).to include("*checkout # v2.2.0")
+            expect(content).not_to include("# v2.1.0")
+          end
+        end
+      end
+
+      context "when a block scalar SHA pin has an existing version comment" do
+        let(:old_sha) { "01aecccf739ca6ff86c0539fbc67a7a5007bbc81" }
+        let(:new_sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:workflow_file_body) do
+          fixture("workflow_files", "workflow_source_forms.yml")
+            .gsub("actions/checkout@v2.1.0", "actions/checkout@#{old_sha}")
+            .sub("- uses: >-", "- uses: >- # v2.1.0")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/checkout",
+                ref: old_sha,
+                branch: nil
+              },
+              metadata: {
+                declaration_string: "actions/checkout@#{old_sha}",
+                yaml_source: { path: ["jobs", "block", "steps", 0, "uses"] }
+              }
+            }],
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: ".github/workflows/workflow.yml",
+              source: {
+                type: "git",
+                url: "https://github.com/actions/checkout",
+                ref: new_sha,
+                branch: nil
+              },
+              metadata: {
+                declaration_string: "actions/checkout@#{old_sha}",
+                yaml_source: { path: ["jobs", "block", "steps", 0, "uses"] }
+              }
+            }]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?).and_return(true)
+          allow(git_checker).to receive(:most_specific_version_tags_for_sha).with(old_sha).and_return(["v2.1.0"])
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(new_sha).and_return("v2.2.0")
+        end
+
+        it "updates the scalar and its header comment" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("- uses: >- # v2.2.0")
+          expect(content).to include("actions/checkout@#{new_sha}")
+          expect(content).not_to include("# v2.1.0")
+        end
+      end
+
+      context "with separate flow sequences sharing one line" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_cross_sequence_collision.yml") }
+        let(:checkout_sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:setup_node_sha) { "5273d0df9c603edc4284ac8402cf650b4f1f6686" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "first", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", checkout_sha, ["jobs", "first", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) do |ref|
+            [checkout_sha, setup_node_sha].include?(ref)
+          end
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha) do |ref|
+            ref == checkout_sha ? "v2.2.0" : "v3.1.0"
+          end
+        end
+
+        it "expands every colliding sequence and keeps comments separate across updates" do
+          first_content = T.must(updated_workflow_file.content)
+
+          expect(first_content.scan("steps: [\n").length).to eq(2)
+          expect(first_content).to include("# keep this sequence note")
+          expect(first_content).to include("actions/checkout@#{checkout_sha} } # v2.2.0")
+
+          second_file = Dependabot::DependencyFile.new(
+            content: first_content,
+            name: ".github/workflows/workflow.yml"
+          )
+          second_dependency = Dependabot::Dependency.new(
+            name: "actions/setup-node",
+            version: "3.1.0",
+            previous_version: "3.0.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/setup-node", "v3.0.0", ["jobs", "second", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/setup-node", setup_node_sha, ["jobs", "second", "steps", 0, "uses"])
+            ]
+          )
+          second_updater = described_class.new(
+            dependency_files: [second_file],
+            dependencies: [second_dependency],
+            credentials: credentials
+          )
+          second_content = T.must(second_updater.updated_dependency_files.first.content)
+
+          expect(second_content).to include("actions/checkout@#{checkout_sha} } # v2.2.0")
+          expect(second_content).to include("actions/setup-node@#{setup_node_sha} } # v3.1.0")
+          expect { YAML.safe_load(second_content, aliases: true) }.not_to raise_error
+        end
+      end
+
+      context "with a comment inside a later colliding sequence" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_cross_sequence_comment.yml") }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "first", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", sha, ["jobs", "first", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "does not overlap the later sequence replacement" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("actions/checkout@#{sha} } # v2.2.0")
+          expect(content).to include("actions/setup-node@v3.0.0 }, # v2.1.0")
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+        end
+      end
+
+      context "with a prior line-end comment after colliding sequences" do
+        let(:old_sha) { "01aecccf739ca6ff86c0539fbc67a7a5007bbc81" }
+        let(:new_sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:workflow_file_body) do
+          fixture("workflow_files", "workflow_cross_sequence_collision.yml")
+            .sub("actions/checkout@v2.1.0", "actions/checkout@#{old_sha}")
+            .sub(" } }\n", " } } # v2.1.0\n")
+        end
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", old_sha, ["jobs", "first", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", new_sha, ["jobs", "first", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?).and_return(true)
+          allow(git_checker).to receive(:most_specific_version_tags_for_sha).with(old_sha).and_return(["v2.1.0"])
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(new_sha).and_return("v2.2.0")
+        end
+
+        it "moves and updates the prior line-end comment" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("actions/checkout@#{new_sha} } # v2.2.0")
+          expect(content).not_to include("# v2.1.0")
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+        end
+      end
+
+      context "with a reusable workflow sharing a line with a step sequence" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_reusable_collision.yml") }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout/.github/workflows/test.yml",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement(
+                "actions/checkout/.github/workflows/test.yml",
+                "v2.1.0",
+                %w(jobs reusable uses)
+              )
+            ],
+            requirements: [
+              flow_requirement(
+                "actions/checkout/.github/workflows/test.yml",
+                sha,
+                %w(jobs reusable uses)
+              )
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "keeps the version comment beside the reusable workflow" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include(
+            "reusable: { uses: actions/checkout/.github/workflows/test.yml@#{sha} } # v2.2.0\n"
+          )
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+        end
+      end
+
+      context "with an action followed by a commented run step on one line" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_action_run_collision.yml") }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "build", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", sha, ["jobs", "build", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "expands the sequence without appending to the run comment" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include("actions/checkout@#{sha} }, # v2.2.0")
+          expect(content).to include("{ run: echo done } # keep run note")
+          expect(content).not_to include("# keep run note # v2.2.0")
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+        end
+      end
+
+      context "with a reusable workflow followed by run-only flow sequences" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_reusable_run_collision.yml") }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout/.github/workflows/test.yml",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement(
+                "actions/checkout/.github/workflows/test.yml",
+                "v2.1.0",
+                %w(jobs reusable uses)
+              )
+            ],
+            requirements: [
+              flow_requirement(
+                "actions/checkout/.github/workflows/test.yml",
+                sha,
+                %w(jobs reusable uses)
+              )
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "uses the same collision predicate for expansion and comment relocation" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include(
+            "reusable: { uses: actions/checkout/.github/workflows/test.yml@#{sha} } # v2.2.0\n"
+          )
+          expect(content).to include("# keep second note")
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
         end
       end
 

--- a/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/file_updater_spec.rb
@@ -1305,6 +1305,130 @@ RSpec.describe Dependabot::GithubActions::FileUpdater do
         end
       end
 
+      context "with comments between flow sequence items" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_flow_trivia.yml") }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:setup_node_sha) { "5273d0df9c603edc4284ac8402cf650b4f1f6686" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "inline", "steps", 0, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", sha, ["jobs", "inline", "steps", 0, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) do |ref|
+            [sha, setup_node_sha].include?(ref)
+          end
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha) do |ref|
+            ref == sha ? "v2.2.0" : "v3.1.0"
+          end
+        end
+
+        it "preserves custom, standalone, and final-item comments" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content).to include(
+            "steps: [\n" \
+            "      { uses: actions/checkout@#{sha} }, # v2.2.0\n" \
+            "      { uses: actions/setup-node@v3.0.0 }, # keep this note\n" \
+            "      # keep this standalone note\n" \
+            "      { run: echo done } # keep this final note\n" \
+            "    ]"
+          )
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+
+          second_file = Dependabot::DependencyFile.new(
+            content: content,
+            name: ".github/workflows/workflow.yml"
+          )
+          second_dependency = Dependabot::Dependency.new(
+            name: "actions/setup-node",
+            version: "3.1.0",
+            previous_version: "3.0.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/setup-node", "v3.0.0", ["jobs", "inline", "steps", 1, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/setup-node", setup_node_sha, ["jobs", "inline", "steps", 1, "uses"])
+            ]
+          )
+          second_updater = described_class.new(
+            dependency_files: [second_file],
+            dependencies: [second_dependency],
+            credentials: credentials
+          )
+          second_content = T.must(second_updater.updated_dependency_files.first.content)
+
+          expect(second_content).to include(
+            "{ uses: actions/setup-node@#{setup_node_sha} }, # keep this note"
+          )
+          expect(second_content).not_to include("# v3.1.0")
+        end
+      end
+
+      context "with an existing version comment between flow sequence items" do
+        let(:workflow_file_body) { fixture("workflow_files", "workflow_flow_version_comment.yml") }
+        let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "actions/checkout",
+            version: "2.2.0",
+            previous_version: "2.1.0",
+            package_manager: "github_actions",
+            previous_requirements: [
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "inline", "steps", 0, "uses"]),
+              flow_requirement("actions/checkout", "v2.1.0", ["jobs", "inline", "steps", 1, "uses"])
+            ],
+            requirements: [
+              flow_requirement("actions/checkout", sha, ["jobs", "inline", "steps", 0, "uses"]),
+              flow_requirement("actions/checkout", sha, ["jobs", "inline", "steps", 1, "uses"])
+            ]
+          )
+        end
+        let(:git_checker) { instance_double(Dependabot::GitCommitChecker) }
+
+        before do
+          allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+          allow(git_checker).to receive(:ref_looks_like_commit_sha?) { |ref| ref == sha }
+          allow(git_checker).to receive(:head_commit_for_local_branch).and_return(nil)
+          allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return("v2.2.0")
+        end
+
+        it "updates the existing comment without adding a duplicate" do
+          content = T.must(updated_workflow_file.content)
+
+          expect(content.scan("# v2.2.0").length).to eq(2)
+          expect(content).not_to include("# v2.1.0")
+          expect { YAML.safe_load(content, aliases: true) }.not_to raise_error
+        end
+
+        context "when the new SHA has no version tag" do
+          before do
+            allow(git_checker).to receive(:most_specific_version_tag_for_sha).with(sha).and_return(nil)
+          end
+
+          it "removes the stale version comment" do
+            content = T.must(updated_workflow_file.content)
+
+            expect(content).not_to include("# v2.1.0")
+            expect(content).not_to include("# v2.2.0")
+          end
+        end
+      end
+
       context "with a reused anchor name" do
         let(:workflow_file_body) { fixture("workflow_files", "workflow_reused_anchors.yml") }
         let(:sha) { "aabbfeb2ce60b5bd82389903509092c4648a9713" }

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -862,6 +862,28 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       end
     end
 
+    context "with YAML source metadata" do
+      let(:reference) { "v1.0.1" }
+      let(:yaml_source) do
+        {
+          path: ["jobs", "build", "steps", 0, "uses"],
+          value: { kind: "scalar", start_line: 5, start_column: 14 },
+          target: { kind: "scalar", style: "plain", start_line: 5, start_column: 14 }
+        }
+      end
+
+      before do
+        dependency.requirements.first[:metadata] = {
+          declaration_string: "#{dependency_name}@#{reference}",
+          yaml_source: yaml_source
+        }
+      end
+
+      it "preserves the metadata when updating the ref" do
+        expect(updated_requirements.first.metadata&.fetch(:yaml_source)).to eq(yaml_source)
+      end
+    end
+
     context "when a root composite action is fetched with an invalid workflow lockfile" do
       let(:dependency_files) do
         [

--- a/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
   let(:raise_on_ignored) { false }
   let(:ignored_versions) { [] }
   let(:security_advisories) { [] }
+  let(:options) { {} }
   let(:checker) do
     described_class.new(
       dependency: dependency,
@@ -61,7 +62,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       security_advisories: security_advisories,
       ignored_versions: ignored_versions,
       raise_on_ignored: raise_on_ignored,
-      update_cooldown: update_cooldown
+      update_cooldown: update_cooldown,
+      options: options
     )
   end
   let(:update_cooldown) { nil }
@@ -133,6 +135,26 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
         let(:reference) { "v1.1.0" }
 
         it { is_expected.to be_falsey }
+
+        context "when SHA pinning is enabled" do
+          let(:options) { { github_actions_pin_to_sha: true } }
+
+          it "creates a requirement-only update" do
+            expect(checker.up_to_date?).to be(false)
+            expect(can_update).to be(true)
+
+            updated_dependency = checker.updated_dependencies(requirements_to_unlock: :own).first
+            expect(updated_dependency.version).to eq("1.1.0")
+            expect(updated_dependency.requirements.first.dig(:source, :ref))
+              .to eq("5273d0df9c603edc4284ac8402cf650b4f1f6686")
+          end
+        end
+
+        context "when SHA pinning is disabled" do
+          let(:options) { { github_actions_pin_to_sha: false } }
+
+          it { is_expected.to be_falsey }
+        end
       end
 
       context "when it is different and up-to-date" do
@@ -1268,7 +1290,8 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           security_advisories: security_advisories,
           ignored_versions: ignored_versions,
           raise_on_ignored: raise_on_ignored,
-          update_cooldown: update_cooldown
+          update_cooldown: update_cooldown,
+          options: options
         )
       end
 
@@ -1333,6 +1356,17 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
           expect(a_request(:get, service_pack_url)).to have_been_made.once
         end
 
+        context "when SHA pinning is enabled" do
+          let(:options) { { github_actions_pin_to_sha: true } }
+
+          it "uses the selected releases' full commit SHAs" do
+            expect(ref_for(updated_requirements, ".github/workflows/major.yml"))
+              .to match(/\A[0-9a-f]{40}\z/)
+            expect(ref_for(updated_requirements, ".github/workflows/patch.yml"))
+              .to match(/\A[0-9a-f]{40}\z/)
+          end
+        end
+
         context "when the combined major ref is already current" do
           let(:dependency_version) { "3" }
 
@@ -1382,6 +1416,16 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       it "keeps the major-only precision instead of rewriting to a full version tag" do
         expect(checker.latest_version).to eq(Dependabot::GithubActions::Version.new("2"))
         expect(updated_requirements.first.dig(:source, :ref)).to eq("v2")
+      end
+
+      context "when SHA pinning is enabled" do
+        let(:options) { { github_actions_pin_to_sha: true } }
+
+        it "pins the cooldown-selected release instead of the filtered major" do
+          expect(checker.latest_version).to eq(Dependabot::GithubActions::Version.new("2"))
+          expect(updated_requirements.first.dig(:source, :ref))
+            .to eq("ee0669bd1cc54295c223e0bb666b733df41de1c5")
+        end
       end
     end
 
@@ -1663,6 +1707,60 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       end
     end
 
+    context "when SHA pinning is enabled" do
+      let(:options) { { github_actions_pin_to_sha: true } }
+      let(:upload_pack_fixture) { "checkout" }
+      let(:dependency_name) { "actions/checkout" }
+
+      context "with an exact version tag" do
+        let(:reference) { "v2.1.0" }
+
+        it "returns the selected release's full commit SHA" do
+          expect(updated_requirements.first.dig(:source, :ref))
+            .to eq("8e5e7e5ab8b370d6c329ec480221332ada57f0ab")
+        end
+      end
+
+      context "with a floating version tag" do
+        let(:reference) { "v2" }
+        let(:ignored_versions) { [">= 3"] }
+
+        it "pins the concrete release selected for the floating tag" do
+          expect(updated_requirements.first.dig(:source, :ref))
+            .to eq("ee0669bd1cc54295c223e0bb666b733df41de1c5")
+        end
+      end
+
+      context "with a vulnerable version tag" do
+        let(:upload_pack_fixture) { "ghas-to-csv" }
+        let(:dependency_name) { "some-natalie/ghas-to-csv" }
+        let(:reference) { "v0.4.0" }
+        let(:security_advisories) do
+          [
+            Dependabot::SecurityAdvisory.new(
+              dependency_name: dependency_name,
+              package_manager: "github_actions",
+              vulnerable_versions: ["< 1.0"]
+            )
+          ]
+        end
+
+        it "returns the lowest security fix's full commit SHA" do
+          expect(updated_requirements.first.dig(:source, :ref))
+            .to eq("d0b521928fa734513b5cd9c7d9d8e09db50e884a")
+        end
+      end
+
+      context "with an existing SHA pin" do
+        let(:reference) { "01aecccf739ca6ff86c0539fbc67a7a5007bbc81" }
+
+        it "retains SHA-to-SHA update behavior" do
+          expect(updated_requirements.first.dig(:source, :ref))
+            .to eq("8e5e7e5ab8b370d6c329ec480221332ada57f0ab")
+        end
+      end
+    end
+
     context "when a dependency has a path based tag reference with semver" do
       let(:service_pack_url) do
         "https://github.com/gopidesupavan/monorepo-actions.git/info/refs" \
@@ -1715,6 +1813,14 @@ RSpec.describe Dependabot::GithubActions::UpdateChecker do
       end
 
       it { is_expected.to eq(expected_requirements) }
+
+      context "when SHA pinning is enabled" do
+        let(:options) { { github_actions_pin_to_sha: true } }
+
+        it "keeps the path-prefixed tag so its update stream remains identifiable" do
+          expect(updated_requirements.first.dig(:source, :ref)).to eq("run/v3.0.0")
+        end
+      end
     end
 
     context "when a dependency has a path based tag reference without semver" do

--- a/github_actions/spec/fixtures/workflow_files/multiple_uses_same_line.yml
+++ b/github_actions/spec/fixtures/workflow_files/multiple_uses_same_line.yml
@@ -1,0 +1,7 @@
+on: [push]
+
+name: Multiple same-line actions
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps: [{ uses: actions/setup-node@master }, { uses: actions/setup-node@master, with: { source: actions/setup-node@master } }]

--- a/github_actions/spec/fixtures/workflow_files/pin_to_sha.yml
+++ b/github_actions/spec/fixtures/workflow_files/pin_to_sha.yml
@@ -13,4 +13,11 @@ jobs:
       - { uses: actions/checkout@v2.1.0 }
       - { name: Checkout, uses: "actions/checkout@v2.1.0" }
       - { uses: actions/checkout@v2.1.0 } # v2.1.0
+      - { uses: actions/checkout@v2.1.0, name: "Checkout #1" }
+      - { uses: actions/checkout@v2.1.0, name: "Checkout \"#1\"" }
+      - { uses: actions/checkout@v2.1.0, name: 'Checkout #1' }
+      - { uses: actions/checkout@v2.1.0, with: { source: actions/checkout@v2.1.0 } }
       - uses: actions/checkout@v2 # v2.7.0
+  inline:
+    runs-on: ubuntu-latest
+    steps: [{ uses: actions/checkout@v2.1.0 }, { uses: actions/checkout@v2.1.0, with: { source: actions/checkout@v2.1.0 } }]

--- a/github_actions/spec/fixtures/workflow_files/pin_to_sha.yml
+++ b/github_actions/spec/fixtures/workflow_files/pin_to_sha.yml
@@ -1,0 +1,16 @@
+on: [push]
+
+name: Pin actions
+jobs:
+  pin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - uses: "actions/checkout@v2.1.0"
+      - uses: 'actions/checkout@v2.1.0'
+      - uses: actions/checkout@v2.1.0 # v2.1.0
+      - uses: actions/checkout@v2.1.0 # keep this custom note
+      - { uses: actions/checkout@v2.1.0 }
+      - { name: Checkout, uses: "actions/checkout@v2.1.0" }
+      - { uses: actions/checkout@v2.1.0 } # v2.1.0
+      - uses: actions/checkout@v2 # v2.7.0

--- a/github_actions/spec/fixtures/workflow_files/workflow_action_run_collision.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_action_run_collision.yml
@@ -1,0 +1,8 @@
+on: [push]
+
+name: Action and run collision
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: [{ uses: actions/checkout@v2.1.0 }, { run: echo done } # keep run note
+    ]

--- a/github_actions/spec/fixtures/workflow_files/workflow_cross_sequence_collision.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_cross_sequence_collision.yml
@@ -1,0 +1,5 @@
+on: [push]
+
+name: Cross-sequence collision
+jobs: { first: { runs-on: ubuntu-latest, steps: [ # keep this sequence note
+      { uses: actions/checkout@v2.1.0 }] }, second: { runs-on: ubuntu-latest, steps: [{ uses: actions/setup-node@v3.0.0 }] } }

--- a/github_actions/spec/fixtures/workflow_files/workflow_cross_sequence_comment.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_cross_sequence_comment.yml
@@ -1,0 +1,5 @@
+on: [push]
+
+name: Cross-sequence comment
+jobs: { first: { runs-on: ubuntu-latest, steps: [{ uses: actions/checkout@v2.1.0 }] }, second: { runs-on: ubuntu-latest, steps: [{ uses: actions/setup-node@v3.0.0 }, # v2.1.0
+      { run: echo done }] } }

--- a/github_actions/spec/fixtures/workflow_files/workflow_flow_trivia.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_flow_trivia.yml
@@ -5,7 +5,9 @@ jobs:
   inline:
     runs-on: ubuntu-latest
     steps: [
+# keep this leading note
       { uses: actions/checkout@v2.1.0 }, { uses: actions/setup-node@v3.0.0 }, # keep this note
-      # keep this standalone note
+# keep this standalone note
       { run: echo done } # keep this final note
+# keep this closing note
     ]

--- a/github_actions/spec/fixtures/workflow_files/workflow_flow_trivia.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_flow_trivia.yml
@@ -1,0 +1,11 @@
+on: [push]
+
+name: Flow comments
+jobs:
+  inline:
+    runs-on: ubuntu-latest
+    steps: [
+      { uses: actions/checkout@v2.1.0 }, { uses: actions/setup-node@v3.0.0 }, # keep this note
+      # keep this standalone note
+      { run: echo done } # keep this final note
+    ]

--- a/github_actions/spec/fixtures/workflow_files/workflow_flow_version_comment.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_flow_version_comment.yml
@@ -1,0 +1,10 @@
+on: [push]
+
+name: Flow version comment
+jobs:
+  inline:
+    runs-on: ubuntu-latest
+    steps: [
+      { uses: actions/checkout@v2.1.0 }, { uses: actions/checkout@v2.1.0 }, # v2.1.0
+      { run: echo done }
+    ]

--- a/github_actions/spec/fixtures/workflow_files/workflow_multiline_flow_collision.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_multiline_flow_collision.yml
@@ -1,0 +1,10 @@
+on: [push]
+
+name: Multiline flow collision
+jobs:
+  inline:
+    runs-on: ubuntu-latest
+    steps: [
+      { uses: actions/checkout@v2.1.0 }, { uses: actions/setup-node@v3.0.0 },
+      { run: echo done }
+    ]

--- a/github_actions/spec/fixtures/workflow_files/workflow_multiline_flow_separate.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_multiline_flow_separate.yml
@@ -1,0 +1,10 @@
+on: [push]
+
+name: Multiline flow without collision
+jobs:
+  inline:
+    runs-on: ubuntu-latest
+    steps: [
+      { uses: actions/checkout@v2.1.0 },
+      { uses: actions/setup-node@v3.0.0 }
+    ]

--- a/github_actions/spec/fixtures/workflow_files/workflow_multiple_actions_flow.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_multiple_actions_flow.yml
@@ -1,0 +1,7 @@
+on: [push]
+
+name: Multiple flow actions
+jobs:
+  inline:
+    runs-on: ubuntu-latest
+    steps: &shared [{ name: "🚀", run: echo, env: { ACTION: &checkout actions/checkout@v2.1.0, SECOND: &checkout2 actions/checkout@v2.1.0 } }, { uses: *checkout }, { uses: *checkout2 }, { name: "Node 🚀", uses: actions/setup-node@v3.0.0 }] # v2.1.0

--- a/github_actions/spec/fixtures/workflow_files/workflow_noncolliding_sequence_comment.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_noncolliding_sequence_comment.yml
@@ -1,0 +1,10 @@
+on: [push]
+
+name: Non-colliding sequence comment
+jobs:
+  inline:
+    runs-on: ubuntu-latest
+    steps: [
+      { uses: actions/checkout@01aecccf739ca6ff86c0539fbc67a7a5007bbc81 },
+      { uses: actions/setup-node@v3.0.0 }
+    ] # v2.1.0

--- a/github_actions/spec/fixtures/workflow_files/workflow_repeated_actions_flow.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_repeated_actions_flow.yml
@@ -1,0 +1,7 @@
+on: [push]
+
+name: Repeated flow actions
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps: [{ uses: actions/checkout@v2.1.0 }, { uses: actions/checkout@v2.1.0 }]

--- a/github_actions/spec/fixtures/workflow_files/workflow_reusable_collision.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_reusable_collision.yml
@@ -1,0 +1,4 @@
+on: [push]
+
+name: Reusable workflow collision
+jobs: { reusable: { uses: actions/checkout/.github/workflows/test.yml@v2.1.0 }, build: { runs-on: ubuntu-latest, steps: [{ uses: actions/setup-node@v3.0.0 }] } }

--- a/github_actions/spec/fixtures/workflow_files/workflow_reusable_run_collision.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_reusable_run_collision.yml
@@ -1,0 +1,5 @@
+on: [push]
+
+name: Reusable and run collision
+jobs: { reusable: { uses: actions/checkout/.github/workflows/test.yml@v2.1.0 }, first: { runs-on: ubuntu-latest, steps: [{ run: echo first }] }, second: { runs-on: ubuntu-latest, steps: [{ run: echo second }, # keep second note
+      { run: echo third }] } }

--- a/github_actions/spec/fixtures/workflow_files/workflow_reused_anchors.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_reused_anchors.yml
@@ -1,0 +1,12 @@
+on: [push]
+
+name: Reused anchors
+jobs:
+  first:
+    runs-on: ubuntu-latest
+    env: { ACTION: &pin actions/checkout@v2.1.0 }
+    steps: [{ uses: *pin }]
+  second:
+    runs-on: ubuntu-latest
+    env: { ACTION: &pin actions/setup-node@v3.0.0 }
+    steps: [{ uses: *pin }]

--- a/github_actions/spec/fixtures/workflow_files/workflow_shared_anchor_sequences.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_shared_anchor_sequences.yml
@@ -1,0 +1,10 @@
+on: [push]
+
+name: Shared anchor sequences
+jobs:
+  first:
+    runs-on: ubuntu-latest
+    steps: [{ uses: &pin actions/checkout@v2.1.0 }, { uses: actions/setup-node@v3.0.0 }]
+  second:
+    runs-on: ubuntu-latest
+    steps: [{ uses: *pin }, { uses: actions/setup-node@v3.0.0 }]

--- a/github_actions/spec/fixtures/workflow_files/workflow_source_forms.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_source_forms.yml
@@ -1,0 +1,24 @@
+on: [push]
+
+name: Source forms
+env:
+  CHECKOUT_ACTION: &checkout "actions\x2Fcheckout@v2.1.0"
+jobs:
+  alias:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: *checkout
+  block:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: >-
+          actions/checkout@v2.1.0
+  literal:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: |
+          actions/checkout@v2.1.0
+  escaped:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions\x2Fcheckout@v2.1.0"

--- a/github_actions/spec/fixtures/workflow_files/workflow_step_alias.yml
+++ b/github_actions/spec/fixtures/workflow_files/workflow_step_alias.yml
@@ -1,0 +1,7 @@
+on: [push]
+
+name: Step alias
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: [&checkout { uses: actions/checkout@v2.1.0 }, *checkout]


### PR DESCRIPTION
### What are you trying to accomplish?

Add an opt-in `github_actions_pin_to_sha` updater option. When enabled, Dependabot replaces version tags with full commit SHAs and adds version comments. It also creates pin-only updates when an action is already on the latest tag.

Closes #7913.

### Anything you want to highlight for special attention from reviewers?

Release selection still uses the existing security, cooldown, per-source precision, and `actions.lock` paths. Path-prefixed tags remain unchanged because a SHA would lose their tag-stream identity. Version comments are placed after flow-style YAML mappings.

### How will you know you've accomplished your goal?

Tests cover exact and floating tags, security updates, existing SHA pins, path-prefixed tags, comments, flow mappings, and lockfile relocking. The targeted specs pass with 159 examples, RuboCop reports no offenses, and Sorbet reports no errors.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
