### PR TITLE
Add typed npm registry package model

### DIFF
--- a/common/lib/dependabot/package/npm_registry_package.rb
+++ b/common/lib/dependabot/package/npm_registry_package.rb
@@ -1,0 +1,161 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "json"
+require "time"
+require "sorbet-runtime"
+
+module Dependabot
+  module Package
+    class NpmRegistryPackage < T::ImmutableStruct
+      extend T::Sig
+
+      ObjectHash = T.type_alias { T::Hash[String, Object] }
+
+      class Repository < T::ImmutableStruct
+        extend T::Sig
+
+        const :url, T.nilable(String), default: nil
+        const :type, T.nilable(String), default: nil
+
+        sig { returns(T::Boolean) }
+        def git?
+          type == "git" || !!url&.start_with?("git+")
+        end
+      end
+
+      class Release < T::ImmutableStruct
+        extend T::Sig
+
+        const :version, String
+        const :released_at, T.nilable(Time), default: nil
+        const :node_requirement, T.nilable(String), default: nil
+        const :repository, T.nilable(Repository), default: nil
+        const :details, ObjectHash
+
+        sig { returns(String) }
+        def package_type
+          repository&.git? ? "git" : "npm"
+        end
+      end
+
+      const :releases, T::Hash[String, Release]
+      const :dist_tags, T.nilable(T::Hash[String, String]), default: nil
+
+      sig { params(json: String).returns(NpmRegistryPackage) }
+      def self.from_json(json)
+        parsed = T.cast(JSON.parse(json), Object)
+        package = object_hash(parsed, "npm registry package")
+
+        versions = package["versions"]
+        times = package["time"]
+        dist_tags = package["dist-tags"]
+
+        release_details = versions.nil? ? {} : object_hash(versions, "versions")
+        release_times = times.nil? ? {} : string_map(times, "time")
+
+        releases = release_details.to_h do |version, details|
+          [
+            version,
+            parse_release(
+              version: version,
+              details: details,
+              released_at: release_times[version]
+            )
+          ]
+        end
+
+        new(
+          releases: releases,
+          dist_tags: dist_tags.nil? ? nil : string_map(dist_tags, "dist-tags")
+        )
+      end
+
+      sig do
+        params(
+          version: String,
+          details: Object,
+          released_at: T.nilable(String)
+        ).returns(Release)
+      end
+      def self.parse_release(version:, details:, released_at:)
+        details_hash = object_hash(details, "version #{version} details")
+
+        Release.new(
+          version: version,
+          released_at: released_at && Time.parse(released_at),
+          node_requirement: parse_node_requirement(details_hash, version),
+          repository: parse_repository(details_hash["repository"], version),
+          details: details_hash
+        )
+      end
+      private_class_method :parse_release
+
+      sig { params(details: ObjectHash, version: String).returns(T.nilable(String)) }
+      def self.parse_node_requirement(details, version)
+        engines = details["engines"]
+        return if engines.nil?
+
+        engines_hash = object_hash(engines, "version #{version} engines")
+        optional_string(
+          engines_hash["node"],
+          "version #{version} engines.node"
+        )
+      end
+      private_class_method :parse_node_requirement
+
+      sig { params(value: T.nilable(Object), version: String).returns(T.nilable(Repository)) }
+      def self.parse_repository(value, version)
+        case value
+        when nil
+          nil
+        when String
+          Repository.new(url: value)
+        when Hash
+          repository = object_hash(value, "version #{version} repository")
+          Repository.new(
+            url: optional_string(repository["url"], "version #{version} repository.url"),
+            type: optional_string(repository["type"], "version #{version} repository.type")
+          )
+        else
+          raise TypeError, "version #{version} repository must be a string or object"
+        end
+      end
+      private_class_method :parse_repository
+
+      sig { params(value: Object, context: String).returns(ObjectHash) }
+      def self.object_hash(value, context)
+        raise TypeError, "#{context} must be an object" unless value.is_a?(Hash)
+
+        result = T.let({}, ObjectHash)
+        value.each do |raw_key, raw_value|
+          key = T.cast(raw_key, Object)
+          raise TypeError, "#{context} keys must be strings" unless key.is_a?(String)
+
+          result[key] = T.cast(raw_value, Object)
+        end
+        result
+      end
+      private_class_method :object_hash
+
+      sig { params(value: Object, context: String).returns(T::Hash[String, String]) }
+      def self.string_map(value, context)
+        object_hash(value, context).to_h do |key, raw_value|
+          raise TypeError, "#{context} values must be strings" unless raw_value.is_a?(String)
+
+          [key, raw_value]
+        end
+      end
+      private_class_method :string_map
+
+      sig { params(value: T.nilable(Object), context: String).returns(T.nilable(String)) }
+      def self.optional_string(value, context)
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise TypeError, "#{context} must be a string"
+      end
+      private_class_method :optional_string
+    end
+  end
+end

--- a/common/spec/dependabot/package/npm_registry_package_spec.rb
+++ b/common/spec/dependabot/package/npm_registry_package_spec.rb
@@ -1,0 +1,133 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/package/npm_registry_package"
+
+RSpec.describe Dependabot::Package::NpmRegistryPackage do
+  describe ".from_json" do
+    subject(:package) { described_class.from_json(JSON.dump(payload)) }
+
+    let(:payload) do
+      {
+        "versions" => {
+          "1.0.0" => {
+            "deprecated" => "use 2.0.0",
+            "engines" => { "node" => ">=18" },
+            "repository" => { "type" => "git", "url" => "https://example.com/repo" },
+            "dist" => { "tarball" => "https://example.com/package.tgz" }
+          },
+          "2.0.0" => {
+            "repository" => "git+https://example.com/repo.git"
+          }
+        },
+        "time" => {
+          "1.0.0" => "2024-01-02T03:04:05Z",
+          "created" => "2024-01-01T00:00:00Z"
+        },
+        "dist-tags" => {
+          "latest" => "2.0.0",
+          "next" => "3.0.0-beta.1"
+        },
+        "unknown" => true
+      }
+    end
+
+    it "parses releases, timestamps, dist-tags, engines, and repository metadata" do
+      first = package.releases.fetch("1.0.0")
+      second = package.releases.fetch("2.0.0")
+
+      expect(first).to have_attributes(
+        version: "1.0.0",
+        released_at: Time.utc(2024, 1, 2, 3, 4, 5),
+        node_requirement: ">=18",
+        package_type: "git"
+      )
+      expect(second).to have_attributes(
+        version: "2.0.0",
+        released_at: nil,
+        node_requirement: nil,
+        package_type: "git"
+      )
+      expect(package.dist_tags).to eq("latest" => "2.0.0", "next" => "3.0.0-beta.1")
+    end
+
+    it "preserves unknown release details" do
+      expect(package.releases.fetch("1.0.0").details).to eq(payload.fetch("versions").fetch("1.0.0"))
+    end
+
+    context "with missing known fields" do
+      let(:payload) { { "name" => "example" } }
+
+      it "uses the existing empty and nil defaults" do
+        expect(package.releases).to eq({})
+        expect(package.dist_tags).to be_nil
+      end
+    end
+
+    context "with an npm repository" do
+      let(:payload) do
+        {
+          "versions" => {
+            "1.0.0" => { "repository" => "https://example.com/package" },
+            "2.0.0" => { "repository" => { "type" => "npm" } },
+            "3.0.0" => {}
+          }
+        }
+      end
+
+      it "defaults package type to npm" do
+        expect(package.releases.values.map(&:package_type)).to eq(%w(npm npm npm))
+      end
+    end
+
+    [
+      [[], "npm registry package must be an object"],
+      [{ "versions" => [] }, "versions must be an object"],
+      [{ "versions" => { "1.0.0" => "invalid" } }, "version 1.0.0 details must be an object"],
+      [{ "time" => [] }, "time must be an object"],
+      [{ "time" => { "1.0.0" => 1 } }, "time values must be strings"],
+      [{ "dist-tags" => [] }, "dist-tags must be an object"],
+      [{ "dist-tags" => { "latest" => 1 } }, "dist-tags values must be strings"],
+      [{
+        "versions" => { "1.0.0" => { "engines" => "invalid" } }
+      }, "version 1.0.0 engines must be an object"],
+      [{
+        "versions" => { "1.0.0" => { "engines" => { "node" => 18 } } }
+      }, "version 1.0.0 engines.node must be a string"],
+      [{
+        "versions" => { "1.0.0" => { "repository" => [] } }
+      }, "version 1.0.0 repository must be a string or object"],
+      [{
+        "versions" => { "1.0.0" => { "repository" => { "type" => 1 } } }
+      }, "version 1.0.0 repository.type must be a string"]
+    ].each do |invalid_payload, message|
+      context "with #{message}" do
+        let(:payload) { invalid_payload }
+
+        it "raises an explicit type error" do
+          expect { package }.to raise_error(TypeError, message)
+        end
+      end
+    end
+
+    context "with invalid JSON" do
+      it "preserves the JSON parser error" do
+        expect { described_class.from_json("{") }.to raise_error(JSON::ParserError)
+      end
+    end
+
+    context "with an invalid timestamp" do
+      let(:payload) do
+        {
+          "versions" => { "1.0.0" => {} },
+          "time" => { "1.0.0" => "not a timestamp" }
+        }
+      end
+
+      it "preserves the timestamp parse failure" do
+        expect { package }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a typed parser for npm registry package metadata. #16031 and #16032 wire it into npm and Bun; this layer does not change fetch behavior.