### PR TITLE
Type npm registry package details

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 730
+# Offense count: 721
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -324,7 +324,6 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/yarn_lockfile_updater.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_finder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb"

--- a/common/lib/dependabot/package/npm_registry_package.rb
+++ b/common/lib/dependabot/package/npm_registry_package.rb
@@ -11,16 +11,18 @@ module Dependabot
       extend T::Sig
 
       ObjectHash = T.type_alias { T::Hash[String, Object] }
+      VersionFilter = T.type_alias { T.proc.params(version: String).returns(T::Boolean) }
 
       class Repository < T::ImmutableStruct
         extend T::Sig
 
+        const :git, T::Boolean
         const :url, T.nilable(String), default: nil
         const :type, T.nilable(String), default: nil
 
         sig { returns(T::Boolean) }
         def git?
-          type == "git" || !!url&.start_with?("git+")
+          git
         end
       end
 
@@ -42,8 +44,8 @@ module Dependabot
       const :releases, T::Hash[String, Release]
       const :dist_tags, T.nilable(T::Hash[String, String]), default: nil
 
-      sig { params(json: String).returns(NpmRegistryPackage) }
-      def self.from_json(json)
+      sig { params(json: String, version_filter: VersionFilter).returns(NpmRegistryPackage) }
+      def self.from_json(json, &version_filter)
         parsed = T.cast(JSON.parse(json), Object)
         package = object_hash(parsed, "npm registry package")
 
@@ -52,17 +54,26 @@ module Dependabot
         dist_tags = package["dist-tags"]
 
         release_details = versions.nil? ? {} : object_hash(versions, "versions")
-        release_times = times.nil? ? {} : string_map(times, "time")
+        rejected_versions = T.let({}, T::Hash[String, T::Boolean])
+        release_details.each_key do |version|
+          rejected_versions[version] = true unless yield(version)
+        end
 
-        releases = release_details.to_h do |version, details|
-          [
-            version,
-            parse_release(
-              version: version,
-              details: details,
-              released_at: release_times[version]
-            )
-          ]
+        release_times = if times.nil?
+                          {}
+                        else
+                          string_map(times, "time", skipped_keys: rejected_versions)
+                        end
+
+        releases = T.let({}, T::Hash[String, Release])
+        release_details.each do |version, details|
+          next if rejected_versions.key?(version)
+
+          releases[version] = parse_release(
+            version: version,
+            details: details,
+            released_at: release_times[version]
+          )
         end
 
         new(
@@ -95,6 +106,7 @@ module Dependabot
       def self.parse_node_requirement(details, version)
         engines = details["engines"]
         return if engines.nil?
+        return if engines.is_a?(Array)
 
         engines_hash = object_hash(engines, "version #{version} engines")
         optional_string(
@@ -110,12 +122,16 @@ module Dependabot
         when nil
           nil
         when String
-          Repository.new(url: value)
+          Repository.new(url: value, git: value.start_with?("git+"))
         when Hash
           repository = object_hash(value, "version #{version} repository")
+          url = optional_string(repository["url"], "version #{version} repository.url")
+          type = optional_string(repository["type"], "version #{version} repository.type")
+
           Repository.new(
-            url: optional_string(repository["url"], "version #{version} repository.url"),
-            type: optional_string(repository["type"], "version #{version} repository.type")
+            url: url,
+            type: type,
+            git: type == "git"
           )
         else
           raise TypeError, "version #{version} repository must be a string or object"
@@ -138,13 +154,23 @@ module Dependabot
       end
       private_class_method :object_hash
 
-      sig { params(value: Object, context: String).returns(T::Hash[String, String]) }
-      def self.string_map(value, context)
-        object_hash(value, context).to_h do |key, raw_value|
+      sig do
+        params(
+          value: Object,
+          context: String,
+          skipped_keys: T.nilable(T::Hash[String, T::Boolean])
+        ).returns(T::Hash[String, String])
+      end
+      def self.string_map(value, context, skipped_keys: nil)
+        result = T.let({}, T::Hash[String, String])
+        object_hash(value, context).each do |key, raw_value|
+          next if skipped_keys&.key?(key)
+
           raise TypeError, "#{context} values must be strings" unless raw_value.is_a?(String)
 
-          [key, raw_value]
+          result[key] = raw_value
         end
+        result
       end
       private_class_method :string_map
 

--- a/common/spec/dependabot/package/npm_registry_package_spec.rb
+++ b/common/spec/dependabot/package/npm_registry_package_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
@@ -6,7 +6,14 @@ require "dependabot/package/npm_registry_package"
 
 RSpec.describe Dependabot::Package::NpmRegistryPackage do
   describe ".from_json" do
-    subject(:package) { described_class.from_json(JSON.dump(payload)) }
+    subject(:package) do
+      described_class.from_json(
+        JSON.dump(payload),
+        &version_filter
+      )
+    end
+
+    let(:version_filter) { ->(_version) { true } }
 
     let(:payload) do
       {
@@ -71,13 +78,58 @@ RSpec.describe Dependabot::Package::NpmRegistryPackage do
           "versions" => {
             "1.0.0" => { "repository" => "https://example.com/package" },
             "2.0.0" => { "repository" => { "type" => "npm" } },
-            "3.0.0" => {}
+            "3.0.0" => { "repository" => { "url" => "git+https://example.com/package.git" } },
+            "4.0.0" => {
+              "repository" => {
+                "type" => "npm",
+                "url" => "git+https://example.com/package.git"
+              }
+            },
+            "5.0.0" => {}
           }
         }
       end
 
       it "defaults package type to npm" do
-        expect(package.releases.values.map(&:package_type)).to eq(%w(npm npm npm))
+        expect(package.releases.values.map(&:package_type)).to eq(%w(npm npm npm npm npm))
+      end
+    end
+
+    context "with legacy engines metadata" do
+      let(:payload) do
+        {
+          "versions" => {
+            "1.0.0" => { "engines" => %w(node rhino) }
+          }
+        }
+      end
+
+      it "treats an engines array as having no Node requirement" do
+        expect(package.releases.fetch("1.0.0").node_requirement).to be_nil
+      end
+    end
+
+    context "when the version filter rejects a release" do
+      let(:version_filter) { ->(_version) { false } }
+      let(:payload) do
+        {
+          "versions" => {
+            "not-a-version" => "invalid",
+            "also-not-a-version" => {
+              "engines" => "invalid",
+              "repository" => []
+            }
+          },
+          "time" => {
+            "not-a-version" => 1,
+            "also-not-a-version" => "not a timestamp",
+            "created" => "2024-01-01T00:00:00Z"
+          }
+        }
+      end
+
+      it "skips the release before parsing its metadata" do
+        expect(package.releases).to eq({})
       end
     end
 
@@ -113,7 +165,9 @@ RSpec.describe Dependabot::Package::NpmRegistryPackage do
 
     context "with invalid JSON" do
       it "preserves the JSON parser error" do
-        expect { described_class.from_json("{") }.to raise_error(JSON::ParserError)
+        expect do
+          described_class.from_json("{", &version_filter)
+        end.to raise_error(JSON::ParserError)
       end
     end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "json"
@@ -6,6 +6,7 @@ require "excon"
 require "time"
 require "dependabot/package/package_release"
 require "dependabot/package/package_details"
+require "dependabot/package/npm_registry_package"
 require "dependabot/npm_and_yarn/package/registry_finder"
 require "dependabot/npm_and_yarn/package/registry_credential_helpers"
 
@@ -23,17 +24,8 @@ module Dependabot
         API_AUTHORIZATION_VALUE_BASIC_PREFIX = "Basic"
         API_RESPONSE_STATUS_SUCCESS_PREFIX = "2"
 
-        RELEASE_TIME_KEY = "time"
-        RELEASE_VERSIONS_KEY = "versions"
-        RELEASE_DIST_TAGS_KEY = "dist-tags"
         RELEASE_DIST_TAGS_LATEST_KEY = "latest"
-        RELEASE_ENGINES_KEY = "engines"
         RELEASE_LANGUAGE_KEY = "node"
-        RELEASE_DEPRECATION_KEY = "deprecated"
-        RELEASE_REPOSITORY_KEY = "repository"
-        RELEASE_PACKAGE_TYPE_KEY = "type"
-        RELEASE_PACKAGE_TYPE_GIT = "git"
-        RELEASE_PACKAGE_TYPE_NPM = "npm"
 
         REGISTRY_FILE_NPMRC = ".npmrc"
         REGISTRY_FILE_YARNRC = ".yarnrc"
@@ -55,7 +47,7 @@ module Dependabot
           @dependency_files = dependency_files
           @credentials = credentials
 
-          @npm_details = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
+          @npm_details = T.let(nil, T.nilable(Dependabot::Package::NpmRegistryPackage))
           @dist_tags = T.let(nil, T.nilable(T::Hash[String, String]))
           @registry_finder = T.let(nil, T.nilable(Package::RegistryFinder))
           @version_endpoint_working = T.let(nil, T.nilable(T::Boolean))
@@ -86,7 +78,7 @@ module Dependabot
           !dist_tags.nil?
         end
 
-        sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+        sig { returns(T.nilable(Dependabot::Package::NpmRegistryPackage)) }
         def npm_details
           @npm_details ||= fetch_npm_details
         end
@@ -165,32 +157,26 @@ module Dependabot
 
         sig do
           params(
-            npm_data: T::Hash[String, T.untyped]
+            npm_data: Dependabot::Package::NpmRegistryPackage
           ).returns(T::Array[Dependabot::Package::PackageRelease])
         end
         def parse_versions(npm_data)
-          time_data = fetch_value_from_hash(npm_data, RELEASE_TIME_KEY) || {}
-          versions_data = fetch_value_from_hash(npm_data, RELEASE_VERSIONS_KEY) || {}
+          latest_version = npm_data.dist_tags&.[](RELEASE_DIST_TAGS_LATEST_KEY)
 
-          dist_tags = fetch_value_from_hash(npm_data, RELEASE_DIST_TAGS_KEY)
-          latest_version = fetch_value_from_hash(dist_tags, RELEASE_DIST_TAGS_LATEST_KEY)
-
-          versions_data.filter_map do |version, details|
-            next unless Dependabot::NpmAndYarn::Version.correct?(version)
-
-            package_type = infer_package_type(details)
+          npm_data.releases.values.filter_map do |release|
+            next unless Dependabot::NpmAndYarn::Version.correct?(release.version)
 
             Dependabot::Package::PackageRelease.new(
-              version: Version.new(version),
-              released_at: time_data[version] ? Time.parse(time_data[version]) : nil,
+              version: Version.new(release.version),
+              released_at: release.released_at,
               yanked: false,
               yanked_reason: nil,
               downloads: nil,
-              latest: latest_version.to_s == version,
-              url: package_version_url(version),
-              package_type: package_type,
-              language: package_language(details),
-              details: details
+              latest: latest_version == release.version,
+              url: package_version_url(release.version),
+              package_type: release.package_type,
+              language: package_language(release.node_requirement),
+              details: release.details
             )
           end.sort_by(&:version).reverse
         end
@@ -200,39 +186,29 @@ module Dependabot
           "#{dependency_registry}/#{@dependency.name}/v/#{version}"
         end
 
-        sig do
-          params(version_details: T::Hash[String, T.untyped])
-            .returns(T.nilable(Dependabot::Package::PackageLanguage))
-        end
-        def package_language(version_details)
-          # Fetch the engines hash from the version details
-          engines = version_details.is_a?(Hash) ? version_details[RELEASE_ENGINES_KEY] : nil
-          # Check if engines is a hash and fetch the node requirement
-          node_requirement = engines.is_a?(Hash) ? engines.fetch(RELEASE_LANGUAGE_KEY, nil) : nil
-
+        sig { params(node_requirement: T.nilable(String)).returns(T.nilable(Dependabot::Package::PackageLanguage)) }
+        def package_language(node_requirement)
           return nil unless node_requirement
 
-          if node_requirement
-            Dependabot::Package::PackageLanguage.new(
-              name: RELEASE_LANGUAGE_KEY,
-              version: nil,
-              requirement: Requirement.new(node_requirement)
-            )
-          end
+          Dependabot::Package::PackageLanguage.new(
+            name: RELEASE_LANGUAGE_KEY,
+            version: nil,
+            requirement: Requirement.new(node_requirement)
+          )
         rescue Gem::Requirement::BadRequirementError
           nil
         end
 
         sig { returns(T.nilable(T::Hash[String, String])) }
         def dist_tags
-          @dist_tags ||= fetch_value_from_hash(npm_details, RELEASE_DIST_TAGS_KEY)
+          @dist_tags ||= npm_details&.dist_tags
         end
 
-        sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+        sig { returns(T.nilable(Dependabot::Package::NpmRegistryPackage)) }
         def fetch_npm_details
           npm_response = fetch_npm_response
           check_npm_response(npm_response) if npm_response
-          JSON.parse(npm_response.body)
+          Dependabot::Package::NpmRegistryPackage.from_json(npm_response.body)
         rescue JSON::ParserError, Excon::Error::Timeout, Excon::Error::Socket, RegistryError => e
           if git_dependency?
             nil
@@ -257,10 +233,10 @@ module Dependabot
           # If a private registry returns a 500 error, check authentication
           return response unless response.status == 500
 
-          auth = fetch_value_from_hash(registry_auth_headers, API_AUTHORIZATION_KEY)
+          auth = registry_auth_headers[API_AUTHORIZATION_KEY]
           return response unless auth
 
-          return response unless auth&.start_with?(API_AUTHORIZATION_VALUE_BASIC_PREFIX)
+          return response unless auth.start_with?(API_AUTHORIZATION_VALUE_BASIC_PREFIX)
 
           decoded_token = Base64.decode64(auth.gsub("#{API_AUTHORIZATION_VALUE_BASIC_PREFIX} ", "")).strip
 
@@ -280,29 +256,6 @@ module Dependabot
           )
         rescue URI::InvalidURIError => e
           raise DependencyFileNotResolvable, e.message
-        end
-
-        sig do
-          params(
-            details: T::Hash[String, T.untyped],
-            git_dependency: T::Boolean
-          )
-            .returns(String)
-        end
-        def infer_package_type(details, git_dependency: false)
-          return RELEASE_PACKAGE_TYPE_GIT if git_dependency
-
-          repository = fetch_value_from_hash(details, RELEASE_REPOSITORY_KEY)
-
-          case repository
-          when String
-            return repository.start_with?("git+") ? RELEASE_PACKAGE_TYPE_GIT : RELEASE_PACKAGE_TYPE_NPM
-          when Hash
-            type = fetch_value_from_hash(repository, RELEASE_PACKAGE_TYPE_KEY)
-            return RELEASE_PACKAGE_TYPE_GIT if type == RELEASE_PACKAGE_TYPE_GIT
-          end
-
-          RELEASE_PACKAGE_TYPE_NPM
         end
 
         sig { params(npm_response: Excon::Response).void }
@@ -339,7 +292,7 @@ module Dependabot
           raise RegistryError.new(status, msg)
         end
 
-        sig { params(error: StandardError).void }
+        sig { params(error: StandardError).returns(T.noreturn) }
         def raise_npm_details_error(error)
           raise if dependency_registry == GLOBAL_REGISTRY
           raise unless error.is_a?(Excon::Error::Timeout) || error.is_a?(Excon::Error::Socket)
@@ -379,8 +332,7 @@ module Dependabot
 
         sig { params(npm_response: Excon::Response).returns(T::Boolean) }
         def response_invalid_json?(npm_response)
-          result = JSON.parse(npm_response.body)
-          result.is_a?(Hash) || result.is_a?(Array)
+          T.cast(JSON.parse(npm_response.body), Object)
           false
         rescue JSON::ParserError, TypeError
           true
@@ -437,15 +389,6 @@ module Dependabot
             dependency: dependency,
             credentials: credentials
           ).git_dependency?
-        end
-
-        # This function safely retrieves a value for a given key from a Hash.
-        # If the hash is valid and the key exists, it will return the value, otherwise nil.
-        sig { params(hash: T.untyped, key: T.untyped).returns(T.untyped) }
-        def fetch_value_from_hash(hash, key)
-          return nil unless hash.is_a?(Hash) # Return nil if the hash is not a Hash
-
-          hash.fetch(key, nil) # Fetch the value for the given key, defaulting to nil if not found
         end
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package/package_details_fetcher.rb
@@ -208,7 +208,9 @@ module Dependabot
         def fetch_npm_details
           npm_response = fetch_npm_response
           check_npm_response(npm_response) if npm_response
-          Dependabot::Package::NpmRegistryPackage.from_json(npm_response.body)
+          Dependabot::Package::NpmRegistryPackage.from_json(npm_response.body) do |version|
+            Dependabot::NpmAndYarn::Version.correct?(version)
+          end
         rescue JSON::ParserError, Excon::Error::Timeout, Excon::Error::Socket, RegistryError => e
           if git_dependency?
             nil

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
@@ -152,12 +152,39 @@ RSpec.describe Dependabot::NpmAndYarn::Package::PackageDetailsFetcher do
       before do
         stub_request(:get, registry_url).to_return(
           status: 200,
-          body: JSON.dump("versions" => { "not-a-version" => { "custom" => { "nested" => true } } })
+          body: JSON.dump(
+            "versions" => {
+              "not-a-version" => "invalid",
+              "also-not-a-version" => {
+                "engines" => "invalid",
+                "repository" => []
+              }
+            },
+            "time" => {
+              "not-a-version" => 1,
+              "also-not-a-version" => "invalid"
+            }
+          )
         )
       end
 
-      it "skips the release" do
+      it "skips the release before parsing its metadata" do
         expect(details.releases).to eq([])
+      end
+    end
+
+    context "when registry metadata uses a legacy engines array" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: fixture("npm_responses", "lodash.json")
+        )
+      end
+
+      it "returns the release without a Node requirement" do
+        release = details.releases.find { |candidate| candidate.version.to_s == "0.1.0" }
+
+        expect(release&.language).to be_nil
       end
     end
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
@@ -111,6 +111,117 @@ RSpec.describe Dependabot::NpmAndYarn::Package::PackageDetailsFetcher do
       end
     end
 
+    context "when known metadata fields are missing" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump("name" => dependency_name)
+        )
+      end
+
+      it "returns no releases or dist-tags" do
+        expect(details.releases).to eq([])
+        expect(details.dist_tags).to be_nil
+      end
+    end
+
+    context "when successful JSON has the wrong top-level shape" do
+      before do
+        stub_request(:get, registry_url).to_return(status: 200, body: "[]")
+      end
+
+      it "raises at the metadata boundary" do
+        expect { details }.to raise_error(TypeError, "npm registry package must be an object")
+      end
+    end
+
+    context "when a release entry has the wrong shape" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump("versions" => { "1.0.0" => "invalid" })
+        )
+      end
+
+      it "raises at the release boundary" do
+        expect { details }.to raise_error(TypeError, "version 1.0.0 details must be an object")
+      end
+    end
+
+    [
+      ["time", { "versions" => { "1.0.0" => {} }, "time" => { "1.0.0" => 1 } }],
+      ["dist-tags", { "dist-tags" => { "latest" => 1 } }],
+      ["engines", { "versions" => { "1.0.0" => { "engines" => "invalid" } } }],
+      ["repository", { "versions" => { "1.0.0" => { "repository" => 1 } } }]
+    ].each do |field, response_body|
+      context "when #{field} has the wrong shape" do
+        before do
+          stub_request(:get, registry_url).to_return(status: 200, body: JSON.dump(response_body))
+        end
+
+        it "raises at the metadata boundary" do
+          expect { details }.to raise_error(TypeError)
+        end
+      end
+    end
+
+    context "when a release timestamp is invalid" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump(
+            "versions" => { "1.0.0" => {} },
+            "time" => { "1.0.0" => "invalid" }
+          )
+        )
+      end
+
+      it "preserves the timestamp parsing failure" do
+        expect { details }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with a git dependency" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "16.6.0",
+          requirements: [{
+            requirement: nil,
+            file: "package.json",
+            groups: ["dependencies"],
+            source: {
+              type: "git",
+              url: "https://github.com/facebook/react",
+              ref: "v16.6.0"
+            }
+          }],
+          package_manager: "npm_and_yarn"
+        )
+      end
+
+      context "when the registry returns invalid JSON" do
+        before do
+          stub_request(:get, registry_url).to_return(status: 200, body: "{")
+        end
+
+        it "keeps the existing empty-result fallback" do
+          expect(details.releases).to eq([])
+          expect(details.dist_tags).to be_nil
+        end
+      end
+
+      context "when the registry returns wrong-shaped valid JSON" do
+        before do
+          stub_request(:get, registry_url).to_return(status: 200, body: "[]")
+        end
+
+        it "raises at the metadata boundary" do
+          expect { details }.to raise_error(TypeError, "npm registry package must be an object")
+        end
+      end
+    end
+
     context "when lockfile source is private but credentials replace the base registry" do
       let(:dependency) do
         Dependabot::Dependency.new(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
@@ -148,6 +148,19 @@ RSpec.describe Dependabot::NpmAndYarn::Package::PackageDetailsFetcher do
       end
     end
 
+    context "when a version key is not valid semantic versioning" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump("versions" => { "not-a-version" => { "custom" => { "nested" => true } } })
+        )
+      end
+
+      it "skips the release" do
+        expect(details.releases).to eq([])
+      end
+    end
+
     [
       ["time", { "versions" => { "1.0.0" => {} }, "time" => { "1.0.0" => 1 } }],
       ["dist-tags", { "dist-tags" => { "latest" => 1 } }],


### PR DESCRIPTION
Parses npm registry responses through the shared model and promotes the fetcher to `typed: strong`. Reduces `T.untyped` from 730 to 721.