### PR TITLE
Type Bun registry package details

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 721
+# Offense count: 712
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -250,7 +250,6 @@ Sorbet/ForbidTUntyped:
     - "bun/lib/dependabot/bun/file_parser/bun_lock.rb"
     - "bun/lib/dependabot/bun/file_parser/lockfile_parser.rb"
     - "bun/lib/dependabot/bun/metadata_finder.rb"
-    - "bun/lib/dependabot/bun/package/package_details_fetcher.rb"
     - "bun/lib/dependabot/bun/package/registry_finder.rb"
     - "bun/lib/dependabot/bun/package_manager.rb"
     - "bun/lib/dependabot/bun/registry_helper.rb"

--- a/bun/lib/dependabot/bun/package/package_details_fetcher.rb
+++ b/bun/lib/dependabot/bun/package/package_details_fetcher.rb
@@ -201,7 +201,9 @@ module Dependabot
         def fetch_npm_details
           npm_response = fetch_npm_response
           check_npm_response(npm_response) if npm_response
-          Dependabot::Package::NpmRegistryPackage.from_json(npm_response.body)
+          Dependabot::Package::NpmRegistryPackage.from_json(npm_response.body) do |version|
+            Dependabot::Bun::Version.correct?(version)
+          end
         rescue JSON::ParserError, Excon::Error::Timeout, Excon::Error::Socket, RegistryError => e
           if git_dependency?
             nil

--- a/bun/lib/dependabot/bun/package/package_details_fetcher.rb
+++ b/bun/lib/dependabot/bun/package/package_details_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "json"
@@ -6,6 +6,7 @@ require "excon"
 require "time"
 require "dependabot/package/package_release"
 require "dependabot/package/package_details"
+require "dependabot/package/npm_registry_package"
 require "dependabot/bun/package/registry_finder"
 
 module Dependabot
@@ -21,17 +22,8 @@ module Dependabot
         API_AUTHORIZATION_VALUE_BASIC_PREFIX = "Basic"
         API_RESPONSE_STATUS_SUCCESS_PREFIX = "2"
 
-        RELEASE_TIME_KEY = "time"
-        RELEASE_VERSIONS_KEY = "versions"
-        RELEASE_DIST_TAGS_KEY = "dist-tags"
         RELEASE_DIST_TAGS_LATEST_KEY = "latest"
-        RELEASE_ENGINES_KEY = "engines"
         RELEASE_LANGUAGE_KEY = "node"
-        RELEASE_DEPRECATION_KEY = "deprecated"
-        RELEASE_REPOSITORY_KEY = "repository"
-        RELEASE_PACKAGE_TYPE_KEY = "type"
-        RELEASE_PACKAGE_TYPE_GIT = "git"
-        RELEASE_PACKAGE_TYPE_NPM = "npm"
 
         REGISTRY_FILE_NPMRC = ".npmrc"
         REGISTRY_FILE_YARNRC = ".yarnrc"
@@ -53,7 +45,7 @@ module Dependabot
           @dependency_files = dependency_files
           @credentials = credentials
 
-          @npm_details = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
+          @npm_details = T.let(nil, T.nilable(Dependabot::Package::NpmRegistryPackage))
           @dist_tags = T.let(nil, T.nilable(T::Hash[String, String]))
           @registry_finder = T.let(nil, T.nilable(Package::RegistryFinder))
           @version_endpoint_working = T.let(nil, T.nilable(T::Boolean))
@@ -84,7 +76,7 @@ module Dependabot
           !dist_tags.nil?
         end
 
-        sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+        sig { returns(T.nilable(Dependabot::Package::NpmRegistryPackage)) }
         def npm_details
           @npm_details ||= fetch_npm_details
         end
@@ -158,32 +150,26 @@ module Dependabot
 
         sig do
           params(
-            npm_data: T::Hash[String, T.untyped]
+            npm_data: Dependabot::Package::NpmRegistryPackage
           ).returns(T::Array[Dependabot::Package::PackageRelease])
         end
         def parse_versions(npm_data)
-          time_data = fetch_value_from_hash(npm_data, RELEASE_TIME_KEY) || {}
-          versions_data = fetch_value_from_hash(npm_data, RELEASE_VERSIONS_KEY) || {}
+          latest_version = npm_data.dist_tags&.[](RELEASE_DIST_TAGS_LATEST_KEY)
 
-          dist_tags = fetch_value_from_hash(npm_data, RELEASE_DIST_TAGS_KEY)
-          latest_version = fetch_value_from_hash(dist_tags, RELEASE_DIST_TAGS_LATEST_KEY)
-
-          versions_data.filter_map do |version, details|
-            next unless Dependabot::Bun::Version.correct?(version)
-
-            package_type = infer_package_type(details)
+          npm_data.releases.values.filter_map do |release|
+            next unless Dependabot::Bun::Version.correct?(release.version)
 
             Dependabot::Package::PackageRelease.new(
-              version: Version.new(version),
-              released_at: time_data[version] ? Time.parse(time_data[version]) : nil,
+              version: Version.new(release.version),
+              released_at: release.released_at,
               yanked: false,
               yanked_reason: nil,
               downloads: nil,
-              latest: latest_version.to_s == version,
-              url: package_version_url(version),
-              package_type: package_type,
-              language: package_language(details),
-              details: details
+              latest: latest_version == release.version,
+              url: package_version_url(release.version),
+              package_type: release.package_type,
+              language: package_language(release.node_requirement),
+              details: release.details
             )
           end.sort_by(&:version).reverse
         end
@@ -193,39 +179,29 @@ module Dependabot
           "#{dependency_registry}/#{@dependency.name}/v/#{version}"
         end
 
-        sig do
-          params(version_details: T::Hash[String, T.untyped])
-            .returns(T.nilable(Dependabot::Package::PackageLanguage))
-        end
-        def package_language(version_details)
-          # Fetch the engines hash from the version details
-          engines = version_details.is_a?(Hash) ? version_details[RELEASE_ENGINES_KEY] : nil
-          # Check if engines is a hash and fetch the node requirement
-          node_requirement = engines.is_a?(Hash) ? engines.fetch(RELEASE_LANGUAGE_KEY, nil) : nil
-
+        sig { params(node_requirement: T.nilable(String)).returns(T.nilable(Dependabot::Package::PackageLanguage)) }
+        def package_language(node_requirement)
           return nil unless node_requirement
 
-          if node_requirement
-            Dependabot::Package::PackageLanguage.new(
-              name: RELEASE_LANGUAGE_KEY,
-              version: nil,
-              requirement: Requirement.new(node_requirement)
-            )
-          end
+          Dependabot::Package::PackageLanguage.new(
+            name: RELEASE_LANGUAGE_KEY,
+            version: nil,
+            requirement: Requirement.new(node_requirement)
+          )
         rescue Gem::Requirement::BadRequirementError
           nil
         end
 
         sig { returns(T.nilable(T::Hash[String, String])) }
         def dist_tags
-          @dist_tags ||= fetch_value_from_hash(npm_details, RELEASE_DIST_TAGS_KEY)
+          @dist_tags ||= npm_details&.dist_tags
         end
 
-        sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+        sig { returns(T.nilable(Dependabot::Package::NpmRegistryPackage)) }
         def fetch_npm_details
           npm_response = fetch_npm_response
           check_npm_response(npm_response) if npm_response
-          JSON.parse(npm_response.body)
+          Dependabot::Package::NpmRegistryPackage.from_json(npm_response.body)
         rescue JSON::ParserError, Excon::Error::Timeout, Excon::Error::Socket, RegistryError => e
           if git_dependency?
             nil
@@ -250,10 +226,10 @@ module Dependabot
           # If a private registry returns a 500 error, check authentication
           return response unless response.status == 500
 
-          auth = fetch_value_from_hash(registry_auth_headers, API_AUTHORIZATION_KEY)
+          auth = registry_auth_headers[API_AUTHORIZATION_KEY]
           return response unless auth
 
-          return response unless auth&.start_with?(API_AUTHORIZATION_VALUE_BASIC_PREFIX)
+          return response unless auth.start_with?(API_AUTHORIZATION_VALUE_BASIC_PREFIX)
 
           decoded_token = Base64.decode64(auth.gsub("#{API_AUTHORIZATION_VALUE_BASIC_PREFIX} ", "")).strip
 
@@ -273,29 +249,6 @@ module Dependabot
           )
         rescue URI::InvalidURIError => e
           raise DependencyFileNotResolvable, e.message
-        end
-
-        sig do
-          params(
-            details: T::Hash[String, T.untyped],
-            git_dependency: T::Boolean
-          )
-            .returns(String)
-        end
-        def infer_package_type(details, git_dependency: false)
-          return RELEASE_PACKAGE_TYPE_GIT if git_dependency
-
-          repository = fetch_value_from_hash(details, RELEASE_REPOSITORY_KEY)
-
-          case repository
-          when String
-            return repository.start_with?("git+") ? RELEASE_PACKAGE_TYPE_GIT : RELEASE_PACKAGE_TYPE_NPM
-          when Hash
-            type = fetch_value_from_hash(repository, RELEASE_PACKAGE_TYPE_KEY)
-            return RELEASE_PACKAGE_TYPE_GIT if type == RELEASE_PACKAGE_TYPE_GIT
-          end
-
-          RELEASE_PACKAGE_TYPE_NPM
         end
 
         sig { params(npm_response: Excon::Response).void }
@@ -332,7 +285,7 @@ module Dependabot
           raise RegistryError.new(status, msg)
         end
 
-        sig { params(error: StandardError).void }
+        sig { params(error: StandardError).returns(T.noreturn) }
         def raise_npm_details_error(error)
           raise if dependency_registry == GLOBAL_REGISTRY
           raise unless error.is_a?(Excon::Error::Timeout) || error.is_a?(Excon::Error::Socket)
@@ -372,8 +325,7 @@ module Dependabot
 
         sig { params(npm_response: Excon::Response).returns(T::Boolean) }
         def response_invalid_json?(npm_response)
-          result = JSON.parse(npm_response.body)
-          result.is_a?(Hash) || result.is_a?(Array)
+          T.cast(JSON.parse(npm_response.body), Object)
           false
         rescue JSON::ParserError, TypeError
           true
@@ -422,15 +374,6 @@ module Dependabot
             dependency: dependency,
             credentials: credentials
           ).git_dependency?
-        end
-
-        # This function safely retrieves a value for a given key from a Hash.
-        # If the hash is valid and the key exists, it will return the value, otherwise nil.
-        sig { params(hash: T.untyped, key: T.untyped).returns(T.untyped) }
-        def fetch_value_from_hash(hash, key)
-          return nil unless hash.is_a?(Hash) # Return nil if the hash is not a Hash
-
-          hash.fetch(key, nil) # Fetch the value for the given key, defaulting to nil if not found
         end
       end
     end

--- a/bun/spec/dependabot/bun/package/package_details_fetcher_spec.rb
+++ b/bun/spec/dependabot/bun/package/package_details_fetcher_spec.rb
@@ -152,12 +152,39 @@ RSpec.describe Dependabot::Bun::Package::PackageDetailsFetcher do
       before do
         stub_request(:get, registry_url).to_return(
           status: 200,
-          body: JSON.dump("versions" => { "not-a-version" => { "custom" => { "nested" => true } } })
+          body: JSON.dump(
+            "versions" => {
+              "not-a-version" => "invalid",
+              "also-not-a-version" => {
+                "engines" => "invalid",
+                "repository" => []
+              }
+            },
+            "time" => {
+              "not-a-version" => 1,
+              "also-not-a-version" => "invalid"
+            }
+          )
         )
       end
 
-      it "skips the release" do
+      it "skips the release before parsing its metadata" do
         expect(details.releases).to eq([])
+      end
+    end
+
+    context "when registry metadata uses a legacy engines array" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: fixture("npm_responses", "lodash.json")
+        )
+      end
+
+      it "returns the release without a Node requirement" do
+        release = details.releases.find { |candidate| candidate.version.to_s == "0.1.0" }
+
+        expect(release&.language).to be_nil
       end
     end
 

--- a/bun/spec/dependabot/bun/package/package_details_fetcher_spec.rb
+++ b/bun/spec/dependabot/bun/package/package_details_fetcher_spec.rb
@@ -148,6 +148,19 @@ RSpec.describe Dependabot::Bun::Package::PackageDetailsFetcher do
       end
     end
 
+    context "when a version key is not valid semantic versioning" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump("versions" => { "not-a-version" => { "custom" => { "nested" => true } } })
+        )
+      end
+
+      it "skips the release" do
+        expect(details.releases).to eq([])
+      end
+    end
+
     [
       ["time", { "versions" => { "1.0.0" => {} }, "time" => { "1.0.0" => 1 } }],
       ["dist-tags", { "dist-tags" => { "latest" => 1 } }],

--- a/bun/spec/dependabot/bun/package/package_details_fetcher_spec.rb
+++ b/bun/spec/dependabot/bun/package/package_details_fetcher_spec.rb
@@ -111,6 +111,117 @@ RSpec.describe Dependabot::Bun::Package::PackageDetailsFetcher do
       end
     end
 
+    context "when known metadata fields are missing" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump("name" => dependency_name)
+        )
+      end
+
+      it "returns no releases or dist-tags" do
+        expect(details.releases).to eq([])
+        expect(details.dist_tags).to be_nil
+      end
+    end
+
+    context "when successful JSON has the wrong top-level shape" do
+      before do
+        stub_request(:get, registry_url).to_return(status: 200, body: "[]")
+      end
+
+      it "raises at the metadata boundary" do
+        expect { details }.to raise_error(TypeError, "npm registry package must be an object")
+      end
+    end
+
+    context "when a release entry has the wrong shape" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump("versions" => { "1.0.0" => "invalid" })
+        )
+      end
+
+      it "raises at the release boundary" do
+        expect { details }.to raise_error(TypeError, "version 1.0.0 details must be an object")
+      end
+    end
+
+    [
+      ["time", { "versions" => { "1.0.0" => {} }, "time" => { "1.0.0" => 1 } }],
+      ["dist-tags", { "dist-tags" => { "latest" => 1 } }],
+      ["engines", { "versions" => { "1.0.0" => { "engines" => "invalid" } } }],
+      ["repository", { "versions" => { "1.0.0" => { "repository" => 1 } } }]
+    ].each do |field, response_body|
+      context "when #{field} has the wrong shape" do
+        before do
+          stub_request(:get, registry_url).to_return(status: 200, body: JSON.dump(response_body))
+        end
+
+        it "raises at the metadata boundary" do
+          expect { details }.to raise_error(TypeError)
+        end
+      end
+    end
+
+    context "when a release timestamp is invalid" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump(
+            "versions" => { "1.0.0" => {} },
+            "time" => { "1.0.0" => "invalid" }
+          )
+        )
+      end
+
+      it "preserves the timestamp parsing failure" do
+        expect { details }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with a git dependency" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: "16.6.0",
+          requirements: [{
+            requirement: nil,
+            file: "package.json",
+            groups: ["dependencies"],
+            source: {
+              type: "git",
+              url: "https://github.com/facebook/react",
+              ref: "v16.6.0"
+            }
+          }],
+          package_manager: "bun"
+        )
+      end
+
+      context "when the registry returns invalid JSON" do
+        before do
+          stub_request(:get, registry_url).to_return(status: 200, body: "{")
+        end
+
+        it "keeps the existing empty-result fallback" do
+          expect(details.releases).to eq([])
+          expect(details.dist_tags).to be_nil
+        end
+      end
+
+      context "when the registry returns wrong-shaped valid JSON" do
+        before do
+          stub_request(:get, registry_url).to_return(status: 200, body: "[]")
+        end
+
+        it "raises at the metadata boundary" do
+          expect { details }.to raise_error(TypeError, "npm registry package must be an object")
+        end
+      end
+    end
+
     context "when the registry raises Excon::Error::Socket" do
       context "with a private registry" do
         let(:registry_url) { "https://npm.fury.io/dependabot/react" }


### PR DESCRIPTION
Reuses the shared registry model and promotes the Bun fetcher to `typed: strong`. Reduces `T.untyped` from 721 to 712.