### PR TITLE
Test regenerated smoke tests in CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,5 @@
 # Runs all ecosystems cached and concurrently.
+# This no-op change verifies regenerated smoke tests in CI.
 name: Smoke
 
 on: # yamllint disable-line rule:truthy


### PR DESCRIPTION
## Summary

This is a test-only PR to verify that regenerated smoke tests are working in CI.

The no-op comment change touches `.github/workflows/smoke.yml`, which intentionally selects every ecosystem in `.github/smoke-filters.yml` without changing workflow behavior.