### PR TITLE
Add NuGet dependency-name subgroups

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/MiscellaneousTests.cs
@@ -15,6 +15,173 @@ namespace NuGetUpdater.Core.Test.Run;
 
 public class MiscellaneousTests
 {
+    [Fact]
+    public void ResolveDependencyGroupToRefreshPrefersExactConfiguredName()
+    {
+        var job = new Job()
+        {
+            Source = new() { Provider = "github", Repo = "some/repo" },
+            Dependencies = ["some.package"],
+            DependencyGroupToRefresh = "PARENT/some.package",
+            DependencyGroups = [
+                new()
+                {
+                    Name = "parent",
+                    Rules = new() { ["group-by"] = "dependency-name" },
+                },
+                new() { Name = "parent/Some.Package" },
+            ],
+        };
+
+        var group = job.ResolveDependencyGroupToRefresh();
+
+        Assert.NotNull(group);
+        Assert.Equal("parent/Some.Package", group.Name);
+        Assert.False(group.IsGroupedByDependencyName);
+    }
+
+    [Fact]
+    public void ResolveDependencyGroupToRefreshCreatesDynamicSubgroup()
+    {
+        var job = new Job()
+        {
+            Source = new() { Provider = "github", Repo = "some/repo" },
+            Dependencies = ["some.package"],
+            DependencyGroupToRefresh = "parent/Some.Package",
+            DependencyGroups = [
+                new()
+                {
+                    Name = "parent",
+                    Rules = new()
+                    {
+                        ["patterns"] = new[] { "*" },
+                        ["group-by"] = "dependency-name",
+                        ["update-types"] = new[] { "minor", "patch" },
+                    },
+                },
+            ],
+        };
+
+        var group = job.ResolveDependencyGroupToRefresh();
+
+        Assert.NotNull(group);
+        Assert.Equal("parent/Some.Package", group.Name);
+        Assert.True(group.IsGroupedByDependencyName);
+        Assert.True(group.GetGroupMatcher().IsMatch("some.package"));
+        Assert.False(group.GetGroupMatcher().IsMatch("Some.Other.Package"));
+        Assert.True(group.GetGroupMatcher().IsAllowedByVersion(
+            NuGetVersion.Parse("1.0.0"),
+            NuGetVersion.Parse("1.1.0")));
+        Assert.False(group.GetGroupMatcher().IsAllowedByVersion(
+            NuGetVersion.Parse("1.0.0"),
+            NuGetVersion.Parse("2.0.0")));
+    }
+
+    [Fact]
+    public void ResolveDependencyGroupToRefreshDoesNotTreatSlashAsDynamic()
+    {
+        var job = new Job()
+        {
+            Source = new() { Provider = "github", Repo = "some/repo" },
+            Dependencies = ["Some.Package"],
+            DependencyGroupToRefresh = "parent/Some.Package",
+            DependencyGroups = [new() { Name = "parent" }],
+        };
+
+        Assert.Null(job.ResolveDependencyGroupToRefresh());
+    }
+
+    [Fact]
+    public void ResolveDependencyGroupToRefreshUsesLongestDynamicParentName()
+    {
+        var job = new Job()
+        {
+            Source = new() { Provider = "github", Repo = "some/repo" },
+            Dependencies = ["Some.Package"],
+            DependencyGroupToRefresh = "parent/nested/Some.Package",
+            DependencyGroups = [
+                new()
+                {
+                    Name = "parent",
+                    Rules = new() { ["group-by"] = "dependency-name" },
+                },
+                new()
+                {
+                    Name = "parent/nested",
+                    Rules = new() { ["group-by"] = "dependency-name" },
+                },
+            ],
+        };
+
+        var group = job.ResolveDependencyGroupToRefresh();
+
+        Assert.NotNull(group);
+        Assert.Equal("parent/nested/Some.Package", group.Name);
+        Assert.Equal("Some.Package", group.DependencyNameGroupTarget);
+        Assert.True(group.GetGroupMatcher().IsMatch("Some.Package"));
+    }
+
+    [Fact]
+    public void DynamicSubgroupStopsMatchingWhenDependencyLeavesParent()
+    {
+        var parent = new DependencyGroup()
+        {
+            Name = "parent",
+            Rules = new()
+            {
+                ["patterns"] = new[] { "Other.*" },
+                ["group-by"] = "dependency-name",
+            },
+        };
+
+        var subgroup = parent.CreateDependencyNameSubgroup("Some.Package");
+
+        Assert.False(subgroup.GetGroupMatcher().IsMatch("Some.Package"));
+    }
+
+    [Fact]
+    public void GetMatchingDynamicGroupPullRequestRequiresGroupIdentity()
+    {
+        var job = new Job()
+        {
+            Source = new() { Provider = "github", Repo = "some/repo" },
+            ExistingGroupPullRequests = [
+                new()
+                {
+                    DependencyGroupName = "other/Some.Package",
+                    Dependencies = [
+                        new()
+                        {
+                            DependencyName = "Some.Package",
+                            DependencyVersion = NuGetVersion.Parse("2.0.0"),
+                        },
+                    ],
+                },
+                new()
+                {
+                    DependencyGroupName = "parent/Some.Package",
+                    Dependencies = [
+                        new()
+                        {
+                            DependencyName = "Some.Package",
+                            DependencyVersion = NuGetVersion.Parse("2.0.0"),
+                        },
+                    ],
+                },
+            ],
+        };
+        var dependencies = new[] { new Dependency("some.package", "2.0.0", DependencyType.Unknown) };
+
+        var existingPr = job.GetExistingGroupPullRequestForDependencies(
+            dependencies,
+            considerVersions: true,
+            dependencyGroupName: "PARENT/some.package"
+        );
+
+        Assert.NotNull(existingPr);
+        Assert.Equal("parent/Some.Package", existingPr.Item1);
+    }
+
     [Theory]
     [MemberData(nameof(IsDependencyIgnoredByNameOnlyTestData))]
     public void IsDependencyIgnoredByNameOnly(Condition[] ignoreConditions, string dependencyName, bool expectedIgnored)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/PullRequestTextTests.cs
@@ -48,6 +48,38 @@ public class PullRequestTextTests
         Assert.Equal(expectedTitle, actualTitle);
     }
 
+    [Fact]
+    public void DependencyNameGroupUsesDependencyFocusedTitle()
+    {
+        var job = FromCommitOptions(null);
+        var updateOperations = new UpdateOperationBase[]
+        {
+            new DirectUpdate()
+            {
+                DependencyName = "Incidental.Package",
+                OldVersion = NuGetVersion.Parse("1.0.0"),
+                NewVersion = NuGetVersion.Parse("2.0.0"),
+                UpdatedFiles = ["src/project.csproj"],
+            },
+            new DirectUpdate()
+            {
+                DependencyName = "Some.Package",
+                OldVersion = NuGetVersion.Parse("1.0.0"),
+                NewVersion = NuGetVersion.Parse("2.0.0"),
+                UpdatedFiles = ["src/project.csproj"],
+            },
+        };
+
+        var actualTitle = PullRequestTextGenerator.GetPullRequestTitle(
+            job,
+            [.. updateOperations],
+            dependencyGroupName: "parent/Some.Package",
+            dependencyNameGroupTarget: "Some.Package",
+            updatedDirectories: ["/src", "/test"]);
+
+        Assert.Equal("Bump Some.Package across 2 directories", actualTitle);
+    }
+
     [Theory]
     [MemberData(nameof(GetPullRequestTextTestData))]
     public async Task PullRequestText(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/SerializationTests.cs
@@ -381,7 +381,8 @@ public class SerializationTests : TestBase
                         {
                             "name": "Some.Dependency",
                             "rules": {
-                                "patterns": ["1.2.3", "4.5.6"]
+                                "patterns": ["1.2.3", "4.5.6"],
+                                "group-by": "dependency-name"
                             }
                         },
                         {
@@ -397,8 +398,9 @@ public class SerializationTests : TestBase
 
         Assert.Equal("Some.Dependency", jobWrapper.Job.DependencyGroups[0].Name);
         Assert.Null(jobWrapper.Job.DependencyGroups[0].AppliesTo);
-        Assert.Single(jobWrapper.Job.DependencyGroups[0].Rules);
+        Assert.Equal(2, jobWrapper.Job.DependencyGroups[0].Rules.Count);
         Assert.Equal("[\"1.2.3\", \"4.5.6\"]", jobWrapper.Job.DependencyGroups[0].Rules["patterns"].ToString());
+        Assert.True(jobWrapper.Job.DependencyGroups[0].IsGroupedByDependencyName);
 
         Assert.Equal("Some.Other.Dependency", jobWrapper.Job.DependencyGroups[1].Name);
         Assert.Equal("something", jobWrapper.Job.DependencyGroups[1].AppliesTo);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/GroupUpdateAllVersionsHandlerTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 using NuGet.Versioning;
 
 using NuGetUpdater.Core.Analyze;
@@ -41,6 +43,329 @@ public class GroupUpdateAllVersionsHandlerTests : UpdateHandlersTestsBase
         Assert.Equal("some.dependency/1.0.0", updateOperation.Key.ToString());
         var operationProjects = updateOperation.Select(p => p.ProjectPath).ToArray();
         AssertEx.Equal(["/project1.csproj", "/project2.csproj"], operationProjects);
+    }
+
+    [Fact]
+    public async Task GeneratesCreatePullRequestsForDependencyNameSubgroups()
+    {
+        var dependencyList = new UpdatedDependencyList()
+        {
+            Dependencies = [
+                new()
+                {
+                    Name = "Package.A",
+                    Version = "1.0.0",
+                    Requirements = [
+                        new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                    ],
+                },
+                new()
+                {
+                    Name = "Package.B",
+                    Version = "2.0.0",
+                    Requirements = [
+                        new() { Requirement = "2.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                    ],
+                },
+            ],
+            DependencyFiles = ["/src/project.csproj"],
+        };
+
+        static CreatePullRequest ExpectedPullRequest(string dependencyName, string previousVersion, string newVersion) =>
+            new()
+            {
+                Dependencies = [
+                    new()
+                    {
+                        Name = dependencyName,
+                        Version = newVersion,
+                        Requirements = [
+                            new()
+                            {
+                                Requirement = newVersion,
+                                File = "/src/project.csproj",
+                                Groups = ["dependencies"],
+                                Source = new() { SourceUrl = null },
+                            },
+                        ],
+                        PreviousVersion = previousVersion,
+                        PreviousRequirements = [
+                            new()
+                            {
+                                Requirement = previousVersion,
+                                File = "/src/project.csproj",
+                                Groups = ["dependencies"],
+                            },
+                        ],
+                    },
+                ],
+                UpdatedDependencyFiles = [
+                    new()
+                    {
+                        Directory = "/src",
+                        Name = "project.csproj",
+                        Content = $"updated {dependencyName}",
+                    },
+                ],
+                BaseCommitSha = "TEST-COMMIT-SHA",
+                CommitMessage = EndToEndTests.TestPullRequestCommitMessage,
+                PrTitle = EndToEndTests.TestPullRequestTitle,
+                PrBody = EndToEndTests.TestPullRequestBody,
+                DependencyGroup = $"parent/{dependencyName}",
+            };
+
+        await TestAsync(
+            job: new Job()
+            {
+                Source = CreateJobSource("/src"),
+                DependencyGroups = [
+                    new()
+                    {
+                        Name = "parent",
+                        Rules = new()
+                        {
+                            ["patterns"] = new[] { "Package.*" },
+                            ["group-by"] = "dependency-name",
+                        },
+                    },
+                ],
+            },
+            files: [("src/project.csproj", "initial contents")],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Package.A", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Package.B", "2.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        },
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var dependencyInfo = input.Item3;
+                var newVersion = dependencyInfo.Name switch
+                {
+                    "Package.A" => "1.1.0",
+                    "Package.B" => "2.1.0",
+                    _ => throw new NotImplementedException($"Unexpected dependency {dependencyInfo.Name}"),
+                };
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = newVersion,
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                var dependencyName = input.Item3;
+                var newVersion = input.Item5;
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), $"updated {dependencyName}");
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [
+                        new DirectUpdate()
+                        {
+                            DependencyName = dependencyName,
+                            NewVersion = NuGetVersion.Parse(newVersion),
+                            UpdatedFiles = [workspacePath],
+                        },
+                    ],
+                };
+            }),
+            expectedUpdateHandler: GroupUpdateAllVersionsHandler.Instance,
+            expectedApiMessages: [
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new() { ["operation"] = "group_update_all_versions" },
+                },
+                dependencyList,
+                ExpectedPullRequest("Package.A", "1.0.0", "1.1.0"),
+                ExpectedPullRequest("Package.B", "2.0.0", "2.1.0"),
+                dependencyList,
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public async Task ConfiguredGroupTakesPrecedenceOverGeneratedSubgroupName()
+    {
+        var dependencyList = new UpdatedDependencyList()
+        {
+            Dependencies = [
+                new()
+                {
+                    Name = "Package.A",
+                    Version = "1.0.0",
+                    Requirements = [
+                        new() { Requirement = "1.0.0", File = "/src/project.csproj", Groups = ["dependencies"] },
+                    ],
+                },
+            ],
+            DependencyFiles = ["/src/project.csproj"],
+        };
+
+        await TestAsync(
+            job: new Job()
+            {
+                Source = CreateJobSource("/src"),
+                DependencyGroups = [
+                    new()
+                    {
+                        Name = "parent",
+                        Rules = new()
+                        {
+                            ["patterns"] = new[] { "Package.*" },
+                            ["group-by"] = "dependency-name",
+                        },
+                    },
+                    new()
+                    {
+                        Name = "PARENT/package.a",
+                        Rules = new() { ["patterns"] = new[] { "Package.A" } },
+                    },
+                ],
+            },
+            files: [("src/project.csproj", "initial contents")],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Package.A", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        },
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(_ => Task.FromResult(new AnalysisResult()
+            {
+                CanUpdate = true,
+                UpdatedVersion = "1.1.0",
+                UpdatedDependencies = [],
+            })),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [
+                        new DirectUpdate()
+                        {
+                            DependencyName = input.Item3,
+                            NewVersion = NuGetVersion.Parse(input.Item5),
+                            UpdatedFiles = [workspacePath],
+                        },
+                    ],
+                };
+            }),
+            expectedUpdateHandler: GroupUpdateAllVersionsHandler.Instance,
+            expectedApiMessages: [
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new() { ["operation"] = "group_update_all_versions" },
+                },
+                dependencyList,
+                dependencyList,
+                new CreatePullRequest()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Package.A",
+                            Version = "1.1.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.1.0",
+                                    File = "/src/project.csproj",
+                                    Groups = ["dependencies"],
+                                    Source = new() { SourceUrl = null },
+                                },
+                            ],
+                            PreviousVersion = "1.0.0",
+                            PreviousRequirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/src/project.csproj",
+                                    Groups = ["dependencies"],
+                                },
+                            ],
+                        },
+                    ],
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = EndToEndTests.TestPullRequestCommitMessage,
+                    PrTitle = EndToEndTests.TestPullRequestTitle,
+                    PrBody = EndToEndTests.TestPullRequestBody,
+                    DependencyGroup = "PARENT/package.a",
+                },
+                dependencyList,
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
+    public void DependencyNameGroupDoesNotFallThroughWhenUpdateTypeIsRejected()
+    {
+        var dependency = new Dependency("Some.Dependency", "1.0.0", DependencyType.PackageReference);
+        var analysis = new AnalysisResult()
+        {
+            CanUpdate = true,
+            UpdatedVersion = "2.0.0",
+            UpdatedDependencies = [],
+        };
+        var groups = ImmutableArray.Create(
+            new DependencyGroup()
+            {
+                Name = "parent",
+                Rules = new()
+                {
+                    ["patterns"] = new[] { "*" },
+                    ["group-by"] = "dependency-name",
+                    ["update-types"] = new[] { "minor", "patch" },
+                },
+            });
+        var logger = new TestLogger();
+
+        var skipped = GroupUpdateAllVersionsHandler.IsUngroupedDependencySkipped(
+            dependency,
+            analysis,
+            groups,
+            logger);
+
+        Assert.True(skipped);
     }
 
     [Fact]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandlerTests.cs
@@ -15,6 +15,192 @@ namespace NuGetUpdater.Core.Test.Run.UpdateHandlers;
 public class RefreshGroupUpdatePullRequestHandlerTests : UpdateHandlersTestsBase
 {
     [Fact]
+    public async Task GeneratesUpdatePullRequestForDependencyNameSubgroup()
+    {
+        await TestAsync(
+            job: new Job()
+            {
+                Dependencies = ["Some.Dependency"],
+                DependencyGroups = [
+                    new()
+                    {
+                        Name = "parent",
+                        Rules = new()
+                        {
+                            ["patterns"] = new[] { "*" },
+                            ["group-by"] = "dependency-name",
+                        },
+                    },
+                ],
+                DependencyGroupToRefresh = "parent/Some.Dependency",
+                ExistingGroupPullRequests = [
+                    new()
+                    {
+                        DependencyGroupName = "parent/Some.Dependency",
+                        Dependencies = [
+                            new()
+                            {
+                                DependencyName = "Some.Dependency",
+                                DependencyVersion = NuGetVersion.Parse("2.0.0"),
+                            },
+                        ],
+                    },
+                ],
+                Source = CreateJobSource("/src1", "/src2"),
+                UpdatingAPullRequest = true,
+            },
+            files: [
+                ("src1/project.csproj", "initial contents"),
+                ("src2/project.csproj", "initial contents"),
+            ],
+            discoveryWorker: TestDiscoveryWorker.FromResults(
+                ("/src1", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src1",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("Some.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                                new("Other.Dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        },
+                    ],
+                }),
+                ("/src2", new WorkspaceDiscoveryResult()
+                {
+                    Path = "/src2",
+                    Projects = [
+                        new()
+                        {
+                            FilePath = "project.csproj",
+                            Dependencies = [
+                                new("some.dependency", "1.0.0", DependencyType.PackageReference, TargetFrameworks: ["net9.0"]),
+                            ],
+                            ImportedFiles = [],
+                            AdditionalFiles = [],
+                        },
+                    ],
+                })
+            ),
+            analyzeWorker: new TestAnalyzeWorker(input =>
+            {
+                var dependencyInfo = input.Item3;
+                Assert.Equal("Some.Dependency", dependencyInfo.Name, ignoreCase: true);
+                return Task.FromResult(new AnalysisResult()
+                {
+                    CanUpdate = true,
+                    UpdatedVersion = "2.0.0",
+                    UpdatedDependencies = [],
+                });
+            }),
+            updaterWorker: new TestUpdaterWorker(async input =>
+            {
+                var repoRoot = input.Item1;
+                var workspacePath = input.Item2;
+                await File.WriteAllTextAsync(Path.Join(repoRoot, workspacePath), "updated contents");
+                return new UpdateOperationResult()
+                {
+                    UpdateOperations = [
+                        new DirectUpdate()
+                        {
+                            DependencyName = input.Item3,
+                            NewVersion = NuGetVersion.Parse("2.0.0"),
+                            UpdatedFiles = [workspacePath],
+                        },
+                    ],
+                };
+            }),
+            expectedUpdateHandler: RefreshGroupUpdatePullRequestHandler.Instance,
+            expectedApiMessages: [
+                new IncrementMetric()
+                {
+                    Metric = "updater.started",
+                    Tags = new() { ["operation"] = "update_version_group_pr" },
+                },
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "Other.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/src1/project.csproj",
+                                    Groups = ["dependencies"],
+                                },
+                            ],
+                        },
+                        new()
+                        {
+                            Name = "Some.Dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/src1/project.csproj",
+                                    Groups = ["dependencies"],
+                                },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src1/project.csproj"],
+                },
+                new UpdatedDependencyList()
+                {
+                    Dependencies = [
+                        new()
+                        {
+                            Name = "some.dependency",
+                            Version = "1.0.0",
+                            Requirements = [
+                                new()
+                                {
+                                    Requirement = "1.0.0",
+                                    File = "/src2/project.csproj",
+                                    Groups = ["dependencies"],
+                                },
+                            ],
+                        },
+                    ],
+                    DependencyFiles = ["/src2/project.csproj"],
+                },
+                new UpdatePullRequest()
+                {
+                    DependencyNames = ["Some.Dependency"],
+                    DependencyGroup = "parent/Some.Dependency",
+                    UpdatedDependencyFiles = [
+                        new()
+                        {
+                            Directory = "/src1",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        },
+                        new()
+                        {
+                            Directory = "/src2",
+                            Name = "project.csproj",
+                            Content = "updated contents",
+                        },
+                    ],
+                    BaseCommitSha = "TEST-COMMIT-SHA",
+                    CommitMessage = EndToEndTests.TestPullRequestCommitMessage,
+                    PrTitle = EndToEndTests.TestPullRequestTitle,
+                    PrBody = EndToEndTests.TestPullRequestBody,
+                },
+                new MarkAsProcessed("TEST-COMMIT-SHA"),
+            ]
+        );
+    }
+
+    [Fact]
     public async Task GeneratesUpdatePullRequest()
     {
         await TestAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyGroup.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/DependencyGroup.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.IO.Enumeration;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using NuGet.Versioning;
 
@@ -19,6 +20,42 @@ public record DependencyGroup
     public Dictionary<string, object> Rules { get; init; } = new();
 
     public GroupMatcher GetGroupMatcher() => GroupMatcher.FromRules(Rules);
+
+    public bool IsGroupedByDependencyName =>
+        GetString(Rules, "group-by")?.Equals("dependency-name", StringComparison.Ordinal) == true;
+
+    [JsonIgnore]
+    public string? DependencyNameGroupTarget { get; init; }
+
+    public DependencyGroup CreateDependencyNameSubgroup(string dependencyName, string? subgroupName = null)
+    {
+        var matchesParent = GetGroupMatcher().IsMatch(dependencyName);
+        var subgroupRules = new Dictionary<string, object>(Rules)
+        {
+            ["patterns"] = matchesParent ? new[] { dependencyName } : Array.Empty<string>(),
+        };
+        return this with
+        {
+            Name = subgroupName ?? $"{Name}/{dependencyName}",
+            Rules = subgroupRules,
+            DependencyNameGroupTarget = dependencyName,
+        };
+    }
+
+    private static string? GetString(Dictionary<string, object> rules, string propertyName)
+    {
+        if (!rules.TryGetValue(propertyName, out var propertyObject))
+        {
+            return null;
+        }
+
+        return propertyObject switch
+        {
+            string value => value,
+            JsonElement { ValueKind: JsonValueKind.String } element => element.GetString(),
+            _ => null,
+        };
+    }
 }
 
 public enum GroupUpdateType

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/ApiModel/Job.cs
@@ -102,7 +102,63 @@ public sealed record Job
         return existingPullRequests;
     }
 
+    public DependencyGroup? ResolveDependencyGroupToRefresh()
+    {
+        if (DependencyGroupToRefresh is null)
+        {
+            return null;
+        }
+
+        var exactGroup = FindConfiguredDependencyGroup(DependencyGroupToRefresh);
+        if (exactGroup is not null)
+        {
+            return exactGroup;
+        }
+
+        var dynamicParent = DependencyGroups
+            .Where(g => g.IsGroupedByDependencyName)
+            .Where(g => DependencyGroupToRefresh.StartsWith($"{g.Name}/", StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(g => g.Name.Length)
+            .FirstOrDefault();
+        if (dynamicParent is null)
+        {
+            return null;
+        }
+
+        var dependencyName = DependencyGroupToRefresh[(dynamicParent.Name.Length + 1)..];
+        if (dependencyName.Length == 0 ||
+            (Dependencies.Length > 0 && !Dependencies.Contains(dependencyName, StringComparer.OrdinalIgnoreCase)))
+        {
+            return null;
+        }
+
+        return dynamicParent.CreateDependencyNameSubgroup(dependencyName, DependencyGroupToRefresh);
+    }
+
+    public DependencyGroup? FindConfiguredDependencyGroup(string name)
+    {
+        return DependencyGroups.FirstOrDefault(g => g.Name == name) ??
+            DependencyGroups.FirstOrDefault(g => g.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+    }
+
     public Tuple<string?, ImmutableArray<PullRequestDependency>>? GetExistingPullRequestForDependencies(IEnumerable<Dependency> dependencies, bool considerVersions)
+    {
+        return GetExistingPullRequestForDependencies(dependencies, considerVersions, dependencyGroupName: null, matchGroupName: false);
+    }
+
+    public Tuple<string?, ImmutableArray<PullRequestDependency>>? GetExistingGroupPullRequestForDependencies(
+        IEnumerable<Dependency> dependencies,
+        bool considerVersions,
+        string dependencyGroupName)
+    {
+        return GetExistingPullRequestForDependencies(dependencies, considerVersions, dependencyGroupName, matchGroupName: true);
+    }
+
+    private Tuple<string?, ImmutableArray<PullRequestDependency>>? GetExistingPullRequestForDependencies(
+        IEnumerable<Dependency> dependencies,
+        bool considerVersions,
+        string? dependencyGroupName,
+        bool matchGroupName)
     {
         if (dependencies.Any(d => d.Version is null))
         {
@@ -119,6 +175,12 @@ public sealed record Job
         var existingPullRequest = existingPullRequests
             .FirstOrDefault(pr =>
             {
+                if (matchGroupName &&
+                    !string.Equals(pr.Item1, dependencyGroupName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
                 var prDependencySet = pr.Item2.Select(d => CreateIdentifier(d.DependencyName, d.DependencyVersion.ToString())).ToHashSet(StringComparer.OrdinalIgnoreCase);
                 return prDependencySet.SetEquals(desiredDependencySet);
             });

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/PullRequestTextGenerator.cs
@@ -14,9 +14,19 @@ public class PullRequestTextGenerator
 {
     private const int MaxTitleLength = 70;
 
-    public static string GetPullRequestTitle(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
+    public static string GetPullRequestTitle(
+        Job job,
+        ImmutableArray<UpdateOperationBase> updateOperationsPerformed,
+        string? dependencyGroupName,
+        string? dependencyNameGroupTarget = null,
+        IEnumerable<string>? updatedDirectories = null)
     {
-        var shortTitle = GetPullRequestShortTitle(job, updateOperationsPerformed, dependencyGroupName);
+        var shortTitle = GetPullRequestShortTitle(
+            job,
+            updateOperationsPerformed,
+            dependencyGroupName,
+            dependencyNameGroupTarget,
+            updatedDirectories);
         var titlePrefix = GetPullRequestTitlePrefix(job);
         var fullTitle = $"{titlePrefix}{shortTitle}";
         return fullTitle;
@@ -43,13 +53,30 @@ public class PullRequestTextGenerator
         return prefix;
     }
 
-    private static string GetPullRequestShortTitle(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
+    private static string GetPullRequestShortTitle(
+        Job job,
+        ImmutableArray<UpdateOperationBase> updateOperationsPerformed,
+        string? dependencyGroupName,
+        string? dependencyNameGroupTarget,
+        IEnumerable<string>? updatedDirectories)
     {
         string title;
         var dependencySets = GetDependencySets(updateOperationsPerformed);
-        if (dependencyGroupName is not null)
+        if (dependencyGroupName is not null && dependencyNameGroupTarget is null)
         {
             title = $"Bump the {dependencyGroupName} group with {dependencySets.Length} update{(dependencySets.Length > 1 ? "s" : "")}";
+        }
+        else if (dependencyNameGroupTarget is not null)
+        {
+            var directories = (updatedDirectories ?? [])
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            title = directories.Length switch
+            {
+                > 1 => $"Bump {dependencyNameGroupTarget} across {directories.Length} directories",
+                1 when directories[0] != "/" => $"Bump {dependencyNameGroupTarget} in {directories[0]}",
+                _ => $"Bump {dependencyNameGroupTarget}",
+            };
         }
         else
         {
@@ -73,13 +100,23 @@ public class PullRequestTextGenerator
         return title;
     }
 
-    public static string GetPullRequestCommitMessage(Job job, ImmutableArray<UpdateOperationBase> updateOperationsPerformed, string? dependencyGroupName)
+    public static string GetPullRequestCommitMessage(
+        Job job,
+        ImmutableArray<UpdateOperationBase> updateOperationsPerformed,
+        string? dependencyGroupName,
+        string? dependencyNameGroupTarget = null,
+        IEnumerable<string>? updatedDirectories = null)
     {
         var sb = new StringBuilder();
-        sb.AppendLine(GetPullRequestTitle(job, updateOperationsPerformed, dependencyGroupName));
+        sb.AppendLine(GetPullRequestTitle(
+            job,
+            updateOperationsPerformed,
+            dependencyGroupName,
+            dependencyNameGroupTarget,
+            updatedDirectories));
         var dependencySets = GetDependencySets(updateOperationsPerformed);
         if (dependencySets.Length > 1 ||
-            dependencyGroupName is not null)
+            (dependencyGroupName is not null && dependencyNameGroupTarget is null))
         {
             // multiple updates performed, enumerate them
             sb.AppendLine();

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/GroupUpdateAllVersionsHandler.cs
@@ -11,6 +11,12 @@ namespace NuGetUpdater.Core.Run.UpdateHandlers;
 
 internal class GroupUpdateAllVersionsHandler : IUpdateHandler
 {
+    private sealed record DirectoryDiscovery(
+        string Directory,
+        WorkspaceDiscoveryResult DiscoveryResult,
+        UpdatedDependencyList UpdatedDependencyList,
+        ImmutableArray<(string ProjectPath, Dependency Dependency)> UpdateOperations);
+
     public static IUpdateHandler Instance { get; } = new GroupUpdateAllVersionsHandler();
 
     public string TagName => "group_update_all_versions";
@@ -61,10 +67,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
         foreach (var group in job.DependencyGroups)
         {
             logger.Info($"Starting update for group {group.Name}");
-            var groupMatcher = group.GetGroupMatcher();
-            var updateOperationsPerformed = new List<UpdateOperationBase>();
-            var updatedDependencies = new List<ReportedDependency>();
-            var allUpdatedDependencyFiles = ImmutableArray.Create<DependencyFile>();
+            var directoryDiscoveries = new List<DirectoryDiscovery>();
             foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
             {
                 var discoveryResult = await discoveryWorker.RunAsync(repoContentsPath.FullName, directory);
@@ -75,14 +78,119 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     return;
                 }
 
-                var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialFiles, logger);
-                await tracker.StartTrackingAsync(discoveryResult);
-
                 var updatedDependencyList = RunWorker.GetUpdatedDependencyListFromDiscovery(discoveryResult, originalRepoContentsPath.FullName, logger, initialFiles);
                 await apiHandler.UpdateDependencyList(updatedDependencyList);
+                var updateOperations = RunWorker.GetUpdateOperations(discoveryResult).ToImmutableArray();
+                directoryDiscoveries.Add(new(directory, discoveryResult, updatedDependencyList, updateOperations));
+            }
 
-                var updateOperationsToPerform = RunWorker.GetUpdateOperations(discoveryResult).ToArray();
-                foreach (var (projectPath, dependency) in updateOperationsToPerform)
+            if (group.IsGroupedByDependencyName)
+            {
+                var groupMatcher = group.GetGroupMatcher();
+                var directoryDiscoveriesByDependencyName = new Dictionary<string, List<DirectoryDiscovery>>(StringComparer.OrdinalIgnoreCase);
+                foreach (var directoryDiscovery in directoryDiscoveries)
+                {
+                    var matchingOperationsByDependencyName = directoryDiscovery.UpdateOperations
+                        .Where(o => job.IsUpdatePermitted(o.Dependency))
+                        .Where(o => groupMatcher.IsMatch(o.Dependency.Name))
+                        .Where(o => !job.IsDependencyIgnoredByNameOnly(o.Dependency.Name))
+                        .GroupBy(o => o.Dependency.Name, StringComparer.OrdinalIgnoreCase);
+                    foreach (var matchingOperations in matchingOperationsByDependencyName)
+                    {
+                        if (!directoryDiscoveriesByDependencyName.TryGetValue(matchingOperations.Key, out var subgroupDiscoveries))
+                        {
+                            subgroupDiscoveries = [];
+                            directoryDiscoveriesByDependencyName.Add(matchingOperations.Key, subgroupDiscoveries);
+                        }
+
+                        subgroupDiscoveries.Add(directoryDiscovery with
+                        {
+                            UpdateOperations = [.. matchingOperations],
+                        });
+                    }
+                }
+
+                foreach (var (dependencyName, subgroupDiscoveries) in directoryDiscoveriesByDependencyName)
+                {
+                    var subgroup = group.CreateDependencyNameSubgroup(dependencyName);
+                    var configuredGroup = job.FindConfiguredDependencyGroup(subgroup.Name);
+                    if (configuredGroup is not null)
+                    {
+                        logger.Info($"Skipping dynamic subgroup {subgroup.Name} because configured group {configuredGroup.Name} has precedence.");
+                        continue;
+                    }
+
+                    var succeeded = await RunEffectiveGroupUpdate(
+                        job,
+                        subgroup,
+                        subgroupDiscoveries,
+                        originalRepoContentsPath,
+                        repoContentsPath,
+                        initialFiles,
+                        baseCommitSha,
+                        analyzeWorker,
+                        updaterWorker,
+                        apiHandler,
+                        experimentsManager,
+                        logger);
+                    if (!succeeded)
+                    {
+                        return;
+                    }
+                }
+            }
+            else
+            {
+                var succeeded = await RunEffectiveGroupUpdate(
+                    job,
+                    group,
+                    directoryDiscoveries,
+                    originalRepoContentsPath,
+                    repoContentsPath,
+                    initialFiles,
+                    baseCommitSha,
+                    analyzeWorker,
+                    updaterWorker,
+                    apiHandler,
+                    experimentsManager,
+                    logger);
+                if (!succeeded)
+                {
+                    return;
+                }
+            }
+        }
+    }
+
+    private static async Task<bool> RunEffectiveGroupUpdate(
+        Job job,
+        DependencyGroup group,
+        IEnumerable<DirectoryDiscovery> directoryDiscoveries,
+        DirectoryInfo originalRepoContentsPath,
+        DirectoryInfo repoContentsPath,
+        HashSet<string> initialFiles,
+        string baseCommitSha,
+        IAnalyzeWorker analyzeWorker,
+        IUpdaterWorker updaterWorker,
+        IApiHandler apiHandler,
+        ExperimentsManager experimentsManager,
+        ILogger logger)
+    {
+        logger.Info($"Starting update for effective group {group.Name}");
+        var groupMatcher = group.GetGroupMatcher();
+        var updateOperationsPerformed = new List<UpdateOperationBase>();
+        var updatedDependencies = new List<ReportedDependency>();
+        var allUpdatedDependencyFiles = ImmutableArray.Create<DependencyFile>();
+        var updatedGroupDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var directoryDiscovery in directoryDiscoveries)
+        {
+            var discoveryResult = directoryDiscovery.DiscoveryResult;
+            var updatedDependencyList = directoryDiscovery.UpdatedDependencyList;
+            var tracker = new ModifiedFilesTracker(originalRepoContentsPath, initialFiles, logger);
+            await tracker.StartTrackingAsync(discoveryResult);
+            try
+            {
+                foreach (var (projectPath, dependency) in directoryDiscovery.UpdateOperations)
                 {
                     if (!job.IsUpdatePermitted(dependency))
                     {
@@ -106,7 +214,7 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
                     {
                         logger.Error($"Error analyzing {dependency.Name} in {projectPath}: {analysisResult.Error.GetReport()}");
                         await apiHandler.RecordUpdateJobError(analysisResult.Error, logger);
-                        return;
+                        return false;
                     }
 
                     if (!analysisResult.CanUpdate)
@@ -143,43 +251,59 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
 
                     updatedDependencies.AddRange(updatedDependenciesForThis);
                     updateOperationsPerformed.AddRange(patchedUpdateOperations);
+                    updatedGroupDirectories.Add(directoryDiscovery.Directory);
                     foreach (var o in patchedUpdateOperations)
                     {
                         logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
                     }
                 }
-
+            }
+            finally
+            {
                 var updatedDependencyFiles = await tracker.StopTrackingAsync(restoreOriginalContents: true);
                 allUpdatedDependencyFiles = ModifiedFilesTracker.MergeUpdatedFileSet(allUpdatedDependencyFiles, updatedDependencyFiles);
             }
+        }
 
-            if (updateOperationsPerformed.Count > 0)
+        if (updateOperationsPerformed.Count > 0)
+        {
+            var dependencies = updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown));
+            var existingPullRequest = group.IsGroupedByDependencyName
+                ? job.GetExistingGroupPullRequestForDependencies(dependencies, considerVersions: true, group.Name)
+                : job.GetExistingPullRequestForDependencies(dependencies, considerVersions: true);
+            if (existingPullRequest is not null)
             {
-                var existingPullRequest = job.GetExistingPullRequestForDependencies(
-                        dependencies: updatedDependencies.Select(d => new Dependency(d.Name, d.Version, DependencyType.Unknown)),
-                        considerVersions: true);
-                if (existingPullRequest is not null)
+                logger.Info($"Pull request already exists for {string.Join(", ", existingPullRequest!.Item2.Select(d => $"{d.DependencyName}/{d.DependencyVersion}"))}");
+            }
+            else
+            {
+                var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(
+                    job,
+                    [.. updateOperationsPerformed],
+                    group.Name,
+                    group.DependencyNameGroupTarget,
+                    updatedGroupDirectories);
+                var prTitle = PullRequestTextGenerator.GetPullRequestTitle(
+                    job,
+                    [.. updateOperationsPerformed],
+                    group.Name,
+                    group.DependencyNameGroupTarget,
+                    updatedGroupDirectories);
+                var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
+                await apiHandler.CreatePullRequest(new CreatePullRequest()
                 {
-                    logger.Info($"Pull request already exists for {string.Join(", ", existingPullRequest!.Item2.Select(d => $"{d.DependencyName}/{d.DependencyVersion}"))}");
-                }
-                else
-                {
-                    var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], group.Name);
-                    var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], group.Name);
-                    var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
-                    await apiHandler.CreatePullRequest(new CreatePullRequest()
-                    {
-                        Dependencies = [.. updatedDependencies],
-                        UpdatedDependencyFiles = [.. allUpdatedDependencyFiles],
-                        BaseCommitSha = baseCommitSha,
-                        CommitMessage = commitMessage,
-                        PrTitle = prTitle,
-                        PrBody = prBody,
-                        DependencyGroup = group.Name,
-                    });
-                }
+                    Dependencies = [.. updatedDependencies],
+                    UpdatedDependencyFiles = [.. allUpdatedDependencyFiles],
+                    BaseCommitSha = baseCommitSha,
+                    CommitMessage = commitMessage,
+                    PrTitle = prTitle,
+                    PrBody = prBody,
+                    DependencyGroup = group.Name,
+                });
             }
         }
+
+        return true;
     }
 
     private async Task RunUngroupedDependencyUpdates(Job job, DirectoryInfo originalRepoContentsPath, DirectoryInfo? caseInsensitiveRepoContentsPath, string baseCommitSha, IDiscoveryWorker discoveryWorker, IAnalyzeWorker analyzeWorker, IUpdaterWorker updaterWorker, IApiHandler apiHandler, ExperimentsManager experimentsManager, ILogger logger)
@@ -316,6 +440,17 @@ internal class GroupUpdateAllVersionsHandler : IUpdateHandler
             .ToImmutableArray();
         if (matcherGroups.Length > 0)
         {
+            var dynamicGroupNames = dependencyGroups
+                .Where(group => group.IsGroupedByDependencyName)
+                .Where(group => group.GetGroupMatcher().IsMatch(dependency.Name))
+                .Select(group => group.Name)
+                .ToArray();
+            if (dynamicGroupNames.Length > 0)
+            {
+                logger.Info($"Dependency {dependency.Name} skipped for ungrouped updates because it's owned by the following dependency-name groups: {string.Join(", ", dynamicGroupNames)}");
+                return true;
+            }
+
             // update matches a group by name
             // if any group allows the proposed version range, then it's not allowed in an ungrouped update
             var oldVersion = NuGetVersion.Parse(dependency.Version!);

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/UpdateHandlers/RefreshGroupUpdatePullRequestHandler.cs
@@ -54,7 +54,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
             throw new InvalidOperationException($"{nameof(job.DependencyGroupToRefresh)} must be non-null.");
         }
 
-        var group = job.DependencyGroups.FirstOrDefault(g => g.Name == job.DependencyGroupToRefresh);
+        var group = job.ResolveDependencyGroupToRefresh();
         if (group is null)
         {
             throw new InvalidOperationException($"Dependency group {job.DependencyGroupToRefresh} not found.");
@@ -63,11 +63,15 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
         logger.Info($"Starting update for group {group.Name}");
         await this.ReportUpdaterStarted(apiHandler);
 
+        var isDynamicSubgroup = group.IsGroupedByDependencyName &&
+            !job.DependencyGroups.Any(
+                g => g.Name.Equals(job.DependencyGroupToRefresh, StringComparison.OrdinalIgnoreCase));
         var groupMatcher = group.GetGroupMatcher();
         var jobDependencies = job.Dependencies.ToHashSet(StringComparer.OrdinalIgnoreCase);
         var updateOperationsPerformed = new List<UpdateOperationBase>();
         var updatedDependencies = new List<ReportedDependency>();
         var allUpdatedDependencyFiles = ImmutableArray.Create<DependencyFile>();
+        var updatedGroupDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var initialFiles = ModifiedFilesTracker.GetInitiallyExistingFiles(repoContentsPath);
         foreach (var directory in job.GetAllDirectories(repoContentsPath.FullName))
         {
@@ -139,6 +143,7 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
 
                     updatedDependencies.AddRange(updatedDependenciesForThis);
                     updateOperationsPerformed.AddRange(patchedUpdateOperations);
+                    updatedGroupDirectories.Add(directory);
                     foreach (var o in patchedUpdateOperations)
                     {
                         logger.Info($"Update operation performed: {o.GetReport(includeFileNames: true)}");
@@ -159,10 +164,23 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
             return;
         }
 
-        var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(job, [.. updateOperationsPerformed], null);
-        var prTitle = PullRequestTextGenerator.GetPullRequestTitle(job, [.. updateOperationsPerformed], null);
+        var textGroupName = isDynamicSubgroup ? group.Name : null;
+        var commitMessage = PullRequestTextGenerator.GetPullRequestCommitMessage(
+            job,
+            [.. updateOperationsPerformed],
+            textGroupName,
+            group.DependencyNameGroupTarget,
+            updatedGroupDirectories);
+        var prTitle = PullRequestTextGenerator.GetPullRequestTitle(
+            job,
+            [.. updateOperationsPerformed],
+            textGroupName,
+            group.DependencyNameGroupTarget,
+            updatedGroupDirectories);
         var prBody = await PullRequestTextGenerator.GetPullRequestBodyAsync(job, [.. updateOperationsPerformed], [.. updatedDependencies], experimentsManager);
-        var existingPullRequest = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
+        var existingPullRequest = isDynamicSubgroup
+            ? job.GetExistingGroupPullRequestForDependencies(rawDependencies, considerVersions: true, group.Name)
+            : job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: true);
         if (existingPullRequest is not null)
         {
             await apiHandler.UpdatePullRequest(new UpdatePullRequest()
@@ -178,7 +196,9 @@ internal class RefreshGroupUpdatePullRequestHandler : IUpdateHandler
         }
         else
         {
-            var existingPrButDifferent = job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
+            var existingPrButDifferent = isDynamicSubgroup
+                ? job.GetExistingGroupPullRequestForDependencies(rawDependencies, considerVersions: false, group.Name)
+                : job.GetExistingPullRequestForDependencies(rawDependencies, considerVersions: false);
             if (existingPrButDifferent is not null)
             {
                 await apiHandler.ClosePullRequest(ClosePullRequest.WithDependenciesChanged(job));


### PR DESCRIPTION
## Summary
- add `group-by: dependency-name` support to the native NuGet updater
- create case-insensitive dynamic subgroups per package across projects and directories
- support subgroup refreshes, group-specific PR identity, and dependency-focused PR text
- preserve existing static group behavior and ignore graduated refresh experiment flags

## Validation
- related NuGet updater tests
- changed-file formatting check
- native NuGet helper publish and version verification
