### PR TITLE
Handle npm unpublished time metadata

### DIFF
--- a/common/lib/dependabot/package/npm_registry_package.rb
+++ b/common/lib/dependabot/package/npm_registry_package.rb
@@ -54,20 +54,20 @@ module Dependabot
         dist_tags = package["dist-tags"]
 
         release_details = versions.nil? ? {} : object_hash(versions, "versions")
-        rejected_versions = T.let({}, T::Hash[String, T::Boolean])
+        accepted_versions = T.let({}, T::Hash[String, T::Boolean])
         release_details.each_key do |version|
-          rejected_versions[version] = true unless yield(version)
+          accepted_versions[version] = true if yield(version)
         end
 
         release_times = if times.nil?
                           {}
                         else
-                          string_map(times, "time", skipped_keys: rejected_versions)
+                          string_map(times, "time", included_keys: accepted_versions)
                         end
 
         releases = T.let({}, T::Hash[String, Release])
         release_details.each do |version, details|
-          next if rejected_versions.key?(version)
+          next unless accepted_versions.key?(version)
 
           releases[version] = parse_release(
             version: version,
@@ -158,13 +158,13 @@ module Dependabot
         params(
           value: Object,
           context: String,
-          skipped_keys: T.nilable(T::Hash[String, T::Boolean])
+          included_keys: T.nilable(T::Hash[String, T::Boolean])
         ).returns(T::Hash[String, String])
       end
-      def self.string_map(value, context, skipped_keys: nil)
+      def self.string_map(value, context, included_keys: nil)
         result = T.let({}, T::Hash[String, String])
         object_hash(value, context).each do |key, raw_value|
-          next if skipped_keys&.key?(key)
+          next if included_keys && !included_keys.key?(key)
 
           raise TypeError, "#{context} values must be strings" unless raw_value.is_a?(String)
 

--- a/common/spec/dependabot/package/npm_registry_package_spec.rb
+++ b/common/spec/dependabot/package/npm_registry_package_spec.rb
@@ -72,6 +72,44 @@ RSpec.describe Dependabot::Package::NpmRegistryPackage do
       end
     end
 
+    context "with unpublished time metadata" do
+      let(:payload) do
+        {
+          "versions" => { "1.0.0" => {} },
+          "time" => {
+            "1.0.0" => "2024-01-01T00:00:00Z",
+            "unpublished" => {
+              "time" => "2024-01-02T00:00:00Z",
+              "versions" => ["0.9.0"]
+            }
+          }
+        }
+      end
+
+      it "ignores the metadata while parsing release timestamps" do
+        expect(package.releases.fetch("1.0.0").released_at).to eq(Time.utc(2024, 1, 1))
+      end
+    end
+
+    context "when the package is fully unpublished" do
+      let(:payload) do
+        {
+          "time" => {
+            "created" => "2024-01-01T00:00:00Z",
+            "modified" => "2024-01-02T00:00:00Z",
+            "unpublished" => {
+              "time" => "2024-01-02T00:00:00Z",
+              "versions" => ["1.0.0"]
+            }
+          }
+        }
+      end
+
+      it "returns no releases" do
+        expect(package.releases).to eq({})
+      end
+    end
+
     context "with an npm repository" do
       let(:payload) do
         {
@@ -138,7 +176,7 @@ RSpec.describe Dependabot::Package::NpmRegistryPackage do
       [{ "versions" => [] }, "versions must be an object"],
       [{ "versions" => { "1.0.0" => "invalid" } }, "version 1.0.0 details must be an object"],
       [{ "time" => [] }, "time must be an object"],
-      [{ "time" => { "1.0.0" => 1 } }, "time values must be strings"],
+      [{ "versions" => { "1.0.0" => {} }, "time" => { "1.0.0" => 1 } }, "time values must be strings"],
       [{ "dist-tags" => [] }, "dist-tags must be an object"],
       [{ "dist-tags" => { "latest" => 1 } }, "dist-tags values must be strings"],
       [{

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
@@ -125,6 +125,30 @@ RSpec.describe Dependabot::NpmAndYarn::Package::PackageDetailsFetcher do
       end
     end
 
+    context "when time includes unpublished metadata" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump(
+            "versions" => { "1.0.0" => {} },
+            "time" => {
+              "1.0.0" => "2024-01-01T00:00:00Z",
+              "unpublished" => {
+                "time" => "2024-01-02T00:00:00Z",
+                "versions" => ["0.9.0"]
+              }
+            }
+          )
+        )
+      end
+
+      it "ignores the metadata while parsing release timestamps" do
+        release = details.releases.find { |candidate| candidate.version.to_s == "1.0.0" }
+
+        expect(release&.released_at).to eq(Time.utc(2024, 1, 1))
+      end
+    end
+
     context "when successful JSON has the wrong top-level shape" do
       before do
         stub_request(:get, registry_url).to_return(status: 200, body: "[]")


### PR DESCRIPTION
### What are you trying to accomplish?

Fix npm package detail fetching for packuments where `time.unpublished` is an object. The parser now validates timestamps only for versions it will return, rather than validating package-level metadata it does not consume.

This fixes the production error after #16031.

### Anything you want to highlight for special attention from reviewers?

The parser derives an allowlist from accepted `versions` entries instead of special-casing `unpublished`. Real release timestamps remain strictly validated, while other non-release fields are ignored.

### How will you know you have accomplished your goal?

Added parser coverage for partially and fully unpublished packuments and a regression through `PackageDetailsFetcher`.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
