### PR TITLE
Resolve pnpm catalog dependencies by their catalog version range

### DIFF
--- a/npm_and_yarn/helpers/lib/pnpm/lockfile-parser.ts
+++ b/npm_and_yarn/helpers/lib/pnpm/lockfile-parser.ts
@@ -9,6 +9,7 @@
 
 import {
   readWantedLockfile,
+  type CatalogSnapshots,
   type PackageSnapshot,
   type ProjectSnapshot,
 } from "@pnpm/lockfile-file";
@@ -45,7 +46,8 @@ export async function parse(directory: string): Promise<PnpmDependency[]> {
       nameVerDevFromPkgSnapshot(
         depPath,
         pkgSnapshot,
-        Object.values(lockfile.importers)
+        Object.values(lockfile.importers),
+        lockfile.catalogs
       )
     );
 }
@@ -111,7 +113,8 @@ function extractMainDocument(content: string): string | null {
 function nameVerDevFromPkgSnapshot(
   depPath: string,
   pkgSnapshot: PackageSnapshot,
-  projectSnapshots: ProjectSnapshot[]
+  projectSnapshots: ProjectSnapshot[],
+  catalogs: CatalogSnapshots | undefined
 ): PnpmDependency {
   let name: string;
   let version: string;
@@ -163,6 +166,22 @@ function nameVerDevFromPkgSnapshot(
 
     return true;
   });
+
+  // An importer that takes a dependency from a catalog records its specifier as
+  // the literal "catalog:" (or "catalog:<name>"), never the version range the
+  // catalog resolves to. That range lives in the lockfile's own `catalogs` block,
+  // and it is also the form a pnpm-workspace.yaml catalog entry is read as, so
+  // collect it here too. Without it a catalogued package is only ever matched by
+  // a caller that already knows to ask for "catalog:".
+  if (!aliased) {
+    for (const catalog of Object.values(catalogs ?? {})) {
+      const entry = catalog[name];
+
+      if (entry?.version === version && !specifiers.includes(entry.specifier)) {
+        specifiers.push(entry.specifier);
+      }
+    }
+  }
 
   return {
     name: name,

--- a/npm_and_yarn/helpers/test/pnpm/fixtures/parser/catalog_duplicate_versions/pnpm-lock.yaml
+++ b/npm_and_yarn/helpers/test/pnpm/fixtures/parser/catalog_duplicate_versions/pnpm-lock.yaml
@@ -1,0 +1,46 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+catalogs:
+  default:
+    globals:
+      specifier: ^17.11.0
+      version: 17.11.0
+
+importers:
+
+  .:
+    devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.6
+        version: 3.3.6
+      globals:
+        specifier: 'catalog:'
+        version: 17.11.0
+
+packages:
+
+  '@eslint/eslintrc@3.3.6':
+    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@17.11.0:
+    resolution: {integrity: sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  '@eslint/eslintrc@3.3.6':
+    dependencies:
+      globals: 14.0.0
+
+  globals@14.0.0: {}
+
+  globals@17.11.0: {}

--- a/npm_and_yarn/helpers/test/pnpm/lockfile-parser.test.ts
+++ b/npm_and_yarn/helpers/test/pnpm/lockfile-parser.test.ts
@@ -91,6 +91,42 @@ describe("generates an updated pnpm lock for the original file", () => {
     }
   );
 
+  // A catalogued dependency's importer specifier is the literal "catalog:", so the
+  // version range it resolves to is only recoverable from the lockfile's own
+  // `catalogs` block. Without it a consumer matching on the range cannot tell the
+  // catalogued resolution apart from an older transitive one of the same name.
+  it("that contains a catalogued dependency with a second transitive version", async () => {
+    copyDependencies("catalog_duplicate_versions", tempDir);
+    const result = await parseLockfile(tempDir);
+
+    expect(result).toEqual([
+      {
+        name: "@eslint/eslintrc",
+        version: "3.3.6",
+        resolved: undefined,
+        dev: false,
+        specifiers: ["^3.3.6"],
+        aliased: false,
+      },
+      {
+        name: "globals",
+        version: "14.0.0",
+        resolved: undefined,
+        dev: false,
+        specifiers: [],
+        aliased: false,
+      },
+      {
+        name: "globals",
+        version: "17.11.0",
+        resolved: undefined,
+        dev: false,
+        specifiers: ["catalog:", "^17.11.0"],
+        aliased: false,
+      },
+    ]);
+  });
+
   // Should have the version in the lock file.
   it("that contains dependencies with an empty version", async () => {
     copyDependencies("empty_version", tempDir);

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -461,6 +461,25 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         end
       end
 
+      context "when a catalogued dependency also resolves to an older transitive version" do
+        let(:dependency_files) { project_dependency_files("pnpm/catalog_duplicate_versions") }
+        let(:dependency_name) { "globals" }
+        let(:requirement) { "^17.11.0" }
+
+        # The requirement here comes from pnpm-workspace.yaml's catalog, but the importer
+        # records its specifier as the literal "catalog:". The range is only recoverable
+        # from the lockfile's own catalogs block.
+        it "finds the catalogued version, not the transitive one" do
+          expect(lockfile_details).to eq(
+            "aliased" => false,
+            "dev" => false,
+            "name" => "globals",
+            "specifiers" => ["catalog:", "^17.11.0"],
+            "version" => "17.11.0"
+          )
+        end
+      end
+
       context "when resolved version has peer disambiguation suffix (lockfileFormat 5.4)" do
         let(:dependency_files) { project_dependency_files("pnpm/peer_disambiguation") }
         let(:dependency_name) { "@typescript-eslint/parser" }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -1703,6 +1703,30 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
           end
         end
       end
+
+      context "when a catalogued dependency also resolves to an older transitive version" do
+        subject(:globals) { top_level_dependencies.find { |dep| dep.name == "globals" } }
+
+        let(:files) { project_dependency_files("pnpm/catalog_duplicate_versions") }
+
+        # globals is catalogued at ^17.11.0 and resolves to 17.11.0, but @eslint/eslintrc
+        # pins a second copy at 14.0.0. Reporting the transitive version here makes the
+        # updater try to bump a dependency that is already current, which yields no file
+        # change at all.
+        it "reports the catalogued version, not the transitive one" do
+          expect(globals.version).to eq("17.11.0")
+        end
+
+        it "keeps the catalog requirement" do
+          expect(globals.requirements).to eq(
+            [{ requirement: "^17.11.0", file: "pnpm-workspace.yaml", groups: ["dependencies"], source: nil }]
+          )
+        end
+
+        it "still sees both resolutions" do
+          expect(globals.metadata[:all_versions].map(&:version)).to contain_exactly("14.0.0", "17.11.0")
+        end
+      end
     end
 
     describe "sub-dependencies" do

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/catalog_duplicate_versions/package.json
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/catalog_duplicate_versions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "packageManager": "pnpm@9.14.2",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.3.6",
+    "globals": "catalog:"
+  }
+}

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/catalog_duplicate_versions/pnpm-lock.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/catalog_duplicate_versions/pnpm-lock.yaml
@@ -1,0 +1,46 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+catalogs:
+  default:
+    globals:
+      specifier: ^17.11.0
+      version: 17.11.0
+
+importers:
+
+  .:
+    devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.6
+        version: 3.3.6
+      globals:
+        specifier: 'catalog:'
+        version: 17.11.0
+
+packages:
+
+  '@eslint/eslintrc@3.3.6':
+    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@17.11.0:
+    resolution: {integrity: sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  '@eslint/eslintrc@3.3.6':
+    dependencies:
+      globals: 14.0.0
+
+  globals@14.0.0: {}
+
+  globals@17.11.0: {}

--- a/npm_and_yarn/spec/fixtures/projects/pnpm/catalog_duplicate_versions/pnpm-workspace.yaml
+++ b/npm_and_yarn/spec/fixtures/projects/pnpm/catalog_duplicate_versions/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - packages/*
+
+catalog:
+  globals: ^17.11.0


### PR DESCRIPTION
Fixes #15515.

## The bug

A pnpm catalog dependency is reported at **an unrelated transitive dependency's version**, whenever the same package name has more than one resolution in the lockfile.

Downstream that surfaces two ways:

- the PR title states a bogus "from" version (#15515), or
- if the catalogued version is already current, `FileUpdater::NoChangeError` — because neither `pnpm-workspace.yaml` nor the lockfile has anything left to change. The dependency is then silently never updated, and the job is marked failed.

## Why it happens

1. `file_parser.rb:241` — `manifest_dependencies` skips every `package.json` entry whose requirement starts with `catalog:`, so `"globals": "catalog:"` contributes nothing.
2. `file_parser.rb:258` — `workspace_catalog_dependencies` re-creates the dependency from `pnpm-workspace.yaml`, passing the catalog's version **range** (`^17.11.0`) as the requirement.
3. `file_parser/pnpm_lock.rb:120` — `PnpmLock#details` resolves that to a lockfile entry:

   ```ruby
   if details_candidates.one?
     details_candidates.first
   else
     details_candidates.find { |info| info["specifiers"]&.include?(requirement) }
   end
   ```

   `specifiers` is built in `helpers/lib/pnpm/lockfile-parser.ts` from the **importer** specifiers — and pnpm records a catalogued importer's specifier as the literal string `catalog:`, never `^17.11.0`. **That match can never succeed.** It only appears to work because the `.one?` shortcut fires whenever the package resolves to exactly one version, which is the case in every existing catalog fixture (`pnpm/catalog_prettier`, `pnpm/catalog_monorepo`).

4. Give the package a second resolution and the shortcut disappears. `details` returns `nil` → `version_for("^17.11.0", nil)` → `exact_version_for` on a range → **`version: nil`**.
5. `common/.../dependency_set.rb:170` — `combined_version`'s first branch (`nil ^ non-nil`) fires *before* the `top_level?` preference, so a lockfile version wins; and among the lockfile entries (all `requirements: []`, so never `top_level?`) the remaining branches always keep the **lowest**.

## The fix

The range is not missing from the lockfile — it sits in the top-level `catalogs` block that `lockfile-parser.ts` never reads:

```yaml
catalogs:
  default:
    globals:
      specifier: ^17.11.0   # byte-identical to the requirement file_parser.rb passes in
      version: 17.11.0
```

So this collects those specifiers alongside the importer ones. `PnpmLock#details` then finds the catalogued entry by the range a `pnpm-workspace.yaml` reader would ask for, `version_for` returns the real version, and — because the catalog dependency now has both a version and requirements — `combined_version`'s existing "prefer a direct dependency over a transitive one" branch finally does its job.

No Ruby change needed. Aliased packages are skipped, matching the importer walk, which already abandons specifier collection there.

## Verification against a real lockfile

Run against a production pnpm workspace (~50 packages, lockfileVersion 9.0) where every one of these is catalogued and has a second resolution pinned by a transitive parent:

| dependency | lockfile resolutions | catalog range | reported before | reported after |
|---|---|---|---|---|
| `globals` | 14.0.0, 17.9.0, **17.11.0** | `^17.11.0` | `14.0.0` ❌ | `17.11.0` ✅ |
| `zod` | 3.25.76, **4.4.3** | `^4.4.3` | `3.25.76` ❌ | `4.4.3` ✅ |
| `@eslint/js` | 9.39.5, **10.0.1** | `^10.0.1` | `9.39.5` ❌ | `10.0.1` ✅ |
| `eslint` | 9.39.5, **10.8.0** | `^10.8.0` | `9.39.5` ❌ | `10.8.0` ✅ |

The "before" column reproduces that job's logs exactly — e.g. `Checking if globals 14.0.0 needs updating` → `pnpm update globals@17.11.0 --lockfile-only` → `Error processing globals (Dependabot::NpmAndYarn::FileUpdater::NoChangeError)`.

## Tests

New fixture `pnpm/catalog_duplicate_versions` (a catalogued `globals@17.11.0` beside a `globals@14.0.0` pinned by `@eslint/eslintrc`), used by both sides:

- `helpers/test/pnpm/lockfile-parser.test.ts` — the catalogued entry carries the catalog range, the transitive one does not.
- `file_parser/lockfile_parser_spec.rb` — `lockfile_details` returns the catalogued entry instead of `nil`.
- `file_parser_spec.rb` — the parsed dependency's version is `17.11.0`, its requirement still points at `pnpm-workspace.yaml`, and `metadata[:all_versions]` still holds both.

All three fail on `main` (`got: nil` / `got: "14.0.0"`).

Existing coverage that pins the surrounding behaviour stays green: `lockfile_parser_spec.rb`'s `async → 1.5.2` and the `babel-register` "requirement doesn't match → nil" case, the `pnpm/catalogs_all_examples` catalog specs, `dependency_grapher_spec.rb`'s multi-version pnpm fixtures, and the jest `result.length` assertions. The change only ever appends to `specifiers`; it never adds, removes or reorders entries.

## Deliberately not addressed

`combined_version` (`common/lib/dependabot/file_parsers/base/dependency_set.rb:170-184`) preferring the **lowest** version, and checking `nil` before `top_level?`. Both are real and both are what turned a failed lookup into a confidently wrong version rather than no version — but they are shared by every ecosystem, and neither needs to change for this fix. Worth a separate look.
