### PR TITLE
bundler: read path-dependency locations verbatim from the lockfile

### DIFF
--- a/bundler/lib/dependabot/bundler/file_fetcher.rb
+++ b/bundler/lib/dependabot/bundler/file_fetcher.rb
@@ -206,13 +206,23 @@ module Dependabot
           .map { |fp| fetch_file_from_host(fp, fetch_submodules: true) }
       end
 
+      # `Bundler::Source::Path#path` is not the value the lockfile declared: it is re-relativised
+      # against `Bundler.root`, and `..` segments that escape the filesystem root are dropped
+      # rather than preserved. A `remote:` reaching further up than `Bundler.root` is deep
+      # therefore resolves to a shallower, wrong directory. The lockfile's own value survives
+      # verbatim in the source's options, so read it from there.
+      sig { params(source: ::Bundler::Source::Path).returns(String) }
+      def lockfile_path_source_path(source)
+        (source.options["path"] || source.path).to_s
+      end
+
       sig { returns(T::Array[String]) }
       def fetch_path_gemspec_paths
         if lockfile
           parsed_lockfile = CachedLockfileParser.parse(T.must(sanitized_lockfile_content))
           parsed_lockfile.specs
                          .select { |s| s.source.instance_of?(::Bundler::Source::Path) }
-                         .map { |s| s.source.path }.uniq
+                         .map { |s| lockfile_path_source_path(s.source) }.uniq
         else
           gemfiles = ([gemfile] + child_gemfiles).compact
           gemfiles.flat_map do |file|

--- a/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_fetcher_spec.rb
@@ -334,6 +334,68 @@ RSpec.describe Dependabot::Bundler::FileFetcher do
         )
     end
 
+    # `Bundler::Source::Path` re-relativises a lockfile `remote:` against `Bundler.root`, and
+    # `..` segments escaping the filesystem root are dropped. Anything reaching further up than
+    # `Bundler.root` is deep therefore resolved to a shallower directory than the lockfile named.
+    # `Bundler.root` has to be stubbed for this to be exercised at all: in a checkout it sits far
+    # enough down that no realistic `remote:` reaches past it.
+    context "when the path escapes further up than Bundler.root is deep" do
+      let(:directory) { "/a/b/c/d" }
+      let(:url) { github_url + "repos/gocardless/bump/contents/a/b/c/d/" }
+
+      before do
+        allow(Bundler).to receive(:root)
+          .and_return(Pathname.new("/home/dependabot/dependabot-updater"))
+
+        stub_request(:get, github_url + "repos/gocardless/bump/contents/a/b/c/d?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_ruby.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "Gemfile?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "gemfile_with_escaping_path_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "Gemfile.lock?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "gemfile_lock_with_escaping_path_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+
+        # The only directory stubbed is the one the lockfile actually names. A request for the
+        # re-relativised path (`a/vendor/bump-core`) is left unstubbed on purpose, so the wrong
+        # target fails loudly rather than 404ing into `PathDependenciesNotReachable`.
+        stub_request(:get, github_url + "repos/gocardless/bump/contents/vendor/bump-core?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "contents_ruby_path_directory.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(
+          :get,
+          github_url + "repos/gocardless/bump/contents/vendor/bump-core/bump-core.gemspec?ref=sha"
+        ).with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "gemspec_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+      end
+
+      it "fetches the gemspec from the directory the lockfile names" do
+        expect(file_fetcher_instance.files.map(&:name))
+          .to include("../../../../vendor/bump-core/bump-core.gemspec")
+      end
+    end
+
     context "when there is a fetchable path" do
       before do
         stub_request(:get, url + "plugins/bump-core?ref=sha")

--- a/bundler/spec/fixtures/github/gemfile_lock_with_escaping_path_content.json
+++ b/bundler/spec/fixtures/github/gemfile_lock_with_escaping_path_content.json
@@ -1,0 +1,13 @@
+{
+  "name": "Gemfile.lock",
+  "path": "Gemfile.lock",
+  "sha": "0000000000000000000000000000000000000000",
+  "size": 239,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/Gemfile.lock?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/Gemfile.lock",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/0000000000000000000000000000000000000000",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/Gemfile.lock",
+  "type": "file",
+  "content": "UEFUSAogIHJlbW90ZTogLi4vLi4vLi4vLi4vdmVuZG9yL2J1bXAtY29yZQog\nIHNwZWNzOgogICAgYnVtcC1jb3JlICgwLjYuNikKICAgICAgZXhjb24gKH4+\nIDAuNTUpCgpHRU0KICByZW1vdGU6IGh0dHBzOi8vcnVieWdlbXMub3JnLwog\nIHNwZWNzOgogICAgZXhjb24gKDAuNTcuMSkKClBMQVRGT1JNUwogIHJ1YnkK\nCkRFUEVOREVOQ0lFUwogIGJ1bXAtY29yZSEKICBleGNvbgoKQlVORExFRCBX\nSVRICiAgIDEuMTUuMQo=\n",
+  "encoding": "base64"
+}

--- a/bundler/spec/fixtures/github/gemfile_with_escaping_path_content.json
+++ b/bundler/spec/fixtures/github/gemfile_with_escaping_path_content.json
@@ -1,0 +1,13 @@
+{
+  "name": "Gemfile",
+  "path": "Gemfile",
+  "sha": "0000000000000000000000000000000000000000",
+  "size": 85,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/Gemfile?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/Gemfile",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/0000000000000000000000000000000000000000",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/Gemfile",
+  "type": "file",
+  "content": "c291cmNlICJodHRwczovL3J1YnlnZW1zLm9yZyIKCmdlbSAiYnVtcC1jb3Jl\nIiwgcGF0aDogIi4uLy4uLy4uLy4uL3ZlbmRvci9idW1wLWNvcmUiCg==\n",
+  "encoding": "base64"
+}


### PR DESCRIPTION
Fixes #16050.

### The problem

`FileFetcher#fetch_path_gemspec_paths` reads path-dependency locations out of the parsed lockfile via `s.source.path`. That is not the value the lockfile declared — `Bundler::Source::Path#initialize` re-relativises it against `Bundler.root`:

```ruby
@path = Pathname.new(options["path"])
expanded_path = expand(@path)                                   # somepath.expand_path(root_path)
@path = expanded_path.relative_path_from(root_path.expand_path) if @path.relative?
```

`expand_path` clamps `..` at the filesystem root, so `..` segments escaping past `Bundler.root` are dropped rather than preserved. In the updater container `Bundler.root` is `/home/dependabot/dependabot-updater` — three segments, per `Dockerfile.updater-core`'s `DEPENDABOT_HOME` / `WORKDIR` — so a `remote:` with four or more `../` silently loses the excess:

```
Bundler.root = /home/dependabot/dependabot-updater   (3 segments)
  ../../../../gems/deep     ->  ../../../gems/deep    # a `..` lost
  ../../gems/shallow        ->  ../../gems/shallow    # unchanged
```

The fetcher then lists a directory the lockfile never named, finds no gemspec, and aborts file fetching with `PathDependenciesNotReachable` — naming a gem that is present and correct in the repo, and that `bundle install` resolves fine.

The threshold is the depth of `Bundler.root`, which makes it an artefact of the container layout rather than a property of the repository: the same lockfile can fetch on one image and fail on another.

### The fix

Read `source.options["path"]`, which `Source::Path.from_lock` populates from `remote:` and never rewrites. `instance_of?` already excludes `Source::Gemspec`, and `from_lock` always sets `options["path"]`, so the `|| source.path` fallback is belt-and-braces.

No normalisation is layered on top. `source.path` happened to normalise as a side effect of re-relativising, but every consumer of these paths already normalises — `basename` for the gem name, and `repo_contents` / `fetch_file_from_host` for the requests and the fetched file's name — so a `./`-prefixed or trailing-slash `remote:` resolves identically either way.

The Gemfile-parsing branch (`PathGemspecFinder`) reads literal strings out of the AST and was never affected; this is lockfile-only.

### The test

`bundler/spec/dependabot/bundler/file_fetcher_spec.rb` gains a context with a `remote: ../../../../vendor/bump-core` lockfile fetched from a four-deep directory. It **stubs `Bundler.root`** to the updater's working directory, which is load-bearing: in a checkout `Bundler.root` sits far enough down that no realistic `remote:` reaches past it, which is why this went unnoticed. Only the directory the lockfile actually names is stubbed, so the wrong target fails loudly rather than 404ing into `PathDependenciesNotReachable`.

Against `main` it fails with the mangled request:

```
An HTTP request has been made that VCR does not know how to handle:
  GET https://api.github.com/repos/gocardless/bump/contents/a/vendor/bump-core?ref=sha
```

With the fix, `file_fetcher_spec.rb` is 36 examples, 0 failures. `rubocop` and `srb tc` are clean.

### Out of scope, but worth knowing

`updater/lib/dependabot/file_fetcher_command.rb` wraps the whole multi-directory fetch in a single `rescue`, so one directory raising here aborts the entire `updates:` entry. In the repo where we hit this, one nested engine silenced updates for every other Ruby directory — no PRs, no red CI, just an absence. Happy to open that separately if it is wanted.
