### PR TITLE
Follow pip long options in requirements files

### DIFF
--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -482,7 +482,7 @@ module Dependabot
 
         file.content.lines
             .reject { |l| l.match?(/^['"]?(?<path>\..*?)(?=\[|#|'|"|$)/) }
-            .reject { |l| l.match?(/^(?:-e)\s+['"]?(?<path>.*?)(?=\[|#|'|"|$)/) }
+            .reject { |l| l.match?(SharedFileFetcher::EDITABLE_REGEX) }
             .join
       end
 

--- a/python/lib/dependabot/python/shared_file_fetcher.rb
+++ b/python/lib/dependabot/python/shared_file_fetcher.rb
@@ -21,8 +21,18 @@ module Dependabot
 
       abstract!
 
-      CHILD_REQUIREMENT_REGEX = /^-r\s?(?<path>.*\.(?:txt|in))/
-      CONSTRAINT_REGEX = /^-c\s?(?<path>.*\.(?:txt|in))/
+      # pip accepts both the short and the long form of these options, with either whitespace or an
+      # `=` separating the value. Two details are load bearing:
+      #
+      # * The leading `-` is factored out of each alternation so the pattern keeps a literal prefix
+      #   to search for; `(?:-r|--requirement)` drops it and makes scanning a large requirements
+      #   file several times slower.
+      # * The separator is matched possessively so a line of nothing but `-r` and spaces cannot
+      #   backtrack through the trailing `.*`, which would be quadratic in the number of spaces.
+      CHILD_REQUIREMENT_REGEX = /^-(?:r\s?|-requirement(?:\s++|=))(?<path>.*\.(?:txt|in))/
+      CONSTRAINT_REGEX = /^-(?:c\s?|-constraint(?:\s++|=))(?<path>.*\.(?:txt|in))/
+      EDITABLE_REGEX = /^-(?:e\s++|-editable(?:\s++|=))/
+      EDITABLE_PATH_REGEX = /(?<name>#{EDITABLE_REGEX}['"]?(?:file:)?(?<path>[^\[#'"\n;]*))/
       DEPENDENCY_TYPES = %w(packages dev-packages).freeze
       MAX_FILE_SIZE = 500_000
 
@@ -367,7 +377,7 @@ module Dependabot
 
         editable_reqs =
           content
-          .scan(/(?<name>^-e\s+['"]?(?:file:)?(?<path>[^\[#'"\n;]*))/)
+          .scan(EDITABLE_PATH_REGEX)
           .filter_map do |match_array|
             n, p = match_array
             unless p.to_s.include?("://") || p.to_s.include?("git@")

--- a/python/lib/dependabot/python/shared_file_fetcher.rb
+++ b/python/lib/dependabot/python/shared_file_fetcher.rb
@@ -29,8 +29,8 @@ module Dependabot
       #   file several times slower.
       # * The separator is matched possessively so a line of nothing but `-r` and spaces cannot
       #   backtrack through the trailing `.*`, which would be quadratic in the number of spaces.
-      CHILD_REQUIREMENT_REGEX = /^-(?:r\s?|-requirement(?:\s++|=))(?<path>.*\.(?:txt|in))/
-      CONSTRAINT_REGEX = /^-(?:c\s?|-constraint(?:\s++|=))(?<path>.*\.(?:txt|in))/
+      CHILD_REQUIREMENT_REGEX = /^-(?:r\s*+|-requirement(?:\s++|=))(?<path>.*\.(?:txt|in))/
+      CONSTRAINT_REGEX = /^-(?:c\s*+|-constraint(?:\s++|=))(?<path>.*\.(?:txt|in))/
       EDITABLE_REGEX = /^-(?:e\s++|-editable(?:\s++|=))/
       EDITABLE_PATH_REGEX = /(?<name>#{EDITABLE_REGEX}['"]?(?:file:)?(?<path>[^\[#'"\n;]*))/
       DEPENDENCY_TYPES = %w(packages dev-packages).freeze

--- a/python/spec/dependabot/python/file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/file_fetcher_spec.rb
@@ -837,6 +837,77 @@ RSpec.describe Dependabot::Python::FileFetcher do
       end
     end
 
+    context "with long options" do
+      let(:repo_contents) do
+        fixture("github", "contents_python_only_requirements.json")
+      end
+
+      before do
+        stub_request(:get, url + "requirements.txt?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "requirements_with_long_options.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "more_requirements.txt?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "requirements_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "no_dot/more_requirements.txt?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "requirements_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "constraints.txt?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "python_constraints_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "my/setup.py?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "setup_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "my/setup.cfg?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 404)
+        stub_request(:get, url + "my?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 200, body: "[]", headers: json_header)
+        stub_request(:get, url + "my-single/setup.py?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(
+            status: 200,
+            body: fixture("github", "setup_content.json"),
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url + "my-single/setup.cfg?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 404)
+        stub_request(:get, url + "my-single?ref=sha")
+          .with(headers: { "Authorization" => "token token" })
+          .to_return(status: 200, body: "[]", headers: json_header)
+      end
+
+      it "fetches the referenced requirements, constraints and path dependencies" do
+        expect(file_fetcher_instance.files.map(&:name))
+          .to match_array(
+            %w(requirements.txt more_requirements.txt no_dot/more_requirements.txt
+               constraints.txt my/setup.py my-single/setup.py)
+          )
+      end
+    end
+
     context "with a constraints file" do
       let(:repo_contents) do
         fixture("github", "contents_python_only_requirements.json")

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -648,6 +648,17 @@ RSpec.describe Dependabot::Python::FileParser do
         end
       end
 
+      context "when written as --editable" do
+        let(:requirements) do
+          Dependabot::DependencyFile.new(
+            name: "requirements.txt",
+            content: fixture("requirements", "with_setup_path_long_option.txt")
+          )
+        end
+
+        its(:length) { is_expected.to eq(15) }
+      end
+
       context "when in a nested requirements file" do
         let(:files) { [requirements, child_requirements, setup_file] }
         let(:requirements) do

--- a/python/spec/dependabot/python/shared_file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/shared_file_fetcher_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Dependabot::Python::SharedFileFetcher do
   describe "CHILD_REQUIREMENT_REGEX" do
     {
       "-r base.txt" => "base.txt",
+      "-r  base.txt" => "base.txt",
       "-rbase.txt" => "base.txt",
       "-r base.in" => "base.in",
       "-r ../base.txt" => "../base.txt",
@@ -39,6 +40,7 @@ RSpec.describe Dependabot::Python::SharedFileFetcher do
   describe "CONSTRAINT_REGEX" do
     {
       "-c constraints.txt" => "constraints.txt",
+      "-c  constraints.txt" => "constraints.txt",
       "-cconstraints.txt" => "constraints.txt",
       "-c constraints.in" => "constraints.in",
       "-c ../constraints.txt" => "../constraints.txt",

--- a/python/spec/dependabot/python/shared_file_fetcher_spec.rb
+++ b/python/spec/dependabot/python/shared_file_fetcher_spec.rb
@@ -1,0 +1,126 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/python/shared_file_fetcher"
+
+RSpec.describe Dependabot::Python::SharedFileFetcher do
+  describe "CHILD_REQUIREMENT_REGEX" do
+    {
+      "-r base.txt" => "base.txt",
+      "-rbase.txt" => "base.txt",
+      "-r base.in" => "base.in",
+      "-r ../base.txt" => "../base.txt",
+      "--requirement base.txt" => "base.txt",
+      "--requirement  base.txt" => "base.txt",
+      "--requirement=base.txt" => "base.txt",
+      "--requirement base.in" => "base.in",
+      "--requirement ../base.txt" => "../base.txt"
+    }.each do |line, path|
+      it "captures #{path.inspect} from #{line.inspect}" do
+        expect(described_class::CHILD_REQUIREMENT_REGEX.match(line)[:path]).to eq(path)
+      end
+    end
+
+    [
+      "--requirementbase.txt",
+      "--requirements-file base.txt",
+      "-r base.cfg",
+      "  -r base.txt",
+      "# -r base.txt",
+      "requests==2.4.1"
+    ].each do |line|
+      it "does not match #{line.inspect}" do
+        expect(described_class::CHILD_REQUIREMENT_REGEX).not_to match(line)
+      end
+    end
+  end
+
+  describe "CONSTRAINT_REGEX" do
+    {
+      "-c constraints.txt" => "constraints.txt",
+      "-cconstraints.txt" => "constraints.txt",
+      "-c constraints.in" => "constraints.in",
+      "-c ../constraints.txt" => "../constraints.txt",
+      "--constraint constraints.txt" => "constraints.txt",
+      "--constraint  constraints.txt" => "constraints.txt",
+      "--constraint=constraints.txt" => "constraints.txt",
+      "--constraint constraints.in" => "constraints.in",
+      "--constraint ../constraints.txt" => "../constraints.txt"
+    }.each do |line, path|
+      it "captures #{path.inspect} from #{line.inspect}" do
+        expect(described_class::CONSTRAINT_REGEX.match(line)[:path]).to eq(path)
+      end
+    end
+
+    [
+      "--constraintconstraints.txt",
+      "--constraints constraints.txt",
+      "-c constraints.cfg",
+      "  -c constraints.txt",
+      "# -c constraints.txt",
+      "requests==2.4.1"
+    ].each do |line|
+      it "does not match #{line.inspect}" do
+        expect(described_class::CONSTRAINT_REGEX).not_to match(line)
+      end
+    end
+  end
+
+  describe "EDITABLE_REGEX" do
+    [
+      "-e .",
+      "-e  .",
+      "--editable .",
+      "--editable  .",
+      "--editable=."
+    ].each do |line|
+      it "matches #{line.inspect}" do
+        expect(described_class::EDITABLE_REGEX).to match(line)
+      end
+    end
+
+    [
+      "-e.",
+      "--editable.",
+      "--editable-package .",
+      "  -e .",
+      "# -e .",
+      "requests==2.4.1"
+    ].each do |line|
+      it "does not match #{line.inspect}" do
+        expect(described_class::EDITABLE_REGEX).not_to match(line)
+      end
+    end
+  end
+
+  describe "EDITABLE_PATH_REGEX" do
+    {
+      "-e ." => ".",
+      "-e ./my" => "./my",
+      '-e "./my"' => "./my",
+      "-e './my'" => "./my",
+      "-e file:." => ".",
+      "--editable ./my" => "./my",
+      "--editable  ./my" => "./my",
+      "--editable=./my" => "./my",
+      '--editable "./my"' => "./my",
+      "--editable file:." => "."
+    }.each do |line, path|
+      it "captures #{path.inspect} from #{line.inspect}" do
+        expect(described_class::EDITABLE_PATH_REGEX.match(line)[:path]).to eq(path)
+      end
+    end
+
+    [
+      "--editable-package .",
+      "  -e .",
+      "./my",
+      "requests==2.4.1"
+    ].each do |line|
+      it "does not match #{line.inspect}" do
+        expect(described_class::EDITABLE_PATH_REGEX).not_to match(line)
+      end
+    end
+  end
+end

--- a/python/spec/fixtures/github/requirements_with_long_options.json
+++ b/python/spec/fixtures/github/requirements_with_long_options.json
@@ -1,0 +1,18 @@
+{
+  "name": "requirements.txt",
+  "path": "requirements.txt",
+  "sha": "8d9a77a86256c11409622fd16d799d9718f1ff62",
+  "size": 167,
+  "url": "https://api.github.com/repos/gocardless/bump/contents/requirements.txt?ref=master",
+  "html_url": "https://github.com/gocardless/bump/blob/master/requirements.txt",
+  "git_url": "https://api.github.com/repos/gocardless/bump/git/blobs/8d9a77a86256c11409622fd16d799d9718f1ff62",
+  "download_url": "https://raw.githubusercontent.com/gocardless/bump/master/requirements.txt?token=ABMwe8vXxd4DBCEsxz3jMusk5sr_fFsoks5WJWE-wA%3D%3D",
+  "type": "file",
+  "content": "cmVxdWVzdHM9PTIuNC4xCi0tcmVxdWlyZW1lbnQgLi9tb3JlX3JlcXVpcmVt\nZW50cy50eHQKLS1yZXF1aXJlbWVudD1ub19kb3QvbW9yZV9yZXF1aXJlbWVu\ndHMudHh0Ci0tY29uc3RyYWludCAuL2NvbnN0cmFpbnRzLnR4dAotLWVkaXRh\nYmxlIC4vbXkKLS1lZGl0YWJsZT0uL215LXNpbmdsZQo=\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/gocardless/bump/contents/requirements.txt?ref=master",
+    "git": "https://api.github.com/repos/gocardless/bump/git/blobs/8d9a77a86256c11409622fd16d799d9718f1ff62",
+    "html": "https://github.com/gocardless/bump/blob/master/requirements.txt"
+  }
+}

--- a/python/spec/fixtures/requirements/with_setup_path_long_option.txt
+++ b/python/spec/fixtures/requirements/with_setup_path_long_option.txt
@@ -1,0 +1,2 @@
+--editable .
+requests==2.1.0

--- a/uv/lib/dependabot/uv/file_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser.rb
@@ -419,7 +419,7 @@ module Dependabot
 
         file.content.lines
             .reject { |l| l.match?(/^['"]?(?<path>\..*?)(?=\[|#|'|"|$)/) }
-            .reject { |l| l.match?(/^(?:-e)\s+['"]?(?<path>.*?)(?=\[|#|'|"|$)/) }
+            .reject { |l| l.match?(Python::SharedFileFetcher::EDITABLE_REGEX) }
             .join
       end
 

--- a/uv/spec/dependabot/uv/file_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe Dependabot::Uv::FileParser do
       its(:length) { is_expected.to eq(5) }
     end
 
+    context "with an editable reference written as --editable" do
+      let(:requirements_fixture_name) { "with_setup_path_long_option.txt" }
+
+      its(:length) { is_expected.to eq(1) }
+    end
+
     context "with jinja templates" do
       let(:requirements_fixture_name) { "jinja_requirements.txt" }
 

--- a/uv/spec/fixtures/requirements/with_setup_path_long_option.txt
+++ b/uv/spec/fixtures/requirements/with_setup_path_long_option.txt
@@ -1,0 +1,2 @@
+--editable .
+requests==2.1.0


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #14528.

pip accepts the long form of every option a requirements file can use, but the Python ecosystem only matched the short forms when looking for referenced requirements, constraint files and editable path dependencies. A file written with `--requirement`, `--constraint` or `--editable` is read as if those lines were not there: the files it references are never fetched, and the dependency grapher builds manifest layers without the files pip needs to resolve them.

For a repository whose `requirements.in` reads

```
--editable .
--requirement requirements/install.in
```

and whose `requirements/unifying_constraints.in` reads

```
--constraint ../requirements.txt
```

every `update_graph` run fails with:

```
dependency_file_not_evaluatable | InstallationError("Could not open requirements file: [Errno 2] No such file or directory: 'dependabot_tmp_dir/requirements/install.in'")
dependency_file_not_evaluatable | InstallationError("Could not open constraint file: [Errno 2] No such file or directory: '<tmp>/requirements.txt'")
```

The files are valid and `pip install -r` resolves them fine — only Dependabot's own reference-following misses the directives.

### Anything you want to highlight for special attention from reviewers?

Three commits, each self-contained:

1. **Follow pip long options in requirements files** — the fix itself, Python only.
2. **Accept extra space before a short pip option's value** — `-r  base.txt` captured the second space as part of the path, so the file was looked up under a name with a leading space. Separated out because it changes short-form behaviour and is not strictly part of #14528; happy to drop this commit if you would rather not carry it.
3. **Share the editable option pattern with the uv parser** — `Uv::FileParser#remove_imports` carried a byte-identical copy of the Python pattern, so it missed `--editable` in the same way. It now reuses the constant rather than keeping a second copy in step.

Two deliberate choices worth a look:

- **The separator is `(?:\s+|=)`**, matching the spelling `PipVersionResolver#constraint_path_from_line` already uses for `--constraint`, rather than introducing a third way to spell the same thing.
- **The leading `-` is factored out of each alternation** — `/^-(?:r\s*|-requirement(?:\s+|=))…/` rather than `/^(?:-r…|--requirement…)…/`. The alternation form puts a choice at position 0 and loses the literal prefix the scan is optimised around. Scanning a 552 KB requirements file 20 times: original `^-r\s?` 12.2 ms, alternation form 32.5 ms, factored form 8.8 ms. There is a comment on the constants so it does not get "simplified" back.

One related gap I left alone as out of scope for this issue: `Package::PackageRegistryFinder` (`python/lib/dependabot/python/package/package_registry_finder.rb:81,89`) matches `--index-url` but not `-i`, which pip also accepts — the mirror image of this bug.

### How will you know you've accomplished your goal?

New `python/spec/dependabot/python/shared_file_fetcher_spec.rb` covers every branch of the four constants — short form, long form with a space, long form with `=`, both `.txt` and `.in`, relative paths, quoted and `file:`-prefixed editable paths — along with near-miss negatives that must *not* match (`--requirements-file`, `--constraints`, `--editable-package`, `--requirementbase.txt`, indented and commented lines).

End-to-end coverage on top of that:

- `file_fetcher_spec.rb` — a requirements file using `--requirement`, `--requirement=`, `--constraint`, `--editable` and `--editable=` fetches all the referenced requirements, constraints and path dependencies.
- `file_parser_spec.rb` (Python and uv) — an `--editable` line is stripped before pip parses the file, the same as `-e`.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

Being straight about the first box: I have not run the suite locally, so this is opened as a draft to let CI do it. Every regex case in the new spec was verified against the constants directly, but `rubocop`, `srb tc` and `rspec` have not been run on my machine.
