### PR TITLE
Resolve indirect dependency updates in uv.lock

### DIFF
--- a/python/lib/dependabot/python/update_checker/latest_version_finder.rb
+++ b/python/lib/dependabot/python/update_checker/latest_version_finder.rb
@@ -42,6 +42,19 @@ module Dependabot
             cooldown.semver_minor_days.to_i.positive? ||
             cooldown.semver_patch_days.to_i.positive?
         end
+
+        sig { returns(T.nilable(T::Array[Dependabot::Package::PackageRelease])) }
+        def eligible_releases
+          releases = available_versions
+          return unless releases
+
+          releases = filter_yanked_versions(releases)
+          releases = filter_by_cooldown(releases)
+          releases = filter_unsupported_versions(releases, nil)
+          releases = filter_prerelease_versions(releases)
+          releases = filter_ignored_versions(releases)
+          apply_post_fetch_latest_versions_filter(releases)
+        end
       end
     end
   end

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -44,21 +44,33 @@ module Dependabot
         sig { returns(T.nilable(String)) }
         attr_reader :repo_contents_path
 
+        sig { returns(T.nilable(String)) }
+        attr_reader :target_requirement
+
         sig do
           params(
             dependencies: T::Array[Dependency],
             dependency_files: T::Array[DependencyFile],
             credentials: T::Array[Dependabot::Credential],
             index_urls: T.nilable(T::Array[T.nilable(String)]),
-            repo_contents_path: T.nilable(String)
+            repo_contents_path: T.nilable(String),
+            target_requirement: T.nilable(String)
           ).void
         end
-        def initialize(dependencies:, dependency_files:, credentials:, index_urls: nil, repo_contents_path: nil)
+        def initialize(
+          dependencies:,
+          dependency_files:,
+          credentials:,
+          index_urls: nil,
+          repo_contents_path: nil,
+          target_requirement: nil
+        )
           @dependencies = dependencies
           @dependency_files = dependency_files
           @credentials = credentials
           @index_urls = index_urls
           @repo_contents_path = repo_contents_path
+          @target_requirement = target_requirement
           @prepared_pyproject = T.let(nil, T.nilable(String))
           @updated_lockfile_content = T.let(nil, T.nilable(String))
           @pyproject = T.let(nil, T.nilable(Dependabot::DependencyFile))
@@ -112,7 +124,9 @@ module Dependabot
             # Use updated_lockfile_content which might raise if the lockfile doesn't change
             new_content = updated_lockfile_content
 
-            raise "Expected lockfile to change!" if T.must(lockfile).content == new_content
+            if T.must(lockfile).content == new_content
+              raise DependencyFileContentNotChanged, "Expected lockfile to change!"
+            end
 
             updated_files << updated_file(file: T.must(lockfile), content: new_content)
           end
@@ -291,7 +305,14 @@ module Dependabot
           # Strip extras from the package name for the uv lock command
           # uv lock --upgrade-package expects the base package name without extras
           base_dep_name = normalise(dep_name)
-          package_spec = dep_version ? "#{base_dep_name}==#{dep_version}" : base_dep_name
+          package_spec =
+            if target_requirement
+              "#{base_dep_name}#{target_requirement}"
+            elsif dep_version
+              "#{base_dep_name}==#{dep_version}"
+            else
+              base_dep_name
+            end
 
           command = "pyenv exec uv lock --upgrade-package #{package_spec} #{options}"
           fingerprint = "pyenv exec uv lock --upgrade-package <dependency_name> #{options_fingerprint}"

--- a/uv/lib/dependabot/uv/update_checker/lock_file_resolver.rb
+++ b/uv/lib/dependabot/uv/update_checker/lock_file_resolver.rb
@@ -2,9 +2,15 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "toml-rb"
 
+require "dependabot/errors"
 require "dependabot/package/release_cooldown_options"
+require "dependabot/update_checkers/version_filters"
 require "dependabot/uv/version"
+require "dependabot/uv/file_updater/lock_file_error_handler"
+require "dependabot/uv/file_updater/lock_file_updater"
+require "dependabot/uv/name_normaliser"
 require "dependabot/uv/requirement"
 require "dependabot/uv/update_checker"
 require "dependabot/uv/update_checker/latest_version_finder"
@@ -42,33 +48,40 @@ module Dependabot
           @security_advisories = security_advisories
           @ignored_versions = ignored_versions
           @update_cooldown = update_cooldown
+          @latest_resolvable_versions = T.let(
+            {},
+            T::Hash[String, T.nilable(Dependabot::Uv::Version)]
+          )
+          @resolved_versions = T.let(
+            {},
+            T::Hash[String, T.nilable(Dependabot::Uv::Version)]
+          )
+          @resolvable_versions = T.let({}, T::Hash[String, T::Boolean])
         end
 
         sig { params(requirement: T.nilable(String)).returns(T.nilable(Dependabot::Uv::Version)) }
         def latest_resolvable_version(requirement:)
           return nil unless requirement
+          return @latest_resolvable_versions[requirement] if @latest_resolvable_versions.key?(requirement)
 
-          req = Uv::Requirement.new(requirement)
-
-          # Get the version from the dependency if available
-          version_from_dependency = dependency.version && Uv::Version.new(dependency.version)
-          return version_from_dependency if version_from_dependency && req.satisfied_by?(version_from_dependency)
-
-          nil
+          @latest_resolvable_versions[requirement] = fetch_latest_resolvable_version(requirement)
         end
 
-        sig { params(_version: T.anything).returns(T::Boolean) }
-        def resolvable?(_version)
-          # Always return true since we don't actually attempt resolution
-          # This is just a placeholder implementation
-          true
+        sig { params(version: Gem::Version).returns(T::Boolean) }
+        def resolvable?(version:)
+          target_version = Uv::Version.new(version.to_s)
+          key = target_version.to_s
+          return T.must(@resolvable_versions[key]) if @resolvable_versions.key?(key)
+
+          @resolvable_versions[key] = resolved_version("==#{key}", target_version)&.to_s == key
         end
 
         sig { returns(T.nilable(Dependabot::Uv::Version)) }
         def lowest_resolvable_security_fix_version
           # Delegate to LatestVersionFinder which handles security advisory filtering
           fix_version = latest_version_finder.lowest_security_fix_version
-          return nil if fix_version.nil?
+          return nil unless fix_version
+          return nil unless resolvable?(version: fix_version)
 
           # Return the fix version cast to Uv::Version
           Uv::Version.new(fix_version.to_s)
@@ -96,6 +109,186 @@ module Dependabot
 
         sig { returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
         attr_reader :update_cooldown
+
+        sig { params(requirement_string: String).returns(T.nilable(Dependabot::Uv::Version)) }
+        def fetch_latest_resolvable_version(requirement_string)
+          requirement = Uv::Requirement.new(requirement_string)
+          current_version = dependency.version && Uv::Version.new(dependency.version)
+          eligible_versions = eligible_versions(requirement, current_version)
+          return current_version if no_newer_eligible_version?(requirement, current_version, eligible_versions)
+
+          native_version = resolved_version(
+            policy_requirement(requirement_string, requirement, current_version, eligible_versions),
+            nil
+          )
+          return native_version if eligible_native_version?(requirement, native_version, eligible_versions)
+
+          current_version if current_version && requirement.satisfied_by?(current_version)
+        end
+
+        sig do
+          params(
+            requirement: Dependabot::Uv::Requirement,
+            current_version: T.nilable(Dependabot::Uv::Version),
+            eligible_versions: T.nilable(T::Array[Dependabot::Uv::Version])
+          ).returns(T::Boolean)
+        end
+        def no_newer_eligible_version?(requirement, current_version, eligible_versions)
+          return false unless current_version && eligible_versions
+
+          requirement.satisfied_by?(current_version) && eligible_versions.empty?
+        end
+
+        sig do
+          params(
+            requirement: Dependabot::Uv::Requirement,
+            native_version: T.nilable(Dependabot::Uv::Version),
+            eligible_versions: T.nilable(T::Array[Dependabot::Uv::Version])
+          ).returns(T::Boolean)
+        end
+        def eligible_native_version?(requirement, native_version, eligible_versions)
+          return false unless native_version && requirement.satisfied_by?(native_version)
+
+          !eligible_versions || eligible_versions.include?(native_version)
+        end
+
+        sig do
+          params(
+            requirement: Dependabot::Uv::Requirement,
+            current_version: T.nilable(Dependabot::Uv::Version)
+          ).returns(T.nilable(T::Array[Dependabot::Uv::Version]))
+        end
+        def eligible_versions(requirement, current_version)
+          releases = latest_version_finder.eligible_releases
+          return unless releases
+
+          releases = Dependabot::UpdateCheckers::VersionFilters
+                     .filter_vulnerable_versions(releases, security_advisories)
+          releases
+            .map { |release| Uv::Version.new(release.version.to_s) }
+            .select { |version| requirement.satisfied_by?(version) && (!current_version || version > current_version) }
+        end
+
+        sig do
+          params(
+            requirement_string: String,
+            requirement: Dependabot::Uv::Requirement,
+            current_version: T.nilable(Dependabot::Uv::Version),
+            eligible_versions: T.nilable(T::Array[Dependabot::Uv::Version])
+          ).returns(String)
+        end
+        def policy_requirement(requirement_string, requirement, current_version, eligible_versions)
+          releases = latest_version_finder.available_versions
+          return requirement_string unless releases && eligible_versions
+
+          excluded_versions = releases
+                              .map { |release| Uv::Version.new(release.version.to_s) }
+                              .select do |version|
+            requirement.satisfied_by?(version) &&
+              (!current_version || version > current_version) &&
+              !eligible_versions.include?(version)
+          end
+
+          ([requirement_string] + excluded_versions.map { |version| "!=#{version}" }).join(",")
+        end
+
+        sig do
+          params(
+            requirement_string: String,
+            target_version: T.nilable(Dependabot::Uv::Version)
+          )
+            .returns(T.nilable(Dependabot::Uv::Version))
+        end
+        def resolved_version(requirement_string, target_version)
+          return @resolved_versions[requirement_string] if @resolved_versions.key?(requirement_string)
+
+          @resolved_versions[requirement_string] = run_resolution(requirement_string, target_version)
+        end
+
+        sig do
+          params(
+            requirement_string: String,
+            target_version: T.nilable(Dependabot::Uv::Version)
+          )
+            .returns(T.nilable(Dependabot::Uv::Version))
+        end
+        def run_resolution(requirement_string, target_version)
+          updated_dependency = Dependabot::Dependency.new(
+            name: dependency.name,
+            version: nil,
+            previous_version: dependency.version,
+            requirements: [],
+            previous_requirements: [],
+            package_manager: dependency.package_manager
+          )
+
+          updated_files = FileUpdater::LockFileUpdater.new(
+            dependencies: [updated_dependency],
+            dependency_files: dependency_files,
+            credentials: credentials,
+            repo_contents_path: repo_contents_path,
+            target_requirement: requirement_string
+          ).updated_dependency_files
+
+          lockfile = updated_files.find { |file| file.name == "uv.lock" } || original_lockfile
+          resolved_locked_version(T.must(lockfile), target_version)
+        rescue Dependabot::DependencyFileContentNotChanged
+          resolved_locked_version(T.must(original_lockfile), target_version)
+        rescue Dependabot::UpdateNotPossible
+          nil
+        rescue Dependabot::DependencyFileNotResolvable => e
+          conflict = e.message.match?(FileUpdater::LockFileErrorHandler::UV_UNRESOLVABLE_REGEX) ||
+                     e.message.include?(FileUpdater::LockFileErrorHandler::RESOLUTION_IMPOSSIBLE_ERROR)
+          raise unless conflict
+
+          nil
+        end
+
+        sig do
+          params(
+            lockfile: Dependabot::DependencyFile,
+            target_version: T.nilable(Dependabot::Uv::Version)
+          ).returns(T.nilable(Dependabot::Uv::Version))
+        end
+        def resolved_locked_version(lockfile, target_version)
+          original_versions = locked_versions(T.must(original_lockfile))
+          updated_versions = locked_versions(lockfile)
+          current_version = dependency.version && Uv::Version.new(dependency.version)
+          return nil unless current_version && original_versions.min == current_version
+          return current_version if updated_versions.include?(current_version)
+
+          updated_version = updated_versions.min
+          return target_version if target_version && updated_version == target_version
+          return nil if target_version
+
+          updated_version
+        end
+
+        sig do
+          params(lockfile: Dependabot::DependencyFile)
+            .returns(T::Array[Dependabot::Uv::Version])
+        end
+        def locked_versions(lockfile)
+          parsed = T.cast(TomlRB.parse(T.must(lockfile.content)), T::Hash[String, Object])
+          packages = T.cast(parsed["package"], T.nilable(T::Array[T::Hash[String, Object]])) || []
+          dependency_name = NameNormaliser.normalise(dependency.name)
+          versions = T.let([], T::Array[Dependabot::Uv::Version])
+          packages.each do |package|
+            package_name = T.cast(package["name"], T.nilable(String))
+            package_version = T.cast(package["version"], T.nilable(String))
+            next unless package_name && NameNormaliser.normalise(package_name) == dependency_name
+            next unless Uv::Version.correct?(package_version)
+
+            versions << Uv::Version.new(package_version)
+          end
+
+          versions
+        end
+
+        sig { returns(T.nilable(Dependabot::DependencyFile)) }
+        def original_lockfile
+          dependency_files.find { |file| file.name == "uv.lock" }
+        end
 
         sig { returns(LatestVersionFinder) }
         def latest_version_finder

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       dependencies: dependencies,
       dependency_files: dependency_files,
       credentials: credentials,
-      index_urls: index_urls
+      index_urls: index_urls,
+      target_requirement: target_requirement
     )
   end
 
@@ -29,6 +30,7 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
     )]
   end
   let(:index_urls) { [] }
+  let(:target_requirement) { nil }
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -164,7 +166,8 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
       end
 
       it "raises an error" do
-        expect { updated_files }.to raise_error("Expected lockfile to change!")
+        expect { updated_files }
+          .to raise_error(Dependabot::DependencyFileContentNotChanged, "Expected lockfile to change!")
       end
     end
 
@@ -1411,6 +1414,24 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         expect(updater).to have_received(:run_command).with(
           expected_command,
           fingerprint: expected_fingerprint,
+          env: {}
+        )
+      end
+    end
+
+    context "with a target requirement" do
+      let(:target_requirement) { ">=2.19.0,<=2.20.0" }
+
+      it "constrains the package upgrade" do
+        expected_command = "pyenv exec uv lock --upgrade-package requests>=2.19.0,<=2.20.0 " \
+                           "--index https://token@example.com/simple " \
+                           "--default-index https://another_token@another.com/simple"
+
+        run_update_command
+
+        expect(updater).to have_received(:run_command).with(
+          expected_command,
+          fingerprint: anything,
           env: {}
         )
       end

--- a/uv/spec/dependabot/uv/update_checker/latest_version_finder_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker/latest_version_finder_spec.rb
@@ -708,6 +708,17 @@ RSpec.describe Dependabot::Uv::UpdateChecker::LatestVersionFinder do
     end
   end
 
+  describe "#eligible_releases" do
+    subject(:eligible_versions) { finder.eligible_releases&.map(&:version) }
+
+    let(:ignored_versions) { ["== 2.4.0"] }
+
+    it "applies the same release filters used for latest_version" do
+      expect(eligible_versions).to include(Gem::Version.new("2.6.0"))
+      expect(eligible_versions).not_to include(Gem::Version.new("2.4.0"))
+    end
+  end
+
   describe "#lowest_security_fix_version" do
     subject(:lowest_security_fix_version) { finder.lowest_security_fix_version }
 

--- a/uv/spec/dependabot/uv/update_checker/lock_file_resolver_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker/lock_file_resolver_spec.rb
@@ -60,16 +60,47 @@ RSpec.describe Dependabot::Uv::UpdateChecker::LockFileResolver do
   end
 
   describe "#latest_resolvable_version" do
+    let(:available_releases) { [package_release("2.33.0"), package_release("2.34.0")] }
+    let(:eligible_releases) { available_releases }
+    let(:latest_version_finder) do
+      instance_double(
+        Dependabot::Uv::UpdateChecker::LatestVersionFinder,
+        available_versions: available_releases,
+        eligible_releases: eligible_releases
+      )
+    end
+
+    before do
+      allow(Dependabot::Uv::UpdateChecker::LatestVersionFinder)
+        .to receive(:new).and_return(latest_version_finder)
+      allow(Dependabot::Uv::FileUpdater::LockFileUpdater)
+        .to receive(:new) do |target_requirement:, **_args|
+          target_version =
+            if target_requirement.start_with?("==")
+              target_requirement.delete_prefix("==")
+            elsif target_requirement.include?("!=2.33.0")
+              "2.34.0"
+            else
+              "2.33.0"
+            end
+          instance_double(
+            Dependabot::Uv::FileUpdater::LockFileUpdater,
+            updated_dependency_files: [resolved_lockfile(target_version)]
+          )
+        end
+    end
+
     context "when requirement is nil" do
       it "returns nil" do
         expect(resolver.latest_resolvable_version(requirement: nil)).to be_nil
+        expect(Dependabot::Uv::FileUpdater::LockFileUpdater).not_to have_received(:new)
       end
     end
 
     context "when requirement is satisfied by the current version" do
-      it "returns the current version" do
+      it "returns the version selected by uv" do
         result = resolver.latest_resolvable_version(requirement: ">=2.30.0")
-        expect(result.to_s).to eq("2.32.3")
+        expect(result.to_s).to eq("2.33.0")
       end
     end
 
@@ -79,12 +110,257 @@ RSpec.describe Dependabot::Uv::UpdateChecker::LockFileResolver do
         expect(result).to be_nil
       end
     end
+
+    context "when no newer allowed version exists" do
+      let(:eligible_releases) { [] }
+
+      it "returns the current version without running uv" do
+        result = resolver.latest_resolvable_version(requirement: ">=2.30.0,<=2.32.3")
+        expect(result.to_s).to eq("2.32.3")
+        expect(Dependabot::Uv::FileUpdater::LockFileUpdater).not_to have_received(:new)
+      end
+    end
+
+    context "when a version inside the range is ignored" do
+      let(:eligible_releases) { [package_release("2.34.0")] }
+
+      it "excludes the ignored version from native resolution" do
+        result = resolver.latest_resolvable_version(requirement: ">=2.30.0,<=2.34.0")
+
+        expect(result.to_s).to eq("2.34.0")
+        expect(Dependabot::Uv::FileUpdater::LockFileUpdater)
+          .to have_received(:new).with(hash_including(target_requirement: ">=2.30.0,<=2.34.0,!=2.33.0"))
+      end
+    end
+
+    context "when all newer versions are filtered out" do
+      let(:eligible_releases) { [] }
+
+      it "returns the current version without running uv" do
+        result = resolver.latest_resolvable_version(requirement: ">=2.30.0")
+
+        expect(result.to_s).to eq("2.32.3")
+        expect(Dependabot::Uv::FileUpdater::LockFileUpdater).not_to have_received(:new)
+      end
+    end
+
+    context "when only a vulnerable intermediate version resolves" do
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: "requests",
+            package_manager: "uv",
+            vulnerable_versions: ["== 2.33.0"]
+          )
+        ]
+      end
+
+      before do
+        allow(Dependabot::Uv::FileUpdater::LockFileUpdater)
+          .to receive(:new) do |target_requirement:, **_args|
+            updater = instance_double(Dependabot::Uv::FileUpdater::LockFileUpdater)
+            if target_requirement.include?("!=2.33.0")
+              allow(updater).to receive(:updated_dependency_files).and_raise(
+                Dependabot::DependencyFileNotResolvable,
+                "× No solution found when resolving dependencies"
+              )
+            else
+              allow(updater).to receive(:updated_dependency_files)
+                .and_return([resolved_lockfile("2.33.0")])
+            end
+            updater
+          end
+      end
+
+      it "excludes the vulnerable version from fallback resolution" do
+        result = resolver.latest_resolvable_version(requirement: ">=2.30.0,<=2.34.0")
+
+        expect(result.to_s).to eq("2.32.3")
+        expect(Dependabot::Uv::FileUpdater::LockFileUpdater)
+          .to have_received(:new).with(hash_including(target_requirement: ">=2.30.0,<=2.34.0,!=2.33.0"))
+      end
+    end
+
+    it "memoizes the result by requirement" do
+      2.times { resolver.latest_resolvable_version(requirement: ">=2.30.0") }
+
+      expect(Dependabot::Uv::FileUpdater::LockFileUpdater).to have_received(:new).once
+    end
+
+    context "when the lockfile does not change" do
+      before do
+        updater = instance_double(Dependabot::Uv::FileUpdater::LockFileUpdater)
+        allow(updater).to receive(:updated_dependency_files)
+          .and_raise(Dependabot::DependencyFileContentNotChanged, "Expected lockfile to change!")
+        allow(Dependabot::Uv::FileUpdater::LockFileUpdater).to receive(:new).and_return(updater)
+      end
+
+      it "returns the version already present in the lockfile" do
+        result = resolver.latest_resolvable_version(requirement: ">=2.30.0")
+        expect(result.to_s).to eq("2.32.3")
+      end
+    end
+
+    context "when an operational error occurs" do
+      before do
+        updater = instance_double(Dependabot::Uv::FileUpdater::LockFileUpdater)
+        allow(updater).to receive(:updated_dependency_files)
+          .and_raise(Dependabot::DependencyFileNotResolvable, "Failed to find workspace member")
+        allow(Dependabot::Uv::FileUpdater::LockFileUpdater).to receive(:new).and_return(updater)
+      end
+
+      it "propagates the classified error" do
+        expect { resolver.latest_resolvable_version(requirement: ">=2.30.0") }
+          .to raise_error(Dependabot::DependencyFileNotResolvable, /workspace member/)
+      end
+    end
+
+    context "when native resolution has a version conflict" do
+      before do
+        updater = instance_double(Dependabot::Uv::FileUpdater::LockFileUpdater)
+        allow(updater).to receive(:updated_dependency_files).and_raise(
+          Dependabot::DependencyFileNotResolvable,
+          "× No solution found when resolving dependencies"
+        )
+        allow(Dependabot::Uv::FileUpdater::LockFileUpdater).to receive(:new).and_return(updater)
+      end
+
+      it "returns the current version" do
+        result = resolver.latest_resolvable_version(requirement: ">=2.30.0")
+        expect(result.to_s).to eq("2.32.3")
+      end
+    end
+
+    context "when uv updates multiple locked occurrences" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "requests",
+          version: "2.19.0",
+          requirements: [],
+          package_manager: "uv"
+        )
+      end
+      let(:dependency_files) do
+        [
+          resolved_lockfile_with_versions("2.19.0", "2.20.0"),
+          Dependabot::DependencyFile.new(
+            name: "pyproject.toml",
+            content: fixture("pyproject_files", "uv_simple.toml")
+          )
+        ]
+      end
+      let(:available_releases) { [package_release("2.20.0"), package_release("2.21.0")] }
+
+      before do
+        allow(Dependabot::Uv::FileUpdater::LockFileUpdater)
+          .to receive(:new).and_return(
+            instance_double(
+              Dependabot::Uv::FileUpdater::LockFileUpdater,
+              updated_dependency_files: [resolved_lockfile_with_versions("2.20.0", "2.21.0")]
+            )
+          )
+      end
+
+      it "returns the lowest updated occurrence parsed by DependencySet" do
+        result = resolver.latest_resolvable_version(requirement: ">=2.19.0,<=2.21.0")
+        expect(result.to_s).to eq("2.20.0")
+      end
+    end
   end
 
   describe "#resolvable?" do
-    it "returns true for any version" do
-      expect(resolver.resolvable?(version: "2.32.3")).to be(true)
-      expect(resolver.resolvable?(version: "999.0.0")).to be(true)
+    before do
+      allow(Dependabot::Uv::FileUpdater::LockFileUpdater)
+        .to receive(:new) do |**_args|
+          instance_double(
+            Dependabot::Uv::FileUpdater::LockFileUpdater,
+            updated_dependency_files: [resolved_lockfile("2.33.0")]
+          )
+        end
+    end
+
+    it "verifies and memoizes the locked version" do
+      2.times { expect(resolver.resolvable?(version: Dependabot::Uv::Version.new("2.34.0"))).to be(false) }
+
+      expect(Dependabot::Uv::FileUpdater::LockFileUpdater).to have_received(:new).once
+      expect(Dependabot::Uv::FileUpdater::LockFileUpdater)
+        .to have_received(:new).with(hash_including(target_requirement: "==2.34.0"))
+    end
+
+    context "when another locked occurrence already has the target version" do
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "requests",
+          version: "2.19.0",
+          requirements: [],
+          package_manager: "uv"
+        )
+      end
+      let(:dependency_files) do
+        [
+          resolved_lockfile_with_versions("2.19.0", "2.20.0"),
+          Dependabot::DependencyFile.new(
+            name: "pyproject.toml",
+            content: fixture("pyproject_files", "uv_simple.toml")
+          )
+        ]
+      end
+
+      before do
+        allow(Dependabot::Uv::FileUpdater::LockFileUpdater)
+          .to receive(:new).and_return(
+            instance_double(
+              Dependabot::Uv::FileUpdater::LockFileUpdater,
+              updated_dependency_files: [resolved_lockfile_with_versions("2.19.0", "2.20.0")]
+            )
+          )
+      end
+
+      it "does not treat the other occurrence as the updated dependency" do
+        expect(resolver.resolvable?(version: Dependabot::Uv::Version.new("2.20.0"))).to be(false)
+      end
+
+      context "when uv replaces the current occurrence" do
+        before do
+          allow(Dependabot::Uv::FileUpdater::LockFileUpdater)
+            .to receive(:new).and_return(
+              instance_double(
+                Dependabot::Uv::FileUpdater::LockFileUpdater,
+                updated_dependency_files: [resolved_lockfile_with_versions("2.20.0", "2.20.0")]
+              )
+            )
+        end
+
+        it "recognizes the increased target occurrence count" do
+          expect(resolver.resolvable?(version: Dependabot::Uv::Version.new("2.20.0"))).to be(true)
+        end
+      end
+
+      context "when one duplicate current occurrence remains" do
+        let(:dependency_files) do
+          [
+            resolved_lockfile_with_versions("2.19.0", "2.19.0"),
+            Dependabot::DependencyFile.new(
+              name: "pyproject.toml",
+              content: fixture("pyproject_files", "uv_simple.toml")
+            )
+          ]
+        end
+
+        before do
+          allow(Dependabot::Uv::FileUpdater::LockFileUpdater)
+            .to receive(:new).and_return(
+              instance_double(
+                Dependabot::Uv::FileUpdater::LockFileUpdater,
+                updated_dependency_files: [resolved_lockfile_with_versions("2.19.0", "2.20.0")]
+              )
+            )
+        end
+
+        it "does not report the higher occurrence as the dependency update" do
+          expect(resolver.resolvable?(version: Dependabot::Uv::Version.new("2.20.0"))).to be(false)
+        end
+      end
     end
   end
 
@@ -97,6 +373,7 @@ RSpec.describe Dependabot::Uv::UpdateChecker::LockFileResolver do
     before do
       stub_request(:get, pypi_url)
         .to_return(status: 200, body: pypi_response)
+      allow(resolver).to receive(:resolvable?).and_return(true)
     end
 
     context "with no security advisories" do
@@ -213,6 +490,26 @@ RSpec.describe Dependabot::Uv::UpdateChecker::LockFileResolver do
         expect(result).to be < Dependabot::Uv::Version.new("2.30.0")
       end
     end
+
+    context "when the lowest security fix is not resolvable" do
+      let(:security_advisories) do
+        [
+          Dependabot::SecurityAdvisory.new(
+            dependency_name: "requests",
+            package_manager: "uv",
+            vulnerable_versions: ["<= 2.1.0"]
+          )
+        ]
+      end
+
+      before do
+        allow(resolver).to receive(:resolvable?).and_return(false)
+      end
+
+      it "returns nil" do
+        expect(resolver.lowest_resolvable_security_fix_version).to be_nil
+      end
+    end
   end
 
   describe "cooldown support" do
@@ -260,5 +557,34 @@ RSpec.describe Dependabot::Uv::UpdateChecker::LockFileResolver do
 
       resolver.lowest_resolvable_security_fix_version
     end
+  end
+
+  def resolved_lockfile(version)
+    resolved_lockfile_with_versions(version)
+  end
+
+  def package_release(version)
+    Dependabot::Package::PackageRelease.new(
+      version: Dependabot::Uv::Version.new(version),
+      released_at: nil,
+      tag: nil
+    )
+  end
+
+  def resolved_lockfile_with_versions(*versions)
+    Dependabot::DependencyFile.new(
+      name: "uv.lock",
+      content: <<~TOML
+        version = 1
+
+        #{versions.map do |version|
+          <<~PACKAGE
+            [[package]]
+            name = "#{dependency.name}"
+            version = "#{version}"
+          PACKAGE
+        end.join("\n")}
+      TOML
+    )
   end
 end

--- a/uv/spec/dependabot/uv/update_checker_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker_spec.rb
@@ -406,6 +406,13 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
     end
 
     context "with a uv.lock file" do
+      let(:lock_file_resolver) do
+        instance_double(
+          Dependabot::Uv::UpdateChecker::LockFileResolver,
+          latest_resolvable_version: Dependabot::Uv::Version.new("2.2.0"),
+          lowest_resolvable_security_fix_version: Dependabot::Uv::Version.new("2.2.0")
+        )
+      end
       let(:dependency_files) { [uv_lock_file, pyproject_file] }
       let(:uv_lock_file) do
         Dependabot::DependencyFile.new(
@@ -444,11 +451,22 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
         ]
       end
 
+      before do
+        allow(checker).to receive(:lock_file_resolver).and_return(lock_file_resolver)
+      end
+
       it "returns the lowest security fix version from the lock file resolver" do
         expect(checker.preferred_resolvable_version).to eq(Gem::Version.new("2.2.0"))
       end
 
       context "when no security fix version is found" do
+        let(:lock_file_resolver) do
+          instance_double(
+            Dependabot::Uv::UpdateChecker::LockFileResolver,
+            latest_resolvable_version: Dependabot::Uv::Version.new("2.2.0"),
+            lowest_resolvable_security_fix_version: nil
+          )
+        end
         let(:security_advisories) do
           [
             Dependabot::SecurityAdvisory.new(
@@ -471,6 +489,12 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
     subject { checker.lowest_resolvable_security_fix_version }
 
     context "with a uv.lock file and security advisory" do
+      let(:lock_file_resolver) do
+        instance_double(
+          Dependabot::Uv::UpdateChecker::LockFileResolver,
+          lowest_resolvable_security_fix_version: Dependabot::Uv::Version.new("2.2.0")
+        )
+      end
       let(:dependency_files) { [uv_lock_file, pyproject_file] }
       let(:uv_lock_file) do
         Dependabot::DependencyFile.new(
@@ -507,6 +531,10 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
             vulnerable_versions: ["<= 2.1.0"]
           )
         ]
+      end
+
+      before do
+        allow(checker).to receive(:lock_file_resolver).and_return(lock_file_resolver)
       end
 
       it "returns the lowest non-vulnerable version" do


### PR DESCRIPTION
### What are you trying to accomplish?

Indirect dependencies locked in `uv.lock` were not updated, even with:

```yaml
allow:
  - dependency-type: "all"
```

In the reproduction, `pytest==9.0.0` depends transitively on `pygments`. Dependabot detected `pygments` 2.20.0 but reported `update_not_possible` for the locked 2.19.0, while native uv updated it successfully:

```console
uv lock --upgrade-package pygments
Updated pygments v2.19.0 -> v2.20.0
```

Root cause: transitive dependencies have `requirements: []`, so uv selects `LockFileResolver`. Its placeholder implementation returned the current version without running native resolution.

Reproduction: https://github.com/dsp-testing/dependabot-15551-uv-indirect-repro

### What changed?

- Resolve lockfile-only dependencies with one constrained native `uv lock --upgrade-package` invocation.
- Reuse the existing release filters for ignored, cooldown, yanked, prerelease, unsupported, and advisory-vulnerable versions.
- Parse the regenerated `uv.lock` and verify the version Dependabot would select, including universal lockfiles containing multiple versions of the same package.
- Verify exact security-fix versions before returning them.
- Memoize requirement and exact-version resolution results.
- Avoid native resolution when no newer eligible release exists.
- Treat an unchanged lockfile as a classified no-change result while preserving operational errors.

GitHub documents `uv` as supporting indirect dependency updates through `dependency-type: "indirect"` and `"all"`:
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#dependency-type-allow

### Validation

- Affected uv specs pass.
- Sorbet passes.
- RuboCop passes.

### Checklist

- [x] I have tested the changes and added regression coverage.
- [x] I have kept native resolution constrained by Dependabot policy.
- [x] I have preserved actionable operational errors.
- [x] I have documented the problem, implementation, and validation.
