### PR TITLE
Ignore non-object npm engines metadata

### DIFF
--- a/bun/spec/dependabot/bun/package/package_details_fetcher_spec.rb
+++ b/bun/spec/dependabot/bun/package/package_details_fetcher_spec.rb
@@ -184,14 +184,34 @@ RSpec.describe Dependabot::Bun::Package::PackageDetailsFetcher do
       it "returns the release without a Node requirement" do
         release = details.releases.find { |candidate| candidate.version.to_s == "0.1.0" }
 
-        expect(release&.language).to be_nil
+        expect(release).not_to be_nil
+        expect(release.language).to be_nil
+      end
+    end
+
+    context "when registry metadata uses a legacy engines string" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump(
+            "versions" => {
+              "5.1.0" => { "engines" => ">=0.10.40" }
+            }
+          )
+        )
+      end
+
+      it "returns the release without a Node requirement" do
+        release = details.releases.find { |candidate| candidate.version.to_s == "5.1.0" }
+
+        expect(release).not_to be_nil
+        expect(release.language).to be_nil
       end
     end
 
     [
       ["time", { "versions" => { "1.0.0" => {} }, "time" => { "1.0.0" => 1 } }],
       ["dist-tags", { "dist-tags" => { "latest" => 1 } }],
-      ["engines", { "versions" => { "1.0.0" => { "engines" => "invalid" } } }],
       ["repository", { "versions" => { "1.0.0" => { "repository" => 1 } } }]
     ].each do |field, response_body|
       context "when #{field} has the wrong shape" do

--- a/common/lib/dependabot/package/npm_registry_package.rb
+++ b/common/lib/dependabot/package/npm_registry_package.rb
@@ -105,8 +105,7 @@ module Dependabot
       sig { params(details: ObjectHash, version: String).returns(T.nilable(String)) }
       def self.parse_node_requirement(details, version)
         engines = details["engines"]
-        return if engines.nil?
-        return if engines.is_a?(Array)
+        return unless engines.is_a?(Hash)
 
         engines_hash = object_hash(engines, "version #{version} engines")
         optional_string(

--- a/common/spec/dependabot/package/npm_registry_package_spec.rb
+++ b/common/spec/dependabot/package/npm_registry_package_spec.rb
@@ -147,6 +147,23 @@ RSpec.describe Dependabot::Package::NpmRegistryPackage do
       end
     end
 
+    context "with string engines metadata" do
+      let(:payload) do
+        {
+          "versions" => {
+            "5.1.0" => { "engines" => ">=0.10.40" }
+          }
+        }
+      end
+
+      it "preserves the release without a Node requirement" do
+        release = package.releases.fetch("5.1.0")
+
+        expect(release.node_requirement).to be_nil
+        expect(release.details["engines"]).to eq(">=0.10.40")
+      end
+    end
+
     context "when the version filter rejects a release" do
       let(:version_filter) { ->(_version) { false } }
       let(:payload) do
@@ -179,9 +196,6 @@ RSpec.describe Dependabot::Package::NpmRegistryPackage do
       [{ "versions" => { "1.0.0" => {} }, "time" => { "1.0.0" => 1 } }, "time values must be strings"],
       [{ "dist-tags" => [] }, "dist-tags must be an object"],
       [{ "dist-tags" => { "latest" => 1 } }, "dist-tags values must be strings"],
-      [{
-        "versions" => { "1.0.0" => { "engines" => "invalid" } }
-      }, "version 1.0.0 engines must be an object"],
       [{
         "versions" => { "1.0.0" => { "engines" => { "node" => 18 } } }
       }, "version 1.0.0 engines.node must be a string"],

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
@@ -208,14 +208,34 @@ RSpec.describe Dependabot::NpmAndYarn::Package::PackageDetailsFetcher do
       it "returns the release without a Node requirement" do
         release = details.releases.find { |candidate| candidate.version.to_s == "0.1.0" }
 
-        expect(release&.language).to be_nil
+        expect(release).not_to be_nil
+        expect(release.language).to be_nil
+      end
+    end
+
+    context "when registry metadata uses a legacy engines string" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump(
+            "versions" => {
+              "5.1.0" => { "engines" => ">=0.10.40" }
+            }
+          )
+        )
+      end
+
+      it "returns the release without a Node requirement" do
+        release = details.releases.find { |candidate| candidate.version.to_s == "5.1.0" }
+
+        expect(release).not_to be_nil
+        expect(release.language).to be_nil
       end
     end
 
     [
       ["time", { "versions" => { "1.0.0" => {} }, "time" => { "1.0.0" => 1 } }],
       ["dist-tags", { "dist-tags" => { "latest" => 1 } }],
-      ["engines", { "versions" => { "1.0.0" => { "engines" => "invalid" } } }],
       ["repository", { "versions" => { "1.0.0" => { "repository" => 1 } } }]
     ].each do |field, response_body|
       context "when #{field} has the wrong shape" do


### PR DESCRIPTION
### What are you trying to accomplish?

Restore the npm fetcher's previous handling of legacy `engines` metadata. Some published `qs` releases use a string instead of an object, which caused `NpmRegistryPackage` to raise and abort update jobs after #16031.

The parser now derives a Node requirement only when `engines` is an object. Other shapes remain in the raw release details but do not block the release.

Fixes an issue seen in production.

### Anything you want to highlight for special attention from reviewers?

Validation inside an `engines` object is unchanged. For example, a non-string `engines.node` value still raises a type error.

### How will you know you've accomplished your goal?

Regression specs cover both the `qs` string shape and the existing legacy array shape through the shared parser and npm package details fetcher.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
