### PR TITLE
Change default SMOKE_TEST_BRANCH back to 'main'

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: ${{ vars.SMOKE_TEST_BRANCH || 'dev/brettfo/nuget-dep-dir' }}
+  SMOKE_TEST_BRANCH: ${{ vars.SMOKE_TEST_BRANCH || 'main' }}
 permissions: {}
 
 jobs:


### PR DESCRIPTION
Earlier PR #15914 redirected the smoke tests to a temporary branch and now that work is complete so we can use `main` again.