### PR TITLE
Add typed npm package manager config

### DIFF
--- a/common/lib/dependabot/package/npm_package_manager_config.rb
+++ b/common/lib/dependabot/package/npm_package_manager_config.rb
@@ -1,0 +1,72 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  module Package
+    class NpmPackageManagerConfig < T::ImmutableStruct
+      extend T::Sig
+
+      ObjectHash = T.type_alias { T::Hash[String, Object] }
+
+      const :package_manager, T.nilable(String), default: nil
+      const :engines, T.nilable(T::Hash[String, String]), default: nil
+
+      sig { params(package_json: T.nilable(Object)).returns(NpmPackageManagerConfig) }
+      def self.from_package_json(package_json)
+        return new if package_json.nil?
+
+        manifest = object_hash(package_json, "package.json")
+
+        new(
+          package_manager: optional_string(manifest["packageManager"], "packageManager"),
+          engines: parse_engines(manifest)
+        )
+      end
+
+      sig { params(manifest: ObjectHash).returns(T.nilable(T::Hash[String, String])) }
+      def self.parse_engines(manifest)
+        return unless manifest.key?("engines")
+
+        raw_engines = manifest["engines"]
+        return if raw_engines.nil?
+
+        engines = T.let({}, T::Hash[String, String])
+        object_hash(raw_engines, "engines").each do |name, raw_requirement|
+          next if raw_requirement.nil?
+
+          raise TypeError, "engines.#{name} must be a string" unless raw_requirement.is_a?(String)
+
+          engines[name] = raw_requirement
+        end
+        engines
+      end
+      private_class_method :parse_engines
+
+      sig { params(value: Object, context: String).returns(ObjectHash) }
+      def self.object_hash(value, context)
+        raise TypeError, "#{context} must be an object" unless value.is_a?(Hash)
+
+        result = T.let({}, ObjectHash)
+        value.each do |raw_key, raw_value|
+          key = T.cast(raw_key, Object)
+          raise TypeError, "#{context} keys must be strings" unless key.is_a?(String)
+
+          result[key] = T.cast(raw_value, Object)
+        end
+        result
+      end
+      private_class_method :object_hash
+
+      sig { params(value: T.nilable(Object), context: String).returns(T.nilable(String)) }
+      def self.optional_string(value, context)
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise TypeError, "#{context} must be a string"
+      end
+      private_class_method :optional_string
+    end
+  end
+end

--- a/common/spec/dependabot/package/npm_package_manager_config_spec.rb
+++ b/common/spec/dependabot/package/npm_package_manager_config_spec.rb
@@ -1,0 +1,99 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/package/npm_package_manager_config"
+
+RSpec.describe Dependabot::Package::NpmPackageManagerConfig do
+  describe ".from_package_json" do
+    subject(:config) { described_class.from_package_json(package_json) }
+
+    let(:package_json) do
+      {
+        "packageManager" => "pnpm@10.11",
+        "engines" => {
+          "node" => ">=20",
+          "pnpm" => ">=10 || >=7 <9",
+          "custom" => "unchanged"
+        },
+        "private" => true
+      }
+    end
+
+    it "parses package-manager metadata without normalizing it" do
+      expect(config).to have_attributes(
+        package_manager: "pnpm@10.11",
+        engines: {
+          "node" => ">=20",
+          "pnpm" => ">=10 || >=7 <9",
+          "custom" => "unchanged"
+        }
+      )
+    end
+
+    context "with missing known fields" do
+      let(:package_json) { { "name" => "example" } }
+
+      it "uses nil defaults" do
+        expect(config).to have_attributes(package_manager: nil, engines: nil)
+      end
+    end
+
+    context "with a nil manifest" do
+      let(:package_json) { nil }
+
+      it "uses nil defaults" do
+        expect(config).to have_attributes(package_manager: nil, engines: nil)
+      end
+    end
+
+    context "with null known fields" do
+      let(:package_json) { { "packageManager" => nil, "engines" => nil } }
+
+      it "uses nil defaults" do
+        expect(config).to have_attributes(package_manager: nil, engines: nil)
+      end
+    end
+
+    context "with an empty engines object" do
+      let(:package_json) { { "engines" => {} } }
+
+      it "preserves the empty object" do
+        expect(config.engines).to eq({})
+      end
+    end
+
+    context "with null engine requirements" do
+      let(:package_json) do
+        {
+          "engines" => {
+            "npm" => nil,
+            "node" => ">=20"
+          }
+        }
+      end
+
+      it "drops the null entries" do
+        expect(config.engines).to eq("node" => ">=20")
+      end
+    end
+
+    [
+      [[], "package.json must be an object"],
+      [{ packageManager: "npm@11" }, "package.json keys must be strings"],
+      [{ "packageManager" => 11 }, "packageManager must be a string"],
+      [{ "engines" => [] }, "engines must be an object"],
+      [{ "engines" => { npm: ">=11" } }, "engines keys must be strings"],
+      [{ "engines" => { "npm" => 11 } }, "engines.npm must be a string"],
+      [{ "engines" => { "npm" => true } }, "engines.npm must be a string"]
+    ].each do |invalid_package_json, message|
+      context "with #{message}" do
+        let(:package_json) { invalid_package_json }
+
+        it "raises an explicit type error" do
+          expect { config }.to raise_error(TypeError, message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Add a shared typed parser for the `packageManager` and `engines` fields so npm and Bun do not pass untyped manifest hashes into package-manager selection.

### Anything you want to highlight for special attention from reviewers?

This is the foundation for #16068 and #16069 and does not change either consumer by itself.

### How will you know you've accomplished your goal?

Parser specs cover valid, missing, null, unknown, and malformed values.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.