### PR TITLE
Type npm package manager config

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 712
+# Offense count: 705
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -324,13 +324,11 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/helpers.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/metadata_finder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/package/registry_finder.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/registry_helper.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/latest_version_finder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/library_detector.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/update_checker/version_resolver.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/version_selector.rb"
     - "opentofu/lib/dependabot/opentofu/file_parser.rb"
     - "opentofu/lib/dependabot/opentofu/package/package_details_fetcher.rb"
     - "opentofu/lib/dependabot/opentofu/registry_client.rb"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/constraint_helper.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/constraint_helper.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb
@@ -125,7 +125,7 @@ module Dependabot
         @detected_package_manager ||= T.let(
           PackageManagerDetector.new(
             lockfiles_hash,
-            parsed_package_json
+            Dependabot::Package::NpmPackageManagerConfig.from_package_json(parsed_package_json)
           ).detect_package_manager,
           T.nilable(String)
         )

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -329,7 +329,7 @@ module Dependabot
       def package_manager_helper
         @package_manager_helper ||= T.let(
           PackageManagerHelper.new(
-            parsed_package_json,
+            Dependabot::Package::NpmPackageManagerConfig.from_package_json(parsed_package_json),
             lockfiles,
             registry_config_files,
             credentials

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -99,7 +99,7 @@ module Dependabot
       def package_manager_helper
         @package_manager_helper ||= T.let(
           PackageManagerHelper.new(
-            parsed_package_json,
+            Dependabot::Package::NpmPackageManagerConfig.from_package_json(parsed_package_json),
             lockfiles,
             registry_config_files,
             credentials

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/package_manager.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
@@ -11,6 +11,7 @@ require "dependabot/npm_and_yarn/yarn_package_manager"
 require "dependabot/npm_and_yarn/pnpm_package_manager"
 require "dependabot/npm_and_yarn/language"
 require "dependabot/npm_and_yarn/constraint_helper"
+require "dependabot/package/npm_package_manager_config"
 
 module Dependabot
   module NpmAndYarn
@@ -82,14 +83,13 @@ module Dependabot
       sig do
         params(
           lockfiles: T::Hash[Symbol, T.nilable(Dependabot::DependencyFile)],
-          package_json: T.nilable(T::Hash[String, T.untyped])
+          config: Dependabot::Package::NpmPackageManagerConfig
         ).void
       end
-      def initialize(lockfiles, package_json)
+      def initialize(lockfiles, config)
         @lockfiles = lockfiles
-        @package_json = package_json
-        @manifest_package_manager = T.let(package_json&.fetch(MANIFEST_PACKAGE_MANAGER_KEY, nil), T.nilable(String))
-        @engines = T.let(package_json&.fetch(MANIFEST_ENGINES_KEY, {}), T::Hash[String, T.untyped])
+        @manifest_package_manager = T.let(config.package_manager, T.nilable(String))
+        @engines = T.let(config.engines || {}, T::Hash[String, String])
       end
 
       # Returns npm, yarn, or pnpm based on the lockfiles, package.json, and engines
@@ -130,8 +130,6 @@ module Dependabot
 
       sig { returns(T.nilable(String)) }
       def name_from_engines
-        return unless @engines.is_a?(Hash)
-
         PACKAGE_MANAGER_CLASSES.each_key do |manager_name|
           return manager_name if @engines[manager_name]
         end
@@ -145,22 +143,21 @@ module Dependabot
 
       sig do
         params(
-          package_json: T.nilable(T::Hash[String, T.untyped]),
+          config: Dependabot::Package::NpmPackageManagerConfig,
           lockfiles: T::Hash[Symbol, T.nilable(Dependabot::DependencyFile)],
           registry_config_files: T::Hash[Symbol, T.nilable(Dependabot::DependencyFile)],
           credentials: T.nilable(T::Array[Dependabot::Credential])
         ).void
       end
-      def initialize(package_json, lockfiles, registry_config_files, credentials)
-        @package_json = package_json
+      def initialize(config, lockfiles, registry_config_files, credentials)
         @lockfiles = lockfiles
         @registry_helper = T.let(
           RegistryHelper.new(registry_config_files, credentials),
           Dependabot::NpmAndYarn::RegistryHelper
         )
-        @package_manager_detector = T.let(PackageManagerDetector.new(lockfiles, package_json), PackageManagerDetector)
-        @manifest_package_manager = T.let(package_json&.fetch(MANIFEST_PACKAGE_MANAGER_KEY, nil), T.nilable(String))
-        @engines = T.let(package_json&.fetch(MANIFEST_ENGINES_KEY, nil), T.nilable(T::Hash[String, T.untyped]))
+        @package_manager_detector = T.let(PackageManagerDetector.new(lockfiles, config), PackageManagerDetector)
+        @manifest_package_manager = T.let(config.package_manager, T.nilable(String))
+        @engines = T.let(config.engines, T.nilable(T::Hash[String, String]))
 
         @installed_versions = T.let({}, T::Hash[String, String])
         @registries = T.let({}, T::Hash[String, String])
@@ -223,9 +220,9 @@ module Dependabot
 
       sig { params(name: String).returns(String) }
       def raw_engine_constraint(name)
-        return "" unless @engines.is_a?(Hash) && @engines[name]
+        return "" unless @engines
 
-        @engines[name].to_s.strip
+        @engines.fetch(name, "").strip
       end
 
       sig { params(raw_constraint: String).returns(T.nilable(T::Array[T::Array[String]])) }
@@ -424,7 +421,7 @@ module Dependabot
 
         # If we can't get the installed version or the version is invalid, we need to get inferred version
         unless @installed_versions[name]&.match?(PACKAGE_MANAGER_VERSION_REGEX)
-          @installed_versions[name] = Helpers.public_send(:"#{name}_version_numeric", @lockfiles[name.to_sym]).to_s
+          @installed_versions[name] = T.must(numeric_lockfile_version(name, @lockfiles[name.to_sym])).to_s
         end
 
         T.must(@installed_versions[name])
@@ -472,25 +469,25 @@ module Dependabot
         match["version"]
       end
 
-      sig { params(name: String).returns(T.nilable(T.any(Integer, String))) }
+      sig { params(name: String).returns(T.nilable(Integer)) }
       def guessed_version(name)
         lockfile = @lockfiles[name.to_sym]
         return unless lockfile
 
-        version = Helpers.send(:"#{name}_version_numeric", lockfile)
+        version = numeric_lockfile_version(name, lockfile)
 
         Dependabot.logger.info("Guessed version info \"#{name}\" : \"#{version}\"")
 
         version
       end
 
-      sig { params(name: T.untyped).returns(T.nilable(String)) }
+      sig { params(name: String).returns(T.nilable(String)) }
       def check_engine_version(name)
-        return if @package_json.nil?
+        return unless @engines
 
         version_selector = VersionSelector.new
 
-        engine_versions = version_selector.setup(@package_json, name, dependabot_versions(name))
+        engine_versions = version_selector.setup(@engines, name, dependabot_versions(name))
 
         return if engine_versions.empty?
 
@@ -508,6 +505,23 @@ module Dependabot
           YarnPackageManager::SUPPORTED_VERSIONS
         when "pnpm"
           PNPMPackageManager::SUPPORTED_VERSIONS
+        end
+      end
+
+      sig do
+        params(
+          name: String,
+          lockfile: T.nilable(Dependabot::DependencyFile)
+        ).returns(T.nilable(Integer))
+      end
+      def numeric_lockfile_version(name, lockfile)
+        case name
+        when NpmPackageManager::NAME
+          Helpers.npm_version_numeric(lockfile)
+        when YarnPackageManager::NAME
+          Helpers.yarn_version_numeric(lockfile)
+        when PNPMPackageManager::NAME
+          Helpers.pnpm_version_numeric(lockfile)
         end
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/version_selector.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/version_selector.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
@@ -10,29 +10,27 @@ module Dependabot
       extend T::Sig
       extend T::Helpers
 
-      # Sets up engine versions from the given manifest JSON.
+      # Sets up the requested engine version from the manifest engines.
       #
-      # @param manifest_json [Hash] The manifest JSON containing version information.
+      # @param engine_versions [Hash] The manifest engine constraints.
       # @param name [String] The engine name to match.
       # @return [Hash] A hash with selected versions, if found.
       sig do
         params(
-          manifest_json: T::Hash[String, T.untyped],
+          engine_versions: T.nilable(T::Hash[String, String]),
           name: String,
           dependabot_versions: T.nilable(T::Array[Dependabot::Version])
         )
-          .returns(T::Hash[Symbol, T.untyped])
+          .returns(T::Hash[String, T.nilable(String)])
       end
-      def setup(manifest_json, name, dependabot_versions = nil)
-        engine_versions = manifest_json["engines"]
-
+      def setup(engine_versions, name, dependabot_versions = nil)
         # Return an empty hash if no engine versions are specified
         return {} if engine_versions.nil?
 
-        versions = {}
+        versions = T.let({}, T::Hash[String, T.nilable(String)])
 
         engine_versions.each do |engine, value|
-          next unless engine.to_s == name
+          next unless engine == name
 
           versions[name] = ConstraintHelper.find_highest_version_from_constraint_expression(
             value, dependabot_versions

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
   it_behaves_like "a dependency file parser"
 
+  describe "#ecosystem" do
+    let(:files) { project_dependency_files("npm6/simple") }
+
+    before do
+      allow(Dependabot::NpmAndYarn::Helpers).to receive(:node_version).and_return("20.0.0")
+    end
+
+    it "builds package-manager metadata from the typed manifest config" do
+      expect(parser.ecosystem.package_manager.name).to eq("npm")
+    end
+  end
+
   describe "parse" do
     subject(:dependencies) { parser.parse }
 

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_detector_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_detector_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerDetector do
 
   let(:lockfiles) { { npm: npm_lockfile, yarn: yarn_lockfile, pnpm: pnpm_lockfile } }
   let(:package_json) { { "packageManager" => "npm@7" } }
-  let(:detector) { described_class.new(lockfiles, package_json) }
+  let(:config) { Dependabot::Package::NpmPackageManagerConfig.from_package_json(package_json) }
+  let(:detector) { described_class.new(lockfiles, config) }
 
   describe "#detect_package_manager" do
     context "when npm lockfile exists" do
@@ -165,6 +166,15 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerDetector do
       context "when there are unknown keys in the engines" do
         let(:lockfiles) { {} }
         let(:package_json) { { "engines" => { "node" => "1" } } }
+
+        it "returns default (npm)" do
+          expect(detector.detect_package_manager).to eq("npm")
+        end
+      end
+
+      context "when a package manager engine has a null requirement" do
+        let(:lockfiles) { {} }
+        let(:package_json) { { "engines" => { "yarn" => nil } } }
 
         it "returns default (npm)" do
           expect(detector.detect_package_manager).to eq("npm")

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package_manager_helper_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerHelper do
   let(:register_config_files) { {} }
 
   let(:package_json) { { "packageManager" => "npm@7" } }
-  let(:helper) { described_class.new(package_json, lockfiles, register_config_files, []) }
+  let(:config) { Dependabot::Package::NpmPackageManagerConfig.from_package_json(package_json) }
+  let(:helper) { described_class.new(config, lockfiles, register_config_files, []) }
 
   describe "#package_manager" do
     context "when npm lockfile exists" do
@@ -249,7 +250,7 @@ RSpec.describe Dependabot::NpmAndYarn::PackageManagerHelper do
   end
 
   describe "#detect_version" do
-    let(:helper) { described_class.new(package_json, lockfiles, register_config_files, []) }
+    let(:helper) { described_class.new(config, lockfiles, register_config_files, []) }
 
     context "when packageManager field exists" do
       let(:package_json) { { "packageManager" => "npm@7.5.2" } }


### PR DESCRIPTION
### What are you trying to accomplish?

Use the shared manifest config for npm package-manager detection and version selection, removing seven `T.untyped` annotations.

### Anything you want to highlight for special attention from reviewers?

The existing lockfile, `packageManager`, `engines`, and default precedence is unchanged.

### How will you know you've accomplished your goal?

Manager, parser, fetcher, and grapher specs pass, and the ratchet falls from 712 to 705.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.