### PR TITLE
Type Bun package manager config

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 705
+# Offense count: 700
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -251,14 +251,12 @@ Sorbet/ForbidTUntyped:
     - "bun/lib/dependabot/bun/file_parser/lockfile_parser.rb"
     - "bun/lib/dependabot/bun/metadata_finder.rb"
     - "bun/lib/dependabot/bun/package/registry_finder.rb"
-    - "bun/lib/dependabot/bun/package_manager.rb"
     - "bun/lib/dependabot/bun/registry_helper.rb"
     - "bun/lib/dependabot/bun/registry_parser.rb"
     - "bun/lib/dependabot/bun/update_checker.rb"
     - "bun/lib/dependabot/bun/update_checker/latest_version_finder.rb"
     - "bun/lib/dependabot/bun/update_checker/library_detector.rb"
     - "bun/lib/dependabot/bun/update_checker/version_resolver.rb"
-    - "bun/lib/dependabot/bun/version_selector.rb"
     - "bundler/lib/dependabot/bundler/file_parser.rb"
     - "bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb"
     - "bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb"

--- a/bun/lib/dependabot/bun/constraint_helper.rb
+++ b/bun/lib/dependabot/bun/constraint_helper.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/bun/lib/dependabot/bun/file_fetcher.rb
+++ b/bun/lib/dependabot/bun/file_fetcher.rb
@@ -116,7 +116,7 @@ module Dependabot
       def package_manager_helper
         @package_manager_helper ||= T.let(
           PackageManagerHelper.new(
-            parsed_package_json,
+            Dependabot::Package::NpmPackageManagerConfig.from_package_json(parsed_package_json),
             lockfiles,
             registry_config_files,
             credentials

--- a/bun/lib/dependabot/bun/file_parser.rb
+++ b/bun/lib/dependabot/bun/file_parser.rb
@@ -98,7 +98,7 @@ module Dependabot
       def package_manager_helper
         @package_manager_helper ||= T.let(
           PackageManagerHelper.new(
-            parsed_package_json,
+            Dependabot::Package::NpmPackageManagerConfig.from_package_json(parsed_package_json),
             lockfiles,
             registry_config_files,
             credentials

--- a/bun/lib/dependabot/bun/package_manager.rb
+++ b/bun/lib/dependabot/bun/package_manager.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
@@ -9,6 +9,7 @@ require "dependabot/bun/registry_helper"
 require "dependabot/bun/bun_package_manager"
 require "dependabot/bun/language"
 require "dependabot/bun/constraint_helper"
+require "dependabot/package/npm_package_manager_config"
 
 module Dependabot
   module Bun
@@ -59,22 +60,21 @@ module Dependabot
 
       sig do
         params(
-          package_json: T.nilable(T::Hash[String, T.untyped]),
+          config: Dependabot::Package::NpmPackageManagerConfig,
           lockfiles: T::Hash[Symbol, T.nilable(Dependabot::DependencyFile)],
           registry_config_files: T::Hash[Symbol, T.nilable(Dependabot::DependencyFile)],
           credentials: T.nilable(T::Array[Dependabot::Credential])
         ).void
       end
-      def initialize(package_json, lockfiles, registry_config_files, credentials)
-        @package_json = package_json
+      def initialize(config, lockfiles, registry_config_files, credentials)
         @lockfiles = lockfiles
         @registry_helper = T.let(
           RegistryHelper.new(registry_config_files, credentials),
           Dependabot::Bun::RegistryHelper
         )
 
-        @manifest_package_manager = T.let(package_json&.fetch(MANIFEST_PACKAGE_MANAGER_KEY, nil), T.nilable(String))
-        @engines = T.let(package_json&.fetch(MANIFEST_ENGINES_KEY, nil), T.nilable(T::Hash[String, T.untyped]))
+        @manifest_package_manager = T.let(config.package_manager, T.nilable(String))
+        @engines = T.let(config.engines, T.nilable(T::Hash[String, String]))
 
         @installed_versions = T.let({}, T::Hash[String, String])
         @registries = T.let({}, T::Hash[String, String])
@@ -105,9 +105,9 @@ module Dependabot
       def find_engine_constraints_as_requirement(name)
         Dependabot.logger.info("Processing engine constraints for #{name}")
 
-        return nil unless @engines.is_a?(Hash) && @engines[name]
+        return nil unless @engines
 
-        raw_constraint = @engines[name].to_s.strip
+        raw_constraint = @engines.fetch(name, "").strip
         return nil if raw_constraint.empty?
 
         constraints = ConstraintHelper.extract_ruby_constraints(raw_constraint)
@@ -227,25 +227,25 @@ module Dependabot
         match["version"]
       end
 
-      sig { params(name: String).returns(T.nilable(T.any(Integer, String))) }
+      sig { params(name: String).returns(T.nilable(Integer)) }
       def guessed_version(name)
         lockfile = @lockfiles[name.to_sym]
         return unless lockfile
 
-        version = Helpers.send(:"#{name}_version_numeric", lockfile)
+        version = Helpers.bun_version_numeric(lockfile)
 
         Dependabot.logger.info("Guessed version info \"#{name}\" : \"#{version}\"")
 
         version
       end
 
-      sig { params(name: T.untyped).returns(T.nilable(String)) }
+      sig { params(name: String).returns(T.nilable(String)) }
       def check_engine_version(name)
-        return if @package_json.nil?
+        return unless @engines
 
         version_selector = VersionSelector.new
 
-        engine_versions = version_selector.setup(@package_json, name, BunPackageManager::SUPPORTED_VERSIONS)
+        engine_versions = version_selector.setup(@engines, name, BunPackageManager::SUPPORTED_VERSIONS)
 
         return if engine_versions.empty?
 

--- a/bun/lib/dependabot/bun/version_selector.rb
+++ b/bun/lib/dependabot/bun/version_selector.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/shared_helpers"
@@ -10,29 +10,27 @@ module Dependabot
       extend T::Sig
       extend T::Helpers
 
-      # Sets up engine versions from the given manifest JSON.
+      # Sets up the requested engine version from the manifest engines.
       #
-      # @param manifest_json [Hash] The manifest JSON containing version information.
+      # @param engine_versions [Hash] The manifest engine constraints.
       # @param name [String] The engine name to match.
       # @return [Hash] A hash with selected versions, if found.
       sig do
         params(
-          manifest_json: T::Hash[String, T.untyped],
+          engine_versions: T.nilable(T::Hash[String, String]),
           name: String,
           dependabot_versions: T.nilable(T::Array[Dependabot::Version])
         )
-          .returns(T::Hash[Symbol, T.untyped])
+          .returns(T::Hash[String, T.nilable(String)])
       end
-      def setup(manifest_json, name, dependabot_versions = nil)
-        engine_versions = manifest_json["engines"]
-
+      def setup(engine_versions, name, dependabot_versions = nil)
         # Return an empty hash if no engine versions are specified
         return {} if engine_versions.nil?
 
-        versions = {}
+        versions = T.let({}, T::Hash[String, T.nilable(String)])
 
         engine_versions.each do |engine, value|
-          next unless engine.to_s == name
+          next unless engine == name
 
           versions[name] = ConstraintHelper.find_highest_version_from_constraint_expression(
             value, dependabot_versions

--- a/bun/spec/dependabot/bun/file_parser_spec.rb
+++ b/bun/spec/dependabot/bun/file_parser_spec.rb
@@ -36,6 +36,21 @@ RSpec.describe Dependabot::Bun::FileParser do
     it_behaves_like "a dependency file parser"
   end
 
+  describe "#ecosystem" do
+    let(:files) { project_dependency_files("javascript/exact_version_requirements_no_lockfile") }
+
+    before do
+      allow(Dependabot::Bun::Helpers).to receive_messages(
+        bun_version: "1.1.39",
+        node_version: "20.0.0"
+      )
+    end
+
+    it "builds package-manager metadata from the typed manifest config" do
+      expect(parser.ecosystem.package_manager.name).to eq("bun")
+    end
+  end
+
   describe "parse" do
     subject(:dependencies) { parser.parse }
 

--- a/bun/spec/dependabot/bun/package_manager_helper_spec.rb
+++ b/bun/spec/dependabot/bun/package_manager_helper_spec.rb
@@ -1,0 +1,74 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/bun/package_manager"
+require "dependabot/bun/helpers"
+
+RSpec.describe Dependabot::Bun::PackageManagerHelper do
+  subject(:helper) do
+    described_class.new(
+      config,
+      lockfiles,
+      {},
+      []
+    )
+  end
+
+  let(:config) { Dependabot::Package::NpmPackageManagerConfig.from_package_json(package_json) }
+  let(:package_json) { {} }
+  let(:lockfiles) { {} }
+
+  describe "#detect_version" do
+    subject(:detected_version) { helper.detect_version("bun") }
+
+    context "with a packageManager version" do
+      let(:package_json) do
+        {
+          "packageManager" => "bun@1.2.3",
+          "engines" => { "bun" => ">=1.1.39" }
+        }
+      end
+
+      it "prefers packageManager over engines" do
+        expect(detected_version).to eq("1.2.3")
+      end
+    end
+
+    context "with an engine constraint" do
+      let(:package_json) { { "engines" => { "bun" => ">=1.1.39" } } }
+
+      it "selects the highest supported version" do
+        expect(detected_version).to eq("1.1.39")
+      end
+    end
+
+    context "with a null engine constraint" do
+      let(:package_json) { { "engines" => { "bun" => nil } } }
+
+      it "treats the constraint as missing" do
+        expect(detected_version).to be_nil
+      end
+    end
+
+    context "with only a lockfile" do
+      let(:bun_lock) { instance_double(Dependabot::DependencyFile) }
+      let(:lockfiles) { { bun: bun_lock } }
+
+      it "uses the typed Bun lockfile fallback" do
+        allow(Dependabot::Bun::Helpers).to receive(:bun_version_numeric).with(bun_lock).and_return(1)
+
+        expect(detected_version).to eq("1")
+        expect(Dependabot::Bun::Helpers).to have_received(:bun_version_numeric).with(bun_lock)
+      end
+    end
+  end
+
+  describe "#find_engine_constraints_as_requirement" do
+    let(:package_json) { { "engines" => { "node" => ">=20" } } }
+
+    it "builds a requirement from the typed engine constraint" do
+      expect(helper.find_engine_constraints_as_requirement("node").to_s).to eq(">= 20")
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Use the shared manifest config for Bun package-manager detection and version selection, removing five `T.untyped` annotations.

### Anything you want to highlight for special attention from reviewers?

Bun keeps its existing manifest, engine, lockfile, and installed-version behavior.

### How will you know you've accomplished your goal?

Manager, parser, and fetcher specs pass, and the ratchet falls from 705 to 700.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.