### PR TITLE
bun: support bun.lock lockfileVersion 2 and 3

### DIFF
--- a/bun/Dockerfile
+++ b/bun/Dockerfile
@@ -2,7 +2,7 @@
 FROM ghcr.io/dependabot/dependabot-updater-core
 
 # Check for updates at https://github.com/oven-sh/bun/releases
-ARG BUN_VERSION=1.3.14
+ARG BUN_VERSION=1.4.0
 
 # See https://github.com/nodesource/distributions#installation-instructions
 ARG NODEJS_VERSION=24

--- a/bun/lib/dependabot/bun/bun_package_manager.rb
+++ b/bun/lib/dependabot/bun/bun_package_manager.rb
@@ -15,9 +15,10 @@ module Dependabot
       MIN_SUPPORTED_VERSION = Version.new("1.1.39")
 
       # The highest bun.lock `lockfileVersion` the bun binary bundled in `bun/Dockerfile` can parse.
-      # Bun 1.4 raised the default to 2 (https://github.com/oven-sh/bun/pull/31539), which the bundled
-      # bun rejects at parse time. Bump this in lockstep with `ARG BUN_VERSION` in `bun/Dockerfile`.
-      MAX_SUPPORTED_LOCKFILE_VERSION = 1
+      # Bun 1.4 writes 2 by default (https://github.com/oven-sh/bun/pull/31539), and 3 for projects
+      # that use nested or version-scoped overrides (https://github.com/oven-sh/bun/pull/38333).
+      # Bump this in lockstep with `ARG BUN_VERSION` in `bun/Dockerfile`.
+      MAX_SUPPORTED_LOCKFILE_VERSION = 3
       SUPPORTED_VERSIONS = T.let([MIN_SUPPORTED_VERSION].freeze, T::Array[Dependabot::Version])
       DEPRECATED_VERSIONS = T.let([].freeze, T::Array[Dependabot::Version])
 

--- a/bun/spec/dependabot/bun/file_parser/lockfile_parser_spec.rb
+++ b/bun/spec/dependabot/bun/file_parser/lockfile_parser_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Dependabot::Bun::FileParser::LockfileParser do
         it "raises a DependencyFileNotSupported error" do
           expect { dependencies }
             .to raise_error(Dependabot::DependencyFileNotSupported) do |error|
-              expect(error.message).to include("Unsupported bun.lock 'lockfileVersion' 2")
+              expect(error.message).to include("Unsupported bun.lock 'lockfileVersion' 4")
               expect(error.message).to include(
                 "supports up to #{Dependabot::Bun::BunPackageManager::MAX_SUPPORTED_LOCKFILE_VERSION}"
               )
@@ -125,6 +125,40 @@ RSpec.describe Dependabot::Bun::FileParser::LockfileParser do
             version: "1.8.1"
           )
           expect(dependencies.length).to eq(17)
+        end
+      end
+
+      context "when dealing with v2 format" do
+        let(:dependency_files) { project_dependency_files("bun/simple_v2") }
+
+        it "parses dependencies properly" do
+          expect(dependencies.find { |d| d.name == "fetch-factory" }).to have_attributes(
+            name: "fetch-factory",
+            version: "0.0.1"
+          )
+          expect(dependencies.find { |d| d.name == "etag" }).to have_attributes(
+            name: "etag",
+            version: "1.8.1"
+          )
+          expect(dependencies.length).to eq(11)
+        end
+      end
+
+      # Bun only writes v3 for projects using nested or version-scoped overrides, which adds a
+      # top-level "overrides" object the parser has to ignore.
+      context "when dealing with v3 format" do
+        let(:dependency_files) { project_dependency_files("bun/simple_v3") }
+
+        it "parses dependencies properly" do
+          expect(dependencies.find { |d| d.name == "fetch-factory" }).to have_attributes(
+            name: "fetch-factory",
+            version: "0.0.1"
+          )
+          expect(dependencies.find { |d| d.name == "node-fetch" }).to have_attributes(
+            name: "node-fetch",
+            version: "1.7.3"
+          )
+          expect(dependencies.length).to eq(11)
         end
       end
 

--- a/bun/spec/fixtures/projects/bun/simple_v2/bun.lock
+++ b/bun/spec/fixtures/projects/bun/simple_v2/bun.lock
@@ -1,0 +1,37 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "fetch-factory": "^0.0.1",
+      },
+      "devDependencies": {
+        "etag": "^1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
+
+    "es6-promise": ["es6-promise@3.3.1", "", {}, "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "fetch-factory": ["fetch-factory@0.0.1", "", { "dependencies": { "es6-promise": "^3.0.2", "isomorphic-fetch": "^2.1.1", "lodash": "^3.10.1" } }, "sha512-gexRwqIhwzDJ2pJvL0UYfiZwW06/bdYWxAmswFFts7C87CF8i6liApihTk7TZFYMDcQjvvDIvyHv0q379z0aWA=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
+
+    "isomorphic-fetch": ["isomorphic-fetch@2.2.1", "", { "dependencies": { "node-fetch": "^1.0.1", "whatwg-fetch": ">=0.10.0" } }, "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA=="],
+
+    "lodash": ["lodash@3.10.1", "", {}, "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="],
+
+    "node-fetch": ["node-fetch@1.7.3", "", { "dependencies": { "encoding": "^0.1.11", "is-stream": "^1.0.1" } }, "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
+  }
+}

--- a/bun/spec/fixtures/projects/bun/simple_v2/package.json
+++ b/bun/spec/fixtures/projects/bun/simple_v2/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "fetch-factory": "^0.0.1"
+  },
+  "devDependencies": {
+    "etag": "^1.0.0"
+  }
+}

--- a/bun/spec/fixtures/projects/bun/simple_v3/bun.lock
+++ b/bun/spec/fixtures/projects/bun/simple_v3/bun.lock
@@ -1,0 +1,43 @@
+{
+  "lockfileVersion": 3,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "fetch-factory": "^0.0.1",
+      },
+      "devDependencies": {
+        "etag": "^1.0.0",
+      },
+    },
+  },
+  "overrides": {
+    "node-fetch": {
+      ".": "1.7.3",
+      "encoding": "0.1.13",
+    },
+  },
+  "packages": {
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
+
+    "es6-promise": ["es6-promise@3.3.1", "", {}, "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "fetch-factory": ["fetch-factory@0.0.1", "", { "dependencies": { "es6-promise": "^3.0.2", "isomorphic-fetch": "^2.1.1", "lodash": "^3.10.1" } }, "sha512-gexRwqIhwzDJ2pJvL0UYfiZwW06/bdYWxAmswFFts7C87CF8i6liApihTk7TZFYMDcQjvvDIvyHv0q379z0aWA=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "is-stream": ["is-stream@1.1.0", "", {}, "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="],
+
+    "isomorphic-fetch": ["isomorphic-fetch@2.2.1", "", { "dependencies": { "node-fetch": "^1.0.1", "whatwg-fetch": ">=0.10.0" } }, "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA=="],
+
+    "lodash": ["lodash@3.10.1", "", {}, "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="],
+
+    "node-fetch": ["node-fetch@1.7.3", "", { "dependencies": { "encoding": "^0.1.11", "is-stream": "^1.0.1" } }, "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
+  }
+}

--- a/bun/spec/fixtures/projects/bun/simple_v3/package.json
+++ b/bun/spec/fixtures/projects/bun/simple_v3/package.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "fetch-factory": "^0.0.1"
+  },
+  "devDependencies": {
+    "etag": "^1.0.0"
+  },
+  "overrides": {
+    "node-fetch": {
+      ".": "1.7.3",
+      "encoding": "0.1.13"
+    }
+  }
+}

--- a/bun/spec/fixtures/projects/bun/unsupported_lockfile_version/bun.lock
+++ b/bun/spec/fixtures/projects/bun/unsupported_lockfile_version/bun.lock
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 4,
   "configVersion": 1,
   "workspaces": {
     "": {


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #16026.

Bun 1.4.0 writes `bun.lock` `lockfileVersion` 2 by default (oven-sh/bun#31539), and 3 for projects that use nested or version-scoped overrides (oven-sh/bun#38333). The updater image bundles bun 1.3.14, which reads only v1.

#15896 stopped bun silently downgrading those lockfiles, by rejecting anything above `MAX_SUPPORTED_LOCKFILE_VERSION` with `DependencyFileNotSupported`. That was the right trade at the time, but it means every repository that has regenerated its lockfile with 1.4 now gets **no bun updates at all** — the state reported in #16026. Reproduced against a real repository with a v2 lockfile:

```
=> parsing dependency files
An error occurred: Dependabot::DependencyFileNotSupported,
Unsupported bun.lock 'lockfileVersion' 2 in /bun.lock. The bun version Dependabot runs supports up to 1.
```

This is the follow-up #15896 said it would need: *"at bun 1.4 GA, `ARG BUN_VERSION` and `MAX_SUPPORTED_LOCKFILE_VERSION` must be bumped together."*

- `ARG BUN_VERSION` 1.3.14 → 1.4.0
- `MAX_SUPPORTED_LOCKFILE_VERSION` 1 → 3
- The `unsupported_lockfile_version` fixture moves to v4 so the guard still guards, and `simple_v2` / `simple_v3` fixtures cover the two formats that are now accepted.

### Anything you want to highlight for special attention from reviewers?

**The ceiling is 3, not 2.** 1.4's default is 2, but a project using nested (`{"node-fetch": {".": "1.7.3", "encoding": "0.1.13"}}`) or version-scoped (`{"ansi-styles@^4.1.0": "4.2.1"}`) overrides gets 3, and the lockfile grows a top-level `overrides` object. Stopping at 2 would leave those repositories broken in exactly the way #16026 describes. Measured with 1.4.0:

| lockfile written by | plain project | nested / version-scoped overrides |
| --- | --- | --- |
| bun 1.3.14 | 1 | 1 (overrides silently dropped) |
| bun 1.4.0 | 2 | 3 |

**No parser change is needed.** v1 and v2 lockfiles generated from the same manifest are byte-identical apart from the version number — the `packages` tuple shape is unchanged. v3 only adds the `overrides` object, which `BunLock#dependencies` ignores; `simple_v3` is a real 1.4.0-generated lockfile that covers it.

**This does not churn anyone's lockfile format.** bun 1.4 leaves an existing v1 lockfile at v1 through both `install` and `add`, and still upgrades v0 → v1 exactly as 1.3.14 did. Running the updater's own command inside the new image against a real v2 lockfile leaves it at v2:

```
$ bun install --save-text-lockfile --ignore-scripts   # bun 1.4.0, image-bundled
  "lockfileVersion": 2,      # unchanged
```

**A behaviour change reviewers should know about, deliberately not addressed here.** In 1.4, `bun update <name>` re-resolves transitive packages within the parent's range instead of hoisting the dependency to the top level. For a transitive `ansi-styles` behind `chalk@4.1.0` (`^4.1.0`):

| | resulting lockfile | `package.json` |
| --- | --- | --- |
| bun 1.3.14 | `ansi-styles@7.0.0`, outside the parent range | gains `"ansi-styles": "^7.0.0"` |
| bun 1.4.0 | `ansi-styles@4.3.0` | untouched |

`SubdependencyVersionResolver#run_bun_updater` keeps only the lockfile and discards the manifest, so today it can emit a lockfile pinning a version the manifest never asked for. 1.4 fixes that, but it changes which version subdependency updates land on. The existing spec stubs `run_bun_command` entirely, so CI does not exercise this either way; I left it alone rather than widen this PR.

**Also out of scope:** in 1.4 a project's `bunfig.toml` takes precedence over `.npmrc` for the same key (oven-sh/bun#38333), which can affect repositories relying on the `.npmrc` that `FileUpdater::NpmrcBuilder` writes for private registry credentials. Happy to file that separately if you'd like it tracked.

**No `github/docs` PR.** `supported-package-managers.md` lists Bun as `>=v1.1.39` and does not name the bundled version, so the documented support range is unchanged.

### How will you know you've accomplished your goal?

All of the below ran inside `ghcr.io/dependabot/dependabot-updater-bun` built from this branch (bun 1.4.0).

- **`bun` suite: 383 examples, 0 failures.** As a control, the suite at `HEAD` (ceiling 1, spec/fixtures unchanged) against the same bun 1.4.0 image is **381 examples, 0 failures** — so the binary bump alone causes no regression, and this branch only adds the two new examples.
- **The guard still guards.** `unsupported_lockfile_version` is now v4, so the `DependencyFileNotSupported` example still fails if the ceiling is raised past 3. Conversely, the new `simple_v2` / `simple_v3` examples fail with the old ceiling of 1, so they exercise the change rather than passing incidentally.
- **End to end.** `bin/dry-run.rb bun <repo>` against a repository with a v2 `bun.lock` fails at "parsing dependency files" with the error quoted above before this change, and completes ("Dry-run completed successfully", 29 dependencies checked) after it.
- `rubocop` clean on `bun/lib` and `bun/spec`. `bun/spec/` is excluded from `sorbet/config`, and the only production change is an integer constant and its comment.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
