### PR TITLE
Skip unsupported Maven wrappers instead of failing the Maven job

### DIFF
--- a/maven/lib/dependabot/maven/file_parser/wrapper_mojo.rb
+++ b/maven/lib/dependabot/maven/file_parser/wrapper_mojo.rb
@@ -4,6 +4,7 @@
 # Parses maven-wrapper.properties and emits Dependency objects for the two
 # tracked Maven coordinates: org.apache.maven:apache-maven (the maven distribution)
 # and org.apache.maven.wrapper:maven-wrapper (the wrapper plugin).
+require "uri"
 require "dependabot/dependency_requirement"
 require "dependabot/maven/file_parser"
 require "dependabot/maven/distributions"
@@ -39,7 +40,8 @@ module Dependabot
           #  - wrapperVersion property (>=3.3.1),
           #  - version segment of wrapperUrl JAR filename (<3.3.0), or
           #  - comment in the mvnw script body (3.3.0 only, see MWRAPPER-120 and MWRAPPER-134).
-          # This field is mandatory and raises if none of the sources yield a version.
+          # When none of the sources yield a version, load_properties returns nil and the
+          # wrapper is skipped, so this field is only ever set to a resolved version.
           const :wrapper_version, String
 
           # The full JAR URL from the wrapperUrl property
@@ -65,7 +67,21 @@ module Dependabot
         DIST_URL_VERSION_REGEX = %r{
           /apache-maven-(?<version>[^/?#]+)-(?:bin|src)\.(?:zip|tar\.gz)(?:[?#].*)?\z
         }x
-        class UnparseableDistributionUrl < RuntimeError; end
+
+        # Apache Maven Wrapper JAR as it appears in a wrapperUrl path. Anchored to the artifact
+        # directory, a numeric version directory, and a `maven-wrapper-<version>.jar` filename whose
+        # version equals that directory (via the \k<version> backreference), mirroring Maven's
+        # mandatory repository layout. This rejects foreign JARs sharing the directory (e.g.
+        # .../maven-wrapper/3.3.4/foreign-3.3.4.jar), non-artifact filenames
+        # (.../3.3.4/maven-wrapper-foreign.jar) and mismatched coordinates
+        # (.../3.3.4/maven-wrapper-9.9.9.jar). Matched on the path only (not the host, query, or
+        # fragment) so wrappers proxied through private registries are still recognised, while
+        # wrappers from other vendors (e.g. legacy io.takari) are not. Applied in apache_wrapper_url?.
+        WRAPPER_COORDINATE_REGEX = %r{
+          /org/apache/maven/wrapper/maven-wrapper/    # Apache Maven Wrapper artifact directory
+          (?<version>\d+\.\d+(?:\.\d+)?(?:-\w+)*)/     # version directory
+          maven-wrapper-\k<version>\.jar\z            # artifact JAR named for that same version
+        }xi
 
         sig do
           params(
@@ -77,23 +93,11 @@ module Dependabot
           content = properties_file.content
           return [] unless content
 
-          distribution_url = get_property_value(content, "distributionUrl")
-          if distribution_url&.include?("mvnd")
-            Dependabot.logger.warn("Maven daemon (mvnd) distribution is not supported, skipping wrapper update")
-            return []
-          end
-
-          begin
-            props = load_properties(content, script_files: script_files)
-          rescue UnparseableDistributionUrl => e
-            Dependabot.logger.warn("#{e.message}, skipping wrapper update")
-            return []
-          end
-
-          if props.wrapper_url&.include?("takari")
-            Dependabot.logger.warn("The Takari distribution is not supported, skipping wrapper update")
-            return []
-          end
+          # load_properties returns nil for wrappers we cannot safely update (missing
+          # mandatory data or an unsupported vendor/distribution). The reason is logged there,
+          # and we skip the wrapper without disrupting ordinary POM dependency parsing.
+          props = load_properties(content, script_files: script_files)
+          return [] unless props
 
           file_name = properties_file.name
           has_debug_scripts = debug_scripts?(script_files)
@@ -252,35 +256,65 @@ module Dependabot
           script_files.any? { |f| debug_scripts.any? { |s| f.name.end_with?(s) } }
         end
 
-        sig { params(content: String, script_files: T::Array[DependencyFile]).returns(WrapperProperties) }
+        sig { params(content: String, script_files: T::Array[DependencyFile]).returns(T.nilable(WrapperProperties)) }
         def self.load_properties(content, script_files: [])
-          distribution_url = get_property_value!(content, "distributionUrl")
+          distribution_url = get_property_value(content, "distributionUrl")
+          return skip_wrapper("distributionUrl property is missing") unless distribution_url
+
+          return skip_wrapper("Maven daemon (mvnd) distribution is not supported") if distribution_url.include?("mvnd")
+
           distribution_version = extract_distribution_version(distribution_url)
-          distribution_sha256_sum = get_property_value(content, "distributionSha256Sum")
+          return skip_wrapper("could not extract Maven version from distributionUrl") unless distribution_version
+
           wrapper_url = get_property_value(content, "wrapperUrl")
-          wrapper_sha256_sum = get_property_value(content, "wrapperSha256Sum")
-          distribution_type = resolve_distribution_type(content, wrapper_url)
+          if wrapper_url && !apache_wrapper_url?(wrapper_url)
+            return skip_wrapper("wrapperUrl is not an Apache Maven Wrapper")
+          end
+
           wrapper_version = resolve_wrapper_version(content, wrapper_url, script_files)
+          unless wrapper_version
+            return skip_wrapper(
+              "could not determine Maven Wrapper version from wrapperVersion, wrapperUrl, or script files"
+            )
+          end
 
           WrapperProperties.new(
             distribution_url: distribution_url,
             distribution_version: distribution_version,
-            distribution_sha256_sum: distribution_sha256_sum,
-            wrapper_sha256_sum: wrapper_sha256_sum,
+            distribution_sha256_sum: get_property_value(content, "distributionSha256Sum"),
+            wrapper_sha256_sum: get_property_value(content, "wrapperSha256Sum"),
             wrapper_version: wrapper_version,
             wrapper_url: wrapper_url,
-            distribution_type: distribution_type
+            distribution_type: resolve_distribution_type(content, wrapper_url)
           )
         end
 
-        sig { params(content: String).returns(String) }
+        # Signals that the wrapper cannot be updated: logs the reason and returns nil so the
+        # caller treats the wrapper as absent rather than aborting the whole Maven parse.
+        sig { params(reason: String).returns(NilClass) }
+        def self.skip_wrapper(reason)
+          Dependabot.logger.warn("#{reason}, skipping Maven Wrapper update")
+          nil
+        end
+
+        sig { params(content: String).returns(T.nilable(String)) }
         def self.extract_distribution_version(content)
           match = content.match(DIST_URL_VERSION_REGEX)
-          unless match && match[:version]
-            raise UnparseableDistributionUrl, "Could not extract Maven version from distributionUrl"
-          end
+          match && match[:version]
+        end
 
-          T.must(match[:version])
+        # True when the wrapperUrl points at the Apache Maven Wrapper artifact. The coordinate is
+        # matched against the URL path only (never the query or fragment) so that a non-Apache JAR
+        # cannot slip through the allowlist by carrying the coordinate in a `?redirect=...` query.
+        # A malformed URL that cannot be parsed is treated as not-Apache.
+        sig { params(url: String).returns(T::Boolean) }
+        def self.apache_wrapper_url?(url)
+          path = URI.parse(url).path
+          return false unless path
+
+          path.match?(WRAPPER_COORDINATE_REGEX)
+        rescue URI::InvalidURIError
+          false
         end
 
         sig { params(content: String, target_key: String).returns(T.nilable(String)) }
@@ -324,15 +358,6 @@ module Dependabot
           end
         end
 
-        sig { params(content: String, target_key: String).returns(String) }
-        def self.get_property_value!(content, target_key)
-          value = get_property_value(content, target_key)
-
-          raise "Missing mandatory property: #{target_key}" if value.nil?
-
-          value
-        end
-
         private_class_method :build_distribution_dependency
         private_class_method :build_wrapper_dependency
         private_class_method :build_distribution_requirements
@@ -353,7 +378,7 @@ module Dependabot
             content: String,
             wrapper_url: T.nilable(String),
             script_files: T::Array[DependencyFile]
-          ).returns(String)
+          ).returns(T.nilable(String))
         end
         def self.resolve_wrapper_version(content, wrapper_url, script_files)
           version = get_property_value(content, "wrapperVersion")
@@ -365,10 +390,6 @@ module Dependabot
           if script_files.any?
             Dependabot.logger.warn "Maven Wrapper with no wrapperVersion or wrapperUrl in properties file"
             version = load_wrapper_version_from_scripts(script_files)
-          end
-
-          if version.nil?
-            raise "Could not determine Maven Wrapper version from wrapperVersion, wrapperUrl, or script files"
           end
 
           version
@@ -401,6 +422,8 @@ module Dependabot
         private_class_method :resolve_wrapper_version
         private_class_method :parse_version_from_wrapper_url
         private_class_method :load_wrapper_version_from_scripts
+        private_class_method :skip_wrapper
+        private_class_method :apache_wrapper_url?
       end
     end
   end

--- a/maven/spec/dependabot/maven/file_parser/wrapper_mojo_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/wrapper_mojo_spec.rb
@@ -172,8 +172,14 @@ RSpec.describe Dependabot::Maven::FileParser::WrapperMojo do
     context "when distributionUrl is missing" do
       let(:content) { "wrapperVersion=3.3.4\n" }
 
-      it "raises a missing mandatory property error" do
-        expect { props }.to raise_error(RuntimeError, /Missing mandatory property: distributionUrl/)
+      it "returns nil so the wrapper is skipped rather than aborting parsing" do
+        expect(props).to be_nil
+      end
+
+      it "logs that the wrapper was skipped" do
+        expect(Dependabot.logger).to receive(:warn)
+          .with(/distributionUrl property is missing, skipping Maven Wrapper update/)
+        props
       end
     end
 
@@ -182,8 +188,14 @@ RSpec.describe Dependabot::Maven::FileParser::WrapperMojo do
         "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip\n"
       end
 
-      it "raises an error about the unresolvable wrapper version" do
-        expect { props }.to raise_error(RuntimeError, /Could not determine Maven Wrapper version/)
+      it "returns nil so the wrapper is skipped rather than aborting parsing" do
+        expect(props).to be_nil
+      end
+
+      it "logs that the wrapper version could not be determined" do
+        expect(Dependabot.logger).to receive(:warn)
+          .with(/could not determine Maven Wrapper version.*skipping Maven Wrapper update/)
+        props
       end
     end
   end
@@ -224,9 +236,8 @@ RSpec.describe Dependabot::Maven::FileParser::WrapperMojo do
       expect(described_class.extract_distribution_version(url)).to eq("3.8.6")
     end
 
-    it "raises when the URL contains no recognizable version path segment" do
-      expect { described_class.extract_distribution_version("https://example.com/some-artifact.zip") }
-        .to raise_error(described_class::UnparseableDistributionUrl, /Could not extract Maven version/)
+    it "returns nil when the URL contains no recognizable version path segment" do
+      expect(described_class.extract_distribution_version("https://example.com/some-artifact.zip")).to be_nil
     end
   end
 
@@ -333,26 +344,165 @@ RSpec.describe Dependabot::Maven::FileParser::WrapperMojo do
 
       it "logs that wrapper tracking was skipped" do
         expect(Dependabot.logger).to receive(:warn)
-          .with(/Could not extract Maven version from distributionUrl, skipping wrapper update/)
+          .with(/could not extract Maven version from distributionUrl, skipping Maven Wrapper update/)
         described_class.resolve_dependencies(properties_file)
       end
     end
 
-    context "when the wrapperUrl points to a Takari distribution" do
-      let(:takari_url) { "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar" }
+    context "when the wrapperUrl points to a non-Apache wrapper (e.g. legacy Takari)" do
+      let(:wrapper_url) { "https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar" }
       let(:dist_url) do
         "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip"
       end
-      let(:content) { "distributionUrl=#{dist_url}\nwrapperUrl=#{takari_url}\n" }
+      let(:content) { "distributionUrl=#{dist_url}\nwrapperUrl=#{wrapper_url}\n" }
 
       it "returns an empty array" do
         expect(described_class.resolve_dependencies(properties_file)).to eq([])
       end
 
-      it "logs a warning that Takari is not supported" do
+      it "logs a warning that the wrapper is not an Apache Maven Wrapper" do
         expect(Dependabot.logger).to receive(:warn)
-          .with(/Takari distribution is not supported/)
+          .with(/wrapperUrl is not an Apache Maven Wrapper/)
         described_class.resolve_dependencies(properties_file)
+      end
+    end
+
+    context "when a non-Apache wrapperUrl carries the Apache coordinate only in its query string" do
+      let(:dist_url) do
+        "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip"
+      end
+      let(:wrapper_url) do
+        "https://evil.example.com/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar" \
+          "?redirect=/org/apache/maven/wrapper/maven-wrapper/"
+      end
+      let(:content) { "distributionUrl=#{dist_url}\nwrapperUrl=#{wrapper_url}\n" }
+
+      it "skips the wrapper because the coordinate is not in the URL path" do
+        expect(Dependabot.logger).to receive(:warn)
+          .with(/wrapperUrl is not an Apache Maven Wrapper/)
+        expect(described_class.resolve_dependencies(properties_file)).to eq([])
+      end
+    end
+
+    context "when a foreign JAR is hosted under the Apache maven-wrapper artifact directory" do
+      let(:dist_url) do
+        "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip"
+      end
+      let(:wrapper_url) do
+        "https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/foreign-3.3.4.jar"
+      end
+      let(:content) { "distributionUrl=#{dist_url}\nwrapperUrl=#{wrapper_url}\n" }
+
+      it "skips the wrapper because the filename is not the maven-wrapper artifact" do
+        expect(Dependabot.logger).to receive(:warn)
+          .with(/wrapperUrl is not an Apache Maven Wrapper/)
+        expect(described_class.resolve_dependencies(properties_file)).to eq([])
+      end
+    end
+
+    context "when a non-artifact filename sits under the Apache maven-wrapper version directory" do
+      let(:content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/" \
+          "apache-maven-3.9.9-bin.zip\nwrapperVersion=3.3.4\n" \
+          "wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/" \
+          "3.3.4/maven-wrapper-foreign.jar\n"
+      end
+
+      it "skips the wrapper even though a valid wrapperVersion is present" do
+        expect(Dependabot.logger).to receive(:warn)
+          .with(/wrapperUrl is not an Apache Maven Wrapper/)
+        expect(described_class.resolve_dependencies(properties_file)).to eq([])
+      end
+    end
+
+    context "when the wrapperUrl version directory and filename version disagree" do
+      let(:content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/" \
+          "apache-maven-3.9.9-bin.zip\n" \
+          "wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/" \
+          "3.3.4/maven-wrapper-9.9.9.jar\n"
+      end
+
+      it "skips the wrapper because the coordinate version is inconsistent" do
+        expect(Dependabot.logger).to receive(:warn)
+          .with(/wrapperUrl is not an Apache Maven Wrapper/)
+        expect(described_class.resolve_dependencies(properties_file)).to eq([])
+      end
+    end
+
+    context "when a legacy wrapper omits wrapperVersion, wrapperUrl, and a script banner" do
+      let(:dist_url) do
+        "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip"
+      end
+      let(:content) { "distributionUrl=#{dist_url}\n" }
+      let(:mvnw_file) do
+        make_properties_file(
+          "mvnw",
+          "#!/bin/sh\njarUrl=\"https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/" \
+          "maven-wrapper-0.4.2.jar\"\n"
+        )
+      end
+
+      it "skips the wrapper without raising" do
+        expect(described_class.resolve_dependencies(properties_file, script_files: [mvnw_file])).to eq([])
+      end
+    end
+
+    context "when an Apache wrapper is served from a private registry" do
+      let(:content) do
+        "distributionUrl=https://nexus.corp.example/repository/maven/org/apache/maven/apache-maven/" \
+          "3.9.9/apache-maven-3.9.9-bin.zip\n" \
+          "wrapperUrl=https://nexus.corp.example/repository/maven/org/apache/maven/wrapper/maven-wrapper/" \
+          "3.3.4/maven-wrapper-3.3.4.jar\n"
+      end
+
+      it "recognises the wrapper by its artifact path and tracks both dependencies" do
+        deps = described_class.resolve_dependencies(properties_file)
+        expect(deps.map(&:name)).to contain_exactly(
+          "org.apache.maven:apache-maven",
+          "org.apache.maven.wrapper:maven-wrapper"
+        )
+      end
+    end
+
+    context "when a supported Apache wrapper retains a commented-out wrapperUrl" do
+      let(:content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/" \
+          "apache-maven-3.9.9-bin.zip\ndistributionType=only-script\nwrapperVersion=3.3.4\n" \
+          "#wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.2/" \
+          "maven-wrapper-0.4.2.jar\n"
+      end
+
+      it "ignores the commented-out line and still tracks both dependencies" do
+        deps = described_class.resolve_dependencies(properties_file)
+        expect(deps.map(&:name)).to contain_exactly(
+          "org.apache.maven:apache-maven",
+          "org.apache.maven.wrapper:maven-wrapper"
+        )
+      end
+    end
+
+    context "when the wrapper has only a distributionUrl and a non-banner mvnw script" do
+      let(:content) do
+        "distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.3/" \
+          "apache-maven-3.5.3-bin.zip\n"
+      end
+      let(:mvnw_file) do
+        make_properties_file(
+          "mvnw",
+          "#!/bin/sh\nexec \"$JAVACMD\" -classpath \"$BASE/.mvn/wrapper/maven-wrapper.jar\" \"$@\"\n"
+        )
+      end
+
+      it "skips the wrapper instead of aborting Maven parsing" do
+        expect(described_class.resolve_dependencies(properties_file, script_files: [mvnw_file])).to eq([])
+      end
+
+      it "logs that the wrapper version could not be determined" do
+        allow(Dependabot.logger).to receive(:warn)
+        described_class.resolve_dependencies(properties_file, script_files: [mvnw_file])
+        expect(Dependabot.logger).to have_received(:warn)
+          .with(/could not determine Maven Wrapper version.*skipping Maven Wrapper update/)
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?

A generic `RuntimeError` in the Maven Wrapper parser was **aborting the entire Maven update job** whenever a wrapper couldn't be resolved (e.g. no `wrapperVersion`, or a non-Apache wrapper). Ordinary POM dependencies stopped being parsed. This surfaced as a high-volume production error affecting hundreds of repositories.

This PR makes an unsupported wrapper a **skip**, not a failure: the wrapper is treated as absent, a warning is logged, and POM parsing continues.

### Anything you want to highlight for special attention from reviewers?

- **Skip instead of raise.** Unsupported/unresolvable wrappers now return `nil` and log a reason, following the Dependabot "not applicable → nil" convention rather than exception-based control flow.
- **Allowlist, not denylist.** We only update wrappers we recognise as Apache Maven Wrappers (matched on the `org.apache.maven.wrapper:maven-wrapper` artifact **path**, host-agnostic). Any other vendor (e.g. legacy `io.takari`) is skipped without enumerating each one.
- **Private-registry safe.** Because the check is on the artifact path and not the host, Apache wrappers proxied through private registries/mirrors are still recognised and updated.
- **Happy path unchanged.** Valid Apache wrappers still contribute both `org.apache.maven:apache-maven` and `org.apache.maven.wrapper:maven-wrapper`.

### How will you know you've accomplished your goal?

- New regression specs cover: versionless wrappers, non-Apache (Takari) wrappers, Apache wrappers from a private registry, and commented-out properties. Happy path still yields both dependencies.
- Verified end-to-end against reproductions of the failing shapes: previously the whole parse aborted; now POM dependencies parse and only the wrapper is skipped.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
