### PR TITLE
Classify pnpm ERR_PNPM_NO_MATURE_MATCHING_VERSION as an expected cooldown failure

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb
@@ -180,6 +180,23 @@ module Dependabot
         ERR_PNPM_TRUST_DOWNGRADE = /ERR_PNPM_TRUST_DOWNGRADE/
         TRUST_DOWNGRADE_PACKAGE = /High-risk trust downgrade for "(?<dep>[^"]+)"/
 
+        # Raised when the release-age gate leaves no eligible version for a package
+        # pnpm has to resolve — typically a transitive dependency pinned to a
+        # release younger than the cooldown window. The gate is doing its job here,
+        # so this is an expected outcome of the cooldown policy rather than a
+        # subprocess failure. Matched on the terminal error code alone: pnpm prints
+        # unrelated registry `WARN ... error (undefined)` noise ahead of it, and
+        # only the terminal error carries this code.
+        ERR_PNPM_NO_MATURE_MATCHING_VERSION = /\bERR_PNPM_NO_MATURE_MATCHING_VERSION\b/
+
+        # Deliberately free of package names, versions, registry URLs and raw
+        # stderr: those stay in the job logs, while this message is what reaches
+        # error reporting.
+        RELEASE_AGE_COOLDOWN_MESSAGE =
+          "A version required by this update was published too recently to satisfy the configured " \
+          "cooldown period (pnpm minimumReleaseAge). This update will become possible once the " \
+          "required version is old enough."
+
         sig do
           params(
             pnpm_lock: Dependabot::DependencyFile,
@@ -636,6 +653,15 @@ module Dependabot
         end
         def handle_pnpm_lock_updater_error(error, pnpm_lock)
           error_message = error.message
+
+          # Checked first: pnpm emits registry warning noise before the terminal
+          # error, so a later matcher could otherwise classify the noise instead of
+          # the actual cause. The cooldown gate rejecting a too-young version is an
+          # expected policy outcome, not an unknown subprocess failure.
+          if error_message.match?(ERR_PNPM_NO_MATURE_MATCHING_VERSION)
+            Dependabot.logger.warn(error_message)
+            raise Dependabot::DependencyFileNotResolvable, RELEASE_AGE_COOLDOWN_MESSAGE
+          end
 
           if error_message.include?(IRRESOLVABLE_PACKAGE) || error_message.include?(INVALID_REQUIREMENT)
             raise_resolvability_error(error_message, pnpm_lock)

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb
@@ -1141,6 +1141,110 @@ RSpec.describe Dependabot::NpmAndYarn::FileUpdater::PnpmLockfileUpdater do
         expect(commands.count { |cmd| cmd.include?("--no-save") }).to eq(1)
       end
 
+      # Regression coverage for the unclassified-error flood tracked in Sentry as
+      # DELTAFORCE-1JSH. pnpm exits with ERR_PNPM_NO_MATURE_MATCHING_VERSION when the
+      # release-age gate added in dependabot/dependabot-core#15485 leaves no eligible
+      # version for a package it must resolve. That is the cooldown policy working as
+      # intended, so it must surface as an expected Dependabot error rather than an
+      # unclassified HelperSubprocessFailed reported as "unknown_error".
+      context "when pnpm reports no mature matching version" do
+        # Mirrors real pnpm output: registry `error (undefined)` warnings precede the
+        # terminal error, and only the terminal error carries the actual cause.
+        let(:no_mature_output) do
+          " WARN  GET https://registry.npmjs.org/posthog-js error (undefined)\n" \
+            " WARN  GET https://registry.npmjs.org/@posthog%2Fcore error (undefined)\n" \
+            " ERR_PNPM_NO_MATURE_MATCHING_VERSION  1 versions do not meet the " \
+            "minimumReleaseAge constraint:\n" \
+            "@posthog/core@1.271.0 was published at 2026-08-24T09:12:44.000Z\n"
+        end
+        let(:commands) { [] }
+
+        before do
+          allow(Dependabot.logger).to receive(:warn)
+          allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+            commands << cmd
+            if cmd.start_with?("update ")
+              raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+                message: no_mature_output,
+                error_context: {}
+              )
+            end
+            ""
+          end
+        end
+
+        it "raises a classified error rather than an unhandled subprocess failure" do
+          expect { updated_pnpm_lock_content }
+            .to raise_error(Dependabot::DependencyFileNotResolvable)
+        end
+
+        it "is reported as a handled updater error rather than an unknown one" do
+          error = begin
+            updated_pnpm_lock_content
+            nil
+          rescue Dependabot::DependencyFileNotResolvable => e
+            e
+          end
+
+          expect(Dependabot.updater_error_details(error).error_type)
+            .to eq("dependency_file_not_resolvable")
+        end
+
+        # The message reaches error reporting, so it must stay low-cardinality; the
+        # raw pnpm output belongs in the job logs instead.
+        it "keeps package names, versions and registry URLs out of the message" do
+          message = begin
+            updated_pnpm_lock_content
+            nil
+          rescue Dependabot::DependencyFileNotResolvable => e
+            e.message
+          end
+
+          expect(message).to be_a(String)
+          expect(message).not_to include("posthog")
+          expect(message).not_to include("1.271.0")
+          expect(message).not_to include("registry.npmjs.org")
+          expect(message).not_to include("ERR_PNPM")
+        end
+
+        it "logs the raw pnpm output so the detail is still available in the job logs" do
+          expect { updated_pnpm_lock_content }
+            .to raise_error(Dependabot::DependencyFileNotResolvable)
+
+          expect(Dependabot.logger).to have_received(:warn).with(no_mature_output)
+        end
+
+        # The cooldown must not be weakened: retrying ungated would admit the very
+        # release the gate exists to reject.
+        it "does not retry the update without the cooldown gate" do
+          expect { updated_pnpm_lock_content }
+            .to raise_error(Dependabot::DependencyFileNotResolvable)
+
+          updates = commands.select { |cmd| cmd.include?("--no-save") }
+          expect(updates.length).to eq(1)
+          expect(updates.first).to include("--config.minimumReleaseAge=10080")
+          expect(commands.join(" ")).not_to include("minimumReleaseAgeExclude")
+        end
+      end
+
+      # The registry warning noise that precedes the terminal error must not on its
+      # own be classified as a cooldown failure.
+      it "does not treat registry warning noise as a cooldown failure" do
+        allow(Dependabot::NpmAndYarn::Helpers).to receive(:run_pnpm_command) do |cmd, **|
+          if cmd.start_with?("update ")
+            raise Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+              message: " WARN  GET https://registry.npmjs.org/posthog-js error (undefined)\n" \
+                       " WARN  GET https://registry.npmjs.org/@posthog%2Fcore error (undefined)\n",
+              error_context: {}
+            )
+          end
+          ""
+        end
+
+        expect { updated_pnpm_lock_content }
+          .to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+      end
+
       # Regression coverage for dependabot/dependabot-core#13165: when a repo sets
       # `minimumReleaseAge` in pnpm-workspace.yaml *and* a Dependabot `cooldown`,
       # the longest release-age of the two takes precedence so neither policy is


### PR DESCRIPTION
## Summary

pnpm exits with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` when the native release-age gate leaves no eligible version for a package it has to resolve — typically a transitive dependency whose required version was published inside the cooldown window.

**The gate is behaving correctly. This PR does not change cooldown behaviour at all — it only fixes classification.** Today that outcome has no handler in `pnpm_lockfile_updater.rb`, so it escapes as an unclassified `Dependabot::SharedHelpers::HelperSubprocessFailed`, falls through `Dependabot.updater_error_details`, and is reported as `unknown_error` via `capture_exception`.

Fixes the error flood tracked in Sentry as `DELTAFORCE-1JSH` (~67,000 occurrences / ~3,000 users, first seen 2026-08-24, escalating).

## Background

- **#15485** — "Apply cooldown to transitive npm/pnpm/yarn deps via native release-age gates" (merge `21eab38a6`, shipped in v0.392.0/v0.393.0) started passing `--config.minimumReleaseAge=<minutes>` to pnpm so the cooldown policy also covers transitive dependencies. This is what surfaces the new terminal error code.
- **#15940** / **#15937** — "Fix npm/pnpm/yarn native release-age gates rejecting Dependabot's own updates" deliberately **re-raises** resolution-time release-age failures, because retrying ungated would admit the very version the gate exists to reject. Re-raising is intentional; what was missing is classification.

Sentry's fingerprint for `HelperSubprocessFailed` is the command string, so every distinct pnpm root cause co-groups under `pnpm update <dependency_updates> --lockfile-only --no-save -r --config.minimumReleaseAge=<minutes>`. Phrase analysis over 14 days shows `ERR_PNPM_NO_MATURE_MATCHING_VERSION` in ~50,899 events / ~4,000 users. The `error (undefined)` string (~15,167 events) is preceding registry **WARN noise** — it never appears without `NO_MATURE` in the sampled corpus, and `NO_MATURE` never appears without it. The terminal code is the real cause.

## What changed

Two surgical edits to `npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater.rb`:

1. Added an `ERR_PNPM_NO_MATURE_MATCHING_VERSION` matcher and a fixed `RELEASE_AGE_COOLDOWN_MESSAGE`.
2. Added an early branch in `handle_pnpm_lock_updater_error` that logs the raw pnpm output and raises `Dependabot::DependencyFileNotResolvable`.

The branch is checked **first** because pnpm prints registry `WARN … error (undefined)` noise *ahead* of the terminal error; checking first guarantees the terminal cause wins rather than a later matcher classifying the preceding noise. The matcher uses word boundaries (`/\bERR_PNPM_NO_MATURE_MATCHING_VERSION\b/`) so it matches both bare and bracketed renderings of the complete code token, and only the terminal code — never a `NO_MATURE` substring in a warning line.

### Before / after

| | Before | After |
|---|---|---|
| Raised | `HelperSubprocessFailed` | `DependencyFileNotResolvable` |
| `error_type` | `unknown_error` | `dependency_file_not_resolvable` |
| Sentry | `capture_exception` → ~67k unknown-error events | not captured as unknown |
| Cooldown | enforced | **unchanged, still enforced** |

## Error-class choice: reusing `Dependabot::DependencyFileNotResolvable`

I considered adding a dedicated class (e.g. `CooldownPeriodNotElapsed`) modelled on `BlockedDependencyVersion`, which is semantically nicer. I went with reuse because:

- It is **already mapped** in `common/lib/dependabot/errors.rb` `updater_error_details` → `"dependency_file_not_resolvable"`, so **no `errors.rb` change is required** and there is no new `error-type` string for the consumer to reject or render as unknown.
- There is **direct precedent**: `ERR_PNPM_NO_VERSIONS` already maps to `DependencyFileNotResolvable` in `PnpmErrorHandler`.
- I could find **no in-repo enumeration** of accepted `error-type` strings, and `github/dependabot-api` is out of scope here — so I couldn't confirm a new type is safe end-to-end. Per the lowest-risk default, reuse wins.

A spec asserts the `updater_error_details` mapping directly, so a future regression in that mapping is caught here.

### Message hygiene

`updater_error_details` forwards `error.message` as `"error-detail": { message: … }`, so the message is deliberately low-cardinality and contains **no package names, versions, registry URLs, or raw stderr**. The full pnpm output goes to `Dependabot.logger.warn` so the detail stays available in job logs. A spec asserts this.

## Cooldown is not weakened

- No ungated retry — the new branch raises, it never re-invokes the command.
- **No `minimumReleaseAgeExclude`** is written anywhere (pnpm's loose mode does this, silently eroding the user's policy; it is also incompatible with the `--no-save` flag Dependabot uses). The repo still has zero references to it, and a spec asserts it never appears in issued commands.

## Tests

Added to `npm_and_yarn/spec/dependabot/npm_and_yarn/file_updater/pnpm_lockfile_updater_spec.rb`:

- Terminal error **with leading WARN / `error (undefined)` noise** raises `DependencyFileNotResolvable`, not `HelperSubprocessFailed`.
- `updater_error_details(error).error_type == "dependency_file_not_resolvable"`.
- Message omits package names, versions, registry URLs and `ERR_PNPM`.
- Raw pnpm output is still logged.
- No ungated retry: exactly one `--no-save` command, it carries `--config.minimumReleaseAge=10080`, and `minimumReleaseAgeExclude` never appears.
- Warning-only, non-`NO_MATURE` failure still raises `HelperSubprocessFailed` (no regression in existing branches).

### ⚠️ Verification honesty — RSpec could not be executed in my environment

Please rely on CI for the spec run. This environment has **no container runtime** (`docker`, `podman`, `colima`, `lima`, `nerdctl` all absent, no Docker.app), so the documented `bin/docker-dev-shell` path was unusable; and the only Rubies available are **3.1.2** and **3.2.2**, below the gemspec's `>= 3.3.0` and `.ruby-version`'s `4.0.5`. **The RSpec examples themselves have never been run.**

What I *was* able to run, all passing:

- **Sorbet** — full-repo `sorbet` static check: **no errors**. The file is `# typed: strong`. I ran a positive control (injecting a bogus method call into the new branch) to confirm Sorbet genuinely analyses the new code and reports errors there, so the clean result is not vacuous.
- **Rubocop 1.88.2** with lockfile-pinned plugins (`rubocop-ast` 1.50.0, `-performance` 1.26.1, `-rspec` 3.10.2, `-sorbet` 0.13.2): **no new offenses**. One `Sorbet/RedundantTLetForLiteral` offense appears at `pnpm_lockfile_updater.rb:117` (`LOCKFILE_VERIFICATION_SETTINGS`), but I verified it reproduces **identically on unmodified `origin/main`** — pre-existing and untouched by this diff, so I left it alone.
- `ruby -c` syntax check on both files.
- A standalone harness that extracts the real shipped constants from the source and asserts matcher/message behaviour across bare, bracketed, warning-only and near-miss inputs (11/11).

## Also verified: npm/yarn have the same gap

`grep -rn "ETARGET\|notarget" --include=*.rb npm_and_yarn/lib` returns **nothing**, so npm's analogue (`ETARGET` / `notarget`, referenced in #15937) is unclassified too. Fixing it would meaningfully grow this diff, so it's noted as a follow-up rather than bundled here.

## Out of scope (follow-ups, not implemented here)

- Redesign `HelperSubprocessFailed` fingerprints in `common/lib/dependabot/shared_helpers.rb` from `error_context[:command]` to `(tool, operation, failure_code)`, so distinct pnpm causes stop co-grouping.
- A general pnpm output classifier that picks the last terminal `ERR_PNPM_[A-Z0-9_]+` code, replacing the hand-maintained matcher list.
- Classify npm `ETARGET` / `notarget` (and the yarn analogue) the same way.
- Changes to `github/dependabot-api` `app/models/updater_error.rb`, whose `rollup` is `SHA256(original_error_class + first backtrace frame + fingerprint)`.
- Metrics / per-job dedupe of `(operation, failure_code)`.