### PR TITLE
Give the security refresh operation a directory to work with

### DIFF
--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -58,8 +58,6 @@ module Dependabot
           Dependabot.logger.info("Starting update job for #{job.source.repo}")
           Dependabot.logger.info("Checking and updating security pull requests...")
 
-          return if abort_multi_directory_refresh?
-
           # Retrieve the list of initial notices from dependency snapshot
           @notices = dependency_snapshot.notices
           # More notices can be added during the update process
@@ -73,30 +71,6 @@ module Dependabot
         end
 
         private
-
-        # A multi-directory pull request should be refreshed through the group
-        # operation, which carries a dependency-group-to-refresh. When such a
-        # payload reaches this individual strategy we end the job cleanly and
-        # report a non-fatal exception instead of raising an unknown error.
-        sig { returns(T::Boolean) }
-        def abort_multi_directory_refresh?
-          directories = job.source.directories
-          return false unless directories && directories.count > 1
-
-          Dependabot.logger.warn(
-            "Skipping refresh for #{T.must(job.dependencies).join(', ')}: an individual pull request " \
-            "refresh cannot span multiple directories (#{directories.join(', ')})."
-          )
-
-          service.capture_exception(
-            error: Dependabot::DependabotError.new(
-              "Individual pull request refresh received multiple directories without a group to refresh."
-            ),
-            job: job
-          )
-
-          true
-        end
 
         sig { returns(Dependabot::Job) }
         attr_reader :job

--- a/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_security_update_pull_request.rb
@@ -47,12 +47,18 @@ module Dependabot
           @error_handler = error_handler
           # A list of notices that will be used in PR messages and/or sent to the dependabot github alerts.
           @notices = T.let([], T::Array[Dependabot::Notice])
+
+          return unless job.source.directory.nil? && job.source.directories&.one?
+
+          job.source.directory = job.source.directories&.first
         end
 
         sig { void }
         def perform
           Dependabot.logger.info("Starting update job for #{job.source.repo}")
           Dependabot.logger.info("Checking and updating security pull requests...")
+
+          return if abort_multi_directory_refresh?
 
           # Retrieve the list of initial notices from dependency snapshot
           @notices = dependency_snapshot.notices
@@ -67,6 +73,30 @@ module Dependabot
         end
 
         private
+
+        # A multi-directory pull request should be refreshed through the group
+        # operation, which carries a dependency-group-to-refresh. When such a
+        # payload reaches this individual strategy we end the job cleanly and
+        # report a non-fatal exception instead of raising an unknown error.
+        sig { returns(T::Boolean) }
+        def abort_multi_directory_refresh?
+          directories = job.source.directories
+          return false unless directories && directories.count > 1
+
+          Dependabot.logger.warn(
+            "Skipping refresh for #{T.must(job.dependencies).join(', ')}: an individual pull request " \
+            "refresh cannot span multiple directories (#{directories.join(', ')})."
+          )
+
+          service.capture_exception(
+            error: Dependabot::DependabotError.new(
+              "Individual pull request refresh received multiple directories without a group to refresh."
+            ),
+            job: job
+          )
+
+          true
+        end
 
         sig { returns(Dependabot::Job) }
         attr_reader :job

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -221,41 +221,6 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
         expect(job.source.directory).to eq("/")
       end
     end
-
-    context "when the refresh job carries more than one directory" do
-      let(:job_definition) do
-        definition = job_definition_fixture("bundler/version_updates/pull_request_simple")
-        definition["job"]["dependencies"] = ["dummy-pkg-a"]
-        definition["job"]["security-updates-only"] = true
-        definition["job"]["updating-a-pull-request"] = true
-        definition["job"]["dependency-groups"] = [
-          {
-            "name" => "all-security-updates",
-            "applies-to" => "security-updates",
-            "rules" => { "patterns" => ["*"] }
-          }
-        ]
-        definition["job"]["source"].delete("directory")
-        definition["job"]["source"]["directories"] = %w(/foo /bar)
-        definition
-      end
-
-      let(:dependency_files) do
-        %w(/foo /bar).flat_map do |dir|
-          original_bundler_files(fixture: "bundler_simple", directory: dir)
-        end
-      end
-
-      it "ends the job gracefully without raising or touching pull requests" do
-        expect(mock_service).to receive(:capture_exception)
-        expect(mock_service).not_to receive(:create_pull_request)
-        expect(mock_service).not_to receive(:update_pull_request)
-        expect(mock_service).not_to receive(:close_pull_request)
-        expect(mock_error_handler).not_to receive(:handle_dependency_error)
-
-        expect { perform }.not_to raise_error
-      end
-    end
   end
 
   describe "#check_and_update_pull_request" do

--- a/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_security_update_pull_request_spec.rb
@@ -189,6 +189,73 @@ RSpec.describe Dependabot::Updater::Operations::RefreshSecurityUpdatePullRequest
         perform
       end
     end
+
+    context "when a `directories`-only refresh job also declares dependency groups" do
+      # DependencySnapshot only backfills job.source.directory for a security job
+      # when the config declares no dependency groups, so a grouped config leaves
+      # this individual refresh with a nil directory.
+      let(:job_definition) do
+        definition = job_definition_fixture("bundler/version_updates/pull_request_simple")
+        definition["job"]["dependencies"] = ["dummy-pkg-a"]
+        definition["job"]["security-updates-only"] = true
+        definition["job"]["updating-a-pull-request"] = true
+        definition["job"]["dependency-groups"] = [
+          {
+            "name" => "all-security-updates",
+            "applies-to" => "security-updates",
+            "rules" => { "patterns" => ["*"] }
+          }
+        ]
+        definition["job"]["source"].delete("directory")
+        definition["job"]["source"]["directories"] = ["/."]
+        definition
+      end
+
+      before do
+        allow(refresh_security_update_pull_request).to receive(:check_and_update_pull_request)
+      end
+
+      it "normalizes the lone directory onto the job source" do
+        perform
+
+        expect(job.source.directory).to eq("/")
+      end
+    end
+
+    context "when the refresh job carries more than one directory" do
+      let(:job_definition) do
+        definition = job_definition_fixture("bundler/version_updates/pull_request_simple")
+        definition["job"]["dependencies"] = ["dummy-pkg-a"]
+        definition["job"]["security-updates-only"] = true
+        definition["job"]["updating-a-pull-request"] = true
+        definition["job"]["dependency-groups"] = [
+          {
+            "name" => "all-security-updates",
+            "applies-to" => "security-updates",
+            "rules" => { "patterns" => ["*"] }
+          }
+        ]
+        definition["job"]["source"].delete("directory")
+        definition["job"]["source"]["directories"] = %w(/foo /bar)
+        definition
+      end
+
+      let(:dependency_files) do
+        %w(/foo /bar).flat_map do |dir|
+          original_bundler_files(fixture: "bundler_simple", directory: dir)
+        end
+      end
+
+      it "ends the job gracefully without raising or touching pull requests" do
+        expect(mock_service).to receive(:capture_exception)
+        expect(mock_service).not_to receive(:create_pull_request)
+        expect(mock_service).not_to receive(:update_pull_request)
+        expect(mock_service).not_to receive(:close_pull_request)
+        expect(mock_error_handler).not_to receive(:handle_dependency_error)
+
+        expect { perform }.not_to raise_error
+      end
+    end
   end
 
   describe "#check_and_update_pull_request" do


### PR DESCRIPTION
Fixes #15843.

### Problem

`RefreshSecurityUpdatePullRequest` reads `job.source.directory` and passes it
straight into `Pathname.new` via `DependencyChangeBuilder#initialize`. When the
job payload carries only `directories`, that read is `nil` and the job dies with
an unhandled `TypeError`:

```
ERROR Error processing google.golang.org/grpc (TypeError)
ERROR Pathname.new requires a String, #to_path or #to_str
ERROR .../lib/dependabot/dependency_change_builder.rb:63
ERROR .../updater/operations/refresh_security_update_pull_request.rb:185
```

The user sees `unknown_error` with no dependency detail, and the pull request is
stuck for good: Dependabot can neither refresh it nor replace it, so the advisory
stays unremediated until someone patches it by hand.

### Why the security path specifically

`DependencySnapshot#initialize` already backfills the directory for a security
job, but only when the configuration declares no dependency groups:

```ruby
if @original_directory.nil? && @dependency_group_engine.dependency_groups.none? && job.security_updates_only?
  @original_directory = T.must(job.source.directories).first
end
```

A repo that declares an `applies-to: security-updates` group keeps that group in
the engine, so `dependency_groups.none?` is false, the backfill is skipped, and
an individual security refresh in that repo is left with a nil directory. The
issue reports this under a multi-directory npm config, but the payload there is
`"directories":["/"]`, a single entry. A grouped config on a plain
`directory: "/"` repo reaches the same nil.

`RefreshVersionUpdatePullRequest` and `UpdateAllVersions` both promote a lone
`directories` entry in their constructor. The security refresh operation never
got that.

### Fix

Promote a single-entry `directories` onto `source.directory` in the constructor,
the same three lines `RefreshVersionUpdatePullRequest` carries. Four lines of
production code in one file.

Multi-directory security refreshes are untouched, since the promotion only fires
for a single-entry `directories`. That matters: unlike the version path, which
aborts multi-directory refreshes since #15872, a multi-directory *security*
refresh is supported and covered by the `su-multidir-rebase` integration test.
My first revision of this PR mirrored #15872's guard here too and broke that
test, so the second commit removes it. Happy to squash.

### Testing

One example added to `refresh_security_update_pull_request_spec.rb`, verified to
fail on `main` (`expected: "/" got: nil`) and pass with the change: a
`directories`-only payload on a repo declaring a security-updates group
normalizes the lone directory onto the job source.

`bundle exec rspec spec/dependabot/updater/operations/` — 114 examples, 0 failures.
`bundle exec rubocop` and `bundle exec srb tc` both clean.

### Not included

`CreateSecurityUpdatePullRequest` has the same missing promotion and calls
`T.must(job.source.directory)` directly, so it would raise on the same payload. I
have no reproduction for it: across a 185-repo fleet I read the job log of every
failed refresh over three weeks and found 36 crashes with this backtrace, all in
the refresh path and none in create. I have left it alone rather than change a
path I cannot exercise. Happy to fold it in if you would prefer.
