### PR TITLE
Skip uv dependencies pinned to a source that can never be updated

### DIFF
--- a/python/lib/dependabot/python/file_parser/pyproject_document.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_document.rb
@@ -216,6 +216,37 @@ module Dependabot
           poetry_sources.find { |source| source.name == name }
         end
 
+        # A name pinned to one of these says nothing about what a package index holds. A git source
+        # carrying a tag is left alone: the tag gives an ordering, so such a pin can be updated from
+        # the remote instead of being skipped.
+        UNRESOLVABLE_UV_SOURCE_KEYS = %w(git url).freeze
+
+        sig { returns(T::Array[String]) }
+        def unresolvable_uv_source_names
+          tool = section(@data, "tool", "tool")
+          uv = tool && section(tool, "uv", "tool.uv")
+          sources = uv && section(uv, "sources", "tool.uv.sources")
+          return [] unless sources
+
+          sources.filter_map do |name, config|
+            # uv accepts either a single source or a list of them, each with its own markers.
+            entries = T.let(config.is_a?(Array) ? config : [config], T::Array[Object])
+            next unless entries.any? { |entry| unresolvable_uv_source_entry?(entry) }
+
+            name
+          end
+        end
+
+        sig { params(entry: Object).returns(T::Boolean) }
+        def unresolvable_uv_source_entry?(entry)
+          return false unless entry.is_a?(Hash)
+
+          keys = entry.keys
+          return false unless keys.intersect?(UNRESOLVABLE_UV_SOURCE_KEYS)
+
+          !(keys.include?("git") && keys.include?("tag"))
+        end
+
         sig { params(key: String).returns(T::Array[String]) }
         def workspace_globs(key)
           tool = section(@data, "tool", "tool")

--- a/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
@@ -89,10 +89,16 @@ module Dependabot
           # undesirable. Leave PDM alone until properly supported
           return dependencies if using_pdm?
 
+          unresolvable_sources = PyprojectDocument.from_file(pyproject_file)
+                                                  .unresolvable_uv_source_names
+                                                  .map { |name| normalise(name) }
+
           parse_pep621_pep735_dependencies(pyproject_file).each do |dep|
             # If a requirement has a `<` or `<=` marker then updating it is
             # probably blocked. Ignore it.
             next if dep.markers&.include?("<")
+
+            next if unresolvable_sources.include?(normalise(dep.name))
 
             # In uv no constraint means any version is acceptable
             requirement_value = dep.requirement == "" ? "*" : dep.requirement

--- a/uv/spec/dependabot/uv/file_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser_spec.rb
@@ -868,6 +868,30 @@ RSpec.describe Dependabot::Uv::FileParser do
       its(:length) { is_expected.to eq(3) }
     end
 
+    context "with dependencies pinned to uv sources" do
+      let(:files) { [pyproject] }
+      let(:pyproject) do
+        Dependabot::DependencyFile.new(
+          name: "pyproject.toml",
+          content: fixture("pyproject_files", "uv_mixed_sources.toml")
+        )
+      end
+
+      # tagged-package survives: its tag gives an ordering, so the pin can be updated from the remote
+      # rather than resolved against an index it is not on
+      it "omits the dependencies pinned to a source that can never be updated" do
+        expect(dependencies.map(&:name))
+          .to contain_exactly(
+            "requests",
+            "local-package",
+            "registry-package",
+            "tagged-package",
+            "setuptools",
+            "wheel"
+          )
+      end
+    end
+
     context "with a pyproject.toml file with no dependencies" do
       let(:files) { [pyproject] }
       let(:pyproject) do

--- a/uv/spec/fixtures/pyproject_files/uv_mixed_sources.toml
+++ b/uv/spec/fixtures/pyproject_files/uv_mixed_sources.toml
@@ -7,6 +7,7 @@ dependencies = [
     "requests>=2.31.0",
     "local-package",
     "git-package",
+    "tagged-package",
     "registry-package",
 ]
 
@@ -16,6 +17,9 @@ local-package = { path = "./local-package" }
 
 # Git dependency - should NOT be detected as path dependency
 git-package = { git = "https://github.com/example/package.git" }
+
+# Git dependency carrying a tag - the tag gives an ordering, so this one is not skipped
+tagged-package = { git = "https://github.com/example/tagged.git", tag = "1.2.3" }
 
 # Registry dependency with custom index - should NOT be detected as path dependency
 registry-package = { index = "https://custom-pypi.example.com/simple" }


### PR DESCRIPTION
### What are you trying to accomplish?

Dependabot resolves every entry in `[project.dependencies]` against a package index. A dependency
pinned to a `url` source in `[tool.uv.sources]`, or to a `git` source carrying no tag, is not a
registry dependency, so that lookup either:

- **finds nothing** — the pin is never updated, and no error says why. On a private repository, six
  upstream releases went by over seventeen days with daily runs and `patterns: ["*"]`, and none was
  proposed;
- or **finds an unrelated package** that happens to share the name, and proposes a version of it.

That second outcome is the same failure #14728 described one layer down, where `pin_pep508_entry` was
rewriting `"pkg @ git+https://…"` into `pkg==<version>`. #14729 fixed it there, and its comment —
*"already pinned to a URL"* — is the same reasoning applied to the updating side.

Details and the code walk-through are in #16129.

### Anything you want to highlight for special attention from reviewers?

**Which source kinds, and why a tagged git source is not one of them.** `url` always, and `git` only
when the entry carries no tag. A tag gives an ordering, so such a pin can be read from the remote and
written back — skipping it would forgo an update that is available. #16151 does exactly that, which
makes these two changes complementary rather than alternatives: this one covers the shapes no
ordering can be derived from, which #16151 leaves with no source and therefore still resolved against
an index.

- `path` entries keep their current behaviour. They are the subject of #14644 and changing them here
  would conflate two requests.
- `index` entries are real registry dependencies and must keep being checked.

**Consistency rather than a new policy.** The Poetry path in this same parser already skips these
source kinds, through `UNSUPPORTED_DEPENDENCY_TYPES`. This makes the PEP 621 path behave the same way.

**Why the table is read per manifest.** `PyprojectDocument.from_file(pyproject_file)` rather than the
memoised root document, because `pep621_pep735_dependencies` is also called for workspace members.

**Why both names are normalised.** uv applies PEP 508 normalisation when matching a source to a
dependency, while the table key is written as the author typed it, so `normalise` is applied to both
sides.

**Not covered.** A PEP 508 direct reference written inline (`"pkg @ git+https://…"`) has the same
problem, but `uv/helpers/lib/parser.py` emits no url for it, so surfacing one is a wider change.

### How will you know you've accomplished your goal?

The spec reuses the existing `uv_mixed_sources.toml` fixture, extended with a `git`-and-tag entry so
that the boundary between what is skipped and what is kept is asserted rather than implied. It checks
the complete set of names the parser emits, so a dependency appearing or disappearing both fail it.

Removing the skip yields `git-package` and `url-package` in that set; narrowing it to `git` alone
drops `tagged-package` from it.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
