### PR TITLE
Fix Maven property requirement selection

### DIFF
--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -133,26 +133,25 @@ module Dependabot
 
         sig { returns(String) }
         def property_name
-          @property_name ||= T.let(
-            dependency.requirements
-                      .find { |r| r.metadata_string("property_name") }
-                      &.metadata_string("property_name"),
-            T.nilable(String)
-          )
-
-          raise "No requirement with a property name!" unless @property_name
-
-          @property_name
+          T.must(property_requirement.metadata_string("property_name"))
         end
 
         sig { returns(T.nilable(String)) }
         def property_source
-          @property_source ||= T.let(
-            dependency.requirements
-                      .find { |r| r.metadata_string("property_name") == property_name }
-                      &.metadata_string("property_source"),
-            T.nilable(String)
-          )
+          property_requirement.metadata_string("property_source")
+        end
+
+        sig { returns(Dependabot::DependencyRequirement) }
+        def property_requirement
+          property_requirements = dependency.requirements.select { |r| r.metadata_string("property_name") }
+          matching_requirement = property_requirements.find do |requirement|
+            requirement.requirement_string == dependency.version
+          end
+          requirement = matching_requirement || property_requirements.first
+
+          raise "No requirement with a property name!" unless requirement
+
+          requirement
         end
 
         sig { params(string: String).returns(T::Boolean) }

--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -145,13 +145,22 @@ module Dependabot
         def property_requirement
           property_requirements = dependency.requirements.select { |r| r.metadata_string("property_name") }
           matching_requirement = property_requirements.find do |requirement|
-            requirement.requirement_string == dependency.version
+            normalized_requirement_version(requirement) == dependency.version
           end
           requirement = matching_requirement || property_requirements.first
 
           raise "No requirement with a property name!" unless requirement
 
           requirement
+        end
+
+        sig { params(requirement: Dependabot::DependencyRequirement).returns(T.nilable(String)) }
+        def normalized_requirement_version(requirement)
+          requirement_string = requirement.requirement_string
+          return unless requirement_string
+          return if requirement_string.include?(",")
+
+          requirement_string.gsub(/[\(\)\[\]]/, "").strip
         end
 
         sig { params(string: String).returns(T::Boolean) }

--- a/maven/lib/dependabot/maven/update_checker/property_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/property_updater.rb
@@ -133,12 +133,22 @@ module Dependabot
 
         sig { returns(String) }
         def property_name
-          T.must(property_requirement.metadata_string("property_name"))
+          @property_name ||= T.let(
+            property_requirement.metadata_string("property_name"),
+            T.nilable(String)
+          )
+
+          raise "No requirement with a property name!" unless @property_name
+
+          @property_name
         end
 
         sig { returns(T.nilable(String)) }
         def property_source
-          property_requirement.metadata_string("property_source")
+          @property_source ||= T.let(
+            property_requirement.metadata_string("property_source"),
+            T.nilable(String)
+          )
         end
 
         sig { returns(Dependabot::DependencyRequirement) }

--- a/maven/spec/dependabot/maven/update_checker/property_updater_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/property_updater_spec.rb
@@ -292,6 +292,57 @@ RSpec.describe Dependabot::Maven::UpdateChecker::PropertyUpdater do
       end
     end
 
+    context "when the same dependency uses different properties in a parent and child POM" do
+      let(:group_id) { "com.flutter.product.catalogue.market.domain.contract" }
+      let(:dependency_name) { "#{group_id}:product-catalogue-market-domain-contract-proto" }
+      let(:ignored_versions) { [">= 2.a0", ">= 1.1.a0, < 2.a0"] }
+      let(:dependency_files) { [pom, docker_pom] }
+      let(:pom_body) { fixture("poms", "prefix_overlapping_property_names.xml") }
+      let(:docker_pom) do
+        Dependabot::DependencyFile.new(
+          name: "docker/pom.xml",
+          content: fixture("poms", "prefix_overlapping_property_names_docker.xml")
+        )
+      end
+      let(:parsed_dependencies) do
+        Dependabot::Maven::FileParser.new(dependency_files: dependency_files, source: nil).parse
+      end
+      let(:dependency) do
+        T.must(parsed_dependencies.find { |parsed_dependency| parsed_dependency.name == dependency_name })
+      end
+      let(:target_version_details) do
+        {
+          version: version_class.new("1.0.11"),
+          source_url: "https://repo.maven.apache.org/maven2"
+        }
+      end
+      let(:version_finder) do
+        instance_double(Dependabot::Maven::UpdateChecker::VersionFinder, releases: [])
+      end
+
+      before do
+        allow(Dependabot::Maven::UpdateChecker::VersionFinder).to receive(:new).and_return(version_finder)
+      end
+
+      it "updates the matching property in the patch-production group" do
+        expect(updated_dependencies).to contain_exactly(
+          have_attributes(
+            name: dependency_name,
+            version: "1.0.11",
+            previous_version: "1.0.7"
+          )
+        )
+
+        updated_requirements = updated_dependencies.first.requirements.to_h do |requirement|
+          [requirement.metadata_string("property_name"), requirement.requirement_string]
+        end
+        expect(updated_requirements).to include(
+          "product-catalogue-market-domain-contract.version" => "2.9.9",
+          "product-catalogue-market-domain-contract-proto-prod.version" => "1.0.11"
+        )
+      end
+    end
+
     context "when one dependency is missing the target version" do
       before do
         body = fixture("maven_central_metadata", "missing_latest.xml")

--- a/maven/spec/dependabot/maven/update_checker/property_updater_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/property_updater_spec.rb
@@ -302,8 +302,10 @@ RSpec.describe Dependabot::Maven::UpdateChecker::PropertyUpdater do
         Dependabot::DependencyFile.new(
           name: "docker/pom.xml",
           content: fixture("poms", "prefix_overlapping_property_names_docker.xml")
+                   .gsub(">1.0.7<", ">#{property_version}<")
         )
       end
+      let(:property_version) { "1.0.7" }
       let(:parsed_dependencies) do
         Dependabot::Maven::FileParser.new(dependency_files: dependency_files, source: nil).parse
       end
@@ -340,6 +342,20 @@ RSpec.describe Dependabot::Maven::UpdateChecker::PropertyUpdater do
           "product-catalogue-market-domain-contract.version" => "2.9.9",
           "product-catalogue-market-domain-contract-proto-prod.version" => "1.0.11"
         )
+      end
+
+      context "when the matching property uses an exact version range" do
+        let(:property_version) { "[1.0.7]" }
+
+        it "updates the matching property" do
+          expect(updated_dependencies).to contain_exactly(
+            have_attributes(
+              name: dependency_name,
+              version: "1.0.11",
+              previous_version: "[1.0.7]"
+            )
+          )
+        end
       end
     end
 

--- a/maven/spec/fixtures/poms/prefix_overlapping_property_names.xml
+++ b/maven/spec/fixtures/poms/prefix_overlapping_property_names.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.flutter.pcc</groupId>
+  <artifactId>pcc-service</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <app.name>pcc-service</app.name>
+    <scala.binary.version>2.13</scala.binary.version>
+    <product-catalogue-market-domain-contract.version>2.9.9</product-catalogue-market-domain-contract.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.flutter.product.catalogue.market.domain.contract</groupId>
+      <artifactId>product-catalogue-market-domain-contract-scalapb_${scala.binary.version}</artifactId>
+      <version>${product-catalogue-market-domain-contract.version}</version>
+    </dependency>
+  </dependencies>
+
+  <modules>
+    <module>docker</module>
+  </modules>
+</project>

--- a/maven/spec/fixtures/poms/prefix_overlapping_property_names_docker.xml
+++ b/maven/spec/fixtures/poms/prefix_overlapping_property_names_docker.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.flutter.pcc</groupId>
+    <artifactId>pcc-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>docker</artifactId>
+  <name>${project.artifactId}</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <product-catalogue-market-domain-contract-proto-prod.version>1.0.7</product-catalogue-market-domain-contract-proto-prod.version>
+    <scalaStyle.skip>true</scalaStyle.skip>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>redeem-proto</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.flutter.product.catalogue.market.domain.contract</groupId>
+                  <artifactId>product-catalogue-market-domain-contract-proto</artifactId>
+                  <version>${product-catalogue-market-domain-contract.version}</version>
+                  <type>jar</type>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.flutter.product.catalogue.market.domain.contract</groupId>
+                  <artifactId>product-catalogue-market-domain-contract-proto</artifactId>
+                  <version>${product-catalogue-market-domain-contract-proto-prod.version}</version>
+                  <type>jar</type>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
### What are you trying to accomplish?

Fix Maven property updates when the same artifact is declared more than once with different version properties.

Dependabot selected the wrong property for a `proto` update from `1.0.7` to `1.0.11`. Because that property was shared with a separate `scalapb` dependency at `2.9.9`, Dependabot incorrectly changed the `scalapb` version property to `1.0.11`.

The fix selects the property whose value matches the dependency version being updated.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

A regression test confirms that Dependabot updates the proto property from `1.0.7` to `1.0.11` while leaving the separate scalapb property at `2.9.9`.

The full Maven test suite passes with 900 examples and no failures.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
