### PR TITLE
Add shared delivery for unavailable cooldown warnings

### DIFF
--- a/common/lib/dependabot/update_checkers/cooldown_calculation.rb
+++ b/common/lib/dependabot/update_checkers/cooldown_calculation.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/dependency"
 require "dependabot/package/release_cooldown_options"
 require "dependabot/version"
 
@@ -16,6 +17,14 @@ module Dependabot
       extend T::Sig
 
       DAY_IN_SECONDS = T.let(24 * 60 * 60, Integer)
+      DATE_UNAVAILABLE_METADATA_KEY = :cooldown_date_unavailable
+
+      # Shared by the pull request notice and the job-level warning so both channels
+      # report the same diagnostic, whether or not the update produced a pull request.
+      DATE_UNAVAILABLE_NOTICE_TYPE = "cooldown_date_unavailable"
+      DATE_UNAVAILABLE_TITLE = "Cooldown was not applied"
+      DATE_UNAVAILABLE_DESCRIPTION =
+        "Cooldown could not be applied because no publication date was available from the registry."
 
       sig { params(release_date: Time, cooldown_days: Integer).returns(T::Boolean) }
       def self.within_cooldown_window?(release_date, cooldown_days)
@@ -49,6 +58,18 @@ module Dependabot
       end
       def self.skip_cooldown?(cooldown, dependency_name, cooldown_enabled: true)
         cooldown.nil? || !cooldown_enabled || !cooldown.included?(dependency_name)
+      end
+
+      sig { params(dependency: Dependabot::Dependency, cooldown_days: Integer).void }
+      def self.mark_cooldown_date_unavailable(dependency, cooldown_days:)
+        return unless cooldown_days.positive?
+
+        dependency.metadata[DATE_UNAVAILABLE_METADATA_KEY] = true
+      end
+
+      sig { params(dependency: Dependabot::Dependency).returns(T::Boolean) }
+      def self.cooldown_date_unavailable?(dependency)
+        dependency.metadata[DATE_UNAVAILABLE_METADATA_KEY] == true
       end
     end
   end

--- a/common/spec/dependabot/update_checkers/cooldown_calculation_spec.rb
+++ b/common/spec/dependabot/update_checkers/cooldown_calculation_spec.rb
@@ -95,4 +95,27 @@ RSpec.describe Dependabot::UpdateCheckers::CooldownCalculation do
       expect(described_class.skip_cooldown?(cooldown, "my-dep", cooldown_enabled: true)).to be false
     end
   end
+
+  describe ".mark_cooldown_date_unavailable" do
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "my-dep",
+        version: "1.0.0",
+        requirements: [],
+        package_manager: "bundler"
+      )
+    end
+
+    it "marks the dependency when the effective cooldown is positive" do
+      described_class.mark_cooldown_date_unavailable(dependency, cooldown_days: 1)
+
+      expect(described_class.cooldown_date_unavailable?(dependency)).to be true
+    end
+
+    it "does not mark the dependency when the effective cooldown is zero" do
+      described_class.mark_cooldown_date_unavailable(dependency, cooldown_days: 0)
+
+      expect(described_class.cooldown_date_unavailable?(dependency)).to be false
+    end
+  end
 end

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -4,7 +4,6 @@
 require "sorbet-runtime"
 require "dependabot/file_fetchers"
 require "dependabot/file_fetchers/base"
-require "dependabot/notices"
 require "dependabot/shared/shared_file_updater"
 
 module Dependabot
@@ -28,21 +27,6 @@ module Dependabot
       sig { override.returns(Regexp) }
       def container_image_regex
         %r{^#{FROM_REGEX}\s+(docker\.io/)?}o
-      end
-
-      sig { override.returns(T::Array[Dependabot::Notice]) }
-      def notices
-        return [] unless dependencies.any? { |dependency| dependency.metadata[:docker_cooldown_date_unavailable] }
-
-        [Dependabot::Notice.new(
-          mode: Dependabot::Notice::NoticeMode::WARN,
-          type: "docker_cooldown_date_unavailable",
-          package_manager_name: "docker",
-          title: "Docker cooldown was not applied",
-          description: "Cooldown could not be applied because no publication date was available from the registry.",
-          show_in_pr: true,
-          show_alert: false
-        )]
       end
     end
   end

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -444,7 +444,10 @@ module Dependabot
           # If we can't determine publication details, skip cooldown for this tag and use it
           # rather than blocking the update when the registry doesn't support the required API calls
           if !details || !details.released_at
-            mark_cooldown_date_unavailable if cooldown_days_for(tag).positive?
+            Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+              dependency,
+              cooldown_days: cooldown_days_for(tag)
+            )
             return [tag]
           end
 
@@ -1068,11 +1071,6 @@ module Dependabot
         )
       end
 
-      sig { void }
-      def mark_cooldown_date_unavailable
-        dependency.metadata[:docker_cooldown_date_unavailable] = true
-      end
-
       # Builds the PackageRelease version for a tag. Non-comparable tags (e.g.
       # "alpine") have no semver, so Docker::Version.new would raise. The version
       # is only consumed by semver-aware version-tag cooldown; the digest cooldown
@@ -1101,7 +1099,10 @@ module Dependabot
 
         released_at = publication_detail(Tag.new(tag_name))&.released_at
         unless released_at
-          mark_cooldown_date_unavailable if cooldown.default_days.positive?
+          Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+            dependency,
+            cooldown_days: cooldown.default_days
+          )
           return false
         end
 

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -139,32 +139,6 @@ RSpec.describe Dependabot::Docker::FileUpdater do
     )
   end
 
-  describe "#notices" do
-    subject(:notices) { updater.notices }
-
-    context "when cooldown could not be applied" do
-      before do
-        dependency.metadata[:docker_cooldown_date_unavailable] = true
-      end
-
-      it "returns a warning for the pull request" do
-        expect(notices.map(&:to_h)).to contain_exactly(
-          mode: Dependabot::Notice::NoticeMode::WARN,
-          type: "docker_cooldown_date_unavailable",
-          package_manager_name: "docker",
-          title: "Docker cooldown was not applied",
-          description: "Cooldown could not be applied because no publication date was available from the registry.",
-          show_in_pr: true,
-          show_alert: false
-        )
-      end
-    end
-
-    context "when cooldown was applied" do
-      it { is_expected.to be_empty }
-    end
-  end
-
   describe "#updated_dependency_files" do
     subject(:updated_files) { updater.updated_dependency_files }
 

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1720,7 +1720,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       it "marks the dependency with the missing cooldown date" do
         latest_version
 
-        expect(dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
 
       context "when no cooldown days are configured" do
@@ -1731,7 +1731,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         it "does not mark the dependency" do
           latest_version
 
-          expect(dependency.metadata).not_to include(:docker_cooldown_date_unavailable)
+          expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
         end
       end
     end
@@ -1831,7 +1831,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
             it "marks the dependency with the missing cooldown date" do
               can_update
 
-              expect(dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+              expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
             end
           end
         end

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -9,6 +9,8 @@ require "dependabot/experiments"
 require "dependabot/file_parsers"
 require "dependabot/file_updaters"
 require "dependabot/dependency_group"
+require "dependabot/notices"
+require "dependabot/update_checkers/cooldown_calculation"
 require "dependabot/updater/blocked_version_detector"
 
 # This class is responsible for generating a DependencyChange for a given
@@ -71,6 +73,7 @@ module Dependabot
       @updated_dependencies = updated_dependencies
       @change_source = change_source
       @notices = notices
+      @cooldown_notices = T.let([], T::Array[Dependabot::Notice])
       @regenerated_dependency_files = T.let(nil, T.nilable(T::Array[Dependabot::DependencyFile]))
     end
 
@@ -101,7 +104,7 @@ module Dependabot
         updated_dependencies: updated_deps,
         updated_dependency_files: updated_files,
         dependency_group: source_dependency_group,
-        notices: notices
+        notices: notices + cooldown_notices
       )
     end
 
@@ -121,6 +124,9 @@ module Dependabot
 
     sig { returns(T::Array[Dependabot::Notice]) }
     attr_reader :notices
+
+    sig { returns(T::Array[Dependabot::Notice]) }
+    attr_reader :cooldown_notices
 
     sig { returns(T.nilable(String)) }
     def source_dependency_name
@@ -169,10 +175,44 @@ module Dependabot
       # Collect notices from file updater after update attempt
       updater_notices = T.let(file_updater.notices, T::Array[Dependabot::Notice])
       @notices.concat(updater_notices)
+      add_cooldown_notice
 
       updated_files = all_files.reject(&:support_file?)
       updated_files = all_files if updated_files.empty? && all_files.any?
       updated_files
+    end
+
+    sig { void }
+    def add_cooldown_notice
+      return unless cooldown_date_unavailable?
+
+      notice = Dependabot::Notice.new(
+        mode: Dependabot::Notice::NoticeMode::WARN,
+        type: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_NOTICE_TYPE,
+        package_manager_name: job.package_manager,
+        title: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_TITLE,
+        description: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_DESCRIPTION,
+        # The job-level warning covers runs that never build a pull request, so this
+        # channel only has to render the notice in the pull request body.
+        show_in_pr: true,
+        show_alert: false
+      )
+      cooldown_notices << notice unless notices.any? { |existing_notice| existing_notice.to_h == notice.to_h }
+    end
+
+    sig { returns(T::Boolean) }
+    def cooldown_date_unavailable?
+      source = change_source
+      dependencies = updated_dependencies.dup
+      if source.is_a?(Dependabot::Dependency)
+        dependencies << source
+      else
+        dependencies.concat(source.dependencies)
+      end
+
+      dependencies.any? do |dependency|
+        Dependabot::UpdateCheckers::CooldownCalculation.cooldown_date_unavailable?(dependency)
+      end
     end
 
     sig { returns(String) }

--- a/updater/lib/dependabot/dependency_change_builder.rb
+++ b/updater/lib/dependabot/dependency_change_builder.rb
@@ -50,6 +50,19 @@ module Dependabot
       ).run
     end
 
+    sig { params(package_manager_name: String).returns(Dependabot::Notice) }
+    def self.cooldown_date_unavailable_notice(package_manager_name:)
+      Dependabot::Notice.new(
+        mode: Dependabot::Notice::NoticeMode::WARN,
+        type: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_NOTICE_TYPE,
+        package_manager_name: package_manager_name,
+        title: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_TITLE,
+        description: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_DESCRIPTION,
+        show_in_pr: true,
+        show_alert: false
+      )
+    end
+
     sig do
       params(
         job: Dependabot::Job,
@@ -186,16 +199,8 @@ module Dependabot
     def add_cooldown_notice
       return unless cooldown_date_unavailable?
 
-      notice = Dependabot::Notice.new(
-        mode: Dependabot::Notice::NoticeMode::WARN,
-        type: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_NOTICE_TYPE,
-        package_manager_name: job.package_manager,
-        title: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_TITLE,
-        description: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_DESCRIPTION,
-        # The job-level warning covers runs that never build a pull request, so this
-        # channel only has to render the notice in the pull request body.
-        show_in_pr: true,
-        show_alert: false
+      notice = self.class.cooldown_date_unavailable_notice(
+        package_manager_name: job.package_manager
       )
       cooldown_notices << notice unless notices.any? { |existing_notice| existing_notice.to_h == notice.to_h }
     end

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -17,6 +17,7 @@ require "dependabot/update_checkers"
 require "dependabot/updater/error_handler"
 require "dependabot/updater/operations"
 require "dependabot/updater/security_update_helpers"
+require "dependabot/update_checkers/cooldown_calculation"
 
 require "wildcard_matcher"
 
@@ -58,6 +59,8 @@ module Dependabot
         dependency_snapshot: dependency_snapshot,
         error_handler: error_handler
       ).perform
+
+      record_cooldown_date_unavailable_warning
     rescue *ErrorHandler::RUN_HALTING_ERRORS.keys => e
       # TODO: Drop this into Security-specific operations
       if e.is_a?(Dependabot::AllVersionsIgnored) && !job.security_updates_only?
@@ -86,5 +89,24 @@ module Dependabot
 
     sig { returns(Dependabot::DependencySnapshot) }
     attr_reader :dependency_snapshot
+
+    # Update checkers mark the dependency when a registry gives them no publication date,
+    # which happens whether or not the check goes on to produce a pull request. Reporting
+    # from here rather than from DependencyChangeBuilder keeps the warning visible on the
+    # fail-closed paths, where the missing date withholds the update and the operation
+    # returns at `up_to_date?` before any dependency change is built.
+    sig { void }
+    def record_cooldown_date_unavailable_warning
+      date_unavailable = dependency_snapshot.all_dependencies.any? do |dependency|
+        Dependabot::UpdateCheckers::CooldownCalculation.cooldown_date_unavailable?(dependency)
+      end
+      return unless date_unavailable
+
+      service.record_update_job_warning(
+        warn_type: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_NOTICE_TYPE,
+        warn_title: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_TITLE,
+        warn_description: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_DESCRIPTION
+      )
+    end
   end
 end

--- a/updater/lib/dependabot/updater.rb
+++ b/updater/lib/dependabot/updater.rb
@@ -107,6 +107,8 @@ module Dependabot
         warn_title: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_TITLE,
         warn_description: Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_DESCRIPTION
       )
+    rescue StandardError => e
+      Dependabot.logger.error("Failed to record cooldown warning: #{e.message}")
     end
   end
 end

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -8,6 +8,7 @@ require "dependabot/updater/dependency_group_change_batch"
 require "dependabot/workspace"
 require "dependabot/updater/security_update_helpers"
 require "dependabot/notices"
+require "dependabot/update_checkers/cooldown_calculation"
 
 # This module contains the methods required to build a DependencyChange for
 # a single DependencyGroup.
@@ -121,6 +122,12 @@ module Dependabot
           end
 
           updated_dependencies = compile_updates_for(dependency, dependency_files, group)
+          if original_dependency &&
+             Dependabot::UpdateCheckers::CooldownCalculation.cooldown_date_unavailable?(dependency)
+            original_dependency.metadata[
+              Dependabot::UpdateCheckers::CooldownCalculation::DATE_UNAVAILABLE_METADATA_KEY
+            ] = true
+          end
           next unless updated_dependencies.any?
 
           lead_dependency = updated_dependencies.find do |dep|

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -153,6 +153,9 @@ module Dependabot
           store_changes(dependency)
         end
 
+        group_notices = notices + group_changes.notices
+        add_cooldown_date_unavailable_notice(group_notices, original_dependencies)
+
         # Create a single Dependabot::DependencyChange that aggregates everything we've updated
         # into a single object we can pass to PR creation.
         dependency_change = Dependabot::DependencyChange.new(
@@ -160,7 +163,7 @@ module Dependabot
           updated_dependencies: group_changes.updated_dependencies,
           updated_dependency_files: group_changes.updated_dependency_files,
           dependency_group: group,
-          notices: notices + group_changes.notices
+          notices: group_notices
         )
 
         unless dependency_change.all_have_previous_version?
@@ -175,6 +178,23 @@ module Dependabot
         dependency_change
       ensure
         cleanup_workspace
+      end
+
+      sig do
+        params(
+          notices: T::Array[Dependabot::Notice],
+          dependencies: T::Array[Dependabot::Dependency]
+        ).void
+      end
+      def add_cooldown_date_unavailable_notice(notices, dependencies)
+        return unless dependencies.any? do |dependency|
+          Dependabot::UpdateCheckers::CooldownCalculation.cooldown_date_unavailable?(dependency)
+        end
+
+        notice = Dependabot::DependencyChangeBuilder.cooldown_date_unavailable_notice(
+          package_manager_name: job.package_manager
+        )
+        notices << notice unless notices.any? { |existing_notice| existing_notice.to_h == notice.to_h }
       end
 
       sig { params(dependency: Dependabot::Dependency, group: Dependabot::DependencyGroup).returns(T::Boolean) }

--- a/updater/spec/dependabot/dependency_change_builder_spec.rb
+++ b/updater/spec/dependabot/dependency_change_builder_spec.rb
@@ -194,6 +194,51 @@ RSpec.describe Dependabot::DependencyChangeBuilder do
         updated_file_names = dependency_change.updated_dependency_files.map(&:name)
         expect(updated_file_names).not_to include("sub_dep", "sub_dep.lock")
       end
+
+      context "when cooldown could not be applied" do
+        before do
+          Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+            lead_dependency_change_source,
+            cooldown_days: 1
+          )
+          stub_file_updater(
+            updated_dependency_files: dependency_files.reject(&:support_file?),
+            notices: []
+          )
+        end
+
+        it "adds the warning independently of file updater notices" do
+          expect(create_change.notices.map(&:to_h)).to contain_exactly(
+            mode: Dependabot::Notice::NoticeMode::WARN,
+            type: "cooldown_date_unavailable",
+            package_manager_name: "bundler",
+            title: "Cooldown was not applied",
+            description: "Cooldown could not be applied because no publication date was available from the registry.",
+            show_in_pr: true,
+            show_alert: false
+          )
+        end
+
+        it "does not add the warning to the caller's notices" do
+          create_change
+
+          expect(notices).to be_empty
+        end
+
+        it "does not duplicate an existing cooldown warning" do
+          notices << Dependabot::Notice.new(
+            mode: Dependabot::Notice::NoticeMode::WARN,
+            type: "cooldown_date_unavailable",
+            package_manager_name: "bundler",
+            title: "Cooldown was not applied",
+            description: "Cooldown could not be applied because no publication date was available from the registry.",
+            show_in_pr: true,
+            show_alert: false
+          )
+
+          expect(create_change.notices.count { |notice| notice.type == "cooldown_date_unavailable" }).to eq(1)
+        end
+      end
     end
 
     context "when the source is a dependency group" do

--- a/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
+++ b/updater/spec/dependabot/updater/dependency_group_change_batch_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe Dependabot::Updater::DependencyGroupChangeBatch do
     it "deduplicates notices from dependency changes" do
       notice = Dependabot::Notice.new(
         mode: Dependabot::Notice::NoticeMode::WARN,
-        type: "docker_cooldown_date_unavailable",
-        package_manager_name: "docker",
+        type: "cooldown_date_unavailable",
+        package_manager_name: "bundler",
         description: "Cooldown was not applied.",
         show_in_pr: true,
         show_alert: false

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
     instance_double(
       Dependabot::Job,
       dependencies: job_dependencies,
+      package_manager: "bundler",
       clone?: clone_job,
       repo_contents_path: repo_contents_path,
       security_advisories_for: security_advisories,
@@ -398,6 +399,14 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
         expect(Dependabot::UpdateCheckers::CooldownCalculation.cooldown_date_unavailable?(original_dependency))
           .to be(true)
+      end
+
+      it "adds the warning to the final grouped dependency change" do
+        test_instance.compile_all_dependency_changes_for(group)
+
+        expect(Dependabot::DependencyChange).to have_received(:new) do |notices:, **|
+          expect(notices.map(&:type)).to include("cooldown_date_unavailable")
+        end
       end
     end
 

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
   let(:dependencies) do
     [
-      instance_double(Dependabot::Dependency, name: "dep1", version: "1.0.0"),
-      instance_double(Dependabot::Dependency, name: "dep2", version: "2.0.0")
+      instance_double(Dependabot::Dependency, name: "dep1", version: "1.0.0", metadata: {}),
+      instance_double(Dependabot::Dependency, name: "dep2", version: "2.0.0", metadata: {})
     ]
   end
 
@@ -322,8 +322,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
       let(:notice) do
         Dependabot::Notice.new(
           mode: Dependabot::Notice::NoticeMode::WARN,
-          type: "docker_cooldown_date_unavailable",
-          package_manager_name: "docker",
+          type: "cooldown_date_unavailable",
+          package_manager_name: "bundler",
           description: "Cooldown was not applied.",
           show_in_pr: true,
           show_alert: false
@@ -339,6 +339,65 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
         expect(Dependabot::DependencyChange).to have_received(:new)
           .with(hash_including(notices: [notice]))
+      end
+    end
+
+    context "when a grouped fail-closed check marks a reparsed dependency" do
+      let(:original_dependency) do
+        Dependabot::Dependency.new(
+          name: "dep1",
+          version: "1.0.0",
+          requirements: [],
+          package_manager: "bundler"
+        )
+      end
+      let(:reparsed_dependency) do
+        Dependabot::Dependency.new(
+          name: "dep1",
+          version: "1.0.0",
+          requirements: [],
+          package_manager: "bundler"
+        )
+      end
+      let(:dependencies) { [original_dependency] }
+      let(:group_dependencies) { [original_dependency] }
+      let(:checker) do
+        instance_double(
+          Dependabot::UpdateCheckers::Base,
+          dependency: reparsed_dependency,
+          up_to_date?: true
+        )
+      end
+
+      before do
+        allow(test_instance).to receive(:compile_updates_for).and_call_original
+        allow(test_instance).to receive_messages(
+          update_checker_for: checker,
+          raise_on_ignored?: false,
+          log_checking_for_update: nil,
+          record_blocked_version_ignored: nil,
+          all_versions_ignored?: false,
+          semver_rules_allow_grouping?: true,
+          log_up_to_date: nil,
+          record_security_update_not_found_if_applicable: nil
+        )
+        allow(test_instance).to receive(:dependency_file_parser).and_return(
+          instance_double(Dependabot::FileParsers::Base, parse: [reparsed_dependency])
+        )
+        allow(checker).to receive(:up_to_date?) do
+          Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+            reparsed_dependency,
+            cooldown_days: 1
+          )
+          true
+        end
+      end
+
+      it "propagates the marker to the dependency snapshot" do
+        test_instance.compile_all_dependency_changes_for(group)
+
+        expect(Dependabot::UpdateCheckers::CooldownCalculation.cooldown_date_unavailable?(original_dependency))
+          .to be(true)
       end
     end
 

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2460,6 +2460,44 @@ RSpec.describe Dependabot::Updater do
       expect(service).not_to receive(:create_pull_request)
       updater.run
     end
+
+    # These exercise Dependabot::Updater#run rather than a specific Operation, which is the
+    # responsibility this file is being repurposed to cover.
+    context "when a registry gave no publication date for a cooldown check" do
+      it "records a job-level warning even though no pull request is created" do
+        stub_update_checker(up_to_date?: true)
+
+        job = build_job
+        service = build_service
+        dependency_snapshot = build_dependency_snapshot(job: job)
+        updater = build_updater(service: service, job: job, dependency_snapshot: dependency_snapshot)
+
+        dependency_snapshot.all_dependencies.each do |dependency|
+          dependency.metadata[:cooldown_date_unavailable] = true
+        end
+
+        expect(service).not_to receive(:create_pull_request)
+        expect(service).to receive(:record_update_job_warning).with(
+          warn_type: "cooldown_date_unavailable",
+          warn_title: "Cooldown was not applied",
+          warn_description: "Cooldown could not be applied because no publication date was available " \
+                            "from the registry."
+        )
+
+        updater.run
+      end
+    end
+
+    it "does not record a cooldown warning when publication dates were available" do
+      stub_update_checker(up_to_date?: true)
+
+      service = build_service
+      updater = build_updater(service: service)
+
+      expect(service).not_to receive(:record_update_job_warning)
+
+      updater.run
+    end
   end
 
   def build_updater(

--- a/updater/spec/dependabot/updater_spec.rb
+++ b/updater/spec/dependabot/updater_spec.rb
@@ -2486,6 +2486,25 @@ RSpec.describe Dependabot::Updater do
 
         updater.run
       end
+
+      it "does not fail the job when the warning cannot be recorded" do
+        stub_update_checker(up_to_date?: true)
+
+        job = build_job
+        service = build_service
+        dependency_snapshot = build_dependency_snapshot(job: job)
+        updater = build_updater(service: service, job: job, dependency_snapshot: dependency_snapshot)
+        dependency_snapshot.all_dependencies.each do |dependency|
+          dependency.metadata[:cooldown_date_unavailable] = true
+        end
+        allow(service).to receive(:record_update_job_warning).and_raise(StandardError, "network error")
+        allow(Dependabot.logger).to receive(:error)
+
+        expect { updater.run }.not_to raise_error
+        expect(Dependabot.logger).to have_received(:error).with(
+          "Failed to record cooldown warning: network error"
+        )
+      end
     end
 
     it "does not record a cooldown warning when publication dates were available" do


### PR DESCRIPTION
### What are you trying to accomplish?

Part of github/dependabot-updates#14365.

Add the shared marker and delivery paths used when a positive cooldown cannot be evaluated because no publication date is available. The warning is shown in an update PR when one is created and recorded at job level when a fail-closed check produces no dependency change.

This root PR also migrates Docker's existing ecosystem-specific warning to the shared contract.

> [!WARNING]
> Cooldown could not be applied because no publication date was available from the registry.

### Stack

Review and merge in this order:

1. **#16142** — shared marker, PR/job delivery, grouped propagation, and Docker migration
2. **#16211** — default `PackageLatestVersionFinder` behavior and passive adopters
   - **#16244** — Dotnet SDK coverage
   - **#16245** — vcpkg coverage
   - **#16246** — Nix coverage
3. **#16212** — Devcontainers, Go Modules, Gradle, and Maven metadata finders
4. **#16213** — shared tag filter with Helm and Terraform
5. **#16214** — OpenTofu only
6. **#16215** — shared git dates with GitHub Actions and Pre-commit
7. **#16216** — Julia only
8. **#16217** — Bazel and Pub

Each child targets the preceding stack branch so its Files changed view contains only that slice. Julia and OpenTofu are intentionally separate PRs.

### Anything you want to highlight for special attention from reviewers?

The diagnostic is generated in `DependencyChangeBuilder`, not the overridable `FileUpdater#notices` hook. A separate job-level warning covers fail-closed paths that return before a dependency change is built.

Grouped updates reparse dependency objects, so the marker is copied back to the corresponding snapshot dependency for final job reporting. Final group notices are recomputed after all dependencies have been checked, avoiding dependency-order gaps. Warning-reporting failures are logged and remain non-fatal.

The effective cooldown must be positive before the marker is set, so excluded dependencies and zero-day cooldowns do not produce warnings.

### How will you know you've accomplished your goal?

Verified in Docker:

- Focused updater delivery specs: 155 examples, 0 failures.
- Docker's existing checker coverage asserts the shared metadata key.
- The complete stack tip accounts for every path from the preserved original change.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.