### PR TITLE
Use registry metadata for Docker cooldown dates

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -45,3 +45,19 @@ Dependabot will recognize build numbers and will update to the highest build num
 
 As an example, `21-ea-32`, `22-ea-7`, and `22-ea-jdk-nanoserver-1809` are mapped to `<version>-ea-<build_num>`, `<version>-ea-<build_num>`, and `<version>-ea-jdk-nanoserver-<build_num>` respectively.
 That means only "22-ea-7" will be considered as a viable update candidate for `21-ea-32`, since it's the only one that respects that format.
+
+### Cooldown publication dates
+
+Cooldown uses only registry-assigned publication timestamps, not dates that an image publisher can supply or backdate. Docker Hub's `tag_last_pushed` is currently the only accepted source.
+
+- **Docker Hub:** Dependabot reads `tag_last_pushed` from the tag metadata API. Pushing a tag again can restart its cooldown. A reported digest must match the resolved manifest digest. Legacy responses that omit the digest or return `null` are accepted only when every requirement is unpinned and automatic digest pinning is disabled.
+- **GitHub Container Registry (GHCR):** Cooldown publication dates are unavailable. GitHub Packages `updated_at` has not been established as the publication time of the relevant tag or digest, so Dependabot does not use it or query that API for cooldown. Normal GHCR dependency updates remain supported.
+- **Other registries:** Publication dates remain unavailable until a registry-assigned timestamp source and its semantics are verified.
+
+Generic `Last-Modified` headers, image-config `created`, OCI creation annotations, package-version `created_at`, and local first-seen times are not cooldown date sources. Missing, conflicting, or unusable metadata never falls back to one of these dates. An old child-manifest header cannot establish the publication age of a new multi-platform index.
+
+Existing and newly introduced digest pins require an exact metadata match. For a multi-platform index, matching one child is insufficient. Dependabot retains the checked digest when generating the update, even if the tag moves during the check. Unpinned tags remain mutable after the check, so their cooldown cannot guarantee the age of the image eventually pulled.
+
+The registry operator is a trust boundary: registry dates cannot protect against an attacker-operated or compromised registry. Adding a source requires establishing that publishers cannot choose or backdate its timestamps, that the timestamp describes the relevant publication, and that hosted authentication works. New pushes, repushes, and retagging existing digests must be covered; successful mocked API responses alone do not establish those guarantees.
+
+When no verified publication date is available, Dependabot retains its existing policy: allow the update and record a `cooldown_date_unavailable` warning. This avoids using an untrusted date but does not guarantee that every update waits through cooldown. Requiring that guarantee would need a separate policy to hold updates with unavailable dates.

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -87,7 +87,6 @@ module Dependabot
       TAGS_PAGE_SIZE = 100
 
       GITHUB_PACKAGES_PAGE_SIZE = 100
-      GITHUB_PACKAGES_MAX_PAGES = 5
 
       DockerSource = T.type_alias do
         T::Hash[Symbol, T.nilable(String)]
@@ -558,6 +557,7 @@ module Dependabot
 
         github_container_registry_tag_release_date(tag) if registry_hostname == "ghcr.io"
       rescue JSON::ParserError, ArgumentError, TypeError, Excon::Error::Socket, Excon::Error::Timeout,
+             RegistryError, PrivateSourceBadResponse, PrivateSourceAuthenticationFailure,
              *transient_docker_errors,
              DockerRegistry2::RegistryAuthenticationException,
              DockerRegistry2::RegistryAuthorizationException,
@@ -574,7 +574,7 @@ module Dependabot
         namespace, repository = docker_repo_name.split("/", 2)
         return unless namespace && repository
 
-        digest = docker_registry_client.manifest_digest(docker_repo_name, tag.name)
+        digest = digest_of(tag.name)
         return unless digest
 
         response = Dependabot::RegistryClient.get(
@@ -603,53 +603,55 @@ module Dependabot
 
       sig { params(tag: Dependabot::Docker::Tag).returns(T.nilable(Time)) }
       def github_container_registry_tag_release_date(tag)
-        digest = docker_registry_client.manifest_digest(docker_repo_name, tag.name)
+        digest = digest_of(tag.name)
         return unless digest
 
-        version = github_package_versions.find do |candidate|
-          matching_digest?(candidate["name"], digest) && github_package_version_tags(candidate).include?(tag.name)
-        end
+        version = github_package_version(tag, digest)
         return unless version
 
         timestamp = version["updated_at"]
         Time.iso8601(timestamp) if timestamp.is_a?(String)
       end
 
-      sig { returns(T::Array[GithubPackageVersion]) }
-      def github_package_versions
-        @github_package_versions ||= T.let(
-          fetch_github_package_versions,
-          T.nilable(T::Array[GithubPackageVersion])
-        )
-      end
+      sig { params(tag: Dependabot::Docker::Tag, digest: String).returns(T.nilable(GithubPackageVersion)) }
+      def github_package_version(tag, digest)
+        page = 1
+        loop do
+          versions = github_package_versions(page)
+          version = versions.find do |candidate|
+            matching_digest?(candidate["name"], digest) && github_package_version_tags(candidate).include?(tag.name)
+          end
+          return version if version
+          return nil if versions.length < GITHUB_PACKAGES_PAGE_SIZE
 
-      sig { returns(T::Array[GithubPackageVersion]) }
-      def fetch_github_package_versions
-        owner, package = docker_repo_name.split("/", 2)
-        token = github_packages_token
-        return [] unless owner && package && token
-
-        owner_type = "orgs"
-        first_response = github_package_versions_response(owner_type, owner, package, token, 1)
-        if first_response.status == 404
-          owner_type = "users"
-          first_response = github_package_versions_response(owner_type, owner, package, token, 1)
-        end
-        return [] unless first_response.status == 200
-
-        versions = parse_github_package_versions(first_response.body)
-        page = 2
-        page_full = T.let(versions.length == GITHUB_PACKAGES_PAGE_SIZE, T::Boolean)
-        while page_full && page <= GITHUB_PACKAGES_MAX_PAGES
-          response = github_package_versions_response(owner_type, owner, package, token, page)
-          break unless response.status == 200
-
-          page_versions = parse_github_package_versions(response.body)
-          versions.concat(page_versions)
-          page_full = page_versions.length == GITHUB_PACKAGES_PAGE_SIZE
           page += 1
         end
-        versions
+      end
+
+      sig { params(page: Integer).returns(T::Array[GithubPackageVersion]) }
+      def github_package_versions(page)
+        @github_package_versions ||= T.let(
+          {},
+          T.nilable(T::Hash[Integer, T::Array[GithubPackageVersion]])
+        )
+        @github_package_versions[page] ||= fetch_github_package_versions(page)
+      end
+
+      sig { params(page: Integer).returns(T::Array[GithubPackageVersion]) }
+      def fetch_github_package_versions(page)
+        owner, package = docker_repo_name.split("/", 2)
+        return [] unless owner && package
+
+        token = github_packages_token
+        @github_package_owner_type ||= T.let("orgs", T.nilable(String))
+        response = github_package_versions_response(@github_package_owner_type, owner, package, token, page)
+        if page == 1 && response.status == 404
+          @github_package_owner_type = "users"
+          response = github_package_versions_response(@github_package_owner_type, owner, package, token, page)
+        end
+        return [] unless response.status == 200
+
+        parse_github_package_versions(response.body)
       end
 
       sig do
@@ -657,7 +659,7 @@ module Dependabot
           owner_type: String,
           owner: String,
           package: String,
-          token: String,
+          token: T.nilable(String),
           page: Integer
         ).returns(Excon::Response)
       end
@@ -665,14 +667,15 @@ module Dependabot
         escaped_owner = URI.encode_www_form_component(owner)
         escaped_package = URI.encode_www_form_component(package)
         url = "https://api.github.com/#{owner_type}/#{escaped_owner}/packages/container/#{escaped_package}/versions"
+        headers = {
+          "Accept" => "application/vnd.github+json",
+          "X-GitHub-Api-Version" => "2022-11-28"
+        }
+        headers["Authorization"] = "Bearer #{token}" if token
         with_retries(max_attempts: 3, errors: [Excon::Error::Socket, Excon::Error::Timeout]) do
           Dependabot::RegistryClient.get(
             url: url,
-            headers: {
-              "Accept" => "application/vnd.github+json",
-              "Authorization" => "Bearer #{token}",
-              "X-GitHub-Api-Version" => "2022-11-28"
-            },
+            headers: headers,
             options: {
               query: { per_page: GITHUB_PACKAGES_PAGE_SIZE, page: page },
               connect_timeout: docker_open_timeout_in_seconds,

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -2,7 +2,10 @@
 # frozen_string_literal: true
 
 require "docker_registry2"
+require "excon"
+require "json"
 require "sorbet-runtime"
+require "uri"
 
 begin
   require "rest-client"
@@ -36,6 +39,7 @@ end
 require "dependabot/update_checkers"
 require "dependabot/update_checkers/base"
 require "dependabot/update_checkers/cooldown_calculation"
+require "dependabot/registry_client"
 require "dependabot/errors"
 require "dependabot/docker/tag"
 require "dependabot/docker/file_parser"
@@ -82,6 +86,9 @@ module Dependabot
       # collect the remaining tags.
       TAGS_PAGE_SIZE = 100
 
+      GITHUB_PACKAGES_PAGE_SIZE = 100
+      GITHUB_PACKAGES_MAX_PAGES = 5
+
       DockerSource = T.type_alias do
         T::Hash[Symbol, T.nilable(String)]
       end
@@ -89,6 +96,9 @@ module Dependabot
       ManifestHash = T.type_alias do
         T::Hash[T.any(String, Symbol), Object]
       end
+
+      GithubPackageVersion = T.type_alias { T::Hash[String, Object] }
+      PublicationDateResult = T.type_alias { [T.nilable(Time), T::Boolean] }
 
       ManifestList = T.type_alias do
         T::Array[ManifestHash]
@@ -479,17 +489,8 @@ module Dependabot
         first_digest = extract_digest_from_response(digest_info, tag)
         return nil unless first_digest
 
-        # When digest_info is an Array the registry returned a manifest list
-        # (OCI image index) and the extracted digest points at a platform-
-        # specific *manifest*, not a blob.  Use the correct endpoint so the
-        # HEAD request succeeds on registries like ghcr.io.
-        endpoint = digest_info.is_a?(Array) ? "manifests" : "blobs"
-        head_response = with_retries(max_attempts: 3, errors: transient_docker_errors) do
-          client = docker_registry_client
-          client.dohead "v2/#{docker_repo_name}/#{endpoint}/#{first_digest}"
-        end
-
-        published_date = published_date_from_response_headers(head_response.headers, tag.name)
+        published_date, details_available = publication_date_for(tag, digest_info, first_digest)
+        return nil unless details_available
 
         Dependabot::Package::PackageRelease.new(
           version: release_version_for(tag),
@@ -509,6 +510,216 @@ module Dependabot
           "skipping cooldown: #{e.class} - #{e.message}"
         )
         nil
+      end
+
+      sig do
+        params(
+          tag: Dependabot::Docker::Tag,
+          digest_info: Object,
+          first_digest: String
+        ).returns(PublicationDateResult)
+      end
+      def publication_date_for(tag, digest_info, first_digest)
+        header_date = publication_date_from_registry_headers(tag, digest_info, first_digest)
+        [header_date || registry_tag_release_date(tag), true]
+      rescue *transient_docker_errors,
+             DockerRegistry2::RegistryAuthenticationException,
+             DockerRegistry2::RegistryAuthorizationException,
+             RestClient::Forbidden,
+             RestClient::TooManyRequests => e
+        fallback_date = registry_tag_release_date(tag)
+        return [fallback_date, true] if fallback_date
+
+        Dependabot.logger.warn(
+          "Failed to fetch publication details for #{docker_repo_name}:#{tag.name}, " \
+          "skipping cooldown: #{e.class} - #{e.message}"
+        )
+        [nil, false]
+      end
+
+      sig do
+        params(
+          tag: Dependabot::Docker::Tag,
+          digest_info: Object,
+          first_digest: String
+        ).returns(T.nilable(Time))
+      end
+      def publication_date_from_registry_headers(tag, digest_info, first_digest)
+        endpoint = digest_info.is_a?(Array) ? "manifests" : "blobs"
+        head_response = with_retries(max_attempts: 3, errors: transient_docker_errors) do
+          docker_registry_client.dohead "v2/#{docker_repo_name}/#{endpoint}/#{first_digest}"
+        end
+        published_date_from_response_headers(head_response.headers, tag.name)
+      end
+
+      sig { params(tag: Dependabot::Docker::Tag).returns(T.nilable(Time)) }
+      def registry_tag_release_date(tag)
+        return docker_hub_tag_release_date(tag) if using_dockerhub?
+
+        github_container_registry_tag_release_date(tag) if registry_hostname == "ghcr.io"
+      rescue JSON::ParserError, ArgumentError, TypeError, Excon::Error::Socket, Excon::Error::Timeout,
+             *transient_docker_errors,
+             DockerRegistry2::RegistryAuthenticationException,
+             DockerRegistry2::RegistryAuthorizationException,
+             RestClient::Forbidden,
+             RestClient::TooManyRequests => e
+        Dependabot.logger.info(
+          "Failed to fetch registry tag metadata for #{docker_repo_name}:#{tag.name}: #{e.message}"
+        )
+        nil
+      end
+
+      sig { params(tag: Dependabot::Docker::Tag).returns(T.nilable(Time)) }
+      def docker_hub_tag_release_date(tag)
+        namespace, repository = docker_repo_name.split("/", 2)
+        return unless namespace && repository
+
+        digest = docker_registry_client.manifest_digest(docker_repo_name, tag.name)
+        return unless digest
+
+        response = Dependabot::RegistryClient.get(
+          url: docker_hub_tag_url(namespace, repository, tag.name),
+          headers: { "Accept" => "application/json" },
+          options: {
+            connect_timeout: docker_open_timeout_in_seconds,
+            read_timeout: docker_read_timeout_in_seconds,
+            write_timeout: docker_read_timeout_in_seconds
+          }
+        )
+        return unless response.status == 200
+
+        metadata = JSON.parse(response.body)
+        return unless matching_digest?(metadata["digest"], digest)
+
+        timestamp = metadata["tag_last_pushed"]
+        Time.iso8601(timestamp) if timestamp.is_a?(String)
+      end
+
+      sig { params(namespace: String, repository: String, tag: String).returns(String) }
+      def docker_hub_tag_url(namespace, repository, tag)
+        escaped = [namespace, repository, tag].map { |value| URI.encode_www_form_component(value) }
+        "https://hub.docker.com/v2/namespaces/#{escaped[0]}/repositories/#{escaped[1]}/tags/#{escaped[2]}"
+      end
+
+      sig { params(tag: Dependabot::Docker::Tag).returns(T.nilable(Time)) }
+      def github_container_registry_tag_release_date(tag)
+        digest = docker_registry_client.manifest_digest(docker_repo_name, tag.name)
+        return unless digest
+
+        version = github_package_versions.find do |candidate|
+          matching_digest?(candidate["name"], digest) && github_package_version_tags(candidate).include?(tag.name)
+        end
+        return unless version
+
+        timestamp = version["updated_at"]
+        Time.iso8601(timestamp) if timestamp.is_a?(String)
+      end
+
+      sig { returns(T::Array[GithubPackageVersion]) }
+      def github_package_versions
+        @github_package_versions ||= T.let(
+          fetch_github_package_versions,
+          T.nilable(T::Array[GithubPackageVersion])
+        )
+      end
+
+      sig { returns(T::Array[GithubPackageVersion]) }
+      def fetch_github_package_versions
+        owner, package = docker_repo_name.split("/", 2)
+        token = github_packages_token
+        return [] unless owner && package && token
+
+        owner_type = "orgs"
+        first_response = github_package_versions_response(owner_type, owner, package, token, 1)
+        if first_response.status == 404
+          owner_type = "users"
+          first_response = github_package_versions_response(owner_type, owner, package, token, 1)
+        end
+        return [] unless first_response.status == 200
+
+        versions = parse_github_package_versions(first_response.body)
+        page = 2
+        page_full = T.let(versions.length == GITHUB_PACKAGES_PAGE_SIZE, T::Boolean)
+        while page_full && page <= GITHUB_PACKAGES_MAX_PAGES
+          response = github_package_versions_response(owner_type, owner, package, token, page)
+          break unless response.status == 200
+
+          page_versions = parse_github_package_versions(response.body)
+          versions.concat(page_versions)
+          page_full = page_versions.length == GITHUB_PACKAGES_PAGE_SIZE
+          page += 1
+        end
+        versions
+      end
+
+      sig do
+        params(
+          owner_type: String,
+          owner: String,
+          package: String,
+          token: String,
+          page: Integer
+        ).returns(Excon::Response)
+      end
+      def github_package_versions_response(owner_type, owner, package, token, page)
+        escaped_owner = URI.encode_www_form_component(owner)
+        escaped_package = URI.encode_www_form_component(package)
+        url = "https://api.github.com/#{owner_type}/#{escaped_owner}/packages/container/#{escaped_package}/versions"
+        with_retries(max_attempts: 3, errors: [Excon::Error::Socket, Excon::Error::Timeout]) do
+          Dependabot::RegistryClient.get(
+            url: url,
+            headers: {
+              "Accept" => "application/vnd.github+json",
+              "Authorization" => "Bearer #{token}",
+              "X-GitHub-Api-Version" => "2022-11-28"
+            },
+            options: {
+              query: { per_page: GITHUB_PACKAGES_PAGE_SIZE, page: page },
+              connect_timeout: docker_open_timeout_in_seconds,
+              read_timeout: docker_read_timeout_in_seconds,
+              write_timeout: docker_read_timeout_in_seconds
+            }
+          )
+        end
+      end
+
+      sig { params(body: String).returns(T::Array[GithubPackageVersion]) }
+      def parse_github_package_versions(body)
+        parsed = JSON.parse(body)
+        return [] unless parsed.is_a?(Array)
+
+        parsed.grep(Hash)
+      end
+
+      sig { params(version: GithubPackageVersion).returns(T::Array[String]) }
+      def github_package_version_tags(version)
+        metadata = version["metadata"]
+        return [] unless metadata.is_a?(Hash)
+
+        container = metadata["container"]
+        return [] unless container.is_a?(Hash)
+
+        tags = container["tags"]
+        tags.is_a?(Array) ? tags.grep(String) : []
+      end
+
+      sig { params(first: Object, second: Object).returns(T::Boolean) }
+      def matching_digest?(first, second)
+        return false unless first.is_a?(String) && second.is_a?(String)
+
+        first.delete_prefix("sha256:").casecmp?(second.delete_prefix("sha256:")) || false
+      end
+
+      sig { returns(T.nilable(String)) }
+      def github_packages_token
+        registry_token = registry_credentials&.fetch("password", nil)
+        return registry_token if registry_token.is_a?(String)
+
+        github_credentials = credentials.find do |credential|
+          credential["type"] == "git_source" && credential["host"] == "github.com"
+        end
+        github_token = github_credentials&.fetch("password", nil)
+        github_token if github_token.is_a?(String)
       end
 
       sig { params(headers: T::Hash[Symbol, String], tag_name: String).returns(T.nilable(Time)) }

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -86,8 +86,6 @@ module Dependabot
       # collect the remaining tags.
       TAGS_PAGE_SIZE = 100
 
-      GITHUB_PACKAGES_PAGE_SIZE = 100
-
       DockerSource = T.type_alias do
         T::Hash[Symbol, T.nilable(String)]
       end
@@ -95,9 +93,6 @@ module Dependabot
       ManifestHash = T.type_alias do
         T::Hash[T.any(String, Symbol), Object]
       end
-
-      GithubPackageVersion = T.type_alias { T::Hash[String, Object] }
-      PublicationDateResult = T.type_alias { [T.nilable(Time), T::Boolean] }
 
       ManifestList = T.type_alias do
         T::Array[ManifestHash]
@@ -480,16 +475,8 @@ module Dependabot
 
       sig { params(tag: Dependabot::Docker::Tag).returns(T.nilable(Dependabot::Package::PackageRelease)) }
       def get_tag_publication_details(tag)
-        digest_info = with_retries(max_attempts: 3, errors: transient_docker_errors) do
-          client = docker_registry_client
-          client.digest(docker_repo_name, tag.name)
-        end
-
-        first_digest = extract_digest_from_response(digest_info, tag)
-        return nil unless first_digest
-
-        published_date, details_available = publication_date_for(tag, digest_info, first_digest)
-        return nil unless details_available
+        published_date = registry_tag_release_date(tag)
+        return nil unless published_date
 
         Dependabot::Package::PackageRelease.new(
           version: release_version_for(tag),
@@ -499,63 +486,17 @@ module Dependabot
           url: nil,
           package_type: "docker"
         )
-      rescue *transient_docker_errors,
-             DockerRegistry2::RegistryAuthenticationException,
-             DockerRegistry2::RegistryAuthorizationException,
-             RestClient::Forbidden,
-             RestClient::TooManyRequests => e
-        Dependabot.logger.warn(
-          "Failed to fetch publication details for #{docker_repo_name}:#{tag.name}, " \
-          "skipping cooldown: #{e.class} - #{e.message}"
-        )
-        nil
-      end
-
-      sig do
-        params(
-          tag: Dependabot::Docker::Tag,
-          digest_info: Object,
-          first_digest: String
-        ).returns(PublicationDateResult)
-      end
-      def publication_date_for(tag, digest_info, first_digest)
-        header_date = publication_date_from_registry_headers(tag, digest_info, first_digest)
-        [header_date || registry_tag_release_date(tag), true]
-      rescue *transient_docker_errors,
-             DockerRegistry2::RegistryAuthenticationException,
-             DockerRegistry2::RegistryAuthorizationException,
-             RestClient::Forbidden,
-             RestClient::TooManyRequests => e
-        fallback_date = registry_tag_release_date(tag)
-        return [fallback_date, true] if fallback_date
-
-        Dependabot.logger.warn(
-          "Failed to fetch publication details for #{docker_repo_name}:#{tag.name}, " \
-          "skipping cooldown: #{e.class} - #{e.message}"
-        )
-        [nil, false]
-      end
-
-      sig do
-        params(
-          tag: Dependabot::Docker::Tag,
-          digest_info: Object,
-          first_digest: String
-        ).returns(T.nilable(Time))
-      end
-      def publication_date_from_registry_headers(tag, digest_info, first_digest)
-        endpoint = digest_info.is_a?(Array) ? "manifests" : "blobs"
-        head_response = with_retries(max_attempts: 3, errors: transient_docker_errors) do
-          docker_registry_client.dohead "v2/#{docker_repo_name}/#{endpoint}/#{first_digest}"
-        end
-        published_date_from_response_headers(head_response.headers, tag.name)
       end
 
       sig { params(tag: Dependabot::Docker::Tag).returns(T.nilable(Time)) }
       def registry_tag_release_date(tag)
         return docker_hub_tag_release_date(tag) if using_dockerhub?
 
-        github_container_registry_tag_release_date(tag) if registry_hostname == "ghcr.io"
+        Dependabot.logger.info(
+          "No verified registry publication date source for #{registry_hostname}; " \
+          "skipping cooldown for #{docker_repo_name}:#{tag.name}"
+        )
+        nil
       rescue JSON::ParserError, ArgumentError, TypeError, Excon::Error::Socket, Excon::Error::Timeout,
              RegistryError, PrivateSourceBadResponse, PrivateSourceAuthenticationFailure,
              *transient_docker_errors,
@@ -589,10 +530,18 @@ module Dependabot
         return unless response.status == 200
 
         metadata = JSON.parse(response.body)
-        return unless matching_digest?(metadata["digest"], digest)
+        return unless metadata.is_a?(Hash)
+        return unless docker_hub_digest_matches_update?(metadata["digest"], digest)
 
         timestamp = metadata["tag_last_pushed"]
         Time.iso8601(timestamp) if timestamp.is_a?(String)
+      end
+
+      sig { params(metadata_digest: Object, digest: String).returns(T::Boolean) }
+      def docker_hub_digest_matches_update?(metadata_digest, digest)
+        return digest_requirements.empty? && !pin_digests? if metadata_digest.nil?
+
+        matching_digest?(metadata_digest, digest)
       end
 
       sig { params(namespace: String, repository: String, tag: String).returns(String) }
@@ -601,170 +550,11 @@ module Dependabot
         "https://hub.docker.com/v2/namespaces/#{escaped[0]}/repositories/#{escaped[1]}/tags/#{escaped[2]}"
       end
 
-      sig { params(tag: Dependabot::Docker::Tag).returns(T.nilable(Time)) }
-      def github_container_registry_tag_release_date(tag)
-        digest = digest_of(tag.name)
-        return unless digest
-
-        version = github_package_version(tag, digest)
-        return unless version
-
-        timestamp = version["updated_at"]
-        Time.iso8601(timestamp) if timestamp.is_a?(String)
-      end
-
-      sig { params(tag: Dependabot::Docker::Tag, digest: String).returns(T.nilable(GithubPackageVersion)) }
-      def github_package_version(tag, digest)
-        page = 1
-        loop do
-          versions = github_package_versions(page)
-          version = versions.find do |candidate|
-            matching_digest?(candidate["name"], digest) && github_package_version_tags(candidate).include?(tag.name)
-          end
-          return version if version
-          return nil if versions.length < GITHUB_PACKAGES_PAGE_SIZE
-
-          page += 1
-        end
-      end
-
-      sig { params(page: Integer).returns(T::Array[GithubPackageVersion]) }
-      def github_package_versions(page)
-        @github_package_versions ||= T.let(
-          {},
-          T.nilable(T::Hash[Integer, T::Array[GithubPackageVersion]])
-        )
-        @github_package_versions[page] ||= fetch_github_package_versions(page)
-      end
-
-      sig { params(page: Integer).returns(T::Array[GithubPackageVersion]) }
-      def fetch_github_package_versions(page)
-        owner, package = docker_repo_name.split("/", 2)
-        return [] unless owner && package
-
-        token = github_packages_token
-        @github_package_owner_type ||= T.let("orgs", T.nilable(String))
-        response = github_package_versions_response(@github_package_owner_type, owner, package, token, page)
-        if page == 1 && response.status == 404
-          @github_package_owner_type = "users"
-          response = github_package_versions_response(@github_package_owner_type, owner, package, token, page)
-        end
-        return [] unless response.status == 200
-
-        parse_github_package_versions(response.body)
-      end
-
-      sig do
-        params(
-          owner_type: String,
-          owner: String,
-          package: String,
-          token: T.nilable(String),
-          page: Integer
-        ).returns(Excon::Response)
-      end
-      def github_package_versions_response(owner_type, owner, package, token, page)
-        escaped_owner = URI.encode_www_form_component(owner)
-        escaped_package = URI.encode_www_form_component(package)
-        url = "https://api.github.com/#{owner_type}/#{escaped_owner}/packages/container/#{escaped_package}/versions"
-        headers = {
-          "Accept" => "application/vnd.github+json",
-          "X-GitHub-Api-Version" => "2022-11-28"
-        }
-        headers["Authorization"] = "Bearer #{token}" if token
-        with_retries(max_attempts: 3, errors: [Excon::Error::Socket, Excon::Error::Timeout]) do
-          Dependabot::RegistryClient.get(
-            url: url,
-            headers: headers,
-            options: {
-              query: { per_page: GITHUB_PACKAGES_PAGE_SIZE, page: page },
-              connect_timeout: docker_open_timeout_in_seconds,
-              read_timeout: docker_read_timeout_in_seconds,
-              write_timeout: docker_read_timeout_in_seconds
-            }
-          )
-        end
-      end
-
-      sig { params(body: String).returns(T::Array[GithubPackageVersion]) }
-      def parse_github_package_versions(body)
-        parsed = JSON.parse(body)
-        return [] unless parsed.is_a?(Array)
-
-        parsed.grep(Hash)
-      end
-
-      sig { params(version: GithubPackageVersion).returns(T::Array[String]) }
-      def github_package_version_tags(version)
-        metadata = version["metadata"]
-        return [] unless metadata.is_a?(Hash)
-
-        container = metadata["container"]
-        return [] unless container.is_a?(Hash)
-
-        tags = container["tags"]
-        tags.is_a?(Array) ? tags.grep(String) : []
-      end
-
       sig { params(first: Object, second: Object).returns(T::Boolean) }
       def matching_digest?(first, second)
         return false unless first.is_a?(String) && second.is_a?(String)
 
         first.delete_prefix("sha256:").casecmp?(second.delete_prefix("sha256:")) || false
-      end
-
-      sig { returns(T.nilable(String)) }
-      def github_packages_token
-        registry_token = registry_credentials&.fetch("password", nil)
-        return registry_token if registry_token.is_a?(String)
-
-        github_credentials = credentials.find do |credential|
-          credential["type"] == "git_source" && credential["host"] == "github.com"
-        end
-        github_token = github_credentials&.fetch("password", nil)
-        github_token if github_token.is_a?(String)
-      end
-
-      sig { params(headers: T::Hash[Symbol, String], tag_name: String).returns(T.nilable(Time)) }
-      def published_date_from_response_headers(headers, tag_name)
-        last_modified = headers[:last_modified]
-        return nil unless last_modified
-
-        Time.parse(last_modified)
-      rescue ArgumentError, TypeError => e
-        Dependabot.logger.info(
-          "Invalid Last-Modified header for #{docker_repo_name}:#{tag_name}: #{e.message}"
-        )
-        nil
-      end
-
-      sig do
-        params(
-          digest_info: Object,
-          tag: Dependabot::Docker::Tag
-        ).returns(T.nilable(String))
-      end
-      def extract_digest_from_response(digest_info, tag)
-        # digest_info can be either a String or an Array depending on the registry response
-        case digest_info
-        when Array
-          if digest_info.empty?
-            Dependabot.logger.warn(
-              "Empty digest_info array for #{docker_repo_name}:#{tag.name}"
-            )
-            return nil
-          end
-          digest = digest_info.first&.fetch("digest")
-          digest if digest.is_a?(String)
-        when String
-          digest_info
-        else
-          Dependabot.logger.warn(
-            "Unexpected digest_info type for #{docker_repo_name}:#{tag.name}: " \
-            "#{digest_info.class} (expected String or Array)"
-          )
-          nil
-        end
       end
 
       sig do
@@ -1302,8 +1092,7 @@ module Dependabot
       # don't change the version string, so the default cooldown window applies
       # (semver-specific windows require a version delta, and the tag may be
       # non-comparable like "alpine"). Fails open (returns false) when the
-      # publication date can't be determined, so a missing Last-Modified header
-      # never permanently blocks an update.
+      # publication date can't be determined and records an unavailable-date warning.
       sig { params(tag_name: String).returns(T::Boolean) }
       def digest_within_cooldown?(tag_name)
         return false if should_skip_cooldown?

--- a/docker/spec/dependabot/docker/update_checker_digest_cooldown_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_digest_cooldown_spec.rb
@@ -99,8 +99,54 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
   context "when the registry omits the Last-Modified header" do
     let(:blob_response) { instance_double(RestClient::Response, headers: {}) }
 
+    before do
+      stub_request(
+        :get,
+        "https://hub.docker.com/v2/namespaces/library/repositories/golang/tags/alpine"
+      ).to_return(status: 404)
+    end
+
     it "fails open and proposes the update" do
       expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+    end
+
+    context "when Docker Hub reports a recent tag push" do
+      before do
+        stub_request(
+          :get,
+          "https://hub.docker.com/v2/namespaces/library/repositories/golang/tags/alpine"
+        ).to_return(
+          status: 200,
+          body: {
+            digest: "sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92",
+            tag_last_pushed: (Time.now - (5 * 86_400)).iso8601
+          }.to_json
+        )
+      end
+
+      it "holds the digest-only update in cooldown" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+        expect(golang_dependency.metadata).not_to include(:docker_cooldown_date_unavailable)
+      end
+    end
+
+    context "when Docker Hub reports an old tag push" do
+      before do
+        stub_request(
+          :get,
+          "https://hub.docker.com/v2/namespaces/library/repositories/golang/tags/alpine"
+        ).to_return(
+          status: 200,
+          body: {
+            digest: "sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92",
+            tag_last_pushed: (Time.now - (30 * 86_400)).iso8601
+          }.to_json
+        )
+      end
+
+      it "proposes the digest-only update" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+      end
     end
   end
 end

--- a/docker/spec/dependabot/docker/update_checker_digest_cooldown_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_digest_cooldown_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       it "fails open when the subsequent digest resolution succeeds" do
         expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
-        expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+        expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
     end
 
@@ -143,7 +143,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       it "holds the digest-only update in cooldown" do
         expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
-        expect(golang_dependency.metadata).not_to include(:docker_cooldown_date_unavailable)
+        expect(golang_dependency.metadata).not_to include(:cooldown_date_unavailable)
       end
     end
 
@@ -222,7 +222,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
     it "holds a recent digest-only update in cooldown" do
       expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
-      expect(golang_dependency.metadata).not_to include(:docker_cooldown_date_unavailable)
+      expect(golang_dependency.metadata).not_to include(:cooldown_date_unavailable)
     end
 
     context "when the publication date is outside cooldown" do
@@ -252,7 +252,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       it "fails open without using the mismatched date" do
         expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
-        expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+        expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
     end
 
@@ -261,7 +261,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       it "fails open without using a date for another tag" do
         expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
-        expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+        expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
     end
 
@@ -304,7 +304,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       it "fails open with an unavailable-date warning" do
         expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
-        expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+        expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
     end
 
@@ -340,7 +340,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
         it "fails open after checking the final page" do
           expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
-          expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+          expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
           expect(WebMock).to have_requested(:get, versions_url)
             .with(query: { "page" => "6", "per_page" => "100" }).once
         end

--- a/docker/spec/dependabot/docker/update_checker_digest_cooldown_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_digest_cooldown_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
@@ -110,6 +110,23 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
     end
 
+    context "when the manifest digest lookup is rate limited" do
+      before do
+        attempts = 0
+        allow(mock_client).to receive(:manifest_digest) do
+          attempts += 1
+          raise DockerRegistry2::RegistryHTTPException, "Registry request failed with status 429" if attempts == 1
+
+          "sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92"
+        end
+      end
+
+      it "fails open when the subsequent digest resolution succeeds" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+        expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+      end
+    end
+
     context "when Docker Hub reports a recent tag push" do
       before do
         stub_request(
@@ -146,6 +163,231 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       it "proposes the digest-only update" do
         expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+      end
+
+      context "when the tag moves after its publication date is checked" do
+        let(:checked_digest) { "98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92" }
+
+        before do
+          allow(mock_client).to receive(:manifest_digest)
+            .and_return("sha256:#{checked_digest}", "sha256:#{'a' * 64}")
+        end
+
+        it "updates to the digest whose cooldown was checked" do
+          expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+          expect(checker.updated_requirements.first.source_string("digest")).to eq(checked_digest)
+          expect(mock_client).to have_received(:manifest_digest).once
+        end
+      end
+    end
+  end
+
+  context "when GHCR omits the Last-Modified header" do
+    let(:blob_response) { instance_double(RestClient::Response, headers: {}) }
+    let(:dependency_tags) { ["latest"] }
+    let(:golang_dependency) do
+      Dependabot::Dependency.new(
+        name: "astral-sh/uv",
+        version: "latest",
+        package_manager: "docker",
+        requirements: dependency_tags.map do |tag|
+          {
+            requirement: nil,
+            groups: [],
+            file: "Dockerfile",
+            source: { registry: "ghcr.io", tag: tag, digest: "old_digest" }
+          }
+        end
+      )
+    end
+    let(:versions_url) { "https://api.github.com/orgs/astral-sh/packages/container/uv/versions" }
+    let(:registry_digest) { "98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92" }
+    let(:metadata_digest) { "sha256:#{registry_digest}" }
+    let(:metadata_tags) { ["latest"] }
+    let(:published_at) { (Time.now - (5 * 86_400)).iso8601 }
+    let(:package_version) do
+      {
+        name: metadata_digest,
+        updated_at: published_at,
+        metadata: { container: { tags: metadata_tags } }
+      }
+    end
+    let(:package_versions) { [package_version] }
+
+    before do
+      stub_request(:get, versions_url)
+        .with(query: { "page" => "1", "per_page" => "100" })
+        .to_return(status: 200, body: package_versions.to_json)
+    end
+
+    it "holds a recent digest-only update in cooldown" do
+      expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+      expect(golang_dependency.metadata).not_to include(:docker_cooldown_date_unavailable)
+    end
+
+    context "when the publication date is outside cooldown" do
+      let(:published_at) { (Time.now - (30 * 86_400)).iso8601 }
+
+      it "proposes the digest-only update" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+        expect(checker.updated_requirements.first.source_string("digest")).to eq(registry_digest)
+      end
+
+      context "when the tag moves after the metadata lookup" do
+        before do
+          allow(mock_client).to receive(:manifest_digest)
+            .and_return("sha256:#{registry_digest}", "sha256:#{'a' * 64}")
+        end
+
+        it "retains the digest whose cooldown was checked" do
+          expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+          expect(checker.updated_requirements.first.source_string("digest")).to eq(registry_digest)
+          expect(mock_client).to have_received(:manifest_digest).once
+        end
+      end
+    end
+
+    context "when the metadata digest is stale" do
+      let(:metadata_digest) { "sha256:#{'b' * 64}" }
+
+      it "fails open without using the mismatched date" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+        expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+      end
+    end
+
+    context "when the metadata does not include the tag" do
+      let(:metadata_tags) { ["other"] }
+
+      it "fails open without using a date for another tag" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+        expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+      end
+    end
+
+    context "when credentials contain only metadata for the credential proxy" do
+      let(:credentials) do
+        [
+          Dependabot::Credential.new("type" => "git_source", "host" => "github.com"),
+          Dependabot::Credential.new("type" => "docker_registry", "registry" => "ghcr.io")
+        ]
+      end
+
+      it "requests metadata without a local token and enforces cooldown" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+        expect(WebMock).to have_requested(:get, versions_url)
+          .with(query: { "page" => "1", "per_page" => "100" }) { |request| !request.headers.key?("Authorization") }
+      end
+    end
+
+    context "when the package is owned by a user" do
+      let(:user_versions_url) { "https://api.github.com/users/astral-sh/packages/container/uv/versions" }
+
+      before do
+        stub_request(:get, versions_url)
+          .with(query: { "page" => "1", "per_page" => "100" }).to_return(status: 404)
+        stub_request(:get, user_versions_url)
+          .with(query: { "page" => "1", "per_page" => "100" })
+          .to_return(status: 200, body: package_versions.to_json)
+      end
+
+      it "uses the user endpoint to enforce cooldown" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+      end
+    end
+
+    context "when the metadata API rejects authentication" do
+      before do
+        stub_request(:get, versions_url)
+          .with(query: { "page" => "1", "per_page" => "100" }).to_return(status: 403)
+      end
+
+      it "fails open with an unavailable-date warning" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+        expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+      end
+    end
+
+    context "when the matching version is beyond the first 500 results" do
+      let(:package_versions) do
+        Array.new(100) do |index|
+          { name: "sha256:#{index.to_s(16).rjust(64, '0')}", metadata: { container: { tags: [] } } }
+        end
+      end
+
+      before do
+        (2..5).each do |page|
+          stub_request(:get, versions_url)
+            .with(query: { "page" => page.to_s, "per_page" => "100" })
+            .to_return(status: 200, body: package_versions.to_json)
+        end
+        stub_request(:get, versions_url)
+          .with(query: { "page" => "6", "per_page" => "100" })
+          .to_return(status: 200, body: [package_version].to_json)
+      end
+
+      it "continues paginating and holds the recent digest in cooldown" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+        expect(WebMock).to have_requested(:get, versions_url)
+          .with(query: { "page" => "6", "per_page" => "100" }).once
+      end
+
+      context "when the API is exhausted without a match" do
+        before do
+          stub_request(:get, versions_url)
+            .with(query: { "page" => "6", "per_page" => "100" }).to_return(status: 200, body: "[]")
+        end
+
+        it "fails open after checking the final page" do
+          expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+          expect(golang_dependency.metadata[:docker_cooldown_date_unavailable]).to be(true)
+          expect(WebMock).to have_requested(:get, versions_url)
+            .with(query: { "page" => "6", "per_page" => "100" }).once
+        end
+      end
+    end
+
+    context "when a full page already contains the matching version" do
+      let(:package_versions) { [package_version] + Array.new(99) { { name: "unrelated" } } }
+
+      it "stops without requesting another page" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+        expect(WebMock).not_to have_requested(:get, versions_url)
+          .with(query: { "page" => "2", "per_page" => "100" })
+      end
+
+      context "when another tag needs the next page" do
+        let(:dependency_tags) { %w(latest stable) }
+
+        before do
+          stable_version = package_version.merge(metadata: { container: { tags: ["stable"] } })
+          stub_request(:get, versions_url)
+            .with(query: { "page" => "2", "per_page" => "100" })
+            .to_return(status: 200, body: [stable_version].to_json)
+        end
+
+        it "reuses the first page and continues searching for the other tag" do
+          expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+          expect(WebMock).to have_requested(:get, versions_url)
+            .with(query: { "page" => "1", "per_page" => "100" }).once
+          expect(WebMock).to have_requested(:get, versions_url)
+            .with(query: { "page" => "2", "per_page" => "100" }).once
+        end
+
+        context "when the package is owned by a user" do
+          let(:versions_url) { "https://api.github.com/users/astral-sh/packages/container/uv/versions" }
+
+          before do
+            stub_request(:get, "https://api.github.com/orgs/astral-sh/packages/container/uv/versions")
+              .with(query: { "page" => "1", "per_page" => "100" }).to_return(status: 404)
+          end
+
+          it "continues pagination on the user endpoint" do
+            expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+            expect(WebMock).to have_requested(:get, versions_url)
+              .with(query: { "page" => "2", "per_page" => "100" }).once
+          end
+        end
       end
     end
   end

--- a/docker/spec/dependabot/docker/update_checker_digest_cooldown_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_digest_cooldown_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
   let(:mock_client) { instance_double(DockerRegistry2::Registry) }
   let(:last_modified) { (Time.now - (5 * 86_400)).httpdate }
   let(:blob_response) { instance_double(RestClient::Response, headers: { last_modified: last_modified }) }
+  let(:tag_last_pushed) { (Time.now - (5 * 86_400)).iso8601 }
 
   let(:checker) do
     described_class.new(
@@ -70,6 +71,16 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     allow(mock_client).to receive(:dohead).and_return(blob_response)
     allow(Dependabot.logger).to receive(:info)
     allow(Dependabot.logger).to receive(:warn)
+    stub_request(
+      :get,
+      "https://hub.docker.com/v2/namespaces/library/repositories/golang/tags/alpine"
+    ).to_return(
+      status: 200,
+      body: {
+        digest: "sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92",
+        tag_last_pushed: tag_last_pushed
+      }.to_json
+    )
   end
 
   it "parses the Dockerfile into a digest-pinned golang:alpine dependency" do
@@ -81,7 +92,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
   end
 
   context "when the new digest is ~5 days old (inside the 14-day cooldown)" do
-    let(:last_modified) { (Time.now - (5 * 86_400)).httpdate }
+    let(:tag_last_pushed) { (Time.now - (5 * 86_400)).iso8601 }
 
     it "does not propose the digest-only update (cooldown respected)" do
       expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
@@ -89,7 +100,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
   end
 
   context "when the new digest is 30 days old (older than the 14-day cooldown)" do
-    let(:last_modified) { (Time.now - (30 * 86_400)).httpdate }
+    let(:tag_last_pushed) { (Time.now - (30 * 86_400)).iso8601 }
 
     it "proposes the digest-only update (cooldown elapsed)" do
       expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
@@ -182,86 +193,161 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
   end
 
-  context "when GHCR omits the Last-Modified header" do
-    let(:blob_response) { instance_double(RestClient::Response, headers: {}) }
+  context "when only verified registry publication dates are accepted" do
+    let(:last_modified) { (Time.now - (30 * 86_400)).httpdate }
+    let(:registry_digest) { "98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92" }
+    let(:metadata_digest) { "sha256:#{registry_digest}" }
+    let(:tag_metadata) do
+      {
+        digest: metadata_digest,
+        tag_last_pushed: (Time.now - (5 * 86_400)).iso8601
+      }
+    end
+
+    before do
+      stub_request(
+        :get,
+        "https://hub.docker.com/v2/namespaces/library/repositories/golang/tags/alpine"
+      ).to_return(status: 200, body: tag_metadata.to_json)
+    end
+
+    it "holds a recent Hub push despite an older manifest header" do
+      expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+      expect(golang_dependency.metadata).not_to include(:cooldown_date_unavailable)
+      expect(mock_client).not_to have_received(:dohead)
+    end
+
+    context "when the Hub digest does not match" do
+      let(:metadata_digest) { "sha256:#{'b' * 64}" }
+
+      it "marks the date unavailable without falling back to the manifest header" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+        expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        expect(mock_client).not_to have_received(:dohead)
+      end
+    end
+
+    context "when the Hub timestamp is missing" do
+      let(:tag_metadata) { { digest: metadata_digest, created: "2000-01-01T00:00:00Z" } }
+
+      it "does not substitute a creation timestamp or manifest header" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+        expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        expect(mock_client).not_to have_received(:dohead)
+      end
+    end
+
+    context "when the tag points to a new multi-platform index" do
+      before do
+        allow(mock_client).to receive(:digest).and_return(
+          [{ "digest" => "sha256:#{'c' * 64}" }, { "digest" => "sha256:#{'d' * 64}" }]
+        )
+      end
+
+      it "uses the matching parent index push date instead of an old child header" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
+        expect(golang_dependency.metadata).not_to include(:cooldown_date_unavailable)
+        expect(mock_client).not_to have_received(:dohead)
+      end
+    end
+
+    %w(ghcr.io registry.example.com).each do |registry|
+      context "when #{registry} has no verified publication-date source" do
+        let(:golang_dependency) do
+          Dependabot::Dependency.new(
+            name: "acme/golang",
+            version: "alpine",
+            package_manager: "docker",
+            requirements: [{
+              requirement: nil,
+              groups: [],
+              file: "Dockerfile",
+              source: { registry: registry, tag: "alpine", digest: "old_digest" }
+            }]
+          )
+        end
+
+        it "marks the date unavailable without trusting registry headers" do
+          expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+          expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
+          expect(mock_client).not_to have_received(:dohead)
+          expect(WebMock).not_to have_requested(:get, %r{\Ahttps://api\.github\.com/})
+        end
+      end
+    end
+  end
+
+  context "when GHCR provides unverified package timestamps" do
     let(:dependency_tags) { ["latest"] }
+    let(:dependency_digest) { "old_digest" }
     let(:golang_dependency) do
       Dependabot::Dependency.new(
         name: "astral-sh/uv",
-        version: "latest",
+        version: dependency_tags.first,
         package_manager: "docker",
         requirements: dependency_tags.map do |tag|
           {
             requirement: nil,
             groups: [],
             file: "Dockerfile",
-            source: { registry: "ghcr.io", tag: tag, digest: "old_digest" }
+            source: { registry: "ghcr.io", tag: tag, digest: dependency_digest }.compact
           }
         end
       )
     end
     let(:versions_url) { "https://api.github.com/orgs/astral-sh/packages/container/uv/versions" }
     let(:registry_digest) { "98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92" }
-    let(:metadata_digest) { "sha256:#{registry_digest}" }
-    let(:metadata_tags) { ["latest"] }
     let(:published_at) { (Time.now - (5 * 86_400)).iso8601 }
     let(:package_version) do
       {
-        name: metadata_digest,
+        name: "sha256:#{registry_digest}",
+        created_at: (Time.now - (30 * 86_400)).iso8601,
         updated_at: published_at,
-        metadata: { container: { tags: metadata_tags } }
+        metadata: { container: { tags: dependency_tags } }
       }
     end
-    let(:package_versions) { [package_version] }
 
     before do
       stub_request(:get, versions_url)
         .with(query: { "page" => "1", "per_page" => "100" })
-        .to_return(status: 200, body: package_versions.to_json)
+        .to_return(status: 200, body: [package_version].to_json)
     end
 
-    it "holds a recent digest-only update in cooldown" do
-      expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
-      expect(golang_dependency.metadata).not_to include(:cooldown_date_unavailable)
+    it "marks the date unavailable while retaining normal digest updates" do
+      expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+      expect(checker.updated_requirements.first.source_string("digest")).to eq(registry_digest)
+      expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      expect(mock_client).not_to have_received(:dohead)
+      expect(WebMock).not_to have_requested(:get, versions_url)
+      expect(Dependabot.logger).to have_received(:info).with(
+        "No verified registry publication date source for ghcr.io; skipping cooldown for astral-sh/uv:latest"
+      )
     end
 
-    context "when the publication date is outside cooldown" do
+    context "when updating an unpinned version tag" do
+      let(:dependency_tags) { ["1.0.0"] }
+      let(:dependency_digest) { nil }
+
+      before do
+        allow(mock_client).to receive(:tags).and_return("tags" => %w(1.0.0 1.1.0))
+      end
+
+      it "proposes the update with a missing-date warning" do
+        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
+        expect(checker.updated_requirements.first.source_string("tag")).to eq("1.1.0")
+        expect(checker.updated_requirements.first.source_string("digest")).to be_nil
+        expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        expect(WebMock).not_to have_requested(:get, versions_url)
+      end
+    end
+
+    context "when updated_at is older than cooldown" do
       let(:published_at) { (Time.now - (30 * 86_400)).iso8601 }
 
-      it "proposes the digest-only update" do
-        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
-        expect(checker.updated_requirements.first.source_string("digest")).to eq(registry_digest)
-      end
-
-      context "when the tag moves after the metadata lookup" do
-        before do
-          allow(mock_client).to receive(:manifest_digest)
-            .and_return("sha256:#{registry_digest}", "sha256:#{'a' * 64}")
-        end
-
-        it "retains the digest whose cooldown was checked" do
-          expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
-          expect(checker.updated_requirements.first.source_string("digest")).to eq(registry_digest)
-          expect(mock_client).to have_received(:manifest_digest).once
-        end
-      end
-    end
-
-    context "when the metadata digest is stale" do
-      let(:metadata_digest) { "sha256:#{'b' * 64}" }
-
-      it "fails open without using the mismatched date" do
+      it "still marks the date unavailable" do
         expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
         expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
-      end
-    end
-
-    context "when the metadata does not include the tag" do
-      let(:metadata_tags) { ["other"] }
-
-      it "fails open without using a date for another tag" do
-        expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
-        expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        expect(WebMock).not_to have_requested(:get, versions_url)
       end
     end
 
@@ -273,121 +359,10 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         ]
       end
 
-      it "requests metadata without a local token and enforces cooldown" do
-        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
-        expect(WebMock).to have_requested(:get, versions_url)
-          .with(query: { "page" => "1", "per_page" => "100" }) { |request| !request.headers.key?("Authorization") }
-      end
-    end
-
-    context "when the package is owned by a user" do
-      let(:user_versions_url) { "https://api.github.com/users/astral-sh/packages/container/uv/versions" }
-
-      before do
-        stub_request(:get, versions_url)
-          .with(query: { "page" => "1", "per_page" => "100" }).to_return(status: 404)
-        stub_request(:get, user_versions_url)
-          .with(query: { "page" => "1", "per_page" => "100" })
-          .to_return(status: 200, body: package_versions.to_json)
-      end
-
-      it "uses the user endpoint to enforce cooldown" do
-        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
-      end
-    end
-
-    context "when the metadata API rejects authentication" do
-      before do
-        stub_request(:get, versions_url)
-          .with(query: { "page" => "1", "per_page" => "100" }).to_return(status: 403)
-      end
-
-      it "fails open with an unavailable-date warning" do
+      it "does not treat authentication as proof of timestamp semantics" do
         expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
         expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
-      end
-    end
-
-    context "when the matching version is beyond the first 500 results" do
-      let(:package_versions) do
-        Array.new(100) do |index|
-          { name: "sha256:#{index.to_s(16).rjust(64, '0')}", metadata: { container: { tags: [] } } }
-        end
-      end
-
-      before do
-        (2..5).each do |page|
-          stub_request(:get, versions_url)
-            .with(query: { "page" => page.to_s, "per_page" => "100" })
-            .to_return(status: 200, body: package_versions.to_json)
-        end
-        stub_request(:get, versions_url)
-          .with(query: { "page" => "6", "per_page" => "100" })
-          .to_return(status: 200, body: [package_version].to_json)
-      end
-
-      it "continues paginating and holds the recent digest in cooldown" do
-        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
-        expect(WebMock).to have_requested(:get, versions_url)
-          .with(query: { "page" => "6", "per_page" => "100" }).once
-      end
-
-      context "when the API is exhausted without a match" do
-        before do
-          stub_request(:get, versions_url)
-            .with(query: { "page" => "6", "per_page" => "100" }).to_return(status: 200, body: "[]")
-        end
-
-        it "fails open after checking the final page" do
-          expect(checker.can_update?(requirements_to_unlock: :own)).to be(true)
-          expect(golang_dependency.metadata[:cooldown_date_unavailable]).to be(true)
-          expect(WebMock).to have_requested(:get, versions_url)
-            .with(query: { "page" => "6", "per_page" => "100" }).once
-        end
-      end
-    end
-
-    context "when a full page already contains the matching version" do
-      let(:package_versions) { [package_version] + Array.new(99) { { name: "unrelated" } } }
-
-      it "stops without requesting another page" do
-        expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
         expect(WebMock).not_to have_requested(:get, versions_url)
-          .with(query: { "page" => "2", "per_page" => "100" })
-      end
-
-      context "when another tag needs the next page" do
-        let(:dependency_tags) { %w(latest stable) }
-
-        before do
-          stable_version = package_version.merge(metadata: { container: { tags: ["stable"] } })
-          stub_request(:get, versions_url)
-            .with(query: { "page" => "2", "per_page" => "100" })
-            .to_return(status: 200, body: [stable_version].to_json)
-        end
-
-        it "reuses the first page and continues searching for the other tag" do
-          expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
-          expect(WebMock).to have_requested(:get, versions_url)
-            .with(query: { "page" => "1", "per_page" => "100" }).once
-          expect(WebMock).to have_requested(:get, versions_url)
-            .with(query: { "page" => "2", "per_page" => "100" }).once
-        end
-
-        context "when the package is owned by a user" do
-          let(:versions_url) { "https://api.github.com/users/astral-sh/packages/container/uv/versions" }
-
-          before do
-            stub_request(:get, "https://api.github.com/orgs/astral-sh/packages/container/uv/versions")
-              .with(query: { "page" => "1", "per_page" => "100" }).to_return(status: 404)
-          end
-
-          it "continues pagination on the user endpoint" do
-            expect(checker.can_update?(requirements_to_unlock: :own)).to be(false)
-            expect(WebMock).to have_requested(:get, versions_url)
-              .with(query: { "page" => "2", "per_page" => "100" }).once
-          end
-        end
       end
     end
   end

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1711,6 +1711,10 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         allow(mock_client).to receive(:dohead).and_raise(DockerRegistry2::NotFound)
         allow(Dependabot.logger).to receive(:warn)
         allow(Dependabot.logger).to receive(:info)
+        stub_request(
+          :get,
+          "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/17.10"
+        ).to_return(status: 404)
       end
 
       it "still returns the latest version instead of crashing" do
@@ -1721,6 +1725,36 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         latest_version
 
         expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+
+      context "when Docker Hub reports a recent tag push" do
+        before do
+          stub_request(
+            :get,
+            "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/17.10"
+          ).to_return(
+            status: 200,
+            body: {
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97eba880ebf600d68608",
+              tag_last_pushed: (Time.now - (2 * 86_400)).iso8601
+            }.to_json
+          )
+          stub_request(
+            :get,
+            "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/17.04"
+          ).to_return(
+            status: 200,
+            body: {
+              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97eba880ebf600d68608",
+              tag_last_pushed: (Time.now - (30 * 86_400)).iso8601
+            }.to_json
+          )
+        end
+
+        it "keeps the current version in cooldown" do
+          expect(latest_version).to eq("17.04")
+          expect(dependency.metadata).not_to include(:docker_cooldown_date_unavailable)
+        end
       end
 
       context "when no cooldown days are configured" do
@@ -1807,6 +1841,13 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         context "when the registry omits the Last-Modified header" do
           let(:blob_headers) { {} }
           let(:last_modified) { nil }
+
+          before do
+            stub_request(
+              :get,
+              "https://hub.docker.com/v2/namespaces/library/repositories/golang/tags/alpine"
+            ).to_return(status: 404)
+          end
 
           context "when the config blob created date is within the cooldown window" do
             before do
@@ -3549,8 +3590,12 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       let(:config_created) { Time.parse("Tue, 10 Jun 2025 00:00:00 GMT") }
 
       before do
-        allow(mock_client).to receive(:digest).and_return(digest_string)
+        allow(mock_client).to receive_messages(digest: digest_string, manifest_digest: digest_string)
         allow(checker).to receive(:fetch_image_config_created).with("1.0.0").and_return(config_created)
+        stub_request(
+          :get,
+          "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
+        ).to_return(status: 404)
       end
 
       it "does not fall back to the publisher-controlled config blob created timestamp" do
@@ -3558,6 +3603,129 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         expect(result).to be_a(Dependabot::Package::PackageRelease)
         expect(result.released_at).to be_nil
         expect(checker).not_to have_received(:fetch_image_config_created)
+      end
+
+      context "when Docker Hub returns tag metadata" do
+        before do
+          allow(mock_client).to receive(:manifest_digest)
+            .with("library/ubuntu", "1.0.0")
+            .and_return("sha256:tag123")
+          stub_request(
+            :get,
+            "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
+          ).to_return(
+            status: 200,
+            body: {
+              digest: "sha256:tag123",
+              tag_last_pushed: "2024-01-15T10:00:00Z"
+            }.to_json
+          )
+        end
+
+        it "uses the registry-managed tag push time" do
+          result = get_tag_publication_details
+
+          expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
+          expect(checker).not_to have_received(:fetch_image_config_created)
+        end
+
+        context "when the metadata digest does not match the registry" do
+          before do
+            stub_request(
+              :get,
+              "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
+            ).to_return(
+              status: 200,
+              body: {
+                digest: "sha256:stale",
+                tag_last_pushed: "2024-01-15T10:00:00Z"
+              }.to_json
+            )
+          end
+
+          it "does not use stale tag metadata" do
+            expect(get_tag_publication_details.released_at).to be_nil
+          end
+        end
+      end
+
+      context "when GHCR returns package metadata" do
+        let(:source) { { tag: version, registry: "ghcr.io" } }
+        let(:dependency_name) { "astral-sh/uv" }
+
+        before do
+          allow(mock_client).to receive(:manifest_digest)
+            .with("astral-sh/uv", "1.0.0")
+            .and_return("sha256:tag123")
+          stub_request(
+            :get,
+            "https://api.github.com/orgs/astral-sh/packages/container/uv/versions"
+          ).with(
+            query: { "page" => "1", "per_page" => "100" },
+            headers: { "Authorization" => "Bearer token" }
+          ).to_return(
+            status: 200,
+            body: [{
+              name: "sha256:tag123",
+              updated_at: "2024-01-15T10:00:00Z",
+              metadata: { container: { tags: ["1.0.0"] } }
+            }].to_json
+          )
+        end
+
+        it "uses the registry-managed package version update time" do
+          result = get_tag_publication_details
+
+          expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
+        end
+
+        context "when the package version digest does not match the registry" do
+          before do
+            stub_request(
+              :get,
+              "https://api.github.com/orgs/astral-sh/packages/container/uv/versions"
+            ).with(query: { "page" => "1", "per_page" => "100" })
+              .to_return(
+                status: 200,
+                body: [{
+                  name: "sha256:stale",
+                  updated_at: "2024-01-15T10:00:00Z",
+                  metadata: { container: { tags: ["1.0.0"] } }
+                }].to_json
+              )
+          end
+
+          it "does not use stale package metadata" do
+            expect(get_tag_publication_details.released_at).to be_nil
+          end
+        end
+      end
+    end
+
+    context "when the publication HEAD request fails and Docker Hub returns tag metadata" do
+      before do
+        allow(mock_client).to receive(:digest).and_return("sha256:abc123")
+        allow(mock_client).to receive(:dohead).and_raise(DockerRegistry2::NotFound)
+        allow(mock_client).to receive(:manifest_digest)
+          .with("library/ubuntu", "1.0.0")
+          .and_return("sha256:tag123")
+        stub_request(
+          :get,
+          "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
+        ).to_return(
+          status: 200,
+          body: {
+            digest: "sha256:tag123",
+            tag_last_pushed: "2024-01-15T10:00:00Z"
+          }.to_json
+        )
+        allow(Dependabot.logger).to receive(:warn)
+      end
+
+      it "uses the registry-managed tag push time" do
+        result = get_tag_publication_details
+
+        expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
       end
     end
 
@@ -3667,9 +3835,13 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
     context "when client.dohead raises DockerRegistry2::NotFound for blob" do
       before do
-        allow(mock_client).to receive(:digest).and_return("sha256:abc123")
+        allow(mock_client).to receive_messages(digest: "sha256:abc123", manifest_digest: "sha256:abc123")
         allow(mock_client).to receive(:dohead).and_raise(DockerRegistry2::NotFound)
         allow(Dependabot.logger).to receive(:warn)
+        stub_request(
+          :get,
+          "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
+        ).to_return(status: 404)
       end
 
       it "returns nil and logs a warning" do

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
@@ -1753,7 +1753,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
         it "keeps the current version in cooldown" do
           expect(latest_version).to eq("17.04")
-          expect(dependency.metadata).not_to include(:docker_cooldown_date_unavailable)
+          expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
         end
       end
 

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -1679,15 +1679,16 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           fixture("docker", "registry_manifest_headers", "generic.json")
         stub_request(:head, repo_url + "manifests/17.10")
           .and_return(status: 200, body: "", headers: JSON.parse(new_headers))
-        stub_request(:get, repo_url + "manifests/17.10")
-          .and_return(status: 200, body: fixture("docker", "registry_manifest_digests", "ubuntu_17.10.json"))
-
-        blob_headers =
-          fixture("docker", "image_blobs_headers", "ubuntu_17.10_38d6c1.json")
-
-        manifest_digest = "sha256:9c4bf7dbb981591d4a1169138471afe4bf5ff5418841d00e30a7ba372e38d6c1"
-        stub_request(:head, repo_url + "manifests/#{manifest_digest}")
-          .and_return(status: 200, headers: JSON.parse(blob_headers))
+        stub_request(
+          :get,
+          "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/17.10"
+        ).to_return(
+          status: 200,
+          body: {
+            digest: JSON.parse(new_headers).fetch("docker_content_digest"),
+            tag_last_pushed: (Time.now - (30 * 86_400)).iso8601
+          }.to_json
+        )
       end
 
       it { is_expected.to eq("17.10") }
@@ -1728,6 +1729,8 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       end
 
       context "when Docker Hub reports a recent tag push" do
+        let(:metadata_digest) { "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97eba880ebf600d68608" }
+
         before do
           stub_request(
             :get,
@@ -1735,7 +1738,7 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           ).to_return(
             status: 200,
             body: {
-              digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97eba880ebf600d68608",
+              digest: metadata_digest,
               tag_last_pushed: (Time.now - (2 * 86_400)).iso8601
             }.to_json
           )
@@ -1754,6 +1757,101 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         it "keeps the current version in cooldown" do
           expect(latest_version).to eq("17.04")
           expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+        end
+
+        context "when the metadata digest does not match" do
+          let(:metadata_digest) { "sha256:#{'b' * 64}" }
+
+          it "fails open without using a date for another digest" do
+            expect(latest_version).to eq("17.10")
+            expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+          end
+        end
+
+        context "when the metadata digest is malformed" do
+          let(:metadata_digest) { 123 }
+
+          it "fails open without treating an invalid digest as missing" do
+            expect(latest_version).to eq("17.10")
+            expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+          end
+        end
+      end
+
+      context "when Docker Hub omits the digest" do
+        let(:tag_last_pushed) { (Time.now - (2 * 86_400)).iso8601 }
+        let(:tag_metadata) { {} }
+
+        before do
+          %w(17.04 17.10).each do |tag|
+            timestamp = tag == "17.10" ? tag_last_pushed : (Time.now - (30 * 86_400)).iso8601
+            stub_request(
+              :get,
+              "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/#{tag}"
+            ).to_return(status: 200, body: tag_metadata.merge(tag_last_pushed: timestamp).to_json)
+          end
+        end
+
+        it "holds the recent tag-only update in cooldown" do
+          expect(latest_version).to eq("17.04")
+          expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+        end
+
+        context "when the digest is explicitly null" do
+          let(:tag_metadata) { { digest: nil } }
+
+          it "holds the tag-only update in cooldown" do
+            expect(latest_version).to eq("17.04")
+            expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+          end
+        end
+
+        context "when the tag push is outside cooldown" do
+          let(:tag_last_pushed) { (Time.now - (30 * 86_400)).iso8601 }
+
+          it "proposes the tag-only update without a missing-date warning" do
+            expect(latest_version).to eq("17.10")
+            expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+          end
+        end
+
+        context "when the dependency is digest-pinned" do
+          let(:source) { { tag: version, digest: "old_digest" } }
+
+          it "fails open without accepting an unverified date" do
+            expect(latest_version).to eq("17.10")
+            expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+          end
+        end
+
+        context "when only another requirement is digest-pinned" do
+          let(:dependency) do
+            super().tap do |dep|
+              dep.requirements << Dependabot::DependencyRequirement.create(
+                requirement: nil,
+                groups: [],
+                file: "Dockerfile.pinned",
+                source: { tag: version, digest: "old_digest" }
+              )
+            end
+          end
+
+          it "requires digest verification for the shared publication date" do
+            expect(latest_version).to eq("17.10")
+            expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+          end
+        end
+
+        context "when automatic digest pinning is enabled" do
+          before do
+            allow(Dependabot::Experiments).to receive(:enabled?).and_call_original
+            allow(Dependabot::Experiments).to receive(:enabled?).with(:docker_pin_digests).and_return(true)
+          end
+
+          it "fails open without accepting an unverified date" do
+            expect(latest_version).to eq("17.10")
+            expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+          end
         end
       end
 
@@ -1780,11 +1878,8 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       before do
         mock_client = instance_double(DockerRegistry2::Registry)
         allow(checker).to receive(:docker_registry_client).and_return(mock_client)
-        allow(mock_client).to receive_messages(
-          tags: { "tags" => %w(17.04 17.10) },
-          manifest_digest: "sha256:3ea1ca1aa8483a38081750953ad75046e6cc9f6b86ca97eba880ebf600d68608"
-        )
-        allow(mock_client).to receive(:digest)
+        allow(mock_client).to receive(:tags).and_return("tags" => %w(17.04 17.10))
+        allow(mock_client).to receive(:manifest_digest)
           .and_raise(DockerRegistry2::RegistryAuthenticationException)
         allow(Dependabot.logger).to receive(:warn)
         allow(Dependabot.logger).to receive(:info)
@@ -1802,8 +1897,6 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         Dependabot::Package::ReleaseCooldownOptions.new(default_days: 14)
       end
       let(:mock_client) { instance_double(DockerRegistry2::Registry) }
-      let(:blob_headers) { { last_modified: last_modified } }
-      let(:blob_response) { instance_double(RestClient::Response, headers: blob_headers) }
 
       before do
         allow(checker).to receive(:docker_registry_client).and_return(mock_client)
@@ -1813,7 +1906,10 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           manifest_digest: "sha256:newdigest",
           manifest: { "mediaType" => "application/vnd.docker.distribution.manifest.v2+json" }
         )
-        allow(mock_client).to receive(:dohead).and_return(blob_response)
+        stub_request(
+          :get,
+          "https://hub.docker.com/v2/namespaces/library/repositories/#{dependency_name}/tags/#{version}"
+        ).to_return(status: 200, body: { digest: "sha256:newdigest", tag_last_pushed: tag_last_pushed }.to_json)
         allow(Dependabot.logger).to receive(:info)
         allow(Dependabot.logger).to receive(:warn)
       end
@@ -1827,20 +1923,19 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         let(:registry_tag_names) { %w(alpine latest) }
 
         context "when the new digest is newer than the cooldown window" do
-          let(:last_modified) { (Time.now - (2 * 86_400)).httpdate }
+          let(:tag_last_pushed) { (Time.now - (2 * 86_400)).iso8601 }
 
           it { is_expected.to be false }
         end
 
         context "when the new digest is older than the cooldown window" do
-          let(:last_modified) { (Time.now - (30 * 86_400)).httpdate }
+          let(:tag_last_pushed) { (Time.now - (30 * 86_400)).iso8601 }
 
           it { is_expected.to be true }
         end
 
-        context "when the registry omits the Last-Modified header" do
-          let(:blob_headers) { {} }
-          let(:last_modified) { nil }
+        context "when the registry publication date is unavailable" do
+          let(:tag_last_pushed) { nil }
 
           before do
             stub_request(
@@ -1887,13 +1982,13 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         let(:registry_tag_names) { %w(4.0.2-alpine3.23 latest) }
 
         context "when the new digest is newer than the cooldown window" do
-          let(:last_modified) { (Time.now - (1 * 86_400)).httpdate }
+          let(:tag_last_pushed) { (Time.now - (1 * 86_400)).iso8601 }
 
           it { is_expected.to be false }
         end
 
         context "when the new digest is older than the cooldown window" do
-          let(:last_modified) { (Time.now - (30 * 86_400)).httpdate }
+          let(:tag_last_pushed) { (Time.now - (30 * 86_400)).iso8601 }
 
           it { is_expected.to be true }
         end
@@ -3566,332 +3661,139 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
   end
 
-  describe "#get_tag_publication_details" do
-    subject(:get_tag_publication_details) do
-      checker.send(:get_tag_publication_details, tag)
-    end
+  describe "registry publication dates" do
+    subject(:latest_version) { checker.latest_version }
 
-    let(:tag) { Dependabot::Docker::Tag.new("1.0.0") }
-    let(:registry_url) { "https://registry.hub.docker.com" }
     let(:dependency_name) { "ubuntu" }
-    let(:version) { "17.10" }
+    let(:version) { "1.0.0" }
+    let(:candidate_version) { "1.1.0" }
+    let(:update_cooldown) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 14) }
     let(:mock_client) { instance_double(DockerRegistry2::Registry) }
-    let(:blob_headers) { { last_modified: "Mon, 15 Jan 2024 10:00:00 GMT" } }
-    let(:mock_blob_response) { instance_double(RestClient::Response, headers: blob_headers) }
+    let(:digest) { "sha256:#{'a' * 64}" }
+    let(:tag_last_pushed) { (Time.now - (2 * 86_400)).iso8601 }
+    let(:tag_metadata) { { digest: digest, tag_last_pushed: tag_last_pushed } }
+    let(:metadata_body) { tag_metadata.to_json }
+    let(:metadata_status) { 200 }
 
     before do
-      allow(checker).to receive(:docker_registry_client).and_return(mock_client)
-      allow(mock_client).to receive(:dohead).and_return(mock_blob_response)
+      allow(checker).to receive_messages(
+        docker_registry_client: mock_client,
+        fetch_image_config_created: Time.utc(2000, 1, 1)
+      )
+      allow(mock_client).to receive_messages(
+        tags: { "tags" => [version, candidate_version] },
+        manifest_digest: digest
+      )
+      allow(mock_client).to receive(:digest)
+      allow(mock_client).to receive(:dohead)
+      allow(Dependabot.logger).to receive(:info)
+      allow(Dependabot.logger).to receive(:warn)
+      stub_request(
+        :get,
+        "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/#{candidate_version}"
+      ).to_return(status: metadata_status, body: metadata_body)
+      stub_request(
+        :get,
+        "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/#{version}"
+      ).to_return(
+        status: 200,
+        body: { digest: digest, tag_last_pushed: (Time.now - (30 * 86_400)).iso8601 }.to_json
+      )
     end
 
-    context "when the Last-Modified header is missing" do
-      let(:blob_headers) { {} }
-      let(:digest_string) { "sha256:abc123" }
-      let(:config_created) { Time.parse("Tue, 10 Jun 2025 00:00:00 GMT") }
+    it "holds a recent Hub tag without consulting image or header timestamps" do
+      expect(latest_version).to eq(version)
+      expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+      expect(mock_client).not_to have_received(:digest)
+      expect(mock_client).not_to have_received(:dohead)
+      expect(checker).not_to have_received(:fetch_image_config_created)
+    end
 
-      before do
-        allow(mock_client).to receive_messages(digest: digest_string, manifest_digest: digest_string)
-        allow(checker).to receive(:fetch_image_config_created).with("1.0.0").and_return(config_created)
-        stub_request(
-          :get,
-          "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
-        ).to_return(status: 404)
+    context "when the Hub push is older than cooldown" do
+      let(:tag_last_pushed) { (Time.now - (30 * 86_400)).iso8601 }
+
+      it "selects the new tag without a missing-date warning" do
+        expect(latest_version).to eq(candidate_version)
+        expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
       end
+    end
 
-      it "does not fall back to the publisher-controlled config blob created timestamp" do
-        result = get_tag_publication_details
-        expect(result).to be_a(Dependabot::Package::PackageRelease)
-        expect(result.released_at).to be_nil
+    context "when the tag has a v prefix" do
+      let(:version) { "v2.7.2" }
+      let(:candidate_version) { "v2.8.0" }
+
+      it "applies cooldown to the prefixed version" do
+        expect(latest_version).to eq(version)
+        expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+      end
+    end
+
+    context "when Hub omits its publication timestamp" do
+      let(:tag_metadata) { { digest: digest, created: "2000-01-01T00:00:00Z" } }
+
+      it "marks the date unavailable without consulting publisher-controlled timestamps" do
+        expect(latest_version).to eq(candidate_version)
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
         expect(checker).not_to have_received(:fetch_image_config_created)
       end
+    end
 
-      context "when Docker Hub returns tag metadata" do
-        before do
-          allow(mock_client).to receive(:manifest_digest)
-            .with("library/ubuntu", "1.0.0")
-            .and_return("sha256:tag123")
-          stub_request(
-            :get,
-            "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
-          ).to_return(
-            status: 200,
-            body: {
-              digest: "sha256:tag123",
-              tag_last_pushed: "2024-01-15T10:00:00Z"
-            }.to_json
-          )
-        end
+    [nil, "not-a-timestamp", 123].each do |timestamp|
+      context "when the Hub push timestamp is #{timestamp.inspect}" do
+        let(:tag_last_pushed) { timestamp }
 
-        it "uses the registry-managed tag push time" do
-          result = get_tag_publication_details
-
-          expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
-          expect(checker).not_to have_received(:fetch_image_config_created)
-        end
-
-        context "when the metadata digest does not match the registry" do
-          before do
-            stub_request(
-              :get,
-              "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
-            ).to_return(
-              status: 200,
-              body: {
-                digest: "sha256:stale",
-                tag_last_pushed: "2024-01-15T10:00:00Z"
-              }.to_json
-            )
-          end
-
-          it "does not use stale tag metadata" do
-            expect(get_tag_publication_details.released_at).to be_nil
-          end
-        end
-      end
-
-      context "when GHCR returns package metadata" do
-        let(:source) { { tag: version, registry: "ghcr.io" } }
-        let(:dependency_name) { "astral-sh/uv" }
-
-        before do
-          allow(mock_client).to receive(:manifest_digest)
-            .with("astral-sh/uv", "1.0.0")
-            .and_return("sha256:tag123")
-          stub_request(
-            :get,
-            "https://api.github.com/orgs/astral-sh/packages/container/uv/versions"
-          ).with(
-            query: { "page" => "1", "per_page" => "100" },
-            headers: { "Authorization" => "Bearer token" }
-          ).to_return(
-            status: 200,
-            body: [{
-              name: "sha256:tag123",
-              updated_at: "2024-01-15T10:00:00Z",
-              metadata: { container: { tags: ["1.0.0"] } }
-            }].to_json
-          )
-        end
-
-        it "uses the registry-managed package version update time" do
-          result = get_tag_publication_details
-
-          expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
-        end
-
-        context "when the package version digest does not match the registry" do
-          before do
-            stub_request(
-              :get,
-              "https://api.github.com/orgs/astral-sh/packages/container/uv/versions"
-            ).with(query: { "page" => "1", "per_page" => "100" })
-              .to_return(
-                status: 200,
-                body: [{
-                  name: "sha256:stale",
-                  updated_at: "2024-01-15T10:00:00Z",
-                  metadata: { container: { tags: ["1.0.0"] } }
-                }].to_json
-              )
-          end
-
-          it "does not use stale package metadata" do
-            expect(get_tag_publication_details.released_at).to be_nil
-          end
+        it "marks the date unavailable without falling back" do
+          expect(latest_version).to eq(candidate_version)
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+          expect(mock_client).not_to have_received(:dohead)
         end
       end
     end
 
-    context "when the publication HEAD request fails and Docker Hub returns tag metadata" do
+    [nil, [], 123].each do |metadata|
+      context "when the Hub metadata is #{metadata.inspect}" do
+        let(:tag_metadata) { metadata }
+
+        it "rejects the unexpected response shape without crashing" do
+          expect(latest_version).to eq(candidate_version)
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        end
+      end
+    end
+
+    context "when Hub returns malformed JSON" do
+      let(:metadata_body) { "{" }
+
+      it "marks the date unavailable" do
+        expect(latest_version).to eq(candidate_version)
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
+
+    [401, 403, 404, 429, 503].each do |status|
+      context "when the Hub API returns HTTP #{status}" do
+        let(:metadata_status) { status }
+
+        it "marks the date unavailable without falling back" do
+          expect(latest_version).to eq(candidate_version)
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+          expect(mock_client).not_to have_received(:dohead)
+        end
+      end
+    end
+
+    context "when the Hub API times out" do
       before do
-        allow(mock_client).to receive(:digest).and_return("sha256:abc123")
-        allow(mock_client).to receive(:dohead).and_raise(DockerRegistry2::NotFound)
-        allow(mock_client).to receive(:manifest_digest)
-          .with("library/ubuntu", "1.0.0")
-          .and_return("sha256:tag123")
         stub_request(
           :get,
-          "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
-        ).to_return(
-          status: 200,
-          body: {
-            digest: "sha256:tag123",
-            tag_last_pushed: "2024-01-15T10:00:00Z"
-          }.to_json
-        )
-        allow(Dependabot.logger).to receive(:warn)
+          "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/#{candidate_version}"
+        ).to_timeout
       end
 
-      it "uses the registry-managed tag push time" do
-        result = get_tag_publication_details
-
-        expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
-      end
-    end
-
-    context "when client.digest returns a String" do
-      let(:digest_string) { "sha256:abc123" }
-
-      before do
-        allow(mock_client).to receive(:digest).and_return(digest_string)
-      end
-
-      it "handles the String case and returns publication details" do
-        result = get_tag_publication_details
-        expect(result).to be_a(Dependabot::Package::PackageRelease)
-        expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
-      end
-
-      it "uses the blobs endpoint for a single-image digest" do
-        get_tag_publication_details
-        expect(mock_client).to have_received(:dohead).with("v2/library/ubuntu/blobs/sha256:abc123")
-      end
-    end
-
-    context "when client.digest returns an Array" do
-      let(:digest_array) { [{ "digest" => "sha256:def456" }] }
-
-      before do
-        allow(mock_client).to receive(:digest).and_return(digest_array)
-      end
-
-      it "handles the Array case and returns publication details" do
-        result = get_tag_publication_details
-        expect(result).to be_a(Dependabot::Package::PackageRelease)
-        expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
-      end
-
-      it "uses the manifests endpoint for a manifest-list digest" do
-        get_tag_publication_details
-        expect(mock_client).to have_received(:dohead).with("v2/library/ubuntu/manifests/sha256:def456")
-      end
-    end
-
-    context "when client.digest returns an empty Array" do
-      let(:empty_array) { [] }
-
-      before do
-        allow(mock_client).to receive(:digest).and_return(empty_array)
-        allow(Dependabot.logger).to receive(:warn)
-      end
-
-      it "returns nil and logs a warning" do
-        expect(get_tag_publication_details).to be_nil
-        expect(Dependabot.logger).to have_received(:warn).with(
-          /Empty digest_info array/
-        )
-      end
-    end
-
-    context "when client.digest returns nil" do
-      before do
-        allow(mock_client).to receive(:digest).and_return(nil)
-        allow(Dependabot.logger).to receive(:warn)
-      end
-
-      it "returns nil and logs a warning" do
-        expect(get_tag_publication_details).to be_nil
-        expect(Dependabot.logger).to have_received(:warn).with(
-          /Unexpected digest_info type.*NilClass/
-        )
-      end
-    end
-
-    context "when tag has a 'v' prefix" do
-      let(:tag) { Dependabot::Docker::Tag.new("v2.7.2") }
-      let(:digest_string) { "sha256:abc123" }
-
-      before do
-        allow(mock_client).to receive(:digest).and_return(digest_string)
-      end
-
-      it "handles the version prefix correctly and returns publication details" do
-        result = get_tag_publication_details
-        expect(result).to be_a(Dependabot::Package::PackageRelease)
-        expect(result.version).to be_a(Dependabot::Docker::Version)
-        expect(result.released_at).to eq(Time.parse("Mon, 15 Jan 2024 10:00:00 GMT"))
-      end
-
-      it "creates a Docker::Version instead of base Dependabot::Version" do
-        result = get_tag_publication_details
-        expect(result.version).to be_a(Dependabot::Docker::Version)
-        expect(result.version.class).to eq(Dependabot::Docker::Version)
-      end
-    end
-
-    context "when client.digest raises DockerRegistry2::NotFound" do
-      before do
-        allow(mock_client).to receive(:digest).and_raise(DockerRegistry2::NotFound)
-        allow(Dependabot.logger).to receive(:warn)
-      end
-
-      it "returns nil and logs a warning" do
-        expect(get_tag_publication_details).to be_nil
-        expect(Dependabot.logger).to have_received(:warn).with(
-          /Failed to fetch publication details.*skipping cooldown.*NotFound/
-        )
-      end
-    end
-
-    context "when client.dohead raises DockerRegistry2::NotFound for blob" do
-      before do
-        allow(mock_client).to receive_messages(digest: "sha256:abc123", manifest_digest: "sha256:abc123")
-        allow(mock_client).to receive(:dohead).and_raise(DockerRegistry2::NotFound)
-        allow(Dependabot.logger).to receive(:warn)
-        stub_request(
-          :get,
-          "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu/tags/1.0.0"
-        ).to_return(status: 404)
-      end
-
-      it "returns nil and logs a warning" do
-        expect(get_tag_publication_details).to be_nil
-        expect(Dependabot.logger).to have_received(:warn).with(
-          /Failed to fetch publication details.*skipping cooldown.*NotFound/
-        )
-      end
-    end
-
-    context "when client.digest raises RegistryAuthenticationException" do
-      before do
-        allow(mock_client).to receive(:digest)
-          .and_raise(DockerRegistry2::RegistryAuthenticationException)
-        allow(Dependabot.logger).to receive(:warn)
-      end
-
-      it "returns nil and logs a warning" do
-        expect(get_tag_publication_details).to be_nil
-        expect(Dependabot.logger).to have_received(:warn).with(
-          /Failed to fetch publication details.*skipping cooldown.*RegistryAuthenticationException/
-        )
-      end
-    end
-
-    context "when client.digest raises RestClient::Forbidden" do
-      before do
-        allow(mock_client).to receive(:digest).and_raise(RestClient::Forbidden)
-        allow(Dependabot.logger).to receive(:warn)
-      end
-
-      it "returns nil and logs a warning" do
-        expect(get_tag_publication_details).to be_nil
-        expect(Dependabot.logger).to have_received(:warn).with(
-          /Failed to fetch publication details.*skipping cooldown.*Forbidden/
-        )
-      end
-    end
-
-    context "when client.digest raises RestClient::TooManyRequests" do
-      before do
-        allow(mock_client).to receive(:digest).and_raise(RestClient::TooManyRequests)
-        allow(Dependabot.logger).to receive(:warn)
-      end
-
-      it "returns nil and logs a warning" do
-        expect(get_tag_publication_details).to be_nil
-        expect(Dependabot.logger).to have_received(:warn).with(
-          /Failed to fetch publication details.*skipping cooldown.*TooManyRequests/
-        )
+      it "marks the date unavailable without falling back" do
+        expect(latest_version).to eq(candidate_version)
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        expect(mock_client).not_to have_received(:dohead)
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Docker Hub and GHCR do not return `Last-Modified` for the OCI objects used by Docker cooldown, so cooldown currently fails open for those registries.

Use registry-managed tag metadata as a fallback: Docker Hub's `tag_last_pushed` and GitHub Packages' `updated_at` for GHCR. This allows version and digest updates to enforce cooldown without trusting the publisher-controlled image config `created` field.

Fixes #16114

### Anything you want to highlight for special attention from reviewers?

Fallback timestamps are accepted only when their tag and normalized digest match the image currently resolved from the registry. Docker Hub metadata comes from its public tags API; GHCR metadata comes from GitHub Packages using credentials already available to the Docker checker.

The existing `Last-Modified` path remains preferred, and updates still fail open with the existing warning when no registry-managed timestamp is available.

### How will you know you've accomplished your goal?

- Docker Hub and GHCR metadata specs cover matching and stale digest responses.
- Version updates remain in cooldown when Docker Hub reports a recent tag push.
- Digest-only updates are held for recent pushes and allowed after the configured window.
- `bin/test docker spec/dependabot/docker/update_checker_spec.rb spec/dependabot/docker/update_checker_digest_cooldown_spec.rb`: 225 examples, 0 failures.
- Scoped Docker RuboCop passes with no offenses.
- `bundle exec srb tc` passes with no errors.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.