### PR TITLE
Handle legacy npm repository arrays

### DIFF
--- a/common/lib/dependabot/package/npm_registry_package.rb
+++ b/common/lib/dependabot/package/npm_registry_package.rb
@@ -132,8 +132,16 @@ module Dependabot
             type: type,
             git: type == "git"
           )
+        when Array
+          repositories = T.let([], T::Array[Repository])
+          value.each do |repository|
+            parsed_repository = parse_repository(repository, version)
+            repositories << parsed_repository if parsed_repository
+          end
+
+          repositories.find(&:git?) || repositories.first
         else
-          raise TypeError, "version #{version} repository must be a string or object"
+          raise TypeError, "version #{version} repository must be a string, object, or array"
         end
       end
       private_class_method :parse_repository

--- a/common/lib/dependabot/package/npm_registry_package.rb
+++ b/common/lib/dependabot/package/npm_registry_package.rb
@@ -134,8 +134,9 @@ module Dependabot
           )
         when Array
           repositories = T.let([], T::Array[Repository])
-          value.each do |repository|
-            parsed_repository = parse_repository(repository, version)
+          value.each do |raw_repository|
+            repository_value = T.cast(raw_repository, Object)
+            parsed_repository = parse_repository(repository_value, version)
             repositories << parsed_repository if parsed_repository
           end
 

--- a/common/spec/dependabot/package/npm_registry_package_spec.rb
+++ b/common/spec/dependabot/package/npm_registry_package_spec.rb
@@ -138,10 +138,16 @@ RSpec.describe Dependabot::Package::NpmRegistryPackage do
         {
           "versions" => {
             "0.0.4" => {
-              "repository" => [{
-                "type" => "git",
-                "url" => "git://github.com/raszi/tmp.git"
-              }]
+              "repository" => [
+                {
+                  "type" => "npm",
+                  "url" => "https://registry.npmjs.org/example"
+                },
+                {
+                  "type" => "git",
+                  "url" => "git://github.com/raszi/tmp.git"
+                }
+              ]
             }
           }
         }

--- a/common/spec/dependabot/package/npm_registry_package_spec.rb
+++ b/common/spec/dependabot/package/npm_registry_package_spec.rb
@@ -133,6 +133,32 @@ RSpec.describe Dependabot::Package::NpmRegistryPackage do
       end
     end
 
+    context "with legacy repository array metadata" do
+      let(:payload) do
+        {
+          "versions" => {
+            "0.0.4" => {
+              "repository" => [{
+                "type" => "git",
+                "url" => "git://github.com/raszi/tmp.git"
+              }]
+            }
+          }
+        }
+      end
+
+      it "uses the first Git repository and preserves the original details" do
+        release = package.releases.fetch("0.0.4")
+
+        expect(release.package_type).to eq("git")
+        expect(release.repository).to have_attributes(
+          type: "git",
+          url: "git://github.com/raszi/tmp.git"
+        )
+        expect(release.details["repository"]).to eq(payload.dig("versions", "0.0.4", "repository"))
+      end
+    end
+
     context "with legacy engines metadata" do
       let(:payload) do
         {
@@ -200,8 +226,8 @@ RSpec.describe Dependabot::Package::NpmRegistryPackage do
         "versions" => { "1.0.0" => { "engines" => { "node" => 18 } } }
       }, "version 1.0.0 engines.node must be a string"],
       [{
-        "versions" => { "1.0.0" => { "repository" => [] } }
-      }, "version 1.0.0 repository must be a string or object"],
+        "versions" => { "1.0.0" => { "repository" => 1 } }
+      }, "version 1.0.0 repository must be a string, object, or array"],
       [{
         "versions" => { "1.0.0" => { "repository" => { "type" => 1 } } }
       }, "version 1.0.0 repository.type must be a string"]

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/package/package_details_fetcher_spec.rb
@@ -233,6 +233,31 @@ RSpec.describe Dependabot::NpmAndYarn::Package::PackageDetailsFetcher do
       end
     end
 
+    context "when registry metadata uses a repository array" do
+      before do
+        stub_request(:get, registry_url).to_return(
+          status: 200,
+          body: JSON.dump(
+            "versions" => {
+              "0.0.4" => {
+                "repository" => [{
+                  "type" => "git",
+                  "url" => "git://github.com/raszi/tmp.git"
+                }]
+              }
+            }
+          )
+        )
+      end
+
+      it "returns the release as a Git package" do
+        release = details.releases.find { |candidate| candidate.version.to_s == "0.0.4" }
+
+        expect(release).not_to be_nil
+        expect(release.package_type).to eq("git")
+      end
+    end
+
     [
       ["time", { "versions" => { "1.0.0" => {} }, "time" => { "1.0.0" => 1 } }],
       ["dist-tags", { "dist-tags" => { "latest" => 1 } }],


### PR DESCRIPTION
### What are you trying to accomplish?

Support older npm package metadata where `repository` is represented as an array.

Dependabot parses the complete release history returned by npm. Some older package versions use an array for repository metadata, but the typed registry model only accepted strings and objects. Encountering one of these versions raised a `TypeError`, even when that version was not installed or being selected for an update.

This change parses repository arrays, prefers a Git entry when one is present, and retains strict validation for unsupported metadata types.

### Anything you want to highlight for special attention from reviewers?

The previous untyped implementation tolerated repository arrays but classified them as npm packages. Normalizing the known legacy shape restores compatibility while retaining useful repository information instead of ignoring it.

The original registry metadata remains unchanged in `PackageRelease#details`.

### How will you know you have accomplished your goal?

- The shared npm registry parser test verifies that legacy repository arrays are parsed and classified correctly.
- The npm/yarn package details fetcher test verifies the complete package metadata fetch path.
- A captured update-job replay passes the affected metadata path, makes no unknown-error call, and reaches `mark_as_processed`.
- Targeted specs pass with 51 examples and 0 failures.
- RuboCop reports no offenses for the changed files.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
