### PR TITLE
Speed up the common RSpec suite

### DIFF
--- a/common/lib/dependabot/command_helpers.rb
+++ b/common/lib/dependabot/command_helpers.rb
@@ -11,7 +11,7 @@ module Dependabot
 
     module TIMEOUTS
       NO_TIME_OUT = -1 # No timeout
-      GRARECFULLY_STOP = 5 # 5 seconds for graceful termination
+      GRACEFULLY_STOP = 5 # 5 seconds for graceful termination
       LOCAL = 30 # 30 seconds
       NETWORK = 120 # 2 minutes
       LONG_RUNNING = 300 # 5 minutes
@@ -185,8 +185,8 @@ module Dependabot
               if observation&.dig(:gracefully_stop)
                 message = observation[:reason] || "Terminated by output_observer"
                 # If the observer indicates a graceful stop, terminate the process
-                # by adjusting the remaining timeout 5 seconds
-                timeout = [timeout, ((Time.now - last_output_time) + 5).to_i].min
+                # by adjusting the remaining timeout
+                timeout = [timeout, ((Time.now - last_output_time) + TIMEOUTS::GRACEFULLY_STOP).to_i].min
                 Dependabot.logger.warn("Terminating process due to observer signal: #{message}")
               end
             rescue EOFError

--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -265,6 +265,7 @@ module Dependabot
 
     sig { returns(T.nilable(String)) }
     def local_tag_for_pinned_sha
+      return @local_tag_for_pinned_sha if defined?(@local_tag_for_pinned_sha)
       return unless pinned_ref_looks_like_commit_sha?
 
       @local_tag_for_pinned_sha = T.let(

--- a/common/spec/dependabot/command_helpers_spec.rb
+++ b/common/spec/dependabot/command_helpers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Dependabot::CommandHelpers do
     let(:error_hang_cmd) { command_fixture("error_hang.sh") }
     let(:invalid_cmd) { "non_existent_command" }
     let(:no_timeout_cmd) { command_fixture("no_timeout.sh") }
-    let(:timeout) { 2 } # Timeout for hanging commands
+    let(:timeout) { 1 } # Timeout for hanging commands
 
     context "when the command runs successfully" do
       it "captures stdout and exits successfully" do
@@ -117,12 +117,17 @@ RSpec.describe Dependabot::CommandHelpers do
 
         expect(stdout).to eq("This is a command result.\n")
         expect(stderr).to eql("")
-        expect(status.exitstatus).to eq(0)
-        expect(elapsed_time).to be_within(0.5).of(3)
+        expect(status).to be_success
+        expect(elapsed_time).to be_positive
+        expect(elapsed_time).to be < 1
       end
     end
 
     context "when output_observer requests graceful stop" do
+      before do
+        stub_const("Dependabot::CommandHelpers::TIMEOUTS::GRACEFULLY_STOP", 1)
+      end
+
       it "terminates early due to observer and logs the reason" do
         # Bash script that prints a trigger then sleeps
         cmd = ["bash", "-c", "echo TRIGGER && sleep 10"]
@@ -140,7 +145,7 @@ RSpec.describe Dependabot::CommandHelpers do
         expect(stdout).to include("TRIGGER")
         expect(status).not_to be_nil
         expect(status.exitstatus).to eq(0).or eq(124) # depending on whether it's handled as graceful or timeout
-        expect(elapsed_time).to be < 6 # confirms early termination
+        expect(elapsed_time).to be < 2 # confirms early termination
       end
     end
 

--- a/common/spec/dependabot/file_fetchers/base_spec.rb
+++ b/common/spec/dependabot/file_fetchers/base_spec.rb
@@ -4,6 +4,7 @@
 require "aws-sdk-codecommit"
 require "octokit"
 require "fileutils"
+require "open3"
 require "spec_helper"
 require "dependabot/credential"
 require "dependabot/source"
@@ -68,6 +69,69 @@ RSpec.describe Dependabot::FileFetchers::Base do
     allow_any_instance_of(
       Dependabot::Clients::CodeCommit
     ).to receive(:cc_client).and_return(stubbed_cc_client)
+  end
+
+  def create_git_repository(path, files)
+    FileUtils.mkdir_p(path)
+    run_git("init", "--initial-branch=main", ".", chdir: path)
+    commit_git_files(path, files, message: "Initial commit")
+  end
+
+  def commit_git_files(path, files, message:)
+    files.each do |name, contents|
+      file_path = File.join(path, name)
+      FileUtils.mkdir_p(File.dirname(file_path))
+      File.write(file_path, contents)
+    end
+
+    run_git("add", "--all", chdir: path)
+    run_git("commit", "--message", message, chdir: path)
+    run_git("rev-parse", "HEAD", chdir: path)
+  end
+
+  def run_git(*arguments, chdir:)
+    git_environment = {
+      "GIT_AUTHOR_EMAIL" => "dependabot@example.com",
+      "GIT_AUTHOR_NAME" => "Dependabot",
+      "GIT_COMMITTER_EMAIL" => "dependabot@example.com",
+      "GIT_COMMITTER_NAME" => "Dependabot"
+    }
+    stdout, stderr, status = Open3.capture3(git_environment, "git", *arguments, chdir: chdir)
+    raise stderr unless status.success?
+
+    stdout.strip
+  end
+
+  def with_file_git_protocol
+    previous_value = ENV.fetch("GIT_ALLOW_PROTOCOL", nil)
+    ENV["GIT_ALLOW_PROTOCOL"] = "file"
+    yield
+  ensure
+    ENV["GIT_ALLOW_PROTOCOL"] = previous_value
+  end
+
+  def create_repositories_with_submodule(source_path:, submodule_path:)
+    submodule_commit = create_git_repository(
+      submodule_path,
+      "go.mod" => "module example.com/examplelib\n\ngo 1.21\n"
+    )
+    run_git("switch", "--create", "latest", chdir: submodule_path)
+    latest_submodule_commit = commit_git_files(
+      submodule_path,
+      { "version.txt" => "latest\n" },
+      message: "Update submodule"
+    )
+    run_git("switch", "main", chdir: submodule_path)
+
+    create_git_repository(source_path, "README" => "Local submodule fixture\n")
+    run_git("submodule", "add", "../examplelib", "examplelib", chdir: source_path)
+    source_commit = commit_git_files(source_path, {}, message: "Add submodule")
+    checked_out_submodule_path = File.join(source_path, "examplelib")
+    run_git("fetch", "origin", "latest", chdir: checked_out_submodule_path)
+    run_git("checkout", latest_submodule_commit, chdir: checked_out_submodule_path)
+    commit_git_files(source_path, {}, message: "Update submodule reference")
+
+    { source: source_commit, submodule: submodule_commit }
   end
 
   describe "#commit" do
@@ -1728,30 +1792,50 @@ RSpec.describe Dependabot::FileFetchers::Base do
         file_fetcher_instance.clone_repo_contents
       end
 
-      let(:repo) do
-        "dependabot-fixtures/go-modules-app"
+      let(:repo) { "local/repository" }
+      let(:local_repositories_path) { Dir.mktmpdir("base-spec-git-repositories") }
+      let(:source_repository_path) { File.join(local_repositories_path, "source") }
+      let(:source_url) { "file://#{source_repository_path}" }
+      let(:shell_metacharacter_branch) { "\"$(time)\"" }
+
+      around do |example|
+        repositories_path = local_repositories_path
+        example.run
+      ensure
+        FileUtils.rm_rf(repositories_path)
       end
 
-      it "clones the repo" do
+      before do
+        create_git_repository(source_repository_path, "README" => "Local clone fixture\n")
+        run_git("switch", "--create", shell_metacharacter_branch, chdir: source_repository_path)
+        commit_git_files(
+          source_repository_path,
+          { "time.md" => "Shell metacharacters are treated literally.\n" },
+          message: "Add shell metacharacter branch"
+        )
+        run_git("switch", "main", chdir: source_repository_path)
+        allow(source).to receive(:url).and_return(source_url)
+      end
+
+      it "shallow clones the repo" do
         clone_repo_contents
-        expect(`ls #{repo_contents_path}`).to include("README")
+
+        expect(Dir.children(repo_contents_path)).to include("README")
+        expect(run_git("rev-parse", "--is-shallow-repository", chdir: repo_contents_path)).to eq("true")
       end
 
       context "with a branch name including bash command" do
-        let(:branch) do
-          "\"$(time)\""
-        end
+        let(:branch) { shell_metacharacter_branch }
 
         it "clones the repo with branch checked out" do
           clone_repo_contents
-          expect(`ls #{repo_contents_path}`).to include("time.md")
+
+          expect(Dir.children(repo_contents_path)).to include("time.md")
         end
       end
 
       context "when the repo can't be found" do
-        let(:repo) do
-          "dependabot-fixtures/not-found"
-        end
+        let(:source_url) { "file://#{File.join(local_repositories_path, 'not-found')}" }
 
         it "raises a not found error" do
           expect { clone_repo_contents }.to raise_error(Dependabot::RepoNotFound)
@@ -1769,16 +1853,33 @@ RSpec.describe Dependabot::FileFetchers::Base do
       end
 
       context "when the submodule can't be reached" do
-        let(:repo) do
-          "dependabot-fixtures/go-modules-app-with-inaccessible-submodules"
+        let(:branch) { "with-git-urls" }
+        let(:inaccessible_submodule_path) do
+          File.join(local_repositories_path, "inaccessible-submodule")
         end
-        let(:branch) do
-          "with-git-urls"
+
+        around do |example|
+          with_file_git_protocol { example.run }
+        end
+
+        before do
+          create_git_repository(inaccessible_submodule_path, "go.mod" => "module example.com/inaccessible\n")
+          run_git("switch", "--create", branch, chdir: source_repository_path)
+          run_git(
+            "submodule",
+            "add",
+            "../inaccessible-submodule",
+            "inaccessible-submodule",
+            chdir: source_repository_path
+          )
+          commit_git_files(source_repository_path, {}, message: "Add inaccessible submodule")
+          FileUtils.rm_rf(inaccessible_submodule_path)
         end
 
         it "does not raise an error" do
           clone_repo_contents
-          expect(`ls #{repo_contents_path}`).to include("README")
+
+          expect(Dir.children(repo_contents_path)).to include("README")
         end
       end
 
@@ -1863,26 +1964,55 @@ RSpec.describe Dependabot::FileFetchers::Base do
   end
 
   context "with submodules" do
-    let(:repo) { "dependabot-fixtures/go-modules-app-with-git-submodules" }
+    let(:repo) { "local/repository-with-submodule" }
     let(:repo_contents_path) { Dir.mktmpdir }
     let(:submodule_contents_path) { File.join(repo_contents_path, "examplelib") }
+    let(:local_repositories_path) { Dir.mktmpdir("base-spec-submodule-repositories") }
+    let(:source_repository_path) { File.join(local_repositories_path, "source") }
+    let(:submodule_repository_path) { File.join(local_repositories_path, "examplelib") }
+    let(:source_url) { "file://#{source_repository_path}" }
+    let(:historical_commits) do
+      create_repositories_with_submodule(
+        source_path: source_repository_path,
+        submodule_path: submodule_repository_path
+      )
+    end
+    let(:historical_source_commit) { historical_commits.fetch(:source) }
+    let(:historical_submodule_commit) { historical_commits.fetch(:submodule) }
 
     after { FileUtils.rm_rf(repo_contents_path) }
+
+    around do |example|
+      previous_value = ENV.fetch("GIT_ALLOW_PROTOCOL", nil)
+      repositories_path = local_repositories_path
+      ENV["GIT_ALLOW_PROTOCOL"] = "file"
+      example.run
+    ensure
+      ENV["GIT_ALLOW_PROTOCOL"] = previous_value
+      FileUtils.rm_rf(repositories_path)
+    end
+
+    before do
+      historical_commits
+      allow(source).to receive(:url).and_return(source_url)
+    end
 
     describe "#clone_repo_contents" do
       it "clones submodules by default" do
         file_fetcher_instance.clone_repo_contents
 
-        expect(`ls -1 #{submodule_contents_path}`.split).to include("go.mod")
+        expect(Dir.children(submodule_contents_path)).to include("go.mod")
       end
 
       context "with a source commit" do
-        let(:source_commit) { "5c7e92a4860382fd31336872f0fe79a848669c4d" }
+        let(:source_commit) { historical_source_commit }
 
         it "fetches/reset submodules by default" do
           file_fetcher_instance.clone_repo_contents
 
-          expect(`ls -1 #{submodule_contents_path}`.split).to include("go.mod")
+          expect(Dir.children(submodule_contents_path)).to include("go.mod")
+          expect(run_git("rev-parse", "HEAD", chdir: repo_contents_path)).to eq(source_commit)
+          expect(run_git("rev-parse", "HEAD", chdir: submodule_contents_path)).to eq(historical_submodule_commit)
         end
       end
 
@@ -1908,16 +2038,18 @@ RSpec.describe Dependabot::FileFetchers::Base do
         it "clones submodules" do
           file_fetcher_instance.clone_repo_contents
 
-          expect(`ls -1 #{submodule_contents_path}`.split).to include("go.mod")
+          expect(Dir.children(submodule_contents_path)).to include("go.mod")
         end
 
         context "with a source commit" do
-          let(:source_commit) { "5c7e92a4860382fd31336872f0fe79a848669c4d" }
+          let(:source_commit) { historical_source_commit }
 
           it "fetches/resets submodules if necessary" do
             file_fetcher_instance.clone_repo_contents
 
-            expect(`ls -1 #{submodule_contents_path}`.split).to include("go.mod")
+            expect(Dir.children(submodule_contents_path)).to include("go.mod")
+            expect(run_git("rev-parse", "HEAD", chdir: repo_contents_path)).to eq(source_commit)
+            expect(run_git("rev-parse", "HEAD", chdir: submodule_contents_path)).to eq(historical_submodule_commit)
           end
         end
       end

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -1112,6 +1112,16 @@ RSpec.describe Dependabot::GitCommitChecker do
             }
           end
 
+          before do
+            stub_request(:get, "https://api.github.com/repos/gocardless/business/releases?per_page=100")
+              .with(headers: { "Authorization" => "token token" })
+              .to_return(
+                status: 200,
+                body: [].to_json,
+                headers: { "Content-Type" => "application/json" }
+              )
+          end
+
           its([:tag]) { is_expected.to eq("gatsby-transformer-sqip@2.0.40") }
         end
 
@@ -1736,6 +1746,7 @@ RSpec.describe Dependabot::GitCommitChecker do
     let(:repo_url) { "https://github.com/gocardless/business.git" }
     let(:upload_pack_fixture) { "gatsby" }
     let(:service_pack_url) { repo_url + "/info/refs?service=git-upload-pack" }
+    let(:releases_url) { "https://api.github.com/repos/gocardless/business/releases?per_page=100" }
 
     before do
       stub_request(:get, service_pack_url)
@@ -1745,6 +1756,13 @@ RSpec.describe Dependabot::GitCommitChecker do
           headers: {
             "content-type" => "application/x-git-upload-pack-advertisement"
           }
+        )
+      stub_request(:get, releases_url)
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: [].to_json,
+          headers: { "Content-Type" => "application/json" }
         )
     end
 
@@ -1764,6 +1782,9 @@ RSpec.describe Dependabot::GitCommitChecker do
         expect(tag_names).to include("0.2.0")
         expect(tag_names).to include("gatsby-transformer-sqip@2.0.39")
         expect(tag_names).to include("gatsby-transformer-sqip@2.0.40")
+        expect(WebMock).to have_requested(:get, releases_url)
+          .with(headers: { "Authorization" => "token token" })
+          .once
       end
 
       it "includes more tags than allowed_version_tags when SHA doesn't match a tag" do
@@ -1849,7 +1870,10 @@ RSpec.describe Dependabot::GitCommitChecker do
       context "when the source commit is a tag" do
         let(:source_commit) { "a81bbbf8298c0fa03ea29cdc473d45769f953675" }
 
-        it { is_expected.to eq("v2.3.3") }
+        it "caches the matching tag" do
+          expect(checker.local_tag_for_pinned_sha).to eq("v2.3.3")
+          expect(checker.local_tag_for_pinned_sha).to eq("v2.3.3")
+        end
       end
 
       context "when the source commit is not a tag" do
@@ -1874,6 +1898,39 @@ RSpec.describe Dependabot::GitCommitChecker do
         let(:source_commit) { "5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f" }
 
         it { is_expected.to eq("v2.3.4") }
+      end
+    end
+
+    context "when the source commit has no matching tag" do
+      let(:source) do
+        {
+          type: "git",
+          url: "https://github.com/actions/checkout",
+          branch: "main",
+          ref: "25a956c84d5dd820d28caab9f86b8d183aeeff3d"
+        }
+      end
+      let(:git_metadata_fetcher) do
+        instance_double(
+          Dependabot::GitMetadataFetcher,
+          head_commit_for_ref: nil,
+          tags_for_upload_pack: []
+        )
+      end
+      let(:checker_with_metadata_fetcher) do
+        described_class.new(
+          dependency: dependency,
+          credentials: credentials,
+          ignored_versions: ignored_versions,
+          raise_on_ignored: raise_on_ignored,
+          git_metadata_fetcher: git_metadata_fetcher
+        )
+      end
+
+      it "caches the missing tag" do
+        expect(checker_with_metadata_fetcher.local_tag_for_pinned_sha).to be_nil
+        expect(checker_with_metadata_fetcher.local_tag_for_pinned_sha).to be_nil
+        expect(git_metadata_fetcher).to have_received(:tags_for_upload_pack).once
       end
     end
   end

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -1,15 +1,57 @@
 # typed: false
 # frozen_string_literal: true
 
-require "cgi/escape"
-require "octokit"
+require "base64"
 require "spec_helper"
 require "dependabot/dependency"
 require "dependabot/dependency_file"
 require "dependabot/pull_request_creator/message_builder"
 
+RSpec.shared_context "with stubbed message builder collaborators" do
+  let(:pr_name_prefix) do
+    vulnerabilities_fixed.values.flatten.any? ? "[Security] " : ""
+  end
+  let(:capitalize_first_word) { true }
+  let(:pr_name_prefixer) do
+    instance_double(
+      Dependabot::PullRequestCreator::PrNamePrefixer,
+      pr_name_prefix: pr_name_prefix,
+      capitalize_first_word?: capitalize_first_word
+    )
+  end
+  let(:metadata_finder_attributes) { {} }
+  let(:metadata_finders) do
+    dependencies.to_h do |dep|
+      attributes = metadata_finder_attributes.fetch(dep.name, {})
+      [dep.name, metadata_finder_double(dependency: dep, **attributes)]
+    end
+  end
+
+  before do
+    allow(Dependabot::PullRequestCreator::PrNamePrefixer)
+      .to receive(:new)
+      .with(
+        source: source,
+        dependencies: dependencies,
+        credentials: credentials,
+        commit_message_options: commit_message_options,
+        security_fix: vulnerabilities_fixed.values.flatten.any?
+      )
+      .and_return(pr_name_prefixer)
+
+    dependencies.each do |dependency|
+      allow(DummyPackageManager::MetadataFinder)
+        .to receive(:new)
+        .with(dependency: dependency, credentials: credentials)
+        .and_return(metadata_finders.fetch(dependency.name))
+    end
+  end
+end
+
 RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
   subject(:message_builder) { builder }
+
+  include_context "with stubbed message builder collaborators"
 
   let(:builder) do
     described_class.new(
@@ -72,8 +114,54 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
     )
   end
 
-  let(:json_header) { { "Content-Type" => "application/json" } }
-  let(:watched_repo_url) { "https://api.github.com/repos/#{source.repo}" }
+  def metadata_finder_double(dependency:, **attributes)
+    defaults = {
+      attestation_changes: nil,
+      changelog_url: nil,
+      changelog_text: nil,
+      commits_url: nil,
+      commits: nil,
+      homepage_url: nil,
+      install_script_changes: nil,
+      maintainer_changes: nil,
+      releases_url: nil,
+      releases_text: nil,
+      source_url: "https://github.com/gocardless/#{dependency.name}",
+      upgrade_guide_url: nil,
+      upgrade_guide_text: nil
+    }
+
+    instance_double(Dependabot::MetadataFinders::Base, **defaults, **attributes)
+  end
+
+  def decoded_github_content(fixture_name)
+    Base64.decode64(JSON.parse(fixture("github", fixture_name)).fetch("content"))
+  end
+
+  def changelog_section(version)
+    decoded_github_content("changelog_contents.json")
+      .match(/^## #{Regexp.escape(version)}.*?(?=^## |\z)/m)
+      .to_s
+  end
+
+  def changelog_from(version)
+    decoded_github_content("changelog_contents.json")
+      .match(/^## #{Regexp.escape(version)}.*\z/m)
+      .to_s
+  end
+
+  def business_commits
+    JSON.parse(fixture("github", "commits-business-1.4.0.json"))
+        .first(7)
+        .reverse
+        .map do |commit|
+      {
+        sha: commit.fetch("sha"),
+        message: commit.fetch("commit").fetch("message"),
+        html_url: commit.fetch("html_url")
+      }
+    end
+  end
 
   def commits_details(base:, head:)
     "<details>\n" \
@@ -174,61 +262,30 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
     context "when dealing with an application" do
       context "when not using a commit convention" do
-        before do
-          stub_request(:get, watched_repo_url + "/commits?per_page=100")
-            .to_return(
-              status: 200,
-              body: commits_response,
-              headers: json_header
-            )
-        end
-
-        let(:commits_response) { fixture("github", "commits.json") }
-
         it { is_expected.to eq("Bump business from 1.4.0 to 1.5.0") }
 
         context "when the internet goes down" do
           before do
-            stub_request(:any, /.*/).to_raise(SocketError)
+            allow(pr_name_prefixer).to receive(:pr_name_prefix).and_raise(SocketError)
           end
+
+          let(:capitalize_first_word) { false }
 
           it { is_expected.to eq("bump business from 1.4.0 to 1.5.0") }
         end
 
-        context "when there are prefixed commits" do
-          let(:commits_response) { fixture("github", "commits_prefixed.json") }
+        context "when the prefixer returns a commit prefix" do
+          let(:pr_name_prefix) { "build(deps): " }
+          let(:capitalize_first_word) { false }
 
           it {
             expect(pr_name).to eq("build(deps): bump business from 1.4.0 to 1.5.0")
           }
         end
 
-        context "when a 409 is returned on asking for commits" do
-          before do
-            stub_request(:get, watched_repo_url + "/commits?per_page=100")
-              .to_return(status: 409, headers: json_header)
-          end
-
-          it { is_expected.to eq("Bump business from 1.4.0 to 1.5.0") }
-        end
-
-        context "when using GitLab" do
+        context "with a GitLab source" do
           let(:source) do
             Dependabot::Source.new(provider: "gitlab", repo: "gocardless/bump")
-          end
-          let(:watched_repo_url) do
-            "https://gitlab.com/api/v4/projects/" \
-              "#{CGI.escape(source.repo)}/repository"
-          end
-          let(:commits_response) { fixture("gitlab", "commits.json") }
-
-          before do
-            stub_request(:get, watched_repo_url + "/commits")
-              .to_return(
-                status: 200,
-                body: commits_response,
-                headers: json_header
-              )
           end
 
           it { is_expected.to eq("Bump business from 1.4.0 to 1.5.0") }
@@ -498,27 +555,17 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
       end
 
-      context "when using angular commits" do
-        before do
-          stub_request(:get, watched_repo_url + "/commits?per_page=100")
-            .to_return(status: 200,
-                       body: fixture("github", "commits_angular.json"),
-                       headers: json_header)
-        end
+      context "when the prefixer returns an angular commit prefix" do
+        let(:pr_name_prefix) { "chore(deps): " }
+        let(:capitalize_first_word) { false }
 
         it do
           expect(pr_name).to eq("chore(deps): bump business from 1.4.0 to 1.5.0")
         end
 
         context "when capitalizing message" do
-          before do
-            stub_request(:get, watched_repo_url + "/commits?per_page=100")
-              .to_return(
-                status: 200,
-                body: fixture("github", "commits_angular_capitalized.json"),
-                headers: json_header
-              )
-          end
+          let(:pr_name_prefix) { "Chore(deps): " }
+          let(:capitalize_first_word) { true }
 
           it do
             expect(pr_name).to eq("Chore(deps): Bump business from 1.4.0 to 1.5.0")
@@ -526,21 +573,14 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "when capitalizing the message but not the prefix" do
-          before do
-            stub_request(:get, watched_repo_url + "/commits?per_page=100")
-              .to_return(
-                status: 200,
-                body: fixture("github", "commits_angular_sentence_case.json"),
-                headers: json_header
-              )
-          end
+          let(:capitalize_first_word) { true }
 
           it do
             expect(pr_name).to eq("chore(deps): Bump business from 1.4.0 to 1.5.0")
           end
 
-          context "when commit messages are explicitly configured" do
-            let(:commit_message_options) { super().merge(prefix: "chore(dependencies)") }
+          context "when the prefixer returns an explicitly configured prefix" do
+            let(:pr_name_prefix) { "chore(dependencies): " }
 
             it do
               expect(pr_name).to eq("chore(dependencies): Bump business from 1.4.0 to 1.5.0")
@@ -550,6 +590,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
         context "with a security vulnerability fixed" do
           let(:vulnerabilities_fixed) { { business: [{}] } }
+          let(:pr_name_prefix) { "chore(deps): [security] " }
 
           it { is_expected.to start_with("chore(deps): [security] bump") }
         end
@@ -575,18 +616,14 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               }]
             )
           end
+          let(:pr_name_prefix) { "chore(deps-dev): " }
 
           it { is_expected.to start_with("chore(deps-dev): bump") }
         end
       end
 
-      context "when using eslint commits" do
-        before do
-          stub_request(:get, watched_repo_url + "/commits?per_page=100")
-            .to_return(status: 200,
-                       body: fixture("github", "commits_eslint.json"),
-                       headers: json_header)
-        end
+      context "when the prefixer returns an eslint commit prefix" do
+        let(:pr_name_prefix) { "Upgrade: " }
 
         it do
           expect(pr_name).to eq("Upgrade: Bump business from 1.4.0 to 1.5.0")
@@ -594,23 +631,20 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
         context "with a security vulnerability fixed" do
           let(:vulnerabilities_fixed) { { business: [{}] } }
+          let(:pr_name_prefix) { "Upgrade: [Security] " }
 
           it { is_expected.to start_with("Upgrade: [Security] Bump") }
         end
       end
 
-      context "when using gitmoji commits" do
-        before do
-          stub_request(:get, watched_repo_url + "/commits?per_page=100")
-            .to_return(status: 200,
-                       body: fixture("github", "commits_gitmoji.json"),
-                       headers: json_header)
-        end
+      context "when the prefixer returns a gitmoji prefix" do
+        let(:pr_name_prefix) { "⬆️ " }
 
         it { is_expected.to start_with("⬆️ Bump business") }
 
         context "with a security vulnerability fixed" do
           let(:vulnerabilities_fixed) { { business: [{}] } }
+          let(:pr_name_prefix) { "⬆️🔒 " }
 
           it { is_expected.to start_with("⬆️🔒 Bump business") }
         end
@@ -637,11 +671,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
 
       context "when not using a commit convention" do
-        before do
-          stub_request(:get, watched_repo_url + "/commits?per_page=100")
-            .to_return(status: 200, body: "[]", headers: json_header)
-        end
-
         it "has the right title" do
           expect(pr_name)
             .to eq("Update business requirement from ~> 1.4.0 to ~> 1.5.0")
@@ -816,13 +845,9 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
       end
 
-      context "when using angular commits" do
-        before do
-          stub_request(:get, watched_repo_url + "/commits?per_page=100")
-            .to_return(status: 200,
-                       body: fixture("github", "commits_angular.json"),
-                       headers: json_header)
-        end
+      context "when the prefixer returns an angular commit prefix" do
+        let(:pr_name_prefix) { "chore(deps): " }
+        let(:capitalize_first_word) { false }
 
         it "uses an angular commit prefix" do
           expect(pr_name)
@@ -834,18 +859,14 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
         context "with a security vulnerability fixed" do
           let(:vulnerabilities_fixed) { { business: [{}] } }
+          let(:pr_name_prefix) { "chore(deps): [security] " }
 
           it { is_expected.to start_with("chore(deps): [security] update") }
         end
       end
 
-      context "when using eslint commits" do
-        before do
-          stub_request(:get, watched_repo_url + "/commits?per_page=100")
-            .to_return(status: 200,
-                       body: fixture("github", "commits_eslint.json"),
-                       headers: json_header)
-        end
+      context "when the prefixer returns an eslint commit prefix" do
+        let(:pr_name_prefix) { "Upgrade: " }
 
         it "uses an eslint commit prefix" do
           expect(pr_name)
@@ -857,6 +878,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
         context "with a security vulnerability fixed" do
           let(:vulnerabilities_fixed) { { business: [{}] } }
+          let(:pr_name_prefix) { "Upgrade: [Security] " }
 
           it { is_expected.to start_with("Upgrade: [Security] Update") }
         end
@@ -866,16 +888,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
     context "when dealing with a dependency group with one dependency" do
       let(:dependency_group) do
         Dependabot::DependencyGroup.new(name: "all-the-things", rules: { patterns: ["*"] })
-      end
-      let(:commits_response) { fixture("github", "commits.json") }
-
-      before do
-        stub_request(:get, watched_repo_url + "/commits?per_page=100")
-          .to_return(
-            status: 200,
-            body: commits_response,
-            headers: json_header
-          )
       end
 
       it { is_expected.to eq("Bump business from 1.4.0 to 1.5.0 in the all-the-things group") }
@@ -975,15 +987,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
       let(:metadata) { { directory: "/foo" } }
 
-      before do
-        stub_request(:get, watched_repo_url + "/commits?per_page=100")
-          .to_return(
-            status: 200,
-            body: commits_response,
-            headers: json_header
-          )
-      end
-
       it { is_expected.to eq("Bump business from 1.4.0 to 1.5.0 in the go_modules group across 1 directory") }
 
       context "with two dependencies" do
@@ -1016,12 +1019,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         )
       end
       let(:metadata) { { directory: "/frontend", updated_directories: ["/frontend", "/backend"] } }
-      let(:commits_response) { fixture("github", "commits.json") }
-
-      before do
-        stub_request(:get, watched_repo_url + "/commits?per_page=100")
-          .to_return(status: 200, body: commits_response, headers: json_header)
-      end
 
       it { is_expected.to eq("Bump business across 2 directories") }
 
@@ -1042,56 +1039,31 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
   describe "#pr_message" do
     subject(:pr_message) { builder.pr_message }
 
-    let(:business_repo_url) do
-      "https://api.github.com/repos/gocardless/business"
+    let(:metadata_finder_attributes) do
+      {
+        "business" => business_metadata,
+        "statesman" => statesman_metadata
+      }
     end
-
-    before do
-      stub_request(:get, watched_repo_url + "/commits?per_page=100")
-        .to_return(status: 200, body: "[]", headers: json_header)
-
-      stub_request(:get, business_repo_url)
-        .to_return(status: 200,
-                   body: fixture("github", "business_repo.json"),
-                   headers: json_header)
-      stub_request(:get, "#{business_repo_url}/contents/")
-        .to_return(status: 200,
-                   body: fixture("github", "business_files.json"),
-                   headers: json_header)
-      stub_request(:get, "#{business_repo_url}/releases?per_page=100")
-        .to_return(status: 200,
-                   body: fixture("github", "business_releases.json"),
-                   headers: json_header)
-      stub_request(
-        :get,
-        "https://api.github.com/repos/gocardless/" \
-        "business/contents/CHANGELOG.md?ref=master"
-      )
-        .to_return(status: 200,
-                   body: fixture("github", "changelog_contents.json"),
-                   headers: json_header)
-      stub_request(:get, "#{business_repo_url}/commits?sha=v1.5.0")
-        .to_return(status: 200,
-                   body: fixture("github", "commits-business-1.4.0.json"),
-                   headers: json_header)
-      stub_request(:get, "#{business_repo_url}/commits?sha=v1.4.0")
-        .to_return(status: 200,
-                   body: fixture("github", "commits-business-1.3.0.json"),
-                   headers: json_header)
-      stub_request(:get, "https://rubygems.org/api/v1/gems/business.json")
-        .to_return(status: 200, body: fixture("ruby", "rubygems_response.json"))
-
-      service_pack_url =
-        "https://github.com/gocardless/business.git/info/refs" \
-        "?service=git-upload-pack"
-      stub_request(:get, service_pack_url)
-        .to_return(
-          status: 200,
-          body: fixture("git", "upload_packs", "business"),
-          headers: {
-            "content-type" => "application/x-git-upload-pack-advertisement"
-          }
-        )
+    let(:business_metadata) do
+      {
+        source_url: "https://github.com/gocardless/business",
+        releases_url: "https://github.com/gocardless/business/releases",
+        changelog_url: "https://github.com/gocardless/business/blob/master/CHANGELOG.md",
+        changelog_text: changelog_section("1.5.0"),
+        commits_url: "https://github.com/gocardless/business/compare/v1.4.0...v1.5.0",
+        commits: business_commits
+      }
+    end
+    let(:statesman_metadata) do
+      {
+        source_url: "https://github.com/gocardless/statesman",
+        releases_url: "https://github.com/gocardless/statesman/releases",
+        changelog_url: "https://github.com/gocardless/statesman/blob/master/CHANGELOG.md",
+        changelog_text: changelog_section("1.7.0"),
+        commits_url: "https://github.com/gocardless/statesman/commits",
+        commits: []
+      }
     end
 
     context "when dealing with an application" do
@@ -1119,7 +1091,9 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
       context "when there's a network error" do
         before do
-          stub_request(:any, /.*/).to_raise(SocketError)
+          allow(metadata_finders.fetch("business"))
+            .to receive(:changelog_text)
+            .and_raise(SocketError)
         end
 
         it "still builds the pr_message without the metadata cascade" do
@@ -1158,8 +1132,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
       context "when github.com is unreachable while fetching metadata" do
         before do
-          allow_any_instance_of(Dependabot::PullRequestCreator::MessageBuilder::MetadataPresenter)
-            .to receive(:to_s)
+          allow(metadata_finders.fetch("business"))
+            .to receive(:changelog_text)
             .and_raise(SocketError, "Connection refused - connect(2) for \"api.github.com\" port 443")
         end
 
@@ -1171,17 +1145,12 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
 
       context "with a relative link in the changelog" do
-        before do
-          stub_request(
-            :get,
-            "https://api.github.com/repos/gocardless/" \
-            "business/contents/CHANGELOG.md?ref=master"
+        let(:business_metadata) do
+          super().merge(
+            changelog_text: Base64.decode64(
+              JSON.parse(fixture("github", "changelog_contents_rel_link.json")).fetch("content")
+            ).match(/^## 1\.5\.0.*?(?=^## |\z)/m).to_s
           )
-            .to_return(
-              status: 200,
-              body: fixture("github", "changelog_contents_rel_link.json"),
-              headers: json_header
-            )
         end
 
         it "has the right text" do
@@ -1241,25 +1210,13 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         let(:previous_version) { "2468a02a6230e59ed1232d95d1ad3ef157195b03" }
         let(:new_ref) { nil }
         let(:old_ref) { nil }
-
-        before do
-          stub_request(
-            :get,
-            "#{business_repo_url}/commits?sha=" \
-            "2468a02a6230e59ed1232d95d1ad3ef157195b03"
-          ).to_return(
-            status: 200,
-            body: fixture("github", "commits-business-1.3.0.json"),
-            headers: json_header
-          )
-          stub_request(
-            :get,
-            "#{business_repo_url}/commits?sha=" \
-            "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2"
-          ).to_return(
-            status: 200,
-            body: fixture("github", "commits-business-1.4.0.json"),
-            headers: json_header
+        let(:business_metadata) do
+          super().merge(
+            changelog_url: nil,
+            changelog_text: nil,
+            commits_url: "https://github.com/gocardless/business/compare/" \
+                         "2468a02a6230e59ed1232d95d1ad3ef157195b03..." \
+                         "cff701b3bfb182afc99a85657d7c9f3d6c1ccce2"
           )
         end
 
@@ -1279,6 +1236,12 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         context "when there is a ref change" do
           let(:new_ref) { "v1.1.0" }
           let(:old_ref) { "v1.0.0" }
+          let(:business_metadata) do
+            super().merge(
+              changelog_url: "https://github.com/gocardless/business/blob/master/CHANGELOG.md",
+              changelog_text: changelog_section("1.1.0")
+            )
+          end
 
           it "has the right text" do
             commits_details = commits_details(
@@ -1308,14 +1271,11 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
           context "with no previous version" do
             let(:previous_version) { nil }
-
-            before do
-              stub_request(:get, "#{business_repo_url}/commits?sha=v1.0.0")
-                .to_return(
-                  status: 200,
-                  body: fixture("github", "commits-business-1.3.0.json"),
-                  headers: json_header
-                )
+            let(:business_metadata) do
+              super().merge(
+                commits_url: "https://github.com/gocardless/business/compare/" \
+                             "v1.0.0...cff701b3bfb182afc99a85657d7c9f3d6c1ccce2"
+              )
             end
 
             it "has the right text" do
@@ -1436,23 +1396,12 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           )
         end
         let(:previous_version) { "2468a02a6230e59ed1232d95d1ad3ef157195b03" }
-
-        before do
-          stub_request(
-            :get,
-            "#{business_repo_url}/commits?sha=" \
-            "2468a02a6230e59ed1232d95d1ad3ef157195b03"
-          ).to_return(
-            status: 200,
-            body: fixture("github", "commits-business-1.3.0.json"),
-            headers: json_header
+        let(:business_metadata) do
+          super().merge(
+            changelog_text: changelog_from("1.5.0"),
+            commits_url: "https://github.com/gocardless/business/compare/" \
+                         "2468a02a6230e59ed1232d95d1ad3ef157195b03...v1.5.0"
           )
-          stub_request(:get, "#{business_repo_url}/commits?sha=v1.5.0")
-            .to_return(
-              status: 200,
-              body: fixture("github", "commits-business-1.4.0.json"),
-              headers: json_header
-            )
         end
 
         it "has the right text" do
@@ -1517,29 +1466,8 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
 
       context "with commits (but no changelog)" do
-        before do
-          stub_request(:get, "#{business_repo_url}/contents/")
-            .to_return(
-              status: 200,
-              body: fixture("github", "business_files_no_changelog.json"),
-              headers: json_header
-            )
-          stub_request(:get, "#{business_repo_url}/contents/?ref=v1.5.0")
-            .to_return(
-              status: 200,
-              body: fixture("github", "business_files_no_changelog.json"),
-              headers: json_header
-            )
-          stub_request(
-            :get,
-            "https://api.github.com/repos/gocardless/business/compare/" \
-            "v1.4.0...v1.5.0"
-          ).with(headers: { "Authorization" => "token token" })
-            .to_return(
-              status: 200,
-              body: fixture("github", "business_compare_commits.json"),
-              headers: { "Content-Type" => "application/json" }
-            )
+        let(:business_metadata) do
+          super().merge(changelog_url: nil, changelog_text: nil)
         end
 
         it "has the right text" do
@@ -1574,25 +1502,12 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
 
-          before do
-            stub_request(:get, "#{business_repo_url}/contents/?ref=v1.6.0")
-              .to_return(
-                status: 200,
-                body: fixture("github", "business_files_no_changelog.json"),
-                headers: json_header
-              )
-            stub_request(:get, "#{business_repo_url}/commits?sha=v1.6.0")
-              .to_return(
-                status: 200,
-                body: fixture("github", "commits-business-1.4.0.json"),
-                headers: json_header
-              )
-            stub_request(:get, "#{business_repo_url}/commits?sha=v1.5.0")
-              .to_return(
-                status: 200,
-                body: fixture("github", "commits-business-1.3.0.json"),
-                headers: json_header
-              )
+          let(:business_metadata) do
+            super().merge(
+              releases_text: "## v1.6.0\n\nMad props to @greysteil and @hmarr for the " \
+                             "`@\u200Bangular/scope` work - see [changelog](CHANGELOG.md).",
+              commits_url: "https://github.com/gocardless/business/compare/v1.5.0...v1.6.0"
+            )
           end
 
           it "has the right text" do
@@ -1666,47 +1581,11 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             previous_requirements: []
           )
         end
-
-        before do
-          statesman_repo_url =
-            "https://api.github.com/repos/gocardless/statesman"
-          stub_request(:get, statesman_repo_url)
-            .to_return(status: 200,
-                       body: fixture("github", "statesman_repo.json"),
-                       headers: json_header)
-          stub_request(:get, "#{statesman_repo_url}/contents/")
-            .to_return(status: 200,
-                       body: fixture("github", "statesman_files.json"),
-                       headers: json_header)
-          stub_request(:get, "#{statesman_repo_url}/releases?per_page=100")
-            .to_return(status: 200,
-                       body: fixture("github", "business_releases.json"),
-                       headers: json_header)
-          stub_request(
-            :get,
-            "https://api.github.com/repos/gocardless/" \
-            "statesman/contents/CHANGELOG.md?ref=master"
+        let(:statesman_metadata) do
+          super().merge(
+            releases_text: "## v1.6.0\n\nRelease notes",
+            changelog_text: changelog_section("1.6.0")
           )
-            .to_return(status: 200,
-                       body: fixture("github", "changelog_contents.json"),
-                       headers: json_header)
-          stub_request(:get, "https://rubygems.org/api/v1/gems/statesman.json")
-            .to_return(
-              status: 200,
-              body: fixture("ruby", "rubygems_response_statesman.json")
-            )
-
-          service_pack_url =
-            "https://github.com/gocardless/statesman.git/info/refs" \
-            "?service=git-upload-pack"
-          stub_request(:get, service_pack_url)
-            .to_return(
-              status: 200,
-              body: fixture("git", "upload_packs", "no_tags"),
-              headers: {
-                "content-type" => "application/x-git-upload-pack-advertisement"
-              }
-            )
         end
 
         it "includes details of both dependencies" do
@@ -1743,35 +1622,13 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             }]
           )
         end
-
-        before do
-          stub_request(
-            :get,
-            "https://api.github.com/repos/gocardless/business/compare/" \
-            "v0.9.0...v1.5.0"
-          ).with(headers: { "Authorization" => "token token" })
-            .to_return(
-              status: 200,
-              body: fixture("github", "business_compare_commits.json"),
-              headers: { "Content-Type" => "application/json" }
-            )
-          stub_request(:get, "#{business_repo_url}/contents/")
-            .to_return(
-              status: 200,
-              body:
-                fixture("github", "business_files_with_upgrade_guide.json"),
-              headers: json_header
-            )
-          stub_request(
-            :get,
-            "https://api.github.com/repos/gocardless/" \
-            "business/contents/UPGRADE.md?ref=master"
+        let(:business_metadata) do
+          super().merge(
+            changelog_text: changelog_from("1.5.0"),
+            commits_url: "https://github.com/gocardless/business/compare/v0.9.0...v1.5.0",
+            upgrade_guide_url: "https://github.com/gocardless/business/blob/master/UPGRADE.md",
+            upgrade_guide_text: decoded_github_content("upgrade_guide_contents.json")
           )
-            .to_return(
-              status: 200,
-              body: fixture("github", "upgrade_guide_contents.json"),
-              headers: json_header
-            )
         end
 
         it "has the right text" do
@@ -1825,7 +1682,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
       context "when there is a change in maintainer" do
         before do
-          allow_any_instance_of(Dependabot::MetadataFinders::Base)
+          allow(metadata_finders.fetch("business"))
             .to receive(:maintainer_changes)
             .and_return("Maintainer change")
         end
@@ -1862,48 +1719,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               source: nil
             }]
           )
-        end
-
-        before do
-          statesman_repo_url =
-            "https://api.github.com/repos/gocardless/statesman"
-          stub_request(:get, statesman_repo_url)
-            .to_return(status: 200,
-                       body: fixture("github", "statesman_repo.json"),
-                       headers: json_header)
-          stub_request(:get, "#{statesman_repo_url}/contents/")
-            .to_return(status: 200,
-                       body: fixture("github", "statesman_files.json"),
-                       headers: json_header)
-          stub_request(:get, "#{statesman_repo_url}/releases?per_page=100")
-            .to_return(status: 200,
-                       body: fixture("github", "business_releases.json"),
-                       headers: json_header)
-          stub_request(
-            :get,
-            "https://api.github.com/repos/gocardless/" \
-            "statesman/contents/CHANGELOG.md?ref=master"
-          )
-            .to_return(status: 200,
-                       body: fixture("github", "changelog_contents.json"),
-                       headers: json_header)
-          stub_request(:get, "https://rubygems.org/api/v1/gems/statesman.json")
-            .to_return(
-              status: 200,
-              body: fixture("ruby", "rubygems_response_statesman.json")
-            )
-
-          service_pack_url =
-            "https://github.com/gocardless/statesman.git/info/refs" \
-            "?service=git-upload-pack"
-          stub_request(:get, service_pack_url)
-            .to_return(
-              status: 200,
-              body: fixture("git", "upload_packs", "no_tags"),
-              headers: {
-                "content-type" => "application/x-git-upload-pack-advertisement"
-              }
-            )
         end
 
         it "includes details of both dependencies" do
@@ -1953,10 +1768,9 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
         context "when one dependency's metadata cascade raises" do
           before do
-            stub_request(
-              :get,
-              "https://api.github.com/repos/gocardless/statesman/contents/CHANGELOG.md?ref=master"
-            ).to_raise(SocketError, "Connection refused - connect(2) for \"api.github.com\" port 443")
+            allow(metadata_finders.fetch("statesman"))
+              .to receive(:changelog_text)
+              .and_raise(SocketError, "Connection refused - connect(2) for \"api.github.com\" port 443")
           end
 
           it "still renders the PR message with the unaffected dependency's metadata" do
@@ -1973,17 +1787,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
         end
 
         context "when dealing with a property dependency (e.g., with Maven)" do
-          before do
-            statesman_repo_url =
-              "https://api.github.com/repos/gocardless/statesman"
-            stub_request(:get, "#{statesman_repo_url}/compare/v1.4.0...v1.5.0")
-              .to_return(
-                status: 200,
-                body: fixture("github", "business_compare_commits.json"),
-                headers: json_header
-              )
-          end
-
           let(:dependency) do
             Dependabot::Dependency.new(
               name: "business",
@@ -2080,6 +1883,12 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       context "with multiple git source requirements", :vcr do
         include_context "with multiple git sources"
 
+        let(:metadata_finder_attributes) do
+          super().merge(
+            "actions/checkout" => { source_url: "https://github.com/gocardless/actions" }
+          )
+        end
+
         it "has the correct message" do
           expect(pr_message).to start_with(
             "Updates the requirements on " \
@@ -2136,48 +1945,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
           let(:dependencies) { [dependency, dependency2] }
-
-          before do
-            business2_repo_url =
-              "https://api.github.com/repos/gocardless/business2"
-            stub_request(:get, business2_repo_url)
-              .to_return(status: 200,
-                         body: fixture("github", "business_repo.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business2_repo_url}/contents/")
-              .to_return(status: 200,
-                         body: fixture("github", "business_files.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business2_repo_url}/releases?per_page=100")
-              .to_return(status: 200,
-                         body: fixture("github", "business_releases.json"),
-                         headers: json_header)
-            stub_request(
-              :get,
-              "https://api.github.com/repos/gocardless/" \
-              "business2/contents/CHANGELOG.md?ref=master"
-            )
-              .to_return(status: 200,
-                         body: fixture("github", "changelog_contents.json"),
-                         headers: json_header)
-            stub_request(:get, "https://rubygems.org/api/v1/gems/business2.json")
-              .to_return(
-                status: 200,
-                body: fixture("ruby", "rubygems_response_statesman.json")
-              )
-
-            business2_service_pack_url =
-              "https://github.com/gocardless/business2.git/info/refs" \
-              "?service=git-upload-pack"
-            stub_request(:get, business2_service_pack_url)
-              .to_return(
-                status: 200,
-                body: fixture("git", "upload_packs", "no_tags"),
-                headers: {
-                  "content-type" => "application/x-git-upload-pack-advertisement"
-                }
-              )
-          end
 
           it "has the correct PR message" do
             expect(pr_message).to start_with(
@@ -2250,88 +2017,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
           let(:dependencies) { [dependency, dependency2, dependency3] }
 
-          before do
-            business2_repo_url =
-              "https://api.github.com/repos/gocardless/business2"
-            stub_request(:get, business2_repo_url)
-              .to_return(status: 200,
-                         body: fixture("github", "business_repo.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business2_repo_url}/contents/")
-              .to_return(status: 200,
-                         body: fixture("github", "business_files.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business2_repo_url}/releases?per_page=100")
-              .to_return(status: 200,
-                         body: fixture("github", "business_releases.json"),
-                         headers: json_header)
-            stub_request(
-              :get,
-              "https://api.github.com/repos/gocardless/" \
-              "business2/contents/CHANGELOG.md?ref=master"
-            )
-              .to_return(status: 200,
-                         body: fixture("github", "changelog_contents.json"),
-                         headers: json_header)
-            stub_request(:get, "https://rubygems.org/api/v1/gems/business2.json")
-              .to_return(
-                status: 200,
-                body: fixture("ruby", "rubygems_response_statesman.json")
-              )
-
-            business2_service_pack_url =
-              "https://github.com/gocardless/business2.git/info/refs" \
-              "?service=git-upload-pack"
-            stub_request(:get, business2_service_pack_url)
-              .to_return(
-                status: 200,
-                body: fixture("git", "upload_packs", "no_tags"),
-                headers: {
-                  "content-type" => "application/x-git-upload-pack-advertisement"
-                }
-              )
-
-            business3_repo_url =
-              "https://api.github.com/repos/gocardless/business3"
-            stub_request(:get, business3_repo_url)
-              .to_return(status: 200,
-                         body: fixture("github", "business_repo.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business3_repo_url}/contents/")
-              .to_return(status: 200,
-                         body: fixture("github", "business_files.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business3_repo_url}/releases?per_page=100")
-              .to_return(status: 200,
-                         body: fixture("github", "business_releases.json"),
-                         headers: json_header)
-            stub_request(
-              :get,
-              "https://api.github.com/repos/gocardless/" \
-              "business3/contents/CHANGELOG.md?ref=master"
-            )
-              .to_return(status: 200,
-                         body: fixture("github", "changelog_contents.json"),
-                         headers: json_header)
-            stub_request(:get, "https://rubygems.org/api/v1/gems/business3.json")
-              .to_return(
-                status: 200,
-                body: fixture("ruby", "rubygems_response.json")
-              )
-
-            business3_service_pack_url =
-              "https://github.com/gocardless/business3.git/info/refs" \
-              "?service=git-upload-pack"
-            stub_request(:get, business3_service_pack_url)
-              .to_return(
-                status: 200,
-                body: fixture("git", "upload_packs", "no_tags"),
-                headers: {
-                  "content-type" => "application/x-git-upload-pack-advertisement"
-                }
-              )
-          end
-
           it "has the correct message" do
             expect(pr_message).to start_with(
               "Bumps the all-the-things group with 3 updates: " \
@@ -2384,51 +2069,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
           let(:dependencies) { [dependency, dependency2, dependency3, dependency4, dependency5] }
-
-          before do
-            (2..5).each do |i|
-              repo_url = "https://api.github.com/repos/gocardless/business#{i}"
-
-              stub_request(:get, repo_url)
-                .to_return(status: 200,
-                           body: fixture("github", "business_repo.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/contents/")
-                .to_return(status: 200,
-                           body: fixture("github", "business_files.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/releases?per_page=100")
-                .to_return(status: 200,
-                           body: fixture("github", "business_releases.json"),
-                           headers: json_header)
-              stub_request(
-                :get,
-                "https://api.github.com/repos/gocardless/" \
-                "business#{i}/contents/CHANGELOG.md?ref=master"
-              )
-                .to_return(status: 200,
-                           body: fixture("github", "changelog_contents.json"),
-                           headers: json_header)
-              stub_request(:get, "https://rubygems.org/api/v1/gems/business#{i}.json")
-                .to_return(
-                  status: 200,
-                  body: fixture("ruby", "rubygems_response_statesman.json")
-                )
-
-              service_pack_url =
-                "https://github.com/gocardless/business#{i}.git/info/refs" \
-                "?service=git-upload-pack"
-
-              stub_request(:get, service_pack_url)
-                .to_return(
-                  status: 200,
-                  body: fixture("git", "upload_packs", "no_tags"),
-                  headers: {
-                    "content-type" => "application/x-git-upload-pack-advertisement"
-                  }
-                )
-            end
-          end
 
           it "has the correct message" do
             expect(pr_message).to start_with(
@@ -2497,51 +2137,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
           let(:dependencies) do
             [dependency, dependency2, dependency3, dependency4, dependency5, dependency5, dependency6]
-          end
-
-          before do
-            (2..6).each do |i|
-              repo_url = "https://api.github.com/repos/gocardless/business#{i}"
-
-              stub_request(:get, repo_url)
-                .to_return(status: 200,
-                           body: fixture("github", "business_repo.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/contents/")
-                .to_return(status: 200,
-                           body: fixture("github", "business_files.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/releases?per_page=100")
-                .to_return(status: 200,
-                           body: fixture("github", "business_releases.json"),
-                           headers: json_header)
-              stub_request(
-                :get,
-                "https://api.github.com/repos/gocardless/" \
-                "business#{i}/contents/CHANGELOG.md?ref=master"
-              )
-                .to_return(status: 200,
-                           body: fixture("github", "changelog_contents.json"),
-                           headers: json_header)
-              stub_request(:get, "https://rubygems.org/api/v1/gems/business#{i}.json")
-                .to_return(
-                  status: 200,
-                  body: fixture("ruby", "rubygems_response_statesman.json")
-                )
-
-              service_pack_url =
-                "https://github.com/gocardless/business#{i}.git/info/refs" \
-                "?service=git-upload-pack"
-
-              stub_request(:get, service_pack_url)
-                .to_return(
-                  status: 200,
-                  body: fixture("git", "upload_packs", "no_tags"),
-                  headers: {
-                    "content-type" => "application/x-git-upload-pack-advertisement"
-                  }
-                )
-            end
           end
 
           it "has the correct message" do
@@ -2636,51 +2231,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
              dependency8]
           end
 
-          before do
-            (2..6).each do |i|
-              repo_url = "https://api.github.com/repos/gocardless/business#{i}"
-
-              stub_request(:get, repo_url)
-                .to_return(status: 200,
-                           body: fixture("github", "business_repo.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/contents/")
-                .to_return(status: 200,
-                           body: fixture("github", "business_files.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/releases?per_page=100")
-                .to_return(status: 200,
-                           body: fixture("github", "business_releases.json"),
-                           headers: json_header)
-              stub_request(
-                :get,
-                "https://api.github.com/repos/gocardless/" \
-                "business#{i}/contents/CHANGELOG.md?ref=master"
-              )
-                .to_return(status: 200,
-                           body: fixture("github", "changelog_contents.json"),
-                           headers: json_header)
-              stub_request(:get, "https://rubygems.org/api/v1/gems/business#{i}.json")
-                .to_return(
-                  status: 200,
-                  body: fixture("ruby", "rubygems_response_statesman.json")
-                )
-
-              service_pack_url =
-                "https://github.com/gocardless/business#{i}.git/info/refs" \
-                "?service=git-upload-pack"
-
-              stub_request(:get, service_pack_url)
-                .to_return(
-                  status: 200,
-                  body: fixture("git", "upload_packs", "no_tags"),
-                  headers: {
-                    "content-type" => "application/x-git-upload-pack-advertisement"
-                  }
-                )
-            end
-          end
-
           it "has the correct message" do
             expect(pr_message).to start_with(
               "Bumps the all-the-things group with 7 updates:\n\n" \
@@ -2743,47 +2293,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
           before do
             (2..5).each do |i|
-              repo_url = "https://api.github.com/repos/gocardless/business#{i}"
-
-              stub_request(:get, repo_url)
-                .to_return(status: 200,
-                           body: fixture("github", "business_repo.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/contents/")
-                .to_return(status: 200,
-                           body: fixture("github", "business_files.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/releases?per_page=100")
-                .to_return(status: 200,
-                           body: fixture("github", "business_releases.json"),
-                           headers: json_header)
-              stub_request(
-                :get,
-                "https://api.github.com/repos/gocardless/" \
-                "business#{i}/contents/CHANGELOG.md?ref=master"
-              )
-                .to_return(status: 200,
-                           body: fixture("github", "changelog_contents.json"),
-                           headers: json_header)
-              stub_request(:get, "https://rubygems.org/api/v1/gems/business#{i}.json")
-                .to_return(
-                  status: 200,
-                  body: fixture("ruby", "rubygems_response_statesman.json")
-                )
-
-              service_pack_url =
-                "https://github.com/gocardless/business#{i}.git/info/refs" \
-                "?service=git-upload-pack"
-
-              stub_request(:get, service_pack_url)
-                .to_return(
-                  status: 200,
-                  body: fixture("git", "upload_packs", "no_tags"),
-                  headers: {
-                    "content-type" => "application/x-git-upload-pack-advertisement"
-                  }
-
-                )
               ignore_conditions.push(
                 {
                   "dependency-name" => "business#{i}",
@@ -2829,51 +2338,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
           let(:dependencies) { [dependency1, dependency2] }
-
-          before do
-            (2..5).each do |i|
-              repo_url = "https://api.github.com/repos/gocardless/business#{i}"
-
-              stub_request(:get, repo_url)
-                .to_return(status: 200,
-                           body: fixture("github", "business_repo.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/contents/")
-                .to_return(status: 200,
-                           body: fixture("github", "business_files.json"),
-                           headers: json_header)
-              stub_request(:get, "#{repo_url}/releases?per_page=100")
-                .to_return(status: 200,
-                           body: fixture("github", "business_releases.json"),
-                           headers: json_header)
-              stub_request(
-                :get,
-                "https://api.github.com/repos/gocardless/" \
-                "business#{i}/contents/CHANGELOG.md?ref=master"
-              )
-                .to_return(status: 200,
-                           body: fixture("github", "changelog_contents.json"),
-                           headers: json_header)
-              stub_request(:get, "https://rubygems.org/api/v1/gems/business#{i}.json")
-                .to_return(
-                  status: 200,
-                  body: fixture("ruby", "rubygems_response_statesman.json")
-                )
-
-              service_pack_url =
-                "https://github.com/gocardless/business#{i}.git/info/refs" \
-                "?service=git-upload-pack"
-
-              stub_request(:get, service_pack_url)
-                .to_return(
-                  status: 200,
-                  body: fixture("git", "upload_packs", "no_tags"),
-                  headers: {
-                    "content-type" => "application/x-git-upload-pack-advertisement"
-                  }
-                )
-            end
-          end
 
           it "does not include the ignore conditions section in the message" do
             expect(pr_message).not_to include("Most Recent Ignore Conditions Applied to This Pull Request")
@@ -2944,48 +2408,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
           let(:dependencies) { [dependency, dependency2] }
 
-          before do
-            business2_repo_url =
-              "https://api.github.com/repos/gocardless/business2"
-            stub_request(:get, business2_repo_url)
-              .to_return(status: 200,
-                         body: fixture("github", "business_repo.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business2_repo_url}/contents/")
-              .to_return(status: 200,
-                         body: fixture("github", "business_files.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business2_repo_url}/releases?per_page=100")
-              .to_return(status: 200,
-                         body: fixture("github", "business_releases.json"),
-                         headers: json_header)
-            stub_request(
-              :get,
-              "https://api.github.com/repos/gocardless/" \
-              "business2/contents/CHANGELOG.md?ref=master"
-            )
-              .to_return(status: 200,
-                         body: fixture("github", "changelog_contents.json"),
-                         headers: json_header)
-            stub_request(:get, "https://rubygems.org/api/v1/gems/business2.json")
-              .to_return(
-                status: 200,
-                body: fixture("ruby", "rubygems_response_statesman.json")
-              )
-
-            business2_service_pack_url =
-              "https://github.com/gocardless/business2.git/info/refs" \
-              "?service=git-upload-pack"
-            stub_request(:get, business2_service_pack_url)
-              .to_return(
-                status: 200,
-                body: fixture("git", "upload_packs", "no_tags"),
-                headers: {
-                  "content-type" => "application/x-git-upload-pack-advertisement"
-                }
-              )
-          end
-
           it "has the correct message" do
             expect(pr_message).to start_with(
               "Bumps the go_modules group with 2 updates in the /foo directory: " \
@@ -3008,48 +2430,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
           let(:dependencies) { [dependency, dependency2] }
-
-          before do
-            business2_repo_url =
-              "https://api.github.com/repos/gocardless/business2"
-            stub_request(:get, business2_repo_url)
-              .to_return(status: 200,
-                         body: fixture("github", "business_repo.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business2_repo_url}/contents/")
-              .to_return(status: 200,
-                         body: fixture("github", "business_files.json"),
-                         headers: json_header)
-            stub_request(:get, "#{business2_repo_url}/releases?per_page=100")
-              .to_return(status: 200,
-                         body: fixture("github", "business_releases.json"),
-                         headers: json_header)
-            stub_request(
-              :get,
-              "https://api.github.com/repos/gocardless/" \
-              "business2/contents/CHANGELOG.md?ref=master"
-            )
-              .to_return(status: 200,
-                         body: fixture("github", "changelog_contents.json"),
-                         headers: json_header)
-            stub_request(:get, "https://rubygems.org/api/v1/gems/business2.json")
-              .to_return(
-                status: 200,
-                body: fixture("ruby", "rubygems_response_statesman.json")
-              )
-
-            business2_service_pack_url =
-              "https://github.com/gocardless/business2.git/info/refs" \
-              "?service=git-upload-pack"
-            stub_request(:get, business2_service_pack_url)
-              .to_return(
-                status: 200,
-                body: fixture("git", "upload_packs", "no_tags"),
-                headers: {
-                  "content-type" => "application/x-git-upload-pack-advertisement"
-                }
-              )
-          end
 
           it "has the correct message" do
             expect(pr_message).to start_with(
@@ -3077,29 +2457,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
           end
           let(:dependencies) { dependencies2 + [dependency] }
 
-          before do
-            json_header = { "Content-Type" => "application/json" }
-
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+})
-              .to_return(status: 200, body: fixture("github", "business_repo.json"), headers: json_header)
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/})
-              .to_return(status: 200, body: fixture("github", "business_files.json"), headers: json_header)
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/releases\?per_page=100})
-              .to_return(status: 200, body: fixture("github", "business_releases.json"), headers: json_header)
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/CHANGELOG\.md\?ref=master})
-              .to_return(status: 200, body: fixture("github", "changelog_contents.json"), headers: json_header)
-            stub_request(:get, %r{https://rubygems\.org/api/v1/gems/.+\.json})
-              .to_return(status: 200, body: fixture("ruby", "rubygems_response_statesman.json"))
-            stub_request(:get, %r{https://github\.com/gocardless/.+\.git/info/refs\?service=git-upload-pack})
-              .to_return(
-                status: 200,
-                body: fixture("git", "upload_packs", "no_tags"),
-                headers: {
-                  "content-type" => "application/x-git-upload-pack-advertisement"
-                }
-              )
-          end
-
           it "has the correct message" do
             expect(pr_message).to include(
               "Bumps the go_modules group with 1 update in the /foo directory: " \
@@ -3124,10 +2481,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
                 removed: true
               )
             end
-
-            before do
-              dependencies2.push(removed_dependency)
-            end
+            let(:dependencies) { dependencies2 + [removed_dependency, dependency] }
 
             it "lists the dependency as removed in the table" do
               expect(pr_message).to include(
@@ -3163,29 +2517,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             )
           end
           let(:dependencies) { dependencies1 + [dependency] + [dependency2] }
-
-          before do
-            json_header = { "Content-Type" => "application/json" }
-
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+})
-              .to_return(status: 200, body: fixture("github", "business_repo.json"), headers: json_header)
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/})
-              .to_return(status: 200, body: fixture("github", "business_files.json"), headers: json_header)
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/releases\?per_page=100})
-              .to_return(status: 200, body: fixture("github", "business_releases.json"), headers: json_header)
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/CHANGELOG\.md\?ref=master})
-              .to_return(status: 200, body: fixture("github", "changelog_contents.json"), headers: json_header)
-            stub_request(:get, %r{https://rubygems\.org/api/v1/gems/.+\.json})
-              .to_return(status: 200, body: fixture("ruby", "rubygems_response_statesman.json"))
-            stub_request(:get, %r{https://github\.com/gocardless/.+\.git/info/refs\?service=git-upload-pack})
-              .to_return(
-                status: 200,
-                body: fixture("git", "upload_packs", "no_tags"),
-                headers: {
-                  "content-type" => "application/x-git-upload-pack-advertisement"
-                }
-              )
-          end
 
           it "has the correct message" do
             expected_message = "Bumps the go_modules group with 6 updates in the /foo directory:\n\n" \
@@ -3231,29 +2562,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
             end
           end
           let(:dependencies) { dependencies1 + dependencies2 + [dependency] }
-
-          before do
-            json_header = { "Content-Type" => "application/json" }
-
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+})
-              .to_return(status: 200, body: fixture("github", "business_repo.json"), headers: json_header)
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/})
-              .to_return(status: 200, body: fixture("github", "business_files.json"), headers: json_header)
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/releases\?per_page=100})
-              .to_return(status: 200, body: fixture("github", "business_releases.json"), headers: json_header)
-            stub_request(:get, %r{https://api\.github\.com/repos/gocardless/.+/contents/CHANGELOG\.md\?ref=master})
-              .to_return(status: 200, body: fixture("github", "changelog_contents.json"), headers: json_header)
-            stub_request(:get, %r{https://rubygems\.org/api/v1/gems/.+\.json})
-              .to_return(status: 200, body: fixture("ruby", "rubygems_response_statesman.json"))
-            stub_request(:get, %r{https://github\.com/gocardless/.+\.git/info/refs\?service=git-upload-pack})
-              .to_return(
-                status: 200,
-                body: fixture("git", "upload_packs", "no_tags"),
-                headers: {
-                  "content-type" => "application/x-git-upload-pack-advertisement"
-                }
-              )
-          end
 
           it "has the correct message" do
             expected_message = "Bumps the go_modules group with 6 updates in the /foo directory:\n\n" \
@@ -3390,48 +2698,6 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
               source: nil
             }]
           )
-        end
-
-        before do
-          statesman_repo_url =
-            "https://api.github.com/repos/gocardless/statesman"
-          stub_request(:get, statesman_repo_url)
-            .to_return(status: 200,
-                       body: fixture("github", "statesman_repo.json"),
-                       headers: json_header)
-          stub_request(:get, "#{statesman_repo_url}/contents/")
-            .to_return(status: 200,
-                       body: fixture("github", "statesman_files.json"),
-                       headers: json_header)
-          stub_request(:get, "#{statesman_repo_url}/releases?per_page=100")
-            .to_return(status: 200,
-                       body: fixture("github", "business_releases.json"),
-                       headers: json_header)
-          stub_request(
-            :get,
-            "https://api.github.com/repos/gocardless/" \
-            "statesman/contents/CHANGELOG.md?ref=master"
-          )
-            .to_return(status: 200,
-                       body: fixture("github", "changelog_contents.json"),
-                       headers: json_header)
-          stub_request(:get, "https://rubygems.org/api/v1/gems/statesman.json")
-            .to_return(
-              status: 200,
-              body: fixture("ruby", "rubygems_response_statesman.json")
-            )
-
-          service_pack_url =
-            "https://github.com/gocardless/statesman.git/info/refs" \
-            "?service=git-upload-pack"
-          stub_request(:get, service_pack_url)
-            .to_return(
-              status: 200,
-              body: fixture("git", "upload_packs", "no_tags"),
-              headers: {
-                "content-type" => "application/x-git-upload-pack-advertisement"
-              }
-            )
         end
 
         it "includes details of both dependencies" do
@@ -3602,6 +2868,17 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
   describe "#commit_message", :vcr do
     subject(:commit_message) { builder.commit_message }
 
+    let(:metadata_finder_attributes) do
+      {
+        "business" => {
+          source_url: "https://github.com/gocardless/business",
+          releases_url: "https://github.com/gocardless/business/releases",
+          changelog_url: "https://github.com/gocardless/business/blob/master/CHANGELOG.md",
+          commits_url: "https://github.com/gocardless/business/compare/v1.4.0...v1.5.0"
+        }
+      }
+    end
+
     let(:expected_commit_message) do
       <<~MSG.chomp
         Bump business from 1.4.0 to 1.5.0
@@ -3721,14 +2998,12 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
       end
     end
 
-    context "when dealing with a repo that uses gitmoji commits" do
+    context "when the prefixer returns a gitmoji prefix" do
       before do
         allow(builder).to receive(:pr_name).and_call_original
-        stub_request(:get, watched_repo_url + "/commits?per_page=100")
-          .to_return(status: 200,
-                     body: fixture("github", "commits_gitmoji.json"),
-                     headers: json_header)
       end
+
+      let(:pr_name_prefix) { "⬆️ " }
 
       it "uses gitmoji" do
         expect(commit_message).to start_with(":arrow_up: Bump ")
@@ -3736,6 +3011,7 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
       context "with a security vulnerability fixed" do
         let(:vulnerabilities_fixed) { { business: [{}] } }
+        let(:pr_name_prefix) { "⬆️🔒 " }
 
         it "uses gitmoji" do
           expect(commit_message).to start_with(":arrow_up::lock: Bump ")

--- a/common/spec/fixtures/commands/no_timeout.sh
+++ b/common/spec/fixtures/commands/no_timeout.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "This is a command result."
-sleep 3
+sleep 0.1
 exit 0


### PR DESCRIPTION
### What are you trying to accomplish?

Reduce the runtime of the `common` RSpec suite by:

• Caching missing Git tag lookups and stubbing unrelated release requests.
• Replacing live Git clones with local fixtures.
• Shortening test waits and isolating MessageBuilder tests from API clients.

### Anything you want to highlight for special attention from reviewers?

Provider-specific behavior remains in its dedicated specs. The MessageBuilder doubles check the exact constructor arguments, so the tests still cover collaborator wiring.

CI sharding is unchanged because the existing setup performs well after these fixes.

### How will you know you've accomplished your goal?

The full suite passes without network access: 2,242 examples and no failures.

Single-process runtime fell from 457.3s to 52.7s.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
