### PR TITLE
Speed up NuGet CI tests

### DIFF
--- a/nuget/README.md
+++ b/nuget/README.md
@@ -19,6 +19,12 @@ Open the solution file at `helpers/lib/NuGetUpdater/NuGetUpdater.slnx` in your p
    [dependabot-core-dev] ~ $ cd nuget && rspec
    ```
 
+Run the reusable C# test suite in the NuGet development container:
+
+```
+$ bin/test nuget ./script/run-csharp-tests
+```
+
 ### Known limitations
 
 #### Projects suppressing `NU1701`

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Discover/SdkProjectDiscoveryTests.cs
@@ -332,6 +332,7 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
     [Theory]
     [InlineData("net7.0")] // under the safe limit for parallel processing
     [InlineData("net7.0", "net8.0")] // at the safe limit for parallel processing
+    [InlineData("net8.0", "net9.0-windows")] // platform-specific TFMs are processed individually
     [InlineData("net7.0", "net8.0", "net9.0")] // above the safe limit for parallel processing
     [InlineData("netstandard2.0", "netstandard2.1", "net6.0", "net7.0", "net8.0", "net9.0", "net10.0")] // well above the safe limit for parallel processing
     public async Task DiscoverWithMultipleTargetFrameworks(params string[] targetFrameworks)
@@ -798,4 +799,3 @@ public class SdkProjectDiscoveryTests : DiscoveryWorkerTestBase
         ValidateProjectResults(expectedProjects, projectDiscovery);
     }
 }
-

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Run/HttpApiHandlerTests.cs
@@ -62,21 +62,24 @@ public class HttpApiHandlerTests
         var requestCount = 0;
         using var http = TestHttpServer.CreateTestServer((method, url) =>
         {
-            if (requestCount < 2)
+            requestCount++;
+            if (requestCount <= 2)
             {
-                requestCount++;
                 return (500, Array.Empty<byte>());
             }
 
             return (200, Array.Empty<byte>());
         });
-        var handler = new HttpApiHandler(http.BaseUrl, "TEST-ID");
+        var handler = new HttpApiHandler(http.BaseUrl, "TEST-ID", static _ => Task.CompletedTask);
 
         // act
         await handler.IncrementMetric(new()
         {
             Metric = "test",
         });
+
+        // assert
+        Assert.Equal(3, requestCount);
     }
 
     [Fact]
@@ -93,7 +96,29 @@ public class HttpApiHandlerTests
 
         // act
         await Assert.ThrowsAsync<HttpRequestException>(() => handler.IncrementMetric(new() { Metric = "test" }));
-        Assert.True(requestCount == 1, $"Expected only 1 request, but received {requestCount}.");
+
+        // assert
+        Assert.Equal(1, requestCount);
+    }
+
+    [Fact]
+    public async Task ApiCallsStopRetryingAfterTheMaximumNumberOfAttempts()
+    {
+        // arrange
+        var requestCount = 0;
+        using var http = TestHttpServer.CreateTestStringServer((method, url) =>
+        {
+            requestCount++;
+            return (500, $"attempt-{requestCount}");
+        });
+        var handler = new HttpApiHandler(http.BaseUrl, "TEST-ID", static _ => Task.CompletedTask);
+
+        // act
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => handler.IncrementMetric(new() { Metric = "test" }));
+
+        // assert
+        Assert.Equal("500 (InternalServerError): attempt-4", exception.Message);
+        Assert.Equal(4, requestCount);
     }
 
     [Theory]

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Utilities/MSBuildHelperTests.cs
@@ -284,6 +284,79 @@ public class MSBuildHelperTests : TestBase
         AssertEx.Equal(expectedDependencies, actualDependencies);
     }
 
+    [Fact]
+    public async Task MultipleProjectPropertiesCanBeEvaluated()
+    {
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(
+        [
+            ("project.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                  </PropertyGroup>
+                </Project>
+                """)
+        ]);
+        var projectPath = Path.Combine(tempDir.DirectoryPath, "project.csproj");
+        var properties = await MSBuildHelper.GetProjectPropertiesAsync(
+            projectPath,
+            ["TargetFrameworks", "NETCoreSdkVersion"],
+            new TestLogger()
+        );
+
+        Assert.NotNull(properties);
+        Assert.Equal("net8.0;net9.0", properties["TargetFrameworks"]);
+        Assert.False(string.IsNullOrEmpty(properties["NETCoreSdkVersion"]));
+    }
+
+    [Theory]
+    [InlineData("TargetFrameworks")]
+    [InlineData("TargetFrameworks", "targetframeworks")]
+    public async Task SingleDistinctProjectPropertyCanBeEvaluated(params string[] propertyNames)
+    {
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(
+        [
+            ("project.csproj", """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                  </PropertyGroup>
+                </Project>
+                """)
+        ]);
+        var projectPath = Path.Combine(tempDir.DirectoryPath, "project.csproj");
+        var properties = await MSBuildHelper.GetProjectPropertiesAsync(
+            projectPath,
+            propertyNames,
+            new TestLogger()
+        );
+
+        Assert.NotNull(properties);
+        Assert.Single(properties);
+        Assert.Equal("net8.0;net9.0", properties["TARGETFRAMEWORKS"]);
+    }
+
+    [Theory]
+    [InlineData(".sln")]
+    [InlineData(".slnx")]
+    public async Task MultipleProjectPropertiesAreNotEvaluatedForSolutions(string extension)
+    {
+        using var tempDir = await TemporaryDirectory.CreateWithContentsAsync(
+        [
+            ($"solution{extension}", string.Empty)
+        ]);
+        var solutionPath = Path.Combine(tempDir.DirectoryPath, $"solution{extension}");
+        var logger = new StringLogger();
+        var properties = await MSBuildHelper.GetProjectPropertiesAsync(
+            solutionPath,
+            ["TargetFrameworks", "NETCoreSdkVersion"],
+            logger
+        );
+
+        Assert.Null(properties);
+        Assert.Empty(logger.Messages);
+    }
+
     [Theory]
     [MemberData(nameof(GetTargetFrameworkValuesFromProjectData))]
     public async Task GetTargetFrameworkValuesFromProject(string projectContents, string[] expectedTfms)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Discover/SdkProjectDiscovery.cs
@@ -65,6 +65,8 @@ internal static class SdkProjectDiscovery
     // these targets are required to evaluate a legacy project with a single operation
     private static readonly ImmutableArray<string> LegacyProjectSingleRestoreTargetNames = ["ResolveProjectReferences"];
 
+    private const string TargetFrameworksPropertyName = "TargetFrameworks";
+
     // this property evaluates to a version number in an SDK-style project and is unset or empty otherwise
     private const string NETCoreSdkVersionPropertyName = "NETCoreSdkVersion";
 
@@ -119,16 +121,30 @@ internal static class SdkProjectDiscovery
         Dictionary<string, HashSet<string>> additionalFiles = new(PathComparer.Instance);
         //    projectPath  additionalFiles
 
+        var startingProjectProperties = await MSBuildHelper.GetProjectPropertiesAsync(
+            startingProjectPath,
+            [TargetFrameworksPropertyName, NETCoreSdkVersionPropertyName],
+            logger
+        );
+        var projectTfms = MSBuildHelper.ParseProjectTargetFrameworks(startingProjectProperties?.GetValueOrDefault(TargetFrameworksPropertyName));
+        var netCoreSdkVersionValue = startingProjectProperties?.GetValueOrDefault(NETCoreSdkVersionPropertyName);
+        var isLegacyProject = string.IsNullOrEmpty(netCoreSdkVersionValue);
+        var requiredTargets = isLegacyProject
+            ? LegacyProjectSingleRestoreTargetNames
+            : SingleRestoreTargetNames;
+
         // due to how MSBuild handles multi-TFM projects with target platforms we may need to process each TFM separately
         // we detect that by determining if there are multiple target frameworks specified and if any of them have a platform suffix (e.g., `-windows`, `-android`, etc)
         // alternately, if there are too many target frameworks specified, they must be handled individually
-        var projectTfms = await MSBuildHelper.GetProjectTargetFrameworksAsync(startingProjectPath, logger);
         var hasPlatformTfms = projectTfms.Any(tfm => tfm.Contains('-'));
         var requiresIndividualRestores = hasPlatformTfms || projectTfms.Length > MaximumParallelTargetFrameworkRestores;
+        var useDirectRestore = requiresIndividualRestores;
         if (!requiresIndividualRestores)
         {
             logger.Info($"Performing single restore for project {startingProjectPath}");
             projectTfms = [string.Empty]; // a single restore can handle everything, but we need to loop at least once and an empty TFM is our signal to not specify anything
+            var actualTargets = await MSBuildHelper.GetProjectTargetsAsync(startingProjectPath, logger);
+            useDirectRestore = requiredTargets.All(actualTargets.Contains);
         }
         else
         {
@@ -158,15 +174,7 @@ internal static class SdkProjectDiscovery
                 // `ResolveProjectReferences` to gather all `PackageReference` items and further down we re-build the transitive
                 // dependency set.  Without the legacy project check, we could incorrectly invoke `Build` which eventually tries
                 // to call `csc.exe` which is unnecessary and can be slow.
-                var netCoreSdkVersionValue = await MSBuildHelper.GetProjectPropertyAsync(startingProjectPath, NETCoreSdkVersionPropertyName, logger);
-                var isLegacyProject = string.IsNullOrEmpty(netCoreSdkVersionValue);
-                var requiredTargets = isLegacyProject
-                    ? LegacyProjectSingleRestoreTargetNames
-                    : SingleRestoreTargetNames;
-
-                var actualTargets = await MSBuildHelper.GetProjectTargetsAsync(startingProjectPath, logger);
-                var useDirectRestore = requiredTargets.All(actualTargets.Contains);
-                if (useDirectRestore || isIndividualTfmRestore)
+                if (useDirectRestore)
                 {
                     // directly call the required targets
                     args.Add($"/t:{string.Join(",", requiredTargets)}");

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/HttpApiHandler.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace NuGetUpdater.Core.Run;
 
-public class HttpApiHandler : IApiHandler
+public class HttpApiHandler : IApiHandler, IApiRetryDelayProvider
 {
     private static readonly HttpClient HttpClient = new();
 
@@ -16,12 +16,21 @@ public class HttpApiHandler : IApiHandler
 
     private readonly string _apiUrl;
     private readonly string _jobId;
+    private readonly Func<TimeSpan, Task> _retryDelay;
 
     public HttpApiHandler(string apiUrl, string jobId)
+        : this(apiUrl, jobId, Task.Delay)
+    {
+    }
+
+    internal HttpApiHandler(string apiUrl, string jobId, Func<TimeSpan, Task> retryDelay)
     {
         _apiUrl = apiUrl.TrimEnd('/');
         _jobId = jobId;
+        _retryDelay = retryDelay;
     }
+
+    Task IApiRetryDelayProvider.DelayAsync(TimeSpan delay) => _retryDelay(delay);
 
     public async Task SendAsync(string endpoint, object body, string method)
     {

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Run/IApiHandler.cs
@@ -7,6 +7,11 @@ public interface IApiHandler
     Task SendAsync(string endpoint, object body, string method);
 }
 
+internal interface IApiRetryDelayProvider
+{
+    Task DelayAsync(TimeSpan delay);
+}
+
 public static class IApiHandlerExtensions
 {
     public static async Task RecordUpdateJobError(this IApiHandler handler, JobErrorBase error, ILogger logger)
@@ -70,7 +75,15 @@ public static class IApiHandlerExtensions
                 (ex.StatusCode is null || ((int)ex.StatusCode) / 100 == 5))
             {
                 retryCount++;
-                await Task.Delay(TimeSpan.FromSeconds(Random.Shared.Next(MinRetryDelay, MaxRetryDelay)));
+                var delay = TimeSpan.FromSeconds(Random.Shared.Next(MinRetryDelay, MaxRetryDelay));
+                if (handler is IApiRetryDelayProvider delayProvider)
+                {
+                    await delayProvider.DelayAsync(delay);
+                }
+                else
+                {
+                    await Task.Delay(delay);
+                }
             }
         }
     }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Utilities/MSBuildHelper.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
@@ -563,6 +564,119 @@ internal static partial class MSBuildHelper
         return targets;
     }
 
+    internal static async Task<ImmutableDictionary<string, string>?> GetProjectPropertiesAsync(
+        string projectPath,
+        IReadOnlyCollection<string> propertyNames,
+        ILogger logger
+    )
+    {
+        var extension = Path.GetExtension(projectPath)?.ToLowerInvariant();
+        if (extension == ".sln" || extension == ".slnx")
+        {
+            // solution files don't specify properties, so we can skip the process invocation
+            return null;
+        }
+
+        var requestedPropertyNames = propertyNames
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToImmutableArray();
+        if (requestedPropertyNames.Length == 0)
+        {
+            return ImmutableDictionary.Create<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        if (requestedPropertyNames.Length == 1)
+        {
+            var propertyName = requestedPropertyNames[0];
+            var propertyValue = await GetProjectPropertyAsync(projectPath, propertyName, logger);
+            return propertyValue is null
+                ? null
+                : ImmutableDictionary.Create<string, string>(StringComparer.OrdinalIgnoreCase).Add(propertyName, propertyValue);
+        }
+
+        var projectDirectory = Path.GetDirectoryName(projectPath)!;
+        var tempDir = Directory.CreateTempSubdirectory("__get_msbuild_properties_");
+        try
+        {
+            var resultOutputPath = Path.Combine(tempDir.FullName, "result.json");
+            var args = new[]
+            {
+                projectPath,
+                $"-getProperty:{string.Join(",", requestedPropertyNames)}",
+                $"-getResultOutputFile:{resultOutputPath}",
+            };
+
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, projectDirectory);
+            if (exitCode != 0)
+            {
+                if (IsGetPropertyUnsupported(stdOut, stdErr))
+                {
+                    var fallbackProperties = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var propertyName in requestedPropertyNames)
+                    {
+                        var propertyValue = await GetProjectPropertyUsingCompatibilityTargetAsync(projectPath, propertyName, logger);
+                        if (propertyValue is null)
+                        {
+                            return null;
+                        }
+
+                        fallbackProperties[propertyName] = propertyValue;
+                    }
+
+                    return fallbackProperties.ToImmutable();
+                }
+
+                logger.Warn($"Unable to determine properties '{string.Join("', '", requestedPropertyNames)}' for project [{projectPath}]:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}\n");
+                return null;
+            }
+
+            if (!File.Exists(resultOutputPath))
+            {
+                logger.Warn($"Unable to determine properties '{string.Join("', '", requestedPropertyNames)}' for project [{projectPath}]: MSBuild did not produce a result output file.\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}\n");
+                return null;
+            }
+
+            var resultOutput = await File.ReadAllTextAsync(resultOutputPath);
+            try
+            {
+                using var resultDocument = JsonDocument.Parse(resultOutput);
+                var root = resultDocument.RootElement;
+                if (root.ValueKind != JsonValueKind.Object ||
+                    !root.TryGetProperty("Properties", out var propertiesElement) ||
+                    propertiesElement.ValueKind != JsonValueKind.Object)
+                {
+                    logger.Warn($"Unable to determine properties '{string.Join("', '", requestedPropertyNames)}' for project [{projectPath}]: MSBuild result output did not contain a properties object.");
+                    return null;
+                }
+
+                var properties = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var propertyName in requestedPropertyNames)
+                {
+                    if (!propertiesElement.TryGetProperty(propertyName, out var propertyElement) ||
+                        propertyElement.ValueKind != JsonValueKind.String ||
+                        propertyElement.GetString() is not string propertyValue)
+                    {
+                        logger.Warn($"Unable to determine property '{propertyName}' for project [{projectPath}]: MSBuild result output did not contain a string value for the property.");
+                        return null;
+                    }
+
+                    properties[propertyName] = propertyValue;
+                }
+
+                return properties.ToImmutable();
+            }
+            catch (JsonException ex)
+            {
+                logger.Warn($"Unable to determine properties '{string.Join("', '", requestedPropertyNames)}' for project [{projectPath}]: MSBuild produced invalid JSON result output: {ex.Message}");
+                return null;
+            }
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
     internal static async Task<string?> GetProjectPropertyAsync(string projectPath, string propertyName, ILogger logger)
     {
         var extension = Path.GetExtension(projectPath)?.ToLowerInvariant();
@@ -582,41 +696,9 @@ internal static partial class MSBuildHelper
         var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, projectDirectory);
         if (exitCode != 0)
         {
-            if (stdOut.Contains("error MSB1001: Unknown switch."))
+            if (IsGetPropertyUnsupported(stdOut, stdErr))
             {
-                // older versions of MSBuild don't allow `-getProperty` so we go a different route
-                // we can't force an indirect property evaluation, but we can force import a custom targets file that effectively renames the property
-                var tempDir = Directory.CreateTempSubdirectory("__get_msbuild_property_");
-                try
-                {
-                    // prepare magic contents
-                    var targetsTemplateContents = await File.ReadAllTextAsync(GetFileFromRuntimeDirectory("GetProperty.targets"));
-                    var targetContents = targetsTemplateContents.Replace("%RequestedPropertyName%", $"$({propertyName})");
-
-                    // write magic contents
-                    var tempTargetsPath = Path.Combine(tempDir.FullName, $"GetProperty_{propertyName}.targets");
-                    await File.WriteAllTextAsync(tempTargetsPath, targetContents);
-
-                    // do it
-                    args = [
-                        projectPath,
-                        $"/p:CustomAfterMicrosoftCommonTargets={tempTargetsPath}",
-                        "/t:_Dependabot_GetProperty",
-                    ];
-                    (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, projectDirectory);
-                    if (exitCode == 0)
-                    {
-                        var match = Regex.Match(stdOut, "__PROPERTY_VALUE:(?<PropertyValue>[^$]*)$", RegexOptions.Multiline);
-                        if (match.Success)
-                        {
-                            return match.Groups["PropertyValue"].Value.Trim();
-                        }
-                    }
-                }
-                finally
-                {
-                    tempDir.Delete(recursive: true);
-                }
+                return await GetProjectPropertyUsingCompatibilityTargetAsync(projectPath, propertyName, logger);
             }
 
             logger.Warn($"Unable to determine property '{propertyName}' for project [{projectPath}]:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}\n");
@@ -629,6 +711,11 @@ internal static partial class MSBuildHelper
     internal static async Task<ImmutableArray<string>> GetProjectTargetFrameworksAsync(string projectPath, ILogger logger)
     {
         var rawValue = await GetProjectPropertyAsync(projectPath, "TargetFrameworks", logger);
+        return ParseProjectTargetFrameworks(rawValue);
+    }
+
+    internal static ImmutableArray<string> ParseProjectTargetFrameworks(string? rawValue)
+    {
         if (rawValue is null)
         {
             return [];
@@ -639,6 +726,49 @@ internal static partial class MSBuildHelper
             .OrderBy(t => t)
             .ToImmutableArray();
         return tfms;
+    }
+
+    private static bool IsGetPropertyUnsupported(string stdOut, string stdErr)
+    {
+        return stdOut.Contains("error MSB1001: Unknown switch.", StringComparison.Ordinal) ||
+            stdErr.Contains("error MSB1001: Unknown switch.", StringComparison.Ordinal);
+    }
+
+    private static async Task<string?> GetProjectPropertyUsingCompatibilityTargetAsync(string projectPath, string propertyName, ILogger logger)
+    {
+        // Older versions of MSBuild don't allow `-getProperty`, so import a custom target that reports the property.
+        var projectDirectory = Path.GetDirectoryName(projectPath)!;
+        var tempDir = Directory.CreateTempSubdirectory("__get_msbuild_property_");
+        try
+        {
+            var targetsTemplateContents = await File.ReadAllTextAsync(GetFileFromRuntimeDirectory("GetProperty.targets"));
+            var targetContents = targetsTemplateContents.Replace("%RequestedPropertyName%", $"$({propertyName})");
+            var tempTargetsPath = Path.Combine(tempDir.FullName, $"GetProperty_{propertyName}.targets");
+            await File.WriteAllTextAsync(tempTargetsPath, targetContents);
+
+            var args = new[]
+            {
+                projectPath,
+                $"/p:CustomAfterMicrosoftCommonTargets={tempTargetsPath}",
+                "/t:_Dependabot_GetProperty",
+            };
+            var (exitCode, stdOut, stdErr) = await ProcessEx.RunDotnetMSBuildSafelyAsync(args, projectDirectory);
+            if (exitCode == 0)
+            {
+                var match = Regex.Match(stdOut, "__PROPERTY_VALUE:(?<PropertyValue>[^$]*)$", RegexOptions.Multiline);
+                if (match.Success)
+                {
+                    return match.Groups["PropertyValue"].Value.Trim();
+                }
+            }
+
+            logger.Warn($"Unable to determine property '{propertyName}' for project [{projectPath}]:\nSTDOUT:\n{stdOut}\nSTDERR:\n{stdErr}\n");
+            return null;
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
     }
 
     internal static string? GetMissingFile(string output)

--- a/nuget/script/ci-test
+++ b/nuget/script/ci-test
@@ -2,16 +2,11 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NUGET_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 # PowerShell unit tests
-pushd ./updater
-pwsh ./test.ps1
-popd
+pwsh "$NUGET_DIR/updater/test.ps1"
 
 # C# unit tests
-pushd ./helpers/lib/NuGetUpdater
-dotnet restore
-dotnet build --configuration Release
-dotnet test --configuration Release --no-restore --no-build --logger "console;verbosity=normal" --blame-hang-timeout 5m ./DotNetPackageCorrelation.Test/DotNetPackageCorrelation.Test.csproj
-dotnet test --configuration Release --no-restore --no-build --logger "console;verbosity=normal" --blame-hang-timeout 5m ./NuGetUpdater.Cli.Test/NuGetUpdater.Cli.Test.csproj
-dotnet test --configuration Release --no-restore --no-build --logger "console;verbosity=normal" --blame-hang-timeout 5m ./NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj
-popd
+"$SCRIPT_DIR/run-csharp-tests"

--- a/nuget/script/run-csharp-tests
+++ b/nuget/script/run-csharp-tests
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NUGET_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 UPDATER_DIR="$NUGET_DIR/helpers/lib/NuGetUpdater"
 SOLUTION="$UPDATER_DIR/NuGetUpdater.slnx"
+CORE_TEST_PROJECT="$UPDATER_DIR/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj"
 LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nuget-csharp-tests.XXXXXX")"
 
 trap 'rm -rf -- "$LOG_DIR"' EXIT
@@ -42,6 +43,22 @@ start_test() {
   phase_labels+=("$label")
   phase_logs+=("$log_file")
   phase_pids+=("$!")
+}
+
+core_remainder_filter=""
+
+start_core_shard() {
+  local label="$1"
+  shift
+
+  local filter=""
+  local pattern
+  for pattern in "$@"; do
+    filter+="${filter:+|}FullyQualifiedName~$pattern"
+    core_remainder_filter+="${core_remainder_filter:+&}FullyQualifiedName!~$pattern"
+  done
+
+  start_test "NuGetUpdater.Core.Test.$label" "$CORE_TEST_PROJECT" "$filter"
 }
 
 wait_for_phase() {
@@ -92,22 +109,22 @@ phase_logs=()
 phase_pids=()
 phase_statuses=()
 
-start_test \
-  "NuGetUpdater.Core.Test.EndToEndTests" \
-  "$UPDATER_DIR/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj" \
-  "FullyQualifiedName~NuGetUpdater.Core.Test.Run.EndToEndTests"
-start_test \
-  "NuGetUpdater.Core.Test.DiscoveryWorkerTests" \
-  "$UPDATER_DIR/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj" \
-  "FullyQualifiedName~NuGetUpdater.Core.Test.Discover.DiscoveryWorkerTests"
-start_test \
-  "NuGetUpdater.Core.Test.FileWriterAndSdkProjectDiscoveryTests" \
-  "$UPDATER_DIR/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj" \
-  "FullyQualifiedName~NuGetUpdater.Core.Test.Update.FileWriters.FileWriterWorkerTests|FullyQualifiedName~NuGetUpdater.Core.Test.Discover.SdkProjectDiscoveryTests"
+start_core_shard \
+  "EndToEndTests" \
+  "NuGetUpdater.Core.Test.Run.EndToEndTests"
+start_core_shard \
+  "DiscoveryWorkerTests" \
+  "NuGetUpdater.Core.Test.Discover.DiscoveryWorkerTests"
+start_core_shard \
+  "FileWriterAndSdkProjectDiscoveryTests" \
+  "NuGetUpdater.Core.Test.Update.FileWriters.FileWriterWorkerTests" \
+  "NuGetUpdater.Core.Test.Discover.SdkProjectDiscoveryTests"
+
+# Any test that does not match a named shard runs here.
 start_test \
   "NuGetUpdater.Core.Test.RemainingTests" \
-  "$UPDATER_DIR/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj" \
-  "FullyQualifiedName!~NuGetUpdater.Core.Test.Run.EndToEndTests&FullyQualifiedName!~NuGetUpdater.Core.Test.Discover.DiscoveryWorkerTests&FullyQualifiedName!~NuGetUpdater.Core.Test.Update.FileWriters.FileWriterWorkerTests&FullyQualifiedName!~NuGetUpdater.Core.Test.Discover.SdkProjectDiscoveryTests"
+  "$CORE_TEST_PROJECT" \
+  "$core_remainder_filter"
 
 if ! wait_for_phase; then
   overall_status=1

--- a/nuget/script/run-csharp-tests
+++ b/nuget/script/run-csharp-tests
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NUGET_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+UPDATER_DIR="$NUGET_DIR/helpers/lib/NuGetUpdater"
+SOLUTION="$UPDATER_DIR/NuGetUpdater.slnx"
+LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nuget-csharp-tests.XXXXXX")"
+
+trap 'rm -rf -- "$LOG_DIR"' EXIT
+
+declare -a phase_labels=()
+declare -a phase_logs=()
+declare -a phase_pids=()
+declare -a phase_statuses=()
+
+start_test() {
+  local label="$1"
+  local project="$2"
+  local filter="${3:-}"
+  local log_file="$LOG_DIR/$label.log"
+  local -a test_args=(
+    "$project"
+    --configuration Release
+    --no-restore
+    --no-build
+    --logger "console;verbosity=normal"
+    --blame-hang-timeout 5m
+  )
+
+  if [[ -n "$filter" ]]; then
+    test_args+=(--filter "$filter")
+  fi
+
+  (
+    export NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS=0
+    export MSBUILDDISABLENODEREUSE=1
+    dotnet test "${test_args[@]}"
+  ) >"$log_file" 2>&1 &
+
+  phase_labels+=("$label")
+  phase_logs+=("$log_file")
+  phase_pids+=("$!")
+}
+
+wait_for_phase() {
+  local phase_failed=0
+  local index
+  local status
+
+  for index in "${!phase_pids[@]}"; do
+    if wait "${phase_pids[$index]}"; then
+      status=0
+    else
+      status=$?
+      phase_failed=1
+    fi
+    phase_statuses[index]="$status"
+  done
+
+  for index in "${!phase_logs[@]}"; do
+    printf '\n===== %s (exit %s) =====\n' "${phase_labels[$index]}" "${phase_statuses[$index]}"
+    if ! cat "${phase_logs[$index]}"; then
+      phase_failed=1
+    fi
+  done
+
+  return "$phase_failed"
+}
+
+cd "$UPDATER_DIR" || exit 1
+
+dotnet restore "$SOLUTION"
+dotnet build "$SOLUTION" --configuration Release --no-restore
+
+overall_status=0
+
+start_test \
+  "DotNetPackageCorrelation.Test" \
+  "$UPDATER_DIR/DotNetPackageCorrelation.Test/DotNetPackageCorrelation.Test.csproj"
+start_test \
+  "NuGetUpdater.Cli.Test" \
+  "$UPDATER_DIR/NuGetUpdater.Cli.Test/NuGetUpdater.Cli.Test.csproj"
+
+if ! wait_for_phase; then
+  overall_status=1
+fi
+
+phase_labels=()
+phase_logs=()
+phase_pids=()
+phase_statuses=()
+
+start_test \
+  "NuGetUpdater.Core.Test.EndToEndTests" \
+  "$UPDATER_DIR/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj" \
+  "FullyQualifiedName~NuGetUpdater.Core.Test.Run.EndToEndTests"
+start_test \
+  "NuGetUpdater.Core.Test.DiscoveryWorkerTests" \
+  "$UPDATER_DIR/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj" \
+  "FullyQualifiedName~NuGetUpdater.Core.Test.Discover.DiscoveryWorkerTests"
+start_test \
+  "NuGetUpdater.Core.Test.FileWriterAndSdkProjectDiscoveryTests" \
+  "$UPDATER_DIR/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj" \
+  "FullyQualifiedName~NuGetUpdater.Core.Test.Update.FileWriters.FileWriterWorkerTests|FullyQualifiedName~NuGetUpdater.Core.Test.Discover.SdkProjectDiscoveryTests"
+start_test \
+  "NuGetUpdater.Core.Test.RemainingTests" \
+  "$UPDATER_DIR/NuGetUpdater.Core.Test/NuGetUpdater.Core.Test.csproj" \
+  "FullyQualifiedName!~NuGetUpdater.Core.Test.Run.EndToEndTests&FullyQualifiedName!~NuGetUpdater.Core.Test.Discover.DiscoveryWorkerTests&FullyQualifiedName!~NuGetUpdater.Core.Test.Update.FileWriters.FileWriterWorkerTests&FullyQualifiedName!~NuGetUpdater.Core.Test.Discover.SdkProjectDiscoveryTests"
+
+if ! wait_for_phase; then
+  overall_status=1
+fi
+
+exit "$overall_status"


### PR DESCRIPTION
### What are you trying to accomplish?

The NuGet test job spends most of its time running the core tests serially. This change:

- runs the C# tests in separate processes with four complementary core shards
- removes real delays from retry tests without changing retry counts
- combines repeated MSBuild property queries and moves invariant work outside the target framework loop

This cuts feedback time without dropping test coverage.

### Anything you want to highlight for special attention from reviewers?

I tried xUnit collection parallelism first, but process-wide NuGet environment variables made it flaky. Separate test processes provide the same speedup without sharing that state.

The runner uses the SDK pinned by `global.json` and disables MSBuild node reuse inside each test process.

### How will you know you've accomplished your goal?

Three clean runs passed in 4:03, 3:54, and 3:45. The median was 3:54, compared with a 9:52 local baseline.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
