### PR TITLE
Update uv dependencies pinned to a git tag

### DIFF
--- a/python/lib/dependabot/python/file_parser/pyproject_document.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_document.rb
@@ -216,6 +216,32 @@ module Dependabot
           poetry_sources.find { |source| source.name == name }
         end
 
+        # Keys come back as the author wrote them, which is what a caller has to match the file on.
+        sig { returns(T::Hash[String, T::Hash[Symbol, String]]) }
+        def uv_git_tag_sources
+          tool = section(@data, "tool", "tool")
+          uv = tool && section(tool, "uv", "tool.uv")
+          sources = uv && section(uv, "sources", "tool.uv.sources")
+          return {} unless sources
+
+          result = T.let({}, T::Hash[String, T::Hash[Symbol, String]])
+          sources.each do |name, config|
+            next unless config.is_a?(Hash)
+
+            entry = PyprojectValueParser.object_hash(config, "tool.uv.sources.#{name}")
+            url = entry["git"]
+            ref = entry["tag"]
+            next unless url.is_a?(String) && ref.is_a?(String)
+
+            result[name] = { url: url, ref: ref }
+          end
+          result
+        rescue TypeError
+          # A malformed table is not this method's business either: it runs for every PEP 621
+          # manifest, so raising would stop every dependency in the repository being updated.
+          {}
+        end
+
         sig { params(key: String).returns(T::Array[String]) }
         def workspace_globs(key)
           tool = section(@data, "tool", "tool")

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -84,6 +84,12 @@ module Dependabot
 
       sig { override.returns(T.nilable(Gem::Version)) }
       def lowest_security_fix_version
+        # A git dependency's version is whatever the lockfile records for that package, not a commit
+        # sha, so `existing_version_is_sha?` does not exclude it from security updates the way it does
+        # elsewhere. Its index has no bearing on the pinned ref: answering with a version from there
+        # would title the pull request with a fix the diff does not apply.
+        return nil if git_dependency?
+
         latest_version_finder.lowest_security_fix_version
       end
 

--- a/python/spec/dependabot/python/file_parser/pyproject_document_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_document_spec.rb
@@ -68,6 +68,49 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectDocument do
     expect(document.workspace_globs("exclude")).to eq(["packages/ignored"])
   end
 
+  describe "#uv_git_tag_sources" do
+    let(:content) do
+      <<~TOML
+        [tool.uv.sources]
+        tagged = { git = "https://example.com/tagged.git", tag = "1.2.3" }
+        Odd_Key = { git = "https://example.com/odd.git", tag = "4.5.6" }
+        branch-only = { git = "https://example.com/branch.git", branch = "main" }
+        no-ref = { git = "https://example.com/no-ref.git" }
+        path-only = { path = "./local" }
+        arrayed = [{ git = "https://example.com/arrayed.git", tag = "7.8.9" }]
+        bad-tag = { git = "https://example.com/bad.git", tag = 1.2 }
+        bad-git = { git = { url = "https://example.com/bad.git" }, tag = "1.0.0" }
+      TOML
+    end
+
+    it "returns only the git-and-tag entries, keyed as the author wrote them" do
+      expect(document.uv_git_tag_sources).to eq(
+        "tagged" => { url: "https://example.com/tagged.git", ref: "1.2.3" },
+        "Odd_Key" => { url: "https://example.com/odd.git", ref: "4.5.6" }
+      )
+    end
+
+    context "without a [tool.uv.sources] table" do
+      let(:content) { "[project]\nname = \"x\"\n" }
+
+      it { expect(document.uv_git_tag_sources).to eq({}) }
+    end
+
+    # This runs for every PEP 621 manifest, so a table it cannot read has to yield nothing rather
+    # than stop every dependency in the repository being updated
+    [
+      ["an array of tables", "[[tool.uv.sources]]\nname = \"x\"\n"],
+      ["a string where the table belongs", "[tool.uv]\nsources = \"nope\"\n"],
+      ["a string where tool.uv belongs", "[tool]\nuv = \"nope\"\n"]
+    ].each do |shape, toml|
+      context "with #{shape}" do
+        let(:content) { toml }
+
+        it { expect(document.uv_git_tag_sources).to eq({}) }
+      end
+    end
+  end
+
   context "with Poetry's reserved PyPI source" do
     let(:content) do
       <<~TOML

--- a/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb
@@ -9,6 +9,7 @@ require "dependabot/uv/file_parser"
 require "dependabot/uv/requirement"
 require "dependabot/errors"
 require "dependabot/uv/name_normaliser"
+require "dependabot/uv/sources_table"
 require "dependabot/python/file_parser/pep_dependency"
 require "dependabot/python/file_parser/poetry_lock"
 require "dependabot/python/file_parser/pyproject_document"
@@ -89,13 +90,25 @@ module Dependabot
           # undesirable. Leave PDM alone until properly supported
           return dependencies if using_pdm?
 
+          git_tag_sources = SourcesTable.writable_for(pyproject_file)
+
           parse_pep621_pep735_dependencies(pyproject_file).each do |dep|
             # If a requirement has a `<` or `<=` marker then updating it is
             # probably blocked. Ignore it.
             next if dep.markers&.include?("<")
 
             # In uv no constraint means any version is acceptable
-            requirement_value = dep.requirement == "" ? "*" : dep.requirement
+            git_source = git_source_for(git_tag_sources, dep.name)
+            # nil alongside a git source, as the Poetry path does (python/lib/.../pyproject_files_parser.rb
+            # git_requirement). Keeping the PEP 508 constraint makes requirements_up_to_date? compare it
+            # against the newest tag, so a `>=` floor above that tag reports the pin as current.
+            requirement_value = if git_source
+                                  nil
+                                elsif dep.requirement == ""
+                                  "*"
+                                else
+                                  dep.requirement
+                                end
 
             dependencies <<
               Dependency.new(
@@ -104,7 +117,7 @@ module Dependabot
                 requirements: [{
                   requirement: requirement_value,
                   file: Pathname.new(dep.file).cleanpath.to_path,
-                  source: nil,
+                  source: git_source,
                   groups: [dep.requirement_type].compact
                 }],
                 package_manager: "uv"
@@ -345,6 +358,20 @@ module Dependabot
         sig { params(name: String).returns(String) }
         def normalise(name)
           NameNormaliser.normalise(name)
+        end
+
+        sig do
+          params(
+            git_tag_sources: T::Hash[String, T::Hash[Symbol, String]],
+            name: String
+          ).returns(T.nilable(T::Hash[Symbol, String]))
+        end
+        def git_source_for(git_tag_sources, name)
+          normalised = normalise(name)
+          match = git_tag_sources.find { |key, _| normalise(key) == normalised }
+          return nil unless match
+
+          { type: "git" }.merge(match[1])
         end
 
         sig { returns(PyprojectDocument) }

--- a/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
+++ b/uv/lib/dependabot/uv/file_updater/lock_file_updater.rb
@@ -14,6 +14,7 @@ require "dependabot/uv/file_updater"
 require "dependabot/uv/native_helpers"
 require "dependabot/uv/name_normaliser"
 require "dependabot/uv/requirement_suffix_helper"
+require "dependabot/uv/sources_table"
 
 module Dependabot
   module Uv
@@ -145,12 +146,17 @@ module Dependabot
           return content unless file_changed?(file)
 
           updated_content = content.dup
+          nothing_to_rewrite = T.let(false, T::Boolean)
 
           T.must(dependency).requirements.zip(T.must(T.must(dependency).previous_requirements)).each do |new_r, old_r|
             next unless new_r.file == file.name && T.must(old_r).file == file.name
 
-            updated_content = replace_dep(T.must(dependency), updated_content, new_r, T.must(old_r))
+            rewritten = rewrite_requirement(updated_content, new_r, T.must(old_r))
+            nothing_to_rewrite = true if rewritten.nil?
+            updated_content = rewritten if rewritten
           end
+
+          return content if nothing_to_rewrite && content == updated_content
 
           raise DependencyFileContentNotChanged, "Content did not change!" if content == updated_content
 
@@ -198,6 +204,106 @@ module Dependabot
           end
 
           updated_content
+        end
+
+        sig { returns(T::Boolean) }
+        def git_dependency?
+          T.must(dependency).requirements.any? { |r| r.source_string("type") == "git" }
+        end
+
+        # nil when this file has nothing to rewrite: updated_git_requirements stamps the resolved source
+        # onto every requirement of the merged dependency, including one from a manifest that does not
+        # declare it, and that file had nothing to rewrite before this either.
+        sig do
+          params(
+            content: String,
+            new_r: Dependabot::DependencyRequirement,
+            old_r: Dependabot::DependencyRequirement
+          ).returns(T.nilable(String))
+        end
+        def rewrite_requirement(content, new_r, old_r)
+          return replace_git_tag(T.must(dependency), content, new_r, old_r) if git_tag_moved?(new_r, old_r)
+          return nil if git_source_arrived?(new_r, old_r)
+
+          replace_dep(T.must(dependency), content, new_r, old_r)
+        end
+
+        sig do
+          params(new_r: Dependabot::DependencyRequirement, old_r: Dependabot::DependencyRequirement)
+            .returns(T::Boolean)
+        end
+        def git_source_arrived?(new_r, old_r)
+          new_r.source_string("type") == "git" && old_r.source_string("type").nil?
+        end
+
+        sig do
+          params(new_r: Dependabot::DependencyRequirement, old_r: Dependabot::DependencyRequirement)
+            .returns(T::Boolean)
+        end
+        def git_tag_moved?(new_r, old_r)
+          return false unless new_r.source_string("type") == "git"
+          return false unless old_r.source_string("type") == "git"
+
+          old_ref = old_r.source_string("ref")
+          new_ref = new_r.source_string("ref")
+          return false if old_ref.nil? || new_ref.nil?
+
+          old_ref != new_ref
+        end
+
+        sig do
+          params(
+            dep: Dependabot::Dependency,
+            content: String,
+            new_r: Dependabot::DependencyRequirement,
+            old_r: Dependabot::DependencyRequirement
+          ).returns(String)
+        end
+        def replace_git_tag(dep, content, new_r, old_r)
+          old_ref = T.must(old_r.source_string("ref"))
+          new_ref = T.must(new_r.source_string("ref"))
+
+          key = raw_source_key(content, dep.name, old_ref)
+          return content unless key
+
+          span = SourcesTable.span(content)
+          return content unless span
+
+          rewritten = span[1].sub(SourcesTable.tag_regex(key, old_ref)) do
+            "#{Regexp.last_match(1)}#{new_ref}#{Regexp.last_match(2)}"
+          end
+          candidate = content.dup.tap { |c| c[span[0]] = rewritten }
+          moved_tag?(candidate, key, new_ref) ? candidate : content
+        end
+
+        # The table is located by pattern over raw text, so a [tool.uv.sources] block quoted inside
+        # a string can answer for the real one. Asking TOML what the result says the tag is turns any
+        # such surprise into the no-op this had before, instead of an edit reported as a bump.
+        sig { params(content: String, key: String, ref: String).returns(T::Boolean) }
+        def moved_tag?(content, key, ref)
+          TomlRB.parse(content).dig("tool", "uv", "sources", key, "tag") == ref
+        rescue TomlRB::ParseError
+          false
+        end
+
+        # uv resolves a source under PEP 508 normalisation, so the file's key can differ from dep.name.
+        # Two keys can normalise the same - `pkg` and `Pkg_` - so the ref decides between them: the
+        # one whose entry actually carries it is the one the parser attached, and the only one this
+        # can rewrite.
+        sig { params(content: String, name: String, ref: String).returns(T.nilable(String)) }
+        def raw_source_key(content, name, ref)
+          sources = TomlRB.parse(content).dig("tool", "uv", "sources")
+          return nil unless sources.is_a?(Hash)
+
+          table = SourcesTable.span(content)&.last
+          return nil unless table
+
+          normalised = normalise(name)
+          sources.keys.find do |key|
+            normalise(key) == normalised && table.match?(SourcesTable.tag_regex(key, ref))
+          end
+        rescue TomlRB::ParseError
+          nil
         end
 
         sig { params(req1: String, req2: String).returns(T::Boolean) }
@@ -306,7 +412,11 @@ module Dependabot
           # uv lock --upgrade-package expects the base package name without extras
           base_dep_name = normalise(dep_name)
           package_spec =
-            if target_requirement
+            if git_dependency?
+              # There is no index to pin a version against: the ref in [tool.uv.sources] has already
+              # been rewritten, so re-resolving the package by name is what picks the new tag up.
+              base_dep_name
+            elsif target_requirement
               "#{base_dep_name}#{target_requirement}"
             elsif dep_version
               "#{base_dep_name}==#{dep_version}"

--- a/uv/lib/dependabot/uv/sources_table.rb
+++ b/uv/lib/dependabot/uv/sources_table.rb
@@ -1,0 +1,79 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/dependency_file"
+require "dependabot/python/file_parser/pyproject_document"
+
+module Dependabot
+  module Uv
+    # Where [tool.uv.sources] sits in a manifest's text. The parser decides which entries can be
+    # rewritten and the file updater rewrites them, so both have to agree on the table's extent: over
+    # the whole file a line of the same shape in another tool's table answers for either.
+    module SourcesTable
+      extend T::Sig
+
+      # A trailing comment and a CRLF line ending both belong on this line, and neither should turn
+      # the feature off without a word.
+      HEADER = /^[ \t]*\[tool\.uv\.sources\][ \t]*(?:\#[^\r\n]*)?\r?$/
+      NEXT_TABLE = /^[ \t]*\[/
+
+      # What the rewrite anchors on: the key verbatim at the start of its line, and the tag it is
+      # expected to carry. Both sides use this, so what the parser accepts is exactly what can be
+      # rewritten - a shape only one of them understood is what turned a silent no-op into a job
+      # failure.
+      sig { params(key: String, ref: String).returns(Regexp) }
+      def self.tag_regex(key, ref)
+        # Quoting is the only legal TOML spelling for a name carrying a dot - zope.interface,
+        # ruamel.yaml - so both the key and the inner `tag` are matched with or without quotes. The
+        # `,` before `tag` is what stops the pattern latching onto the tail of another key.
+        /
+          (^[ \t]*["']?#{Regexp.escape(key)}["']?[ \t]*=[ \t]*
+           \{(?:[^}]*?,)?[ \t]*["']?tag["']?[ \t]*=[ \t]*["'])
+          #{Regexp.escape(ref)}
+          (["'])
+        /x
+      end
+
+      # The git-and-tag entries of a manifest that this file can rewrite, keyed as the author wrote
+      # them. TomlRB is stricter than the tomli the Python helper uses, and this is the first time the
+      # Ruby side reads a workspace member manifest, so one it rejects yields nothing rather than
+      # failing the job.
+      sig { params(file: Dependabot::DependencyFile).returns(T::Hash[String, T::Hash[Symbol, String]]) }
+      def self.writable_for(file)
+        document = Dependabot::Python::FileParser::PyprojectDocument.from_file(file)
+        writable(T.must(file.content), document.uv_git_tag_sources)
+      rescue Dependabot::DependencyFileNotParseable
+        {}
+      end
+
+      # The entries of `sources` this file can rewrite. Reporting a moved ref for one it cannot reach
+      # would fail the job, where before the pin was never updated.
+      sig do
+        params(content: String, sources: T::Hash[String, T::Hash[Symbol, String]])
+          .returns(T::Hash[String, T::Hash[Symbol, String]])
+      end
+      def self.writable(content, sources)
+        found = span(content)
+        return {} unless found
+
+        table = found[1]
+        sources.select { |key, source| table.match?(tag_regex(key, T.must(source[:ref]))) }
+      end
+
+      # The table's own text, and the range it occupies in the manifest.
+      sig { params(content: String).returns(T.nilable([T::Range[Integer], String])) }
+      def self.span(content)
+        header = content.match(HEADER)
+        return nil unless header
+
+        from = header.end(0)
+        rest = content[from..] || ""
+        nxt = rest.match(NEXT_TABLE)
+        to = nxt ? from + nxt.begin(0) : content.length
+        [Range.new(from, to, true), T.must(content[from...to])]
+      end
+    end
+  end
+end

--- a/uv/lib/dependabot/uv/update_checker.rb
+++ b/uv/lib/dependabot/uv/update_checker.rb
@@ -34,6 +34,8 @@ module Dependabot
 
       sig { override.returns(T::Array[Dependabot::DependencyRequirement]) }
       def updated_requirements
+        return updated_git_requirements if git_dependency?
+
         RequirementsUpdater.new(
           requirements: dependency.requirements,
           latest_resolvable_version: preferred_resolvable_version&.to_s,

--- a/uv/spec/dependabot/uv/file_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser_spec.rb
@@ -738,6 +738,92 @@ RSpec.describe Dependabot::Uv::FileParser do
       its(:length) { is_expected.to eq(3) }
     end
 
+    context "with dependencies pinned to a uv git source" do
+      let(:files) { [pyproject] }
+      let(:pyproject) do
+        Dependabot::DependencyFile.new(
+          name: "pyproject.toml",
+          content: fixture("pyproject_files", "uv_git_tag_sources.toml")
+        )
+      end
+
+      # The requirement goes with the source: keeping the PEP 508 constraint makes
+      # requirements_up_to_date? compare it against the newest tag, so a floor above that tag would
+      # report the pin as current and it would never be updated
+      it "drops the requirement of the ones it enriches, and keeps the others'" do
+        expect(dependencies.map { |dep| [dep.name, dep.requirements.first[:requirement]] }).to eq(
+          [
+            ["requests", ">=2.31.0"],
+            ["malformed-package", "*"],
+            ["tagged-package", nil],
+            ["acme-tagged-package", nil],
+            ["other-tagged-package", nil],
+            ["array-package", "*"],
+            ["branch-package", "*"],
+            ["untagged-package", "*"],
+            ["quoted-package", nil]
+          ]
+        )
+      end
+
+      it "gives a git source to every tag it can rewrite, and to nothing else" do
+        expect(dependencies.map { |dep| [dep.name, dep.requirements.first[:source]] }).to eq(
+          [
+            ["requests", nil],
+            ["malformed-package", nil],
+            ["tagged-package", { type: "git", url: "https://github.com/example/tagged.git", ref: "1.2.3" }],
+            ["acme-tagged-package",
+             { type: "git", url: "https://github.com/example/acme-tagged.git", ref: "1.2.3" }],
+            # The key is written `Other_Tagged_Package`; uv resolves it under PEP 508 normalisation
+            ["other-tagged-package", { type: "git", url: "https://github.com/example/other.git", ref: "7.8.9" }],
+            # Valid uv, in forms the rewrite cannot reach
+            ["array-package", nil],
+            ["branch-package", nil],
+            ["untagged-package", nil],
+            # Quoting is the only legal spelling for a name carrying a dot, so it is supported
+            ["quoted-package",
+             { type: "git", url: "https://github.com/example/quoted.git", ref: "3.2.1" }]
+          ]
+        )
+      end
+
+      context "with the uv.lock a real repository has" do
+        let(:files) { [pyproject, lockfile] }
+        let(:lockfile) do
+          Dependabot::DependencyFile.new(
+            name: "uv.lock",
+            content: fixture("uv_locks", "git_tag_sources.lock")
+          )
+        end
+
+        # The version comes from the lock, and for a git pin it is the package's own distribution
+        # version rather than a commit sha. Several shared code paths key on that difference, so the
+        # shape tested without a lockfile is not the shape a repository actually has.
+        it "carries the locked version alongside the git source" do
+          dep = dependencies.find { |d| d.name == "tagged-package" }
+
+          expect(dep.version).to eq("0.3.0")
+          expect(dep.requirements.first[:source])
+            .to eq(type: "git", url: "https://github.com/example/tagged.git", ref: "1.2.3")
+        end
+      end
+
+      context "when a source carries a tag that is not a string" do
+        let(:pyproject) do
+          Dependabot::DependencyFile.new(
+            name: "pyproject.toml",
+            content: fixture("pyproject_files", "uv_git_tag_sources.toml").sub('tag = "1.2.3" }', "tag = 1.2 }")
+          )
+        end
+
+        it "skips that entry rather than failing the whole manifest" do
+          expect(dependencies.map(&:name)).to include("requests", "tagged-package")
+          expect(dependencies.find { |dep| dep.name == "acme-tagged-package" }.requirements.first[:source])
+            .to be_nil
+        end
+      end
+    end
+
     context "with a pyproject.toml file with no dependencies" do
       let(:files) { [pyproject] }
       let(:pyproject) do

--- a/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/lock_file_updater_spec.rb
@@ -490,6 +490,224 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
     end
   end
 
+  describe "#updated_pyproject_content_for" do
+    subject(:updated_content) { updater.send(:updated_pyproject_content_for, pyproject_file) }
+
+    context "when only the git tag of a [tool.uv.sources] pin moved" do
+      let(:pyproject_content) { fixture("pyproject_files", "uv_git_tag_sources.toml") }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "tagged-package",
+          version: nil,
+          requirements: [{
+            file: "pyproject.toml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/example/tagged.git", ref: "1.3.0" }
+          }],
+          previous_requirements: [{
+            file: "pyproject.toml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/example/tagged.git", ref: "1.2.3" }
+          }],
+          package_manager: "uv"
+        )
+      end
+
+      context "when the file spells the key differently from the dependency name" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "other-tagged-package",
+            version: nil,
+            requirements: [{
+              file: "pyproject.toml", requirement: nil, groups: [],
+              source: { type: "git", url: "https://github.com/example/other.git", ref: "8.0.0" }
+            }],
+            previous_requirements: [{
+              file: "pyproject.toml", requirement: nil, groups: [],
+              source: { type: "git", url: "https://github.com/example/other.git", ref: "7.8.9" }
+            }],
+            package_manager: "uv"
+          )
+        end
+
+        # The table key is Other_Tagged_Package; uv resolves it under PEP 508 normalisation, so the
+        # updater has to find the file's own spelling back from the normalised dependency name
+        it "finds the key back and moves its tag" do
+          expect(updated_content).to include("Other_Tagged_Package = { git = ")
+          expect(updated_content).to include('other.git", tag = "8.0.0" }')
+        end
+      end
+
+      it "moves that entry's tag and no other" do
+        # acme-tagged-package precedes it in the file, ends with its name and carries the same tag,
+        # so an unanchored substitution would move this line instead
+        expect(updated_content).to include('acme-tagged.git", tag = "1.2.3"')
+        expect(updated_content).to include('tagged.git", tag = "1.3.0"')
+        expect(updated_content).to include('other.git", tag = "7.8.9"')
+        expect(updated_content).to include('branch = "main"')
+        expect(updated_content).to include('untagged-package = { git = "https://github.com/example/untagged.git" }')
+      end
+
+      # The table boundary is written to, so an off-by-one on the span eats the next table's bracket
+      # and the updater emits invalid TOML
+      it "leaves the table that follows byte for byte" do
+        expect(updated_content).to include("\n[tool.other]\n")
+        expect(updated_content).to include('decoy.git", tag = "1.2.3"')
+      end
+    end
+  end
+
+  describe "#moved_tag?" do
+    let(:table) do
+      <<~TOML
+        [tool.uv.sources]
+        pkg = { git = "https://example.com/pkg.git", tag = "1.4.0" }
+      TOML
+    end
+
+    it { expect(updater.send(:moved_tag?, table, "pkg", "1.4.0")).to be(true) }
+    it { expect(updater.send(:moved_tag?, table, "pkg", "9.9.9")).to be(false) }
+    it { expect(updater.send(:moved_tag?, table, "absent", "1.4.0")).to be(false) }
+    it { expect(updater.send(:moved_tag?, "[tool.uv.sources\npkg = {", "pkg", "1.4.0")).to be(false) }
+  end
+
+  describe "#updated_pyproject_content_for with a quoted copy of the sources table" do
+    subject(:updated) { updater.send(:updated_pyproject_content_for, pyproject_file) }
+
+    # The table is found by pattern over raw text, so a copy quoted inside a string can answer for
+    # the real one. Editing prose and reporting a bump is the outcome to prevent.
+    let(:pyproject_content) do
+      <<~TOML
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.9"
+        dependencies = ["pkg"]
+        readme = { content-type = "text/markdown", text = """
+        [tool.uv.sources]
+        pkg = { git = "https://example.com/pkg.git", tag = "1.2.3" }
+        """ }
+
+        [tool.uv.sources]
+        pkg = { git = "https://example.com/pkg.git", tag = "1.2.3" }
+      TOML
+    end
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "pkg",
+        version: "0.1.0",
+        requirements: [{
+          file: "pyproject.toml", requirement: nil, groups: [],
+          source: { type: "git", url: "https://example.com/pkg.git", ref: "1.4.0" }
+        }],
+        previous_requirements: [{
+          file: "pyproject.toml", requirement: nil, groups: [],
+          source: { type: "git", url: "https://example.com/pkg.git", ref: "1.2.3" }
+        }],
+        package_manager: "uv"
+      )
+    end
+
+    it "reports no change rather than editing the prose" do
+      expect { updated }.to raise_error(Dependabot::DependencyFileContentNotChanged)
+    end
+  end
+
+  describe "#updated_pyproject_content_for on a manifest that does not declare the source" do
+    subject(:updated) { updater.send(:updated_pyproject_content_for, member_file) }
+
+    # updated_git_requirements stamps the resolved source onto every requirement of the merged
+    # dependency, including one from a workspace member that declares only the package. That file has
+    # nothing to rewrite, and had nothing to rewrite before this either.
+    let(:member_file) do
+      Dependabot::DependencyFile.new(
+        name: "packages/member/pyproject.toml",
+        content: "[project]\nname = \"m\"\nversion = \"0.1.0\"\ndependencies = [\"pkg\"]\n"
+      )
+    end
+    let(:dependency_files) { [pyproject_file, member_file, lockfile] }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "pkg",
+        version: "0.1.0",
+        requirements: [{
+          file: "packages/member/pyproject.toml", requirement: nil, groups: [],
+          source: { type: "git", url: "https://example.com/pkg.git", ref: "1.4.0" }
+        }],
+        previous_requirements: [{
+          file: "packages/member/pyproject.toml", requirement: nil, groups: [], source: nil
+        }],
+        package_manager: "uv"
+      )
+    end
+
+    it "hands the file back unchanged instead of failing the job" do
+      expect(updated).to eq(member_file.content)
+    end
+  end
+
+  describe "#raw_source_key" do
+    let(:content) { fixture("pyproject_files", "uv_git_tag_sources.toml") }
+
+    # uv resolves a source under PEP 508 normalisation, so the dependency name reaching the updater is
+    # normalised while the file keeps the author's spelling; the updater has to find that back
+    it "returns the key as the file spells it" do
+      expect(updater.send(:raw_source_key, content, "other-tagged-package", "7.8.9")).to eq("Other_Tagged_Package")
+    end
+
+    it "returns nil when no key matches" do
+      expect(updater.send(:raw_source_key, content, "absent-package", "1.0.0")).to be_nil
+    end
+
+    it "returns nil when the manifest has no sources table" do
+      expect(updater.send(:raw_source_key, "[project]\nname = \"p\"\n", "pkg", "1.0.0")).to be_nil
+    end
+
+    # Two keys normalising the same is what made a shared regex insufficient: only the ref says which
+    # entry the parser attached, and picking the other one fails the job
+    it "picks the key whose entry carries the ref, not merely the first that normalises" do
+      colliding = <<~TOML
+        [tool.uv.sources]
+        pkg = { git = "https://example.com/a.git", branch = "main" }
+        Pkg = { git = "https://example.com/b.git", tag = "1.2.3" }
+      TOML
+
+      expect(updater.send(:raw_source_key, colliding, "pkg", "1.2.3")).to eq("Pkg")
+    end
+
+    # TomlRB is stricter than the tomli the Python helper uses, and the text handed here has been
+    # rewritten by regex, so a refusal must leave the pin alone rather than fail the job
+    it "returns nil when the manifest is not valid TOML" do
+      expect(updater.send(:raw_source_key, "[tool.uv.sources\npkg = {", "pkg", "1.0.0")).to be_nil
+    end
+  end
+
+  describe "#git_tag_moved?" do
+    let(:git) { { type: "git", url: "https://github.com/example/tagged.git", ref: "1.2.3" } }
+
+    def req(source)
+      Dependabot::DependencyRequirement.create(
+        file: "pyproject.toml", requirement: "*", groups: [], source: source
+      )
+    end
+
+    it { expect(updater.send(:git_tag_moved?, req(git.merge(ref: "1.3.0")), req(git))).to be(true) }
+    it { expect(updater.send(:git_tag_moved?, req(git), req(git))).to be(false) }
+    it { expect(updater.send(:git_tag_moved?, req(git.merge(ref: nil)), req(git))).to be(false) }
+    it { expect(updater.send(:git_tag_moved?, req(git.merge(type: "registry")), req(git))).to be(false) }
+    it { expect(updater.send(:git_tag_moved?, req(git.merge(ref: "1.3.0")), req(nil))).to be(false) }
+    it { expect(updater.send(:git_tag_moved?, req(git), req(git.merge(ref: nil)))).to be(false) }
+
+    # The only shape the nil-ref guard below does not already cover: a previous source that is not
+    # git and still carries a ref. Taking the git path there loses the ordinary requirement rewrite.
+    it "is false when the previous source carries a ref under another type" do
+      expect(updater.send(:git_tag_moved?, req(git.merge(ref: "1.3.0")), req(git.merge(type: "registry"))))
+        .to be(false)
+    end
+  end
+
   describe "with a requirements.txt or requirements.in file only" do
     let(:dependencies) do
       [
@@ -1337,6 +1555,92 @@ RSpec.describe Dependabot::Uv::FileUpdater::LockFileUpdater do
         fingerprint: expected_fingerprint,
         env: {}
       )
+    end
+
+    context "when the dependency is pinned to a git tag" do
+      let(:credentials) { [] }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "tagged-package",
+          version: "1.3.0",
+          requirements: [{
+            file: "pyproject.toml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/example/tagged.git", ref: "1.3.0" }
+          }],
+          previous_requirements: [{
+            file: "pyproject.toml",
+            requirement: nil,
+            groups: [],
+            source: { type: "git", url: "https://github.com/example/tagged.git", ref: "1.2.3" }
+          }],
+          previous_version: "1.2.3",
+          package_manager: "uv"
+        )
+      end
+
+      context "when the source is a registry rather than git" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "tagged-package",
+            version: "1.3.0",
+            requirements: [{
+              file: "pyproject.toml", requirement: nil, groups: [],
+              source: { type: "registry", url: "https://example.com/simple" }
+            }],
+            package_manager: "uv"
+          )
+        end
+
+        it "keeps the version specifier" do
+          run_update_command
+
+          expect(updater).to have_received(:run_command).with(
+            "pyenv exec uv lock --upgrade-package tagged-package==1.3.0 ",
+            fingerprint: "pyenv exec uv lock --upgrade-package <dependency_name> ",
+            env: {}
+          )
+        end
+      end
+
+      # A workspace where one member pins the git source and another only states a constraint merges
+      # into a single dependency. There is still no index the pin can be resolved against.
+      context "when only one of the manifests pins the git source" do
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "tagged-package",
+            version: "1.3.0",
+            requirements: [{
+              file: "pyproject.toml", requirement: nil, groups: [],
+              source: { type: "git", url: "https://github.com/example/tagged.git", ref: "1.3.0" }
+            }, {
+              file: "member/pyproject.toml", requirement: ">=1.0.0", groups: [], source: nil
+            }],
+            package_manager: "uv"
+          )
+        end
+
+        it "still asks uv to re-resolve the package by name" do
+          run_update_command
+
+          expect(updater).to have_received(:run_command).with(
+            "pyenv exec uv lock --upgrade-package tagged-package ",
+            fingerprint: "pyenv exec uv lock --upgrade-package <dependency_name> ",
+            env: {}
+          )
+        end
+      end
+
+      it "asks uv to re-resolve the package by name, with no version specifier" do
+        run_update_command
+
+        expect(updater).to have_received(:run_command).with(
+          "pyenv exec uv lock --upgrade-package tagged-package ",
+          fingerprint: "pyenv exec uv lock --upgrade-package <dependency_name> ",
+          env: {}
+        )
+      end
     end
 
     context "when dependency has extras" do

--- a/uv/spec/dependabot/uv/sources_table_spec.rb
+++ b/uv/spec/dependabot/uv/sources_table_spec.rb
@@ -1,0 +1,165 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency_file"
+require "dependabot/uv/sources_table"
+
+RSpec.describe Dependabot::Uv::SourcesTable do
+  let(:entry) { 'pkg = { git = "https://example.com/pkg.git", tag = "1.2.3" }' }
+
+  describe ".span" do
+    subject(:table) { described_class.span(content)&.last }
+
+    context "when the header is the plain form" do
+      let(:content) { "[project]\nname = \"p\"\n\n[tool.uv.sources]\n#{entry}\n" }
+
+      it { is_expected.to include(entry) }
+      it { expect(table).not_to include("[project]") }
+    end
+
+    # Both of these turned the whole feature off without a word before they were handled
+    context "when the file uses CRLF line endings" do
+      let(:content) { "[tool.uv.sources]\r\n#{entry}\r\n" }
+
+      it { is_expected.to include("tag = \"1.2.3\"") }
+    end
+
+    context "when a comment follows the header" do
+      let(:content) { "[tool.uv.sources] # git pins live here\n#{entry}\n" }
+
+      it { is_expected.to include("tag = \"1.2.3\"") }
+    end
+
+    context "when the header is indented" do
+      let(:content) { "  [tool.uv.sources]\n#{entry}\n" }
+
+      it { is_expected.to include("tag = \"1.2.3\"") }
+    end
+
+    context "when another table follows" do
+      let(:content) { "[tool.uv.sources]\n#{entry}\n\n[tool.other]\npkg = { tag = \"9.9.9\" }\n" }
+
+      it "stops at that table" do
+        expect(table).to include(entry)
+        expect(table).not_to include("9.9.9")
+      end
+    end
+
+    # TOML allows an indented header, so the span has to stop at one too: a `tag` line under
+    # another tool's table would otherwise be rewritten as though it were a uv source
+    context "when the table that follows is indented" do
+      let(:content) { "[tool.uv.sources]\n#{entry}\n\n  [tool.other]\npkg = { tag = \"9.9.9\" }\n" }
+
+      it "stops at that table" do
+        expect(table).to include(entry)
+        expect(table).not_to include("9.9.9")
+      end
+    end
+
+    context "when the table runs to the end of the file" do
+      let(:content) { "[tool.uv.sources]\n#{entry}" }
+
+      it { is_expected.to include(entry) }
+    end
+
+    context "when there is no such table" do
+      let(:content) { "[project]\nname = \"p\"\n" }
+
+      it { expect(described_class.span(content)).to be_nil }
+    end
+
+    context "when only a sub-table header names it" do
+      let(:content) { "[tool.uv.sources.pkg]\ngit = \"https://example.com/pkg.git\"\ntag = \"1.2.3\"\n" }
+
+      # There is no inline entry to rewrite in this form, so there is no table to hand back
+      it { expect(described_class.span(content)).to be_nil }
+    end
+
+    context "when a table merely starts with the same name" do
+      let(:content) { "[tool.uv.sources-extra]\n#{entry}\n" }
+
+      it { expect(described_class.span(content)).to be_nil }
+    end
+  end
+
+  describe ".tag_regex" do
+    it "matches the key on its own line, and not the tail of a longer one carrying the same tag" do
+      table = "acme-pkg = { git = \"x\", tag = \"1.2.3\" }\n#{entry}\n"
+
+      expect(table).to match(described_class.tag_regex("pkg", "1.2.3"))
+      expect(table[/^acme-pkg.*$/]).not_to match(described_class.tag_regex("pkg", "1.2.3"))
+    end
+
+    it "does not match a commented-out entry" do
+      expect("# #{entry}\n").not_to match(described_class.tag_regex("pkg", "1.2.3"))
+    end
+
+    it "does not match another tag than the one expected" do
+      expect(entry).not_to match(described_class.tag_regex("pkg", "9.9.9"))
+    end
+
+    # Quoting is the only legal TOML spelling for a name carrying a dot, so both the key and the
+    # inner `tag` have to be matched either way
+    it "matches a quoted key and a quoted tag" do
+      quoted = '"zope.interface" = { "git" = "x", "tag" = "1.2.3" }'
+
+      expect(quoted).to match(described_class.tag_regex("zope.interface", "1.2.3"))
+    end
+
+    it "does not match the tail of another key ending in tag" do
+      other = 'pkg = { git = "x", other_tag = "1.2.3" }'
+
+      expect(other).not_to match(described_class.tag_regex("pkg", "1.2.3"))
+    end
+
+    it "does not cross into a neighbouring entry" do
+      neighbours = "pkg = { git = \"x\" }\nother = { git = \"y\", tag = \"1.2.3\" }\n"
+
+      expect(neighbours).not_to match(described_class.tag_regex("pkg", "1.2.3"))
+    end
+  end
+
+  describe ".writable" do
+    subject(:writable) { described_class.writable(content, sources) }
+
+    let(:sources) do
+      {
+        "pkg" => { url: "https://example.com/pkg.git", ref: "1.2.3" },
+        "sub" => { url: "https://example.com/sub.git", ref: "4.5.6" }
+      }
+    end
+    let(:content) do
+      "[tool.uv.sources]\n#{entry}\n\n[tool.uv.sources.sub]\ngit = \"https://example.com/sub.git\"\n"
+    end
+
+    # `sub` is written as a sub-table, which nothing can rewrite textually
+    it { is_expected.to eq("pkg" => { url: "https://example.com/pkg.git", ref: "1.2.3" }) }
+
+    context "when the manifest has no sources table" do
+      let(:content) { "[project]\nname = \"p\"\n" }
+
+      it { is_expected.to eq({}) }
+    end
+  end
+
+  describe ".writable_for" do
+    subject(:writable_for) { described_class.writable_for(file) }
+
+    let(:file) { Dependabot::DependencyFile.new(name: "pyproject.toml", content: content) }
+
+    context "with an inline git-and-tag entry" do
+      let(:content) { "[tool.uv.sources]\n#{entry}\n" }
+
+      it { is_expected.to eq("pkg" => { url: "https://example.com/pkg.git", ref: "1.2.3" }) }
+    end
+
+    # TomlRB is stricter than the tomli the Python helper uses, and this is the first time the Ruby
+    # side reads a workspace member manifest, so one it rejects must not fail the job
+    context "when the manifest is not valid TOML" do
+      let(:content) { "[tool.uv.sources\npkg = {" }
+
+      it { is_expected.to eq({}) }
+    end
+  end
+end

--- a/uv/spec/dependabot/uv/update_checker_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker_spec.rb
@@ -1138,4 +1138,100 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
       end
     end
   end
+
+  describe "Git dependencies" do
+    # The version comes from uv.lock, as it does in any repository that has one: it is the package's
+    # own distribution version, never a commit sha - which is what makes the guards below necessary
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "fastapi",
+        version: "0.3.0",
+        requirements: dependency_requirements,
+        package_manager: "uv"
+      )
+    end
+    let(:dependency_requirements) do
+      [{
+        requirement: "*",
+        file: "pyproject.toml",
+        groups: [],
+        source: {
+          type: "git",
+          url: "https://github.com/tiangolo/fastapi",
+          ref: "0.110.0"
+        }
+      }]
+    end
+    let(:dependency_files) { [pyproject] }
+    let(:pyproject_fixture_name) { "uv_git_tag_sources.toml" }
+
+    before do
+      git_header = { "content-type" => "application/x-git-upload-pack-advertisement" }
+      stub_request(:get, "https://github.com/tiangolo/fastapi.git/info/refs?service=git-upload-pack")
+        .to_return(status: 200, body: fixture("git", "upload_packs", "fastapi"), headers: git_header)
+      # Stubbed so that the ref assertion below is what fails when the git path is not taken, rather
+      # than an unhandled request. That the request is never made is asserted on its own.
+      stub_request(:get, "https://pypi.org/pypi/git-sources-project/json/").to_return(status: 404)
+    end
+
+    describe "#lowest_security_fix_version" do
+      let(:security_advisories) do
+        [Dependabot::SecurityAdvisory.new(
+          dependency_name: "fastapi",
+          package_manager: "uv",
+          vulnerable_versions: [Dependabot::Uv::Requirement.new("< 0.120.0")]
+        )]
+      end
+
+      # The version in uv.lock is the package's own, so `existing_version_is_sha?` does not keep a git
+      # pin out of the security path. Answering with a version from that name's index would title the
+      # pull request with a fix the diff does not apply: the diff moves a tag.
+      it "declines to answer for a git dependency" do
+        expect(checker.lowest_security_fix_version).to be_nil
+      end
+    end
+
+    describe "#updated_requirements" do
+      subject(:updated_requirements) { checker.updated_requirements }
+
+      # A branch is not a version, so nothing can say what the next one is. The shared Python path
+      # guards this with pinned_ref_looks_like_version?, and without it the newest tag would be
+      # written over a ref the author deliberately left moving.
+      context "when the source is pinned to a branch rather than a tag" do
+        let(:dependency_requirements) do
+          [{
+            requirement: "*",
+            file: "pyproject.toml",
+            groups: [],
+            source: { type: "git", url: "https://github.com/tiangolo/fastapi", ref: "main" }
+          }]
+        end
+
+        it "leaves the requirement exactly as it was" do
+          expect(updated_requirements).to eq(dependency_requirements)
+        end
+      end
+
+      it "moves the tag to the newest version the remote advertises" do
+        expect(updated_requirements).to eq(
+          [{
+            requirement: "*",
+            file: "pyproject.toml",
+            groups: [],
+            source: {
+              type: "git",
+              url: "https://github.com/tiangolo/fastapi",
+              ref: "0.128.0"
+            }
+          }]
+        )
+      end
+
+      it "does not consult an index about the manifest's own name" do
+        updated_requirements
+
+        expect(WebMock).not_to have_requested(:get, "https://pypi.org/pypi/git-sources-project/json/")
+      end
+    end
+  end
 end

--- a/uv/spec/fixtures/git/upload_packs/fastapi
+++ b/uv/spec/fixtures/git/upload_packs/fastapi
@@ -1,0 +1,13 @@
+001e# service=git-upload-pack
+00000160d4a12f1e9f1e9c8e6b5a3c2d1e0f9a8b7c6d5e4f3a2b1c HEAD\0multi_ack thin-pack side-band side-band-64k ofs-delta shallow no-progress include-tag multi_ack_detailed symref=HEAD:refs/heads/master agent=git/2.39.0
+003fd4a12f1e9f1e9c8e6b5a3c2d1e0f9a8b7c6d5e4f3a2b1c refs/heads/master
+003e8f7e6d5c4b3a2918273645f6e5d4c3b2a19182736 refs/tags/0.110.0
+003e9a8b7c6d5e4f3a2b1c0d1e2f3a4b5c6d7e8f9a0b1 refs/tags/0.111.0
+003e1a2b3c4d5e6f7890abcdef1234567890abcdef12 refs/tags/0.120.0
+003e2b3c4d5e6f7890abcdef1234567890abcdef1234 refs/tags/0.124.0
+003e3c4d5e6f7890abcdef1234567890abcdef123456 refs/tags/0.124.2
+003e4d5e6f7890abcdef1234567890abcdef12345678 refs/tags/0.125.0
+003e5e6f7890abcdef1234567890abcdef1234567890 refs/tags/0.126.0
+003e6f7890abcdef1234567890abcdef12345678901a refs/tags/0.127.0
+003eabcdef1234567890abcdef1234567890abcdef12 refs/tags/0.128.0
+0000

--- a/uv/spec/fixtures/pyproject_files/uv_git_tag_sources.toml
+++ b/uv/spec/fixtures/pyproject_files/uv_git_tag_sources.toml
@@ -1,0 +1,47 @@
+[project]
+name = "git-sources-project"
+version = "0.1.0"
+description = "Test uv git sources"
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.31.0",
+    "malformed-package",
+    "tagged-package",
+    "acme-tagged-package",
+    "Other_Tagged_Package",
+    "array-package",
+    "branch-package",
+    "untagged-package",
+    "quoted-package",
+]
+
+[tool.uv.sources]
+# An array of sources is valid uv and cannot be rewritten textually, so no source is attached.
+# Deliberately before every usable entry: skipping it must not stop them being read.
+array-package = [{ git = "https://github.com/example/array.git", tag = "9.9.9" }]
+
+# Malformed, and deliberately first: skipping it must not stop the entries below being read
+malformed-package = { git = "https://github.com/example/malformed.git", tag = 1.2 }
+
+# A key ending with another key's name, on the same tag: an unanchored rewrite moves this one instead
+acme-tagged-package = { git = "https://github.com/example/acme-tagged.git", tag = "1.2.3" }
+
+# Pinned to an exact tag: the shape this change is about
+tagged-package = { git = "https://github.com/example/tagged.git", tag = "1.2.3" }
+
+# uv resolves the key under PEP 508 normalisation, so the file can spell it any of several ways
+Other_Tagged_Package = { git = "https://github.com/example/other.git", tag = "7.8.9" }
+
+# Pinned to a moving ref, out of scope and must keep its current behaviour
+branch-package = { git = "https://github.com/example/branch.git", branch = "main" }
+
+# No ref at all, out of scope for the same reason
+untagged-package = { git = "https://github.com/example/untagged.git" }
+
+# TOML allows a quoted inner key. It parses to a git-and-tag source, so only the rewrite's own
+# pattern can reject it - which is what keeps what the parser accepts equal to what it can rewrite.
+quoted-package = { "git" = "https://github.com/example/quoted.git", "tag" = "3.2.1" }
+
+# Anything after the sources table must be left alone by a rewrite
+[tool.other]
+tagged-package = { git = "https://github.com/example/decoy.git", tag = "1.2.3" }

--- a/uv/spec/fixtures/uv_locks/git_tag_sources.lock
+++ b/uv/spec/fixtures/uv_locks/git_tag_sources.lock
@@ -1,0 +1,18 @@
+version = 1
+revision = 1
+requires-python = ">=3.9"
+
+[[package]]
+name = "git-sources-project"
+version = "0.1.0"
+source = { editable = "." }
+
+[[package]]
+name = "tagged-package"
+version = "0.3.0"
+source = { git = "https://github.com/example/tagged.git?tag=1.2.3#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #16129.

A `uv` dependency pinned to a git tag in `[tool.uv.sources]` is never updated. The tag stays where the
author left it, and no error says why. Moving it is the behaviour that issue asks for, the way
`GitCommitChecker` already serves `bundler`, `npm_and_yarn` and `gomod`.

The parser emits `source: nil` for every PEP 621 dependency, so such a dependency is indistinguishable
from a registry one: it is resolved against a package index, where its name either matches nothing or
matches an unrelated package. `GitCommitChecker#git_dependency?` reads
`dependency_source_details&.type == "git"`, so nothing downstream can tell either — which is why the
Python update checker's `return updated_git_requirements if git_dependency?` guard is absent from the
`uv` override, and why restoring it alone would be dead code.

Four places have to agree for the tag to move, and this changes each of them:

| | |
|---|---|
| `PyprojectDocument#uv_git_tag_sources` | reads the table and returns the sources carrying both a git url and a tag |
| `Uv::FileParser::PyprojectFilesParser` | turns those into `{ type: "git", url:, ref: }` |
| `Uv::UpdateChecker#updated_requirements` | carries the git guard, so the ref moves to the newest version the remote advertises |
| `Uv::FileUpdater::LockFileUpdater` | rewrites `tag = "…"` in the sources table, and re-resolves by name when locking |

### Anything you want to highlight for special attention from reviewers?

**Scope is `tag` only.** A source pinned to a branch, or carrying a git url and no ref, keeps
`source: nil` and its current behaviour: there is no ordering on a moving ref, so nothing can say what
the next version is. Same for a source written as an array of entries. The parser spec asserts the
requirement and the source of all three, the updater spec asserts the branch and no-ref entries are
left byte-identical, and the checker spec asserts a branch ref survives `updated_requirements` — that
last one because the guard deciding it lives in the shared Python path, where nothing else pins it.

**This shares a loop with #16132, and the two are complementary.** That one skips the shapes no
ordering can be derived from — a `url` source, and a `git` source carrying no tag — so they stop being
resolved against an index; this one enriches the one shape that does have an ordering, `git` with a
tag, so it resolves against the remote. The two sets are disjoint by construction: that predicate
returns false for exactly the entries this enriches.

**They cannot both land without a two-line spec edit, and neither CI can see it.** Both changes touch
the same loop, the same `PyprojectDocument`, and the same spec context, so the second to land conflicts
textually. Resolved by keeping both sides, the production behaviour composes and is the one both
changes want; what fails is *this* PR's two full-list assertions, which pin `branch-package` and
`untagged-package` as present with no source — true on this base, and no longer true once the other
change skips them. Measured on a tree carrying both: those two rows, in both assertions, and nothing
else. Whichever lands second drops them; the "scope is `tag` only" guarantee is then carried by the
other change's own assertion instead.

**A dedicated branch rather than a wider `replace_dep`.** That method matches
`["']name<requirement>["']`, the `[project.dependencies]` shape, which cannot reach a tag written under
an unquoted key in the sources table. Widening its pattern would change the path every dependency in
every uv repository goes through; the git case gets its own branch instead. The substitution is
anchored on the old tag and bounded by the entry's closing brace, so it cannot reach another entry and
only fires when the tag present is the one that was checked.

**Three defects on the shared git path are older than this change, and it leaves them alone.** All
three are in `python/lib/dependabot/python/update_checker.rb`, line-identical on `main`, and reachable
today by a Poetry git dependency, whose `poetry.lock` entry carries a distribution `version` in the same
place `uv.lock` does. Measured, not read: `latest_resolvable_version_with_no_unlock` raises
`TypeError: T.cast: Expected type T.nilable(Gem::Version), got type String` for a pinned git dependency,
which is the whole `requirements_to_unlock: :none` path; `up_to_date?` compares the newest tag against
that distribution version, so a package whose tags and distribution version follow different schemes is
reported as current with a newer tag available; and `GitCommitChecker` is built without
`ignored_versions`, so `ignore` conditions never reach the choice of tag. Fixing any of them changes
the Poetry path too, which is not what this change is about, so it leaves all three as they are.

**Refs are read with `DependencyRequirement#source_string`.** Its own comment records that file
parsers emit symbol keys while deserialised job definitions emit strings, so indexing the hash
directly would pass a spec and return `nil` in production.

**The guard also removes work that could never apply.** Without it, resolving one git dependency issues a
run of requests to that name's index endpoint, plus one to the manifest's own `[project] name`, because
the `library?` heuristic runs to choose a versioning strategy for a dependency with no index to widen a
range against. The spec asserts that last request is not made.

**Not covered.** A PEP 508 direct reference written inline (`"pkg @ git+https://…"`) has the same
problem, but fixing it means surfacing `req.url` from `uv/helpers/lib/parser.py`, which emits no url at
all, through `PepDependency`, a struct shared with the `python` ecosystem. That belongs in its own change.

### How will you know you've accomplished your goal?

Each of the four steps has a spec asserting the complete value it produces, not a field of it: the
parser's `requirements` hash for all three git shapes, the checker's `updated_requirements`, the
rewritten manifest, and the `uv lock` command with its fingerprint.

Every assertion was checked to fail on its own terms when its production branch is removed — on a
value comparison or by naming the call — rather than on an unhandled request or a missing stub, which
is what one of them did before its arrangement was fixed.

The `uv` suite is green, and `rubocop` over the whole repository reports no offenses. `python` carries
only the pre-existing `PipCompileVersionResolver` failure that is also on `main`: its fixture pins
`moto==1.3.3`, which pulls a 2018 `cryptography` sdist whose metadata no longer builds.

**What this does not prove.** The chain is covered at the unit level; no `uv lock` was run against a
live git remote, which needs network and a real repository. The e2e suite is the place for that.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.





