### PR TITLE
helm: fix scalar image tag updates and dropped trailing newline

### DIFF
--- a/helm/lib/dependabot/helm/file_updater/image_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/image_updater.rb
@@ -174,12 +174,35 @@ module Dependabot
             next unless value_node.value == old_declaration
 
             new_declaration = scalar_image_declaration(dependency_name, req, dependency_version)
-
-            line = value_node.start_line
-            content[line] = T.must(content[line]).sub(old_declaration, new_declaration)
+            replace_within_node_span(value_node, content, old_declaration, new_declaration)
           end
 
           content
+        end
+
+        sig do
+          params(
+            value_node: Psych::Nodes::Scalar,
+            content: T::Array[String],
+            old_declaration: String,
+            new_declaration: String
+          ).void
+        end
+        def replace_within_node_span(value_node, content, old_declaration, new_declaration)
+          start_line = value_node.start_line
+          end_line = value_node.end_line
+
+          if start_line == end_line
+            line = T.must(content[start_line])
+            prefix = line[0...value_node.start_column]
+            rest = T.must(line[value_node.start_column..])
+            content[start_line] = "#{prefix}#{rest.sub(old_declaration, new_declaration)}"
+          else
+            # block/folded scalar: the declaration text lives on a line after start_line, so
+            # search the node's whole line span rather than just the line Psych anchors it to
+            segment = T.must(content[start_line..end_line]).join("\n")
+            content[start_line..end_line] = segment.sub(old_declaration, new_declaration).split("\n", -1)
+          end
         end
 
         sig do

--- a/helm/lib/dependabot/helm/file_updater/image_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/image_updater.rb
@@ -171,7 +171,7 @@ module Dependabot
             next if req.source_string("digest")
 
             old_declaration = scalar_image_declaration(dependency_name, req, old_tag)
-            next unless value_node.value == old_declaration
+            next unless value_node.value.chomp == old_declaration
 
             new_declaration = scalar_image_declaration(dependency_name, req, dependency_version)
             replace_within_node_span(value_node, content, old_declaration, new_declaration)

--- a/helm/lib/dependabot/helm/file_updater/image_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/image_updater.rb
@@ -40,7 +40,8 @@ module Dependabot
 
         sig { params(yaml_stream: Psych::Nodes::Stream, content: String).returns(String) }
         def update_image_tags_recursive(yaml_stream, content)
-          updated_content = content.dup.split("\n")
+          # -1 keeps a trailing empty element so join restores a final newline
+          updated_content = content.dup.split("\n", -1)
 
           yaml_stream.children.each do |document|
             document.children.each do |root_node|
@@ -90,14 +91,31 @@ module Dependabot
 
         sig { params(key: String, value_node: Psych::Nodes::Node, content: T::Array[String]).returns(T::Array[String]) }
         def process_image_key(key, value_node, content)
-          return content unless key == "image" && value_node.is_a?(Psych::Nodes::Mapping)
+          return content unless key == "image"
 
+          if value_node.is_a?(Psych::Nodes::Mapping)
+            process_mapping_image(value_node, content)
+          elsif value_node.is_a?(Psych::Nodes::Scalar)
+            process_scalar_image(value_node, content)
+          else
+            content
+          end
+        end
+
+        sig { params(value_node: Psych::Nodes::Mapping, content: T::Array[String]).returns(T::Array[String]) }
+        def process_mapping_image(value_node, content)
           dependency_name = dependency.name
           has_dependency = contains_dependency?(value_node, dependency_name)
           return content unless has_dependency
 
           dependency_version = T.must(dependency.version)
           update_version_tags(value_node, content, dependency_version)
+        end
+
+        sig { params(value_node: Psych::Nodes::Scalar, content: T::Array[String]).returns(T::Array[String]) }
+        def process_scalar_image(value_node, content)
+          dependency_version = T.must(dependency.version)
+          update_scalar_image_tag(value_node, content, dependency_version)
         end
 
         sig { params(node: Psych::Nodes::Node, dependency_name: String).returns(T::Boolean) }
@@ -132,6 +150,51 @@ module Dependabot
           end
 
           content
+        end
+
+        sig do
+          params(
+            value_node: Psych::Nodes::Scalar,
+            content: T::Array[String],
+            dependency_version: String
+          ).returns(T::Array[String])
+        end
+        def update_scalar_image_tag(value_node, content, dependency_version)
+          dependency_name = dependency.name
+
+          dependency.requirements.each do |req|
+            next unless req.metadata_symbol("type") == :docker_image
+
+            old_tag = req.source_string("tag")
+            next unless old_tag
+
+            old_declaration = scalar_image_declaration(dependency_name, req, old_tag)
+            next unless value_node.value == old_declaration
+
+            new_declaration = scalar_image_declaration(dependency_name, req, dependency_version)
+
+            line = value_node.start_line
+            content[line] = T.must(content[line]).sub(old_declaration, new_declaration)
+          end
+
+          content
+        end
+
+        sig do
+          params(
+            name: String,
+            req: Dependabot::DependencyRequirement,
+            tag: String
+          ).returns(String)
+        end
+        def scalar_image_declaration(name, req, tag)
+          registry = req.source_string("registry")
+          digest = req.source_string("digest")
+
+          declaration = registry ? "#{registry}/#{name}" : name
+          declaration += ":#{tag}"
+          declaration += "@sha256:#{digest.delete_prefix('sha256:')}" if digest
+          declaration
         end
       end
     end

--- a/helm/lib/dependabot/helm/file_updater/image_updater.rb
+++ b/helm/lib/dependabot/helm/file_updater/image_updater.rb
@@ -167,6 +167,8 @@ module Dependabot
 
             old_tag = req.source_string("tag")
             next unless old_tag
+            # digest-pinned images resolve by digest, so a tag-only bump would silently keep the old image
+            next if req.source_string("digest")
 
             old_declaration = scalar_image_declaration(dependency_name, req, old_tag)
             next unless value_node.value == old_declaration
@@ -189,12 +191,9 @@ module Dependabot
         end
         def scalar_image_declaration(name, req, tag)
           registry = req.source_string("registry")
-          digest = req.source_string("digest")
-
-          declaration = registry ? "#{registry}/#{name}" : name
-          declaration += ":#{tag}"
-          declaration += "@sha256:#{digest.delete_prefix('sha256:')}" if digest
-          declaration
+          # the parser already folds a detected registry into the name itself (e.g. "docker.io/nginx")
+          declaration = registry && !name.start_with?("#{registry}/") ? "#{registry}/#{name}" : name
+          "#{declaration}:#{tag}"
         end
       end
     end

--- a/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
+++ b/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
@@ -217,6 +217,82 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
       end
     end
 
+    context "with a sibling key sharing the same line as the scalar image" do
+      let(:dependency_name) { "nginx" }
+      let(:dependency_version) { "1.21.0" }
+      let(:dependency_previous_version) { "1.20.0" }
+      let(:dependency_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            tag: dependency_previous_version
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+      let(:dependency_previous_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_previous_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            tag: dependency_previous_version
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+
+      let(:fixture_content) { "config: {other: nginx:1.20.0, image: nginx:1.20.0}\n" }
+
+      it "only updates the image key, leaving the identical sibling value untouched" do
+        updated_content = updater.updated_values_yaml_content("values.yaml")
+
+        expect(updated_content).to eq("config: {other: nginx:1.20.0, image: nginx:1.21.0}\n")
+      end
+    end
+
+    context "with a block-style scalar image spanning multiple lines" do
+      let(:dependency_name) { "nginx" }
+      let(:dependency_version) { "1.21.0" }
+      let(:dependency_previous_version) { "1.20.0" }
+      let(:dependency_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            tag: dependency_previous_version
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+      let(:dependency_previous_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_previous_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            tag: dependency_previous_version
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+
+      let(:fixture_content) { "image: >-\n  nginx:1.20.0\n" }
+
+      it "finds the declaration on the line after Psych's reported start_line" do
+        updated_content = updater.updated_values_yaml_content("values.yaml")
+
+        expect(updated_content).to eq("image: >-\n  nginx:1.21.0\n")
+      end
+    end
+
     context "with multiple documents in the YAML file" do
       let(:fixture_content) do
         <<~YAML

--- a/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
+++ b/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
@@ -136,6 +136,87 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
       end
     end
 
+    context "with a registry-prefixed scalar image reference" do
+      let(:dependency_name) { "docker.io/nginx" }
+      let(:dependency_version) { "1.21.0" }
+      let(:dependency_previous_version) { "1.20.0" }
+      let(:dependency_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            registry: "docker.io",
+            tag: dependency_previous_version
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+      let(:dependency_previous_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_previous_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            registry: "docker.io",
+            tag: dependency_previous_version
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+
+      let(:fixture_content) do
+        "image: docker.io/nginx:1.20.0\n"
+      end
+
+      it "updates the tag without doubling the registry" do
+        updated_content = updater.updated_values_yaml_content("values.yaml")
+
+        expect(updated_content).to eq("image: docker.io/nginx:1.21.0\n")
+      end
+    end
+
+    context "with a digest-pinned scalar image reference" do
+      let(:dependency_name) { "nginx" }
+      let(:dependency_version) { "1.21.0" }
+      let(:dependency_previous_version) { "1.20.0" }
+      let(:dependency_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            tag: dependency_previous_version,
+            digest: "sha256:abc123"
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+      let(:dependency_previous_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_previous_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            tag: dependency_previous_version,
+            digest: "sha256:abc123"
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+
+      let(:fixture_content) { "image: nginx:1.20.0@sha256:abc123\n" }
+
+      it "raises an error instead of bumping the tag while keeping the stale digest" do
+        expect { updater.updated_values_yaml_content("values.yaml") }
+          .to raise_error("Expected content to change!")
+      end
+    end
+
     context "with multiple documents in the YAML file" do
       let(:fixture_content) do
         <<~YAML

--- a/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
+++ b/helm/spec/dependabot/helm/file_updater/image_updater_spec.rb
@@ -94,6 +94,48 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
       end
     end
 
+    context "with a scalar image reference" do
+      let(:dependency_name) { "otel/opentelemetry-collector-contrib" }
+      let(:dependency_version) { "0.159.0" }
+      let(:dependency_previous_version) { "0.139.0" }
+      let(:dependency_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            tag: dependency_previous_version
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+      let(:dependency_previous_requirements) do
+        [{
+          file: "values.yaml",
+          requirement: dependency_previous_version,
+          groups: [],
+          source: {
+            type: "docker_registry",
+            tag: dependency_previous_version
+          },
+          metadata: { type: :docker_image }
+        }]
+      end
+
+      let(:fixture_content) do
+        "collector:\n  image: otel/opentelemetry-collector-contrib:0.139.0\n"
+      end
+
+      it "updates the image tag and preserves the final newline" do
+        updated_content = updater.updated_values_yaml_content("values.yaml")
+
+        expect(updated_content).to eq(
+          "collector:\n  image: otel/opentelemetry-collector-contrib:0.159.0\n"
+        )
+      end
+    end
+
     context "with multiple documents in the YAML file" do
       let(:fixture_content) do
         <<~YAML
@@ -327,9 +369,9 @@ RSpec.describe Dependabot::Helm::FileUpdater::ImageUpdater do
         YAML
       end
 
-      it "processes the image tag and preserving complex structures" do
-        updated_content = updater.updated_values_yaml_content("values.yaml")
-        expect(updated_content).to include("- 1.20.0")
+      it "raises an error because a list-valued tag is not a supported form" do
+        expect { updater.updated_values_yaml_content("values.yaml") }
+          .to raise_error("Expected content to change!")
       end
     end
   end


### PR DESCRIPTION


### What are you trying to accomplish?

- ImageUpdater now handles scalar 'image: repo:tag' values, not just mapping-form image.repository/image.tag
- split("\n", -1) preserves the file's trailing newline through the split/join reconstruction, so no-op changes are no longer masked as successful updates
- corrected an existing spec that only passed because of the newline bug

Fixes dependabot/dependabot-core#16110

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

### Anything you want to highlight for special attention from reviewers?


<img width="500" alt="image" src="https://github.com/user-attachments/assets/0d845de8-b840-405f-a402-9a4d83647a9f" />




<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
