### PR TITLE
Fix Maven Wrapper regeneration hanging behind private registries

### DIFF
--- a/maven/lib/dependabot/maven/file_updater/wrapper_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater/wrapper_updater.rb
@@ -222,6 +222,7 @@ module Dependabot
             wrapper_plugin_version: wrapper_version,
             env: build_env,
             distribution_type: distribution_type,
+            registry_base: resolved_registry_base,
             extra_args: extra_args,
             cwd: wrapper_dir
           )
@@ -288,8 +289,10 @@ module Dependabot
         end
 
         # Builds the environment hash passed to the native wrapper command.
-        # Sets the proxy host and, for a private/mirror registry, MVNW_REPOURL. Registry auth is
-        # injected by Dependabot's proxy, so no username/password is set here (core never receives them).
+        # Sets only the proxy host. Registry routing is handled by the native
+        # helper's generated settings mirror (see `resolved_registry_base`), and
+        # registry auth is injected by Dependabot's proxy, so no username/password
+        # is set here (core never receives them).
         sig { returns(T::Hash[String, String]) }
         def build_env
           env = T.let({}, T::Hash[String, String])
@@ -299,9 +302,6 @@ module Dependabot
             env["PROXY_HOST"] = proxy_url.host.to_s
           end
 
-          registry_base, cred = resolve_registry_base_and_credential
-          env.merge!(build_registry_env(registry_base, cred))
-
           if Dependabot.logger.debug?
             env["MVNW_VERBOSE"] = "true"
             Dependabot.logger.debug "build_env result: #{env}"
@@ -310,51 +310,18 @@ module Dependabot
           env
         end
 
-        sig do
-          returns([T.nilable(String), T.nilable(Dependabot::Credential)])
-        end
-        def resolve_registry_base_and_credential
-          properties = wrapper_properties_file&.content.to_s
-          dist_url = effective_distribution_url(properties)
-          Dependabot.logger.debug "Effective distribution URL: #{dist_url}"
-
-          registry_base_regex = %r{^(https?://[^/]+(?:/[^/]+)*)/org/apache/maven/apache-maven/}
-          registry_base = dist_url&.match(registry_base_regex)&.captures&.first
-          Dependabot.logger.debug "Extracted registry base: #{registry_base || '(none)'}"
-
-          cred = maven_registry_credential(registry_base)
-          Dependabot.logger.debug "Matched credential: #{cred ? "url=#{cred.fetch('url', '(none)')}" : '(none)'}"
-
-          [registry_base, cred]
-        end
-
-        sig do
-          params(registry_base: T.nilable(String), cred: T.nilable(Dependabot::Credential))
-            .returns(T::Hash[String, String])
-        end
-        def build_registry_env(registry_base, cred)
-          if registry_base
-            { "MVNW_REPOURL" => registry_base }
-          elsif cred&.replaces_base?
-            { "MVNW_REPOURL" => cred.fetch("url").chomp("/") }
-          else
-            {}
-          end
-        end
-
-        sig { params(registry_base: T.nilable(String)).returns(T.nilable(Dependabot::Credential)) }
-        def maven_registry_credential(registry_base)
-          maven_creds = @credentials.select { |c| c["type"] == "maven_repository" }
-
-          if registry_base
-            url_matches = maven_creds.select do |c|
-              cred_url = c.fetch("url", "").chomp("/")
-              !cred_url.empty? && registry_base.start_with?(cred_url)
-            end
-            return url_matches.max_by { |c| c.fetch("url", "").length } if url_matches.any?
-          end
-
-          maven_creds.find(&:replaces_base?)
+        # The registry that actually served the release we're updating to. `source_url` on the
+        # resolved requirement is `release.url` from version resolution
+        # (base_version_finder: `{ version: release.version, source_url: release.url }`), so it is
+        # the one place `mvn` is guaranteed to find this version. The native regeneration mirrors
+        # plugin/distribution resolution there instead of falling back to Central and hanging behind
+        # a no-egress registry. Nil only when no version resolved, leaving the Central default.
+        #
+        # A trailing slash is stripped so Maven appends the artifact path to a canonical base
+        # (`base/org/...`, not `base//org/...`) and registries don't 301-redirect every request.
+        sig { returns(T.nilable(String)) }
+        def resolved_registry_base
+          dependency.requirements.filter_map { |req| req.metadata_string("source_url") }.first&.chomp("/")
         end
 
         sig { params(buildfile: DependencyFile).returns(String) }

--- a/maven/lib/dependabot/maven/native_helpers.rb
+++ b/maven/lib/dependabot/maven/native_helpers.rb
@@ -3,10 +3,12 @@
 
 require "fileutils"
 require "open3"
+require "tempfile"
 require "uri"
 require "sorbet-runtime"
 require "nokogiri"
 require "dependabot/errors"
+require "dependabot/command_helpers"
 require "dependabot/shared_helpers"
 
 module Dependabot
@@ -32,6 +34,11 @@ module Dependabot
       # output (e.g. `-Dstyle.color=always`), wrapping markers like `[ERROR]` in escape
       # codes; we strip these so classification and the surfaced summary see plain text.
       ANSI_ESCAPE_REGEX = %r{\e\[[0-9;?]*[ -/]*[@-~]}
+
+      # Bounded inactivity timeout for the wrapper download. `run_shell_command`'s watchdog
+      # resets on output, and with transfer progress restored a healthy download keeps it
+      # alive, so this only trips on genuine silence — well below the 900s DEFAULT.
+      WRAPPER_DOWNLOAD_TIMEOUT = CommandHelpers::TIMEOUTS::LONG_RUNNING
 
       pom_path = File.join(__dir__, "pom.xml")
 
@@ -86,21 +93,32 @@ module Dependabot
           wrapper_plugin_version: String,
           env: T::Hash[String, String],
           distribution_type: String,
+          registry_base: T.nilable(String),
           extra_args: T::Array[String],
           cwd: T.nilable(String)
         ).void
       end
-      def self.run_mvnw_wrapper(version:, wrapper_plugin_version:, env:, distribution_type:, extra_args: [], cwd: nil)
+      def self.run_mvnw_wrapper(
+        version:,
+        wrapper_plugin_version:,
+        env:,
+        distribution_type:,
+        registry_base: nil,
+        extra_args: [],
+        cwd: nil
+      )
         # Use the fully-qualified plugin goal so the exact plugin version is
         # invoked regardless of the project's plugin group configuration.
         plugin_goal = "org.apache.maven.plugins:maven-wrapper-plugin:" \
                       "#{wrapper_plugin_version}:wrapper"
 
+        # Do NOT add `--no-transfer-progress`: Maven's transfer progress is the liveness signal
+        # that keeps `run_shell_command`'s inactivity watchdog alive during a large download.
+        # Suppressing it made a healthy-but-slow fetch look hung and get killed at the timeout.
         standard_args = [
           plugin_goal,
           "-Dmaven=#{version}",
-          "-Dtype=#{distribution_type}",
-          "--no-transfer-progress"
+          "-Dtype=#{distribution_type}"
         ] + extra_args
 
         # Pass the argument vector directly instead of a pre-joined shell string.
@@ -111,7 +129,22 @@ module Dependabot
         cmd = ["mvn"] + standard_args
         run_cwd = cwd && cwd != "." ? cwd : nil
 
-        output = SharedHelpers.run_shell_command(cmd, env: env, cwd: run_cwd)
+        # Route the native `mvn`'s plugin/distribution resolution to the registry that served the
+        # resolved version via a generated settings mirror; without it `mvn` falls back to Central
+        # and hangs behind a no-egress registry. Absent when no version resolved, leaving the baked
+        # Central default. The bounded timeout is explained on WRAPPER_DOWNLOAD_TIMEOUT.
+        settings_file = registry_base && wrapper_settings_file(registry_base)
+        settings_args = settings_file ? ["-s", T.must(settings_file.path)] : []
+        begin
+          output = SharedHelpers.run_shell_command(
+            cmd + settings_args,
+            env: env,
+            cwd: run_cwd,
+            timeout: WRAPPER_DOWNLOAD_TIMEOUT
+          )
+        ensure
+          settings_file&.close! # deletes the temp file
+        end
         Dependabot.logger.info("mvn wrapper output: STDOUT:#{output}")
         output
       rescue SharedHelpers::HelperSubprocessFailed => e
@@ -122,6 +155,46 @@ module Dependabot
         # the `run_mvn_dependency_tree_plugin` path.
         Dependabot.logger.warn("mvn wrapper command failed:\n#{e.message}")
         handle_wrapper_error(e)
+      end
+
+      # Writes a temporary Maven settings file that keeps the proxy block and adds a
+      # mirror pointing every external repository at the resolved base. Registry
+      # auth still flows through the Dependabot proxy; no credentials are written here.
+      # The caller is responsible for deleting the returned file (via `close!`).
+      sig { params(registry_base: String).returns(Tempfile) }
+      def self.wrapper_settings_file(registry_base)
+        file = Tempfile.new(["dependabot-mvn-wrapper-settings", ".xml"])
+        file.write(wrapper_settings_xml(registry_base))
+        file.close
+        file
+      end
+
+      # Builds the settings XML used for the wrapper invocation: the same proxy block as
+      # the baked settings (auth is injected by the proxy) plus a `mirrorOf=external:*`
+      # mirror so plugin, transitive POM, and distribution resolution all route through
+      # the resolved base instead of Central.
+      sig { params(registry_base: String).returns(String) }
+      def self.wrapper_settings_xml(registry_base)
+        <<~XML
+          <settings>
+            <proxies>
+              <proxy>
+                <id>dependabot-proxy</id>
+                <active>true</active>
+                <protocol>http</protocol>
+                <host>${env.PROXY_HOST}</host>
+                <port>1080</port>
+              </proxy>
+            </proxies>
+            <mirrors>
+              <mirror>
+                <id>dependabot-wrapper-mirror</id>
+                <mirrorOf>external:*</mirrorOf>
+                <url>#{registry_base.encode(xml: :text)}</url>
+              </mirror>
+            </mirrors>
+          </settings>
+        XML
       end
 
       # Classifies a failed Maven Wrapper invocation into an actionable Dependabot

--- a/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
@@ -86,13 +86,13 @@ module Dependabot
         sig { returns(T::Array[Dependabot::DependencyRequirement]) }
         attr_reader :requirements
 
-        # Bumps a wrapper (maven-wrapper.properties) requirement. As well as the requirement
-        # string, it updates the fields the FileUpdater actually reads so a real update regenerates
-        # the *new* release rather than the old one:
-        #   - distributionUrl  -> metadata[:distribution_version] and the versioned source url
-        #   - wrapperVersion   -> metadata[:wrapper_version]
-        # The wrapperUrl tag-along requirement (present only on the distribution dependency) is left
-        # otherwise untouched, since bumping the distribution does not change the wrapper JAR.
+        # Bumps a wrapper (maven-wrapper.properties) requirement to the resolved version, keeping the
+        # fields the FileUpdater reads in sync so it regenerates the *new* release, not the old one:
+        #   - distributionUrl -> metadata[:distribution_version] + the versioned source url
+        #   - wrapperVersion  -> metadata[:wrapper_version]
+        #   - both            -> metadata[:source_url] (registry that served the version, so the
+        #                        FileUpdater can mirror the native `mvn` there)
+        #   - wrapperUrl      -> left untouched (tag-along; bumping the distribution doesn't move it)
         sig do
           params(req: Dependabot::DependencyRequirement)
             .returns(Dependabot::DependencyRequirement)
@@ -105,13 +105,30 @@ module Dependabot
           when "distributionUrl"
             updated = Dependabot::DependencyRequirement.create(req.merge(requirement: new_version))
             updated = merge_metadata_version(updated, :distribution_version, new_version)
-            merge_source_url(updated, old_version, new_version)
+            updated = merge_source_url(updated, old_version, new_version)
+            merge_registry_source_url(updated)
           when "wrapperVersion"
             updated = Dependabot::DependencyRequirement.create(req.merge(requirement: new_version))
-            merge_metadata_version(updated, :wrapper_version, new_version)
+            updated = merge_metadata_version(updated, :wrapper_version, new_version)
+            merge_registry_source_url(updated)
           else
             req
           end
+        end
+
+        # Stamps the registry that served the resolved version (source_url = release.url) onto the
+        # wrapper requirement metadata, so the FileUpdater can mirror the native `mvn` regeneration
+        # to the same registry the version was resolved and vetted against. Nil when no version
+        # resolved (no key added), leaving the wrapper's Central default.
+        sig do
+          params(req: Dependabot::DependencyRequirement).returns(Dependabot::DependencyRequirement)
+        end
+        def merge_registry_source_url(req)
+          base = source_url
+          return req unless base
+
+          metadata = req.metadata || {}
+          Dependabot::DependencyRequirement.create(req.merge(metadata: metadata.merge(source_url: base)))
         end
 
         sig do

--- a/maven/spec/dependabot/maven/file_updater/wrapper_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater/wrapper_updater_spec.rb
@@ -298,6 +298,8 @@ RSpec.describe Dependabot::Maven::FileUpdater::WrapperUpdater do
         "distributionUrl=#{dist_url}\ndistributionType=only-script\nwrapperVersion=3.3.3\n"
       end
 
+      let(:resolved_source_url) { nil }
+
       let(:dependency) do
         Dependabot::Dependency.new(
           name: "org.apache.maven.wrapper:maven-wrapper",
@@ -313,7 +315,7 @@ RSpec.describe Dependabot::Maven::FileUpdater::WrapperUpdater do
               },
               groups: [],
               metadata: { wrapper_version: "3.3.4", distribution_version: "3.9.9", distribution_type: "only-script",
-                          include_debug_script: false }
+                          include_debug_script: false, source_url: resolved_source_url }
             },
             {
               requirement: "3.9.9",
@@ -363,34 +365,50 @@ RSpec.describe Dependabot::Maven::FileUpdater::WrapperUpdater do
         expect(received[:extra_args]).to include("-DdistributionUrl=#{dist_url}")
       end
 
-      context "with only the wrapper requirement and a private distribution URL" do
-        let(:dist_url) do
-          "https://repo.example.test/maven/releases/org/apache/maven/apache-maven/" \
-            "3.9.9/apache-maven-3.9.9-bin.zip"
-        end
-        let(:dependency) do
-          Dependabot::Dependency.new(
-            name: "org.apache.maven.wrapper:maven-wrapper",
-            version: "3.3.4",
-            previous_version: "3.3.3",
-            requirements: [{
-              requirement: "3.3.4",
-              file: ".mvn/wrapper/maven-wrapper.properties",
-              source: { type: "maven-distribution", property: "wrapperVersion" },
-              groups: [],
-              metadata: { wrapper_version: "3.3.4", distribution_version: "3.9.9",
-                          distribution_type: "only-script", include_debug_script: false }
-            }],
-            package_manager: "maven"
-          )
-        end
+      context "when the version resolved from a private registry" do
+        let(:resolved_source_url) { "https://repo.example.test/maven/releases" }
 
-        it "derives MVNW_REPOURL from the existing properties" do
+        it "routes the native helper through the resolved registry base" do
           received = {}
           allow(Dependabot::Maven::NativeHelpers).to receive(:run_mvnw_wrapper) { |**kwargs| received = kwargs }
           updater.update_files(buildfile)
 
-          expect(received[:env]).to include("MVNW_REPOURL" => "https://repo.example.test/maven/releases")
+          expect(received[:registry_base]).to eq("https://repo.example.test/maven/releases")
+          expect(received[:env]).not_to have_key("MVNW_REPOURL")
+        end
+
+        context "when the resolved base has a trailing slash" do
+          let(:resolved_source_url) { "https://repo.example.test/maven/releases/" }
+
+          it "strips it so Maven builds a canonical base path without redirects" do
+            received = {}
+            allow(Dependabot::Maven::NativeHelpers).to receive(:run_mvnw_wrapper) { |**kwargs| received = kwargs }
+            updater.update_files(buildfile)
+
+            expect(received[:registry_base]).to eq("https://repo.example.test/maven/releases")
+          end
+        end
+      end
+
+      context "when the version resolved from Maven Central" do
+        let(:resolved_source_url) { "https://repo.maven.apache.org/maven2" }
+
+        it "passes the resolved registry base through unchanged" do
+          received = {}
+          allow(Dependabot::Maven::NativeHelpers).to receive(:run_mvnw_wrapper) { |**kwargs| received = kwargs }
+          updater.update_files(buildfile)
+
+          expect(received[:registry_base]).to eq("https://repo.maven.apache.org/maven2")
+        end
+      end
+
+      context "without a resolved registry source_url" do
+        it "passes no registry base, leaving the Central default in place" do
+          received = {}
+          allow(Dependabot::Maven::NativeHelpers).to receive(:run_mvnw_wrapper) { |**kwargs| received = kwargs }
+          updater.update_files(buildfile)
+
+          expect(received[:registry_base]).to be_nil
         end
       end
     end

--- a/maven/spec/dependabot/maven/native_helpers_spec.rb
+++ b/maven/spec/dependabot/maven/native_helpers_spec.rb
@@ -135,17 +135,18 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
     let(:env) { { "SOME_VAR" => "value" } }
 
     it "passes an argument vector (not a pre-escaped shell string) to run_shell_command" do
-      expect(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd, **_kwargs|
+      expect(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd, **kwargs|
         expect(cmd).to be_an(Array)
         expect(cmd).to eq(
           [
             "mvn",
             "org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper",
             "-Dmaven=3.6.3",
-            "-Dtype=only-script",
-            "--no-transfer-progress"
+            "-Dtype=only-script"
           ]
         )
+        # A bounded inactivity timeout is passed explicitly, not left to the 900s DEFAULT.
+        expect(kwargs[:timeout]).to eq(Dependabot::CommandHelpers::TIMEOUTS::LONG_RUNNING)
         # No shell escaping should leak into the arguments.
         expect(cmd.join(" ")).not_to include("\\")
         ""
@@ -157,6 +158,90 @@ RSpec.describe Dependabot::Maven::NativeHelpers do
         env: env,
         distribution_type: "only-script"
       )
+    end
+
+    context "with a resolved registry base" do
+      it "routes resolution through a generated settings mirror passed via -s" do
+        captured_settings = nil
+
+        expect(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd, **_kwargs|
+          s_index = cmd.index("-s")
+          expect(s_index).not_to be_nil
+          settings_path = cmd[s_index + 1]
+          captured_settings = File.read(settings_path)
+          ""
+        end
+
+        described_class.run_mvnw_wrapper(
+          version: "3.6.3",
+          wrapper_plugin_version: "3.3.4",
+          env: env,
+          distribution_type: "only-script",
+          registry_base: "https://repo.example.test/maven/releases"
+        )
+
+        expect(captured_settings).to include("<mirrorOf>external:*</mirrorOf>")
+        expect(captured_settings).to include("<url>https://repo.example.test/maven/releases</url>")
+        # The proxy block is retained so auth still flows through the Dependabot proxy.
+        expect(captured_settings).to include("${env.PROXY_HOST}")
+      end
+
+      it "removes the temporary settings file after the invocation" do
+        settings_path = nil
+
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd, **_kwargs|
+          settings_path = cmd[cmd.index("-s") + 1]
+          ""
+        end
+
+        described_class.run_mvnw_wrapper(
+          version: "3.6.3",
+          wrapper_plugin_version: "3.3.4",
+          env: env,
+          distribution_type: "only-script",
+          registry_base: "https://repo.example.test/maven/releases"
+        )
+
+        expect(File.exist?(settings_path)).to be(false)
+      end
+
+      it "removes the temporary settings file even when the invocation fails" do
+        settings_path = nil
+
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd, **_kwargs|
+          settings_path = cmd[cmd.index("-s") + 1]
+          raise wrapper_failure("[ERROR] boom")
+        end
+
+        expect do
+          described_class.run_mvnw_wrapper(
+            version: "3.6.3",
+            wrapper_plugin_version: "3.3.4",
+            env: env,
+            distribution_type: "only-script",
+            registry_base: "https://repo.example.test/maven/releases"
+          )
+        end.to raise_error(Dependabot::DependabotError)
+
+        expect(settings_path).not_to be_nil
+        expect(File.exist?(settings_path)).to be(false)
+      end
+    end
+
+    context "without a resolved registry base" do
+      it "does not pass -s, leaving the baked Central default settings in place" do
+        expect(Dependabot::SharedHelpers).to receive(:run_shell_command) do |cmd, **_kwargs|
+          expect(cmd).not_to include("-s")
+          ""
+        end
+
+        described_class.run_mvnw_wrapper(
+          version: "3.6.3",
+          wrapper_plugin_version: "3.3.4",
+          env: env,
+          distribution_type: "only-script"
+        )
+      end
     end
 
     it "appends extra_args and forwards a non-'.' cwd" do

--- a/maven/spec/dependabot/maven/update_checker/requirements_updater_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/requirements_updater_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe Dependabot::Maven::UpdateChecker::RequirementsUpdater do
     described_class.new(
       requirements: requirements.map { |requirement| Dependabot::DependencyRequirement.create(requirement) },
       latest_version: latest_version,
-      source_url: "new_url",
+      source_url: source_url,
       properties_to_update: []
     )
   end
+
+  let(:source_url) { "new_url" }
 
   let(:requirements) { [pom_req] }
   let(:pom_req) do
@@ -228,6 +230,18 @@ RSpec.describe Dependabot::Maven::UpdateChecker::RequirementsUpdater do
         it "leaves the unrelated wrapper_version metadata untouched" do
           expect(updated.dig(:metadata, :wrapper_version)).to eq("3.3.4")
         end
+
+        it "records the resolved registry source_url onto the requirement metadata" do
+          expect(updated.dig(:metadata, :source_url)).to eq("new_url")
+        end
+
+        context "when no source_url was resolved" do
+          let(:source_url) { nil }
+
+          it "does not record a source_url on the requirement metadata" do
+            expect(updated[:metadata]).not_to have_key(:source_url)
+          end
+        end
       end
 
       context "when bumping a wrapperVersion requirement" do
@@ -248,6 +262,10 @@ RSpec.describe Dependabot::Maven::UpdateChecker::RequirementsUpdater do
 
         it "updates metadata[:wrapper_version] to the new version" do
           expect(updated.dig(:metadata, :wrapper_version)).to eq("3.3.4")
+        end
+
+        it "records the resolved registry source_url onto the requirement metadata" do
+          expect(updated.dig(:metadata, :source_url)).to eq("new_url")
         end
 
         it "does not synthesise a source url" do


### PR DESCRIPTION
### What are you trying to accomplish?

Maven Wrapper regeneration was hanging and getting killed by the shared inactivity watchdog on repositories that resolve all dependencies through a private registry.

Root cause: the wrapper's native `mvn` invocation did not resolve from the same registry that the normal dependency-update check already selected for the wrapper version. Plugin, transitive POM, and wrapper-distribution resolution therefore fell back to Maven Central. In no-egress enterprise setups that request connects but never responds, so the job stayed silent until the inactivity timeout tripped much later.

This change:

- Routes the wrapper's native `mvn` to the registry that actually served the resolved wrapper version — the one the update check already selected and vetted — instead of letting it fall back to Central.
- Restores Maven transfer-progress output so the inactivity watchdog can distinguish a healthy-but-slow download from a genuinely stalled one.
- Bounds the wrapper invocation with an explicit inactivity timeout so true silence fails deterministically.

Behavior stays gated by the existing `maven_wrapper_updater` experiment.

### Anything you want to highlight for special attention from reviewers?

- The resolved registry is applied to the native `mvn` by dynamically generating a settings file for the invocation that keeps the existing proxy block and adds a catch-all mirror (`external:*`) pointing at that registry. This is deliberate: the wrapper regen resolves both the wrapper plugin (plus its transitive deps) and the distribution, and the plugin has no explicit repo — so a narrower mirror would let plugin resolution fall back to Central and hang again. The private base is the replaces-base Central mirror, so it serves all of these. The settings file is scoped to this one invocation (`-s`), so normal dependency updates (which never shell to `mvn`) are unaffected. Registry auth continues to flow through the Dependabot proxy; no credentials are written into the settings.
- The registry is taken from the version already resolved by the update check (its source URL), so no separate registry-guessing logic is introduced. When the version resolves from Maven Central, resolution is unchanged.
- The shared retry/backoff primitive that was previously bundled here has been split out into a separate change; this PR is intentionally scoped to visibility + bounded timeout + registry alignment.

### How will you know you've accomplished your goal?

- Updated targeted Maven specs (wrapper updater, native helpers, and requirements updater) pass in the Docker/Linux environment.
- Sorbet type-check and RuboCop pass on the touched files.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

