### PR TITLE
Add shadow image build selection

### DIFF
--- a/.github/image-filters.yml
+++ b/.github/image-filters.yml
@@ -1,0 +1,128 @@
+shared: &shared
+  - .dockerignore
+  - .github/image-filters.yml
+  - .github/workflows/images-branch.yml
+  - .github/workflows/images-latest.yml
+  - .github/workflows/images-updater-core.yml
+  - Dockerfile.updater-core
+  - Dockerfile.validation
+  - LICENSE
+  - common/**
+  - docker-bake.hcl
+  - omnibus/**
+  - updater/**
+  - '*/.bundle/**'
+  - '*/*.gemspec'
+
+bazel:
+  - *shared
+  - bazel/**
+bun:
+  - *shared
+  - bun/**
+bundler:
+  - *shared
+  - bundler/**
+cargo:
+  - *shared
+  - cargo/**
+composer:
+  - *shared
+  - composer/**
+conda:
+  - *shared
+  - conda/**
+  - python/**
+deno:
+  - *shared
+  - deno/**
+devcontainers:
+  - *shared
+  - devcontainers/**
+docker:
+  - *shared
+  - docker/**
+docker-compose:
+  - *shared
+  - docker/**
+dotnet-sdk:
+  - *shared
+  - dotnet_sdk/**
+elm:
+  - *shared
+  - elm/**
+gitsubmodule:
+  - *shared
+  - git_submodules/**
+github-actions:
+  - *shared
+  - github_actions/**
+gomod:
+  - *shared
+  - go_modules/**
+gradle:
+  - *shared
+  - gradle/**
+  - maven/**
+helm:
+  - *shared
+  - docker/**
+  - helm/**
+mix:
+  - *shared
+  - hex/**
+julia:
+  - *shared
+  - julia/**
+maven:
+  - *shared
+  - maven/**
+nix:
+  - *shared
+  - nix/**
+npm:
+  - *shared
+  - npm_and_yarn/**
+nuget:
+  - *shared
+  - nuget/**
+opentofu:
+  - *shared
+  - opentofu/**
+pip:
+  - *shared
+  - cargo/**
+  - python/**
+pre-commit:
+  - *shared
+  - bundler/**
+  - cargo/**
+  - go_modules/**
+  - npm_and_yarn/**
+  - pre_commit/**
+  - pub/**
+  - python/**
+pub:
+  - *shared
+  - pub/**
+rust-toolchain:
+  - *shared
+  - rust_toolchain/**
+sbt:
+  - *shared
+  - maven/**
+  - sbt/**
+swift:
+  - *shared
+  - swift/**
+terraform:
+  - *shared
+  - terraform/**
+uv:
+  - *shared
+  - cargo/**
+  - python/**
+  - uv/**
+vcpkg:
+  - *shared
+  - vcpkg/**

--- a/.github/image-filters.yml
+++ b/.github/image-filters.yml
@@ -85,6 +85,7 @@ npm:
   - npm_and_yarn/**
 nuget:
   - *shared
+  - .gitmodules
   - nuget/**
 opentofu:
   - *shared

--- a/.github/image-filters.yml
+++ b/.github/image-filters.yml
@@ -10,6 +10,7 @@ shared: &shared
   - common/**
   - docker-bake.hcl
   - omnibus/**
+  - script/resolve-image-matrix
   - updater/**
   - '*/.bundle/**'
   - '*/*.gemspec'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
         with:
           bundler-cache: true
       - run: ./bin/lint
+      - run: ./script/test-image-build-matrix
       # yamllint is installed in GitHub Actions base runner image: https://github.com/adrienverge/yamllint/pull/588
       - run: yamllint .
 

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ needs.approval.outputs.base_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Preserve trusted image selection
         run: |
@@ -112,6 +112,12 @@ jobs:
           [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
           git fetch origin "$BASE_REF"
 
+      - name: Generate publication matrix
+        id: publication-bake-matrix
+        uses: docker/bake-action/subaction/matrix@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          target: ecosystem
+
       - name: Find affected ecosystems
         id: changes
         continue-on-error: true
@@ -125,13 +131,14 @@ jobs:
       - name: Remove internal targets
         id: matrix
         env:
-          BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
+          BAKE_MATRIX: ${{ steps.publication-bake-matrix.outputs.matrix }}
         run: |
           MATRIX=$(jq -c '[.[] | select(.target != "updater-core")]' <<< "$BAKE_MATRIX")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Resolve proposed image matrix
         id: proposed
+        continue-on-error: true
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
           CHANGED_TARGETS: ${{ steps.changes.outputs.changes || '[]' }}

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -16,6 +16,10 @@ on: # yamllint disable-line rule:truthy
         required: true
         type: number
         description: PR number
+      force_all:
+        description: Build every ecosystem image
+        type: boolean
+        default: false
 permissions: {}
 
 jobs:
@@ -29,7 +33,10 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      base_ref: ${{ steps.decision.outputs.base_ref }}
       decision: ${{ steps.decision.outputs.decision }}
+      head_sha: ${{ steps.decision.outputs.head_sha }}
+      pr: ${{ steps.decision.outputs.pr }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,8 +58,13 @@ jobs:
         run: |
           # For security, the `gh` call that retrieves the PR approval status *must* also retrieve the commit at the
           # tip of the PR to ensure that any subsequent unreviewed commits are not pulled into this action workflow.
-          DECISION=$(gh pr view "$PR" --json reviewDecision,state,commits --jq '"\(.reviewDecision):\(.state):\(.commits | last .oid)"')
+          PR_DATA=$(gh pr view "$PR" --json baseRefName,commits,reviewDecision,state)
+          HEAD_SHA=$(jq -r '.commits | last | .oid' <<< "$PR_DATA")
+          DECISION=$(jq -r --arg head_sha "$HEAD_SHA" '"\(.reviewDecision):\(.state):\($head_sha)"' <<< "$PR_DATA")
+          echo "base_ref=$(jq -r '.baseRefName' <<< "$PR_DATA")" >> "$GITHUB_OUTPUT"
           echo "decision=$DECISION" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
 
   prepare:
     runs-on: ubuntu-latest
@@ -60,19 +72,52 @@ jobs:
     if: startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN')
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      proposed_build_count: ${{ steps.proposed.outputs.build_count }}
+      proposed_build_matrix: ${{ steps.proposed.outputs.build_matrix }}
+      proposed_promote_count: ${{ steps.proposed.outputs.promote_count }}
+      proposed_promote_matrix: ${{ steps.proposed.outputs.promote_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Preserve trusted image selection
+        run: |
+          cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+          cp .github/image-filters.yml "$RUNNER_TEMP/image-filters.yml"
+          cp script/resolve-image-matrix "$RUNNER_TEMP/resolve-image-matrix"
 
       - name: Generate ecosystem matrix
         id: bake-matrix
         uses: docker/bake-action/subaction/matrix@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
+          files: ${{ runner.temp }}/docker-bake.hcl
           target: ecosystem
+
+      - name: Checkout approved pull request
+        env:
+          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+          BASE_REF: ${{ needs.approval.outputs.base_ref }}
+          PR: ${{ needs.approval.outputs.pr }}
+        run: |
+          gh pr checkout "$PR"
+          [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
+          git fetch origin "$BASE_REF"
+
+      - name: Find affected ecosystems
+        id: changes
+        continue-on-error: true
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          token: ''
+          base: ${{ needs.approval.outputs.base_ref }}
+          ref: ${{ needs.approval.outputs.head_sha }}
+          filters: ${{ runner.temp }}/image-filters.yml
 
       - name: Remove internal targets
         id: matrix
@@ -81,6 +126,29 @@ jobs:
         run: |
           MATRIX=$(jq -c '[.[] | select(.target != "updater-core")]' <<< "$BAKE_MATRIX")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve proposed image matrix
+        id: proposed
+        env:
+          BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
+          CHANGED_TARGETS: ${{ steps.changes.outputs.changes || '[]' }}
+          FORCE_ALL: ${{ inputs.force_all || steps.changes.outcome != 'success' }}
+        run: |
+          RESULT=$("$RUNNER_TEMP/resolve-image-matrix")
+          echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "build_matrix=$(jq -c '.build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "promote_count=$(jq -r '.promote_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "promote_matrix=$(jq -c '.promote' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Proposed image selection"
+            echo
+            echo "Build: $(jq -r '.build_count' <<< "$RESULT")"
+            jq -r '.build[]? | "- `\(.target)`"' <<< "$RESULT"
+            echo
+            echo "Promote unchanged: $(jq -r '.promote_count' <<< "$RESULT")"
+            jq -r '.promote[]? | "- `\(.target)`"' <<< "$RESULT"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   push-updater-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -34,6 +34,7 @@ jobs:
       pull-requests: read
     outputs:
       base_ref: ${{ steps.decision.outputs.base_ref }}
+      base_sha: ${{ steps.decision.outputs.base_sha }}
       decision: ${{ steps.decision.outputs.decision }}
       head_sha: ${{ steps.decision.outputs.head_sha }}
       pr: ${{ steps.decision.outputs.pr }}
@@ -58,10 +59,11 @@ jobs:
         run: |
           # For security, the `gh` call that retrieves the PR approval status *must* also retrieve the commit at the
           # tip of the PR to ensure that any subsequent unreviewed commits are not pulled into this action workflow.
-          PR_DATA=$(gh pr view "$PR" --json baseRefName,commits,reviewDecision,state)
+          PR_DATA=$(gh pr view "$PR" --json baseRefName,baseRefOid,commits,reviewDecision,state)
           HEAD_SHA=$(jq -r '.commits | last | .oid' <<< "$PR_DATA")
           DECISION=$(jq -r --arg head_sha "$HEAD_SHA" '"\(.reviewDecision):\(.state):\($head_sha)"' <<< "$PR_DATA")
           echo "base_ref=$(jq -r '.baseRefName' <<< "$PR_DATA")" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(jq -r '.baseRefOid' <<< "$PR_DATA")" >> "$GITHUB_OUTPUT"
           echo "decision=$DECISION" >> "$GITHUB_OUTPUT"
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
@@ -85,6 +87,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ needs.approval.outputs.base_sha }}
 
       - name: Preserve trusted image selection
         run: |

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -7,6 +7,12 @@ on: # yamllint disable-line rule:truthy
       - main
     paths-ignore:
       - "common/lib/dependabot.rb"
+  workflow_dispatch:
+    inputs:
+      force_all:
+        description: Build every ecosystem image
+        type: boolean
+        default: true
 permissions: {}
 
 jobs:
@@ -31,10 +37,15 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      proposed_build_count: ${{ steps.proposed.outputs.build_count }}
+      proposed_build_matrix: ${{ steps.proposed.outputs.build_matrix }}
+      proposed_promote_count: ${{ steps.proposed.outputs.promote_count }}
+      proposed_promote_matrix: ${{ steps.proposed.outputs.promote_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Generate ecosystem matrix
@@ -50,6 +61,40 @@ jobs:
         run: |
           MATRIX=$(jq -c '[.[] | select(.target != "updater-core")]' <<< "$BAKE_MATRIX")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+      - name: Find affected ecosystems
+        id: changes
+        if: github.event_name == 'push'
+        continue-on-error: true
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          token: ''
+          base: ${{ github.event.before }}
+          ref: ${{ github.sha }}
+          filters: .github/image-filters.yml
+
+      - name: Resolve proposed image matrix
+        id: proposed
+        env:
+          BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
+          CHANGED_TARGETS: ${{ steps.changes.outputs.changes || '[]' }}
+          FORCE_ALL: ${{ github.event_name != 'push' || inputs.force_all || steps.changes.outcome != 'success' }}
+        run: |
+          RESULT=$(script/resolve-image-matrix)
+          echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "build_matrix=$(jq -c '.build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "promote_count=$(jq -r '.promote_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "promote_matrix=$(jq -c '.promote' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Proposed image selection"
+            echo
+            echo "Build: $(jq -r '.build_count' <<< "$RESULT")"
+            jq -r '.build[]? | "- `\(.target)`"' <<< "$RESULT"
+            echo
+            echo "Promote unchanged: $(jq -r '.promote_count' <<< "$RESULT")"
+            jq -r '.promote[]? | "- `\(.target)`"' <<< "$RESULT"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   push-updater-image:
     name: Deploy

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -8,11 +8,6 @@ on: # yamllint disable-line rule:truthy
     paths-ignore:
       - "common/lib/dependabot.rb"
   workflow_dispatch:
-    inputs:
-      force_all:
-        description: Build every ecosystem image
-        type: boolean
-        default: true
 permissions: {}
 
 jobs:
@@ -78,7 +73,7 @@ jobs:
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
           CHANGED_TARGETS: ${{ steps.changes.outputs.changes || '[]' }}
-          FORCE_ALL: ${{ github.event_name != 'push' || inputs.force_all || steps.changes.outcome != 'success' }}
+          FORCE_ALL: ${{ github.event_name != 'push' || steps.changes.outcome != 'success' }}
         run: |
           RESULT=$(script/resolve-image-matrix)
           echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Resolve proposed image matrix
         id: proposed
+        continue-on-error: true
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
           CHANGED_TARGETS: ${{ steps.changes.outputs.changes || '[]' }}

--- a/bin/lint
+++ b/bin/lint
@@ -15,7 +15,9 @@ shellcheck \
   ./script/ci-test-updater \
   ./script/dependabot \
   ./script/generate-coverage-report \
+  ./script/resolve-image-matrix \
   ./script/setup \
+  ./script/test-image-build-matrix \
   ./script/updater-e2e \
   ./updater/bin/run \
   "$@"

--- a/script/resolve-image-matrix
+++ b/script/resolve-image-matrix
@@ -25,6 +25,11 @@ if [[ "$force_all" != "true" && "$force_all" != "false" ]]; then
   exit 1
 fi
 
+if [[ "$(jq -r 'index("shared") != null' <<< "$changed_targets")" == "true" ]]; then
+  force_all=true
+fi
+changed_targets=$(jq -c '[.[] | select(. != "shared")]' <<< "$changed_targets")
+
 targets=$(jq -c '[.[] | select(.target != "updater-core") | .target]' <<< "$BAKE_MATRIX")
 unknown_targets=$(jq -cn --argjson changed "$changed_targets" --argjson targets "$targets" '$changed - $targets')
 

--- a/script/resolve-image-matrix
+++ b/script/resolve-image-matrix
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${BAKE_MATRIX:-}" ]]; then
+  echo "BAKE_MATRIX must contain the Docker Bake matrix JSON" >&2
+  exit 1
+fi
+
+changed_targets="${CHANGED_TARGETS:-[]}"
+force_all="${FORCE_ALL:-false}"
+
+if ! jq -e 'type == "array" and all(.[]; (.target | type) == "string")' <<< "$BAKE_MATRIX" > /dev/null; then
+  echo "BAKE_MATRIX must be an array of target objects" >&2
+  exit 1
+fi
+
+if ! jq -e 'type == "array" and all(.[]; type == "string")' <<< "$changed_targets" > /dev/null; then
+  echo "CHANGED_TARGETS must be an array of target names" >&2
+  exit 1
+fi
+
+if [[ "$force_all" != "true" && "$force_all" != "false" ]]; then
+  echo "FORCE_ALL must be true or false" >&2
+  exit 1
+fi
+
+targets=$(jq -c '[.[] | select(.target != "updater-core") | .target]' <<< "$BAKE_MATRIX")
+unknown_targets=$(jq -cn --argjson changed "$changed_targets" --argjson targets "$targets" '$changed - $targets')
+
+if [[ "$(jq 'length' <<< "$unknown_targets")" -ne 0 ]]; then
+  echo "CHANGED_TARGETS contains unknown targets: $(jq -c '.' <<< "$unknown_targets")" >&2
+  exit 1
+fi
+
+jq -c \
+  --arg force_all "$force_all" \
+  --argjson changed "$changed_targets" \
+  '
+    [.[] | select(.target != "updater-core")] as $matrix
+    | if $force_all == "true" then
+        {
+          reason: "force-all",
+          build: $matrix,
+          promote: [],
+          build_count: ($matrix | length),
+          promote_count: 0
+        }
+      else
+        {
+          reason: "changed-targets",
+          build: [
+            $matrix[] as $item
+            | select($changed | index($item.target))
+            | $item
+          ],
+          promote: [
+            $matrix[] as $item
+            | select(($changed | index($item.target)) | not)
+            | $item
+          ],
+          build_count: ([
+            $matrix[] as $item
+            | select($changed | index($item.target))
+          ] | length),
+          promote_count: ([
+            $matrix[] as $item
+            | select(($changed | index($item.target)) | not)
+          ] | length)
+        }
+      end
+  ' <<< "$BAKE_MATRIX"

--- a/script/test-image-build-matrix
+++ b/script/test-image-build-matrix
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+matrix='[
+  {"target":"updater-core","dockerfile":"Dockerfile.updater-core"},
+  {"target":"bundler","dockerfile":"bundler/Dockerfile"},
+  {"target":"nuget","dockerfile":"nuget/Dockerfile"},
+  {"target":"pre-commit","dockerfile":"pre_commit/Dockerfile"}
+]'
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [[ "$expected" != "$actual" ]]; then
+    echo "$message: expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+result=$(
+  BAKE_MATRIX="$matrix" \
+  CHANGED_TARGETS='["nuget","pre-commit"]' \
+  script/resolve-image-matrix
+)
+assert_equal '2' "$(jq -r '.build_count' <<< "$result")" "filtered build count"
+assert_equal '1' "$(jq -r '.promote_count' <<< "$result")" "filtered promotion count"
+assert_equal '["nuget","pre-commit"]' "$(jq -c '[.build[].target] | sort' <<< "$result")" "filtered targets"
+
+result=$(
+  BAKE_MATRIX="$matrix" \
+  CHANGED_TARGETS='[]' \
+  FORCE_ALL=true \
+  script/resolve-image-matrix
+)
+assert_equal '3' "$(jq -r '.build_count' <<< "$result")" "forced build count"
+assert_equal '0' "$(jq -r '.promote_count' <<< "$result")" "forced promotion count"
+
+if BAKE_MATRIX="$matrix" CHANGED_TARGETS='["unknown"]' script/resolve-image-matrix > /dev/null 2>&1; then
+  echo "unknown target should fail" >&2
+  exit 1
+fi
+
+bake_targets=$(
+  docker buildx bake --print ecosystem 2> /dev/null |
+    jq -c '.group.ecosystem.targets | map(select(. != "updater-core")) | sort'
+)
+filter_targets=$(
+  ruby -ryaml -rjson -e '
+    filters = YAML.safe_load_file(ARGV.fetch(0), aliases: true)
+    puts JSON.generate(filters.keys.reject { |key| key == "shared" }.sort)
+  ' .github/image-filters.yml
+)
+assert_equal "$bake_targets" "$filter_targets" "filter and Bake targets"
+
+ruby -ryaml -e '
+  filters = YAML.safe_load_file(ARGV.fetch(0), aliases: true)
+  expected = {
+    "conda" => ["python/**"],
+    "gradle" => ["maven/**"],
+    "helm" => ["docker/**"],
+    "pip" => ["cargo/**", "python/**"],
+    "pre-commit" => [
+      "bundler/**",
+      "cargo/**",
+      "go_modules/**",
+      "npm_and_yarn/**",
+      "pub/**",
+      "python/**"
+    ],
+    "sbt" => ["maven/**"],
+    "uv" => ["cargo/**", "python/**"]
+  }
+
+  expected.each do |target, paths|
+    missing = paths - filters.fetch(target).flatten
+    abort("#{target} is missing paths: #{missing.join(", ")}") unless missing.empty?
+  end
+' .github/image-filters.yml

--- a/script/test-image-build-matrix
+++ b/script/test-image-build-matrix
@@ -40,6 +40,15 @@ result=$(
 assert_equal '3' "$(jq -r '.build_count' <<< "$result")" "forced build count"
 assert_equal '0' "$(jq -r '.promote_count' <<< "$result")" "forced promotion count"
 
+result=$(
+  BAKE_MATRIX="$matrix" \
+  CHANGED_TARGETS='["shared"]' \
+  script/resolve-image-matrix
+)
+assert_equal '3' "$(jq -r '.build_count' <<< "$result")" "shared build count"
+assert_equal '0' "$(jq -r '.promote_count' <<< "$result")" "shared promotion count"
+assert_equal '"force-all"' "$(jq -c '.reason' <<< "$result")" "shared selection reason"
+
 if BAKE_MATRIX="$matrix" CHANGED_TARGETS='["unknown"]' script/resolve-image-matrix > /dev/null 2>&1; then
   echo "unknown target should fail" >&2
   exit 1

--- a/script/test-image-build-matrix
+++ b/script/test-image-build-matrix
@@ -72,6 +72,7 @@ ruby -ryaml -e '
     "conda" => ["python/**"],
     "gradle" => ["maven/**"],
     "helm" => ["docker/**"],
+    "nuget" => [".gitmodules"],
     "pip" => ["cargo/**", "python/**"],
     "pre-commit" => [
       "bundler/**",

--- a/script/test-image-build-matrix
+++ b/script/test-image-build-matrix
@@ -69,6 +69,7 @@ assert_equal "$bake_targets" "$filter_targets" "filter and Bake targets"
 ruby -ryaml -e '
   filters = YAML.safe_load_file(ARGV.fetch(0), aliases: true)
   expected = {
+    "shared" => ["script/resolve-image-matrix"],
     "conda" => ["python/**"],
     "gradle" => ["maven/**"],
     "helm" => ["docker/**"],


### PR DESCRIPTION
> **Stack 1/8** · Base: `main` · Next: #16155

### What are you trying to accomplish?

Add a trusted, dependency-aware image selector in shadow mode before changing which images are published.

The current workflow builds all 33 ecosystem images for every qualifying merge. The profiled baseline used 91.8 runner-minutes and 9 minutes 11 seconds for a NuGet-only commit, with 90.5% of runner time spent on unaffected images.

This layer adds:

- `.github/image-filters.yml`, including cross-ecosystem source dependencies.
- A deterministic Bake-matrix resolver with empty, partial, and forced-full behavior.
- Fixture tests and target/filter consistency checks.
- Main and approved-PR workflow summaries showing proposed build and promotion sets.
- An explicit `force_all` fallback.

Publication behavior remains full-matrix in this layer.

### Anything you want to highlight for special attention from reviewers?

The branch workflow snapshots the selector, filter, and Bake definition before checking out the approved PR head. Selector failures fall back to a full build rather than silently skipping images.

### How will you know you've accomplished your goal?

- Resolver fixtures cover global, NuGet, Python, Maven, Docker, empty, and forced-full selections.
- Filter keys match all 33 public Bake image targets.
- Shellcheck and yamllint pass in a Docker CLI container.
- The workflow only reports the proposed matrix; it does not consume it yet.

**Rollback:** remove the shadow steps and selector files. Image publication is otherwise unchanged.

### Checklist

- [ ] Complete test suite passes in CI.
- [x] Targeted resolver, shell, and workflow checks pass.
- [x] Commit messages are descriptive.
- [x] The change and rollback are documented.
