### PR TITLE
Publish validated images in a single build

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -133,7 +133,7 @@ jobs:
         env:
           BAKE_MATRIX: ${{ steps.publication-bake-matrix.outputs.matrix }}
         run: |
-          MATRIX=$(jq -c '[.[] | select(.target != "updater-core")]' <<< "$BAKE_MATRIX")
+          MATRIX=$(jq -c '[.[] | select(.target != "updater-core" and (.target | endswith("-raw") | not))]' <<< "$BAKE_MATRIX")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Resolve proposed image matrix
@@ -220,29 +220,7 @@ jobs:
         id: metadata
         run: echo "version=$DEPENDABOT_UPDATER_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Build ecosystem image for validation
-        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
-        with:
-          source: .
-          files: ${{ runner.temp }}/docker-bake.hcl
-          targets: ${{ matrix.target }}
-          provenance: false
-          set: |
-            ${{ matrix.target }}.output=type=docker
-            ${{ matrix.target }}.tags=${{ env.UPDATER_IMAGE }}:validation-${{ github.run_id }}
-
-      - name: Validate ecosystem image
-        env:
-          IMAGE: ${{ env.UPDATER_IMAGE }}:validation-${{ github.run_id }}
-        run: |
-          docker run --rm "$IMAGE" \
-            bash -lc "cd /home/dependabot/dependabot-updater && bundle check"
-
-          IMAGE_LAYERS=$(docker history -q "$IMAGE" | wc -l | sed -e 's/ //g')
-          echo "$IMAGE contains $IMAGE_LAYERS layers"
-          [[ $IMAGE_LAYERS -lt 126 ]]
-
-      - name: Build and push branch image
+      - name: Build and push validated branch image
         id: build
         uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
@@ -253,6 +231,18 @@ jobs:
           set: |
             ${{ matrix.target }}.output=type=registry
             ${{ matrix.target }}.tags=${{ env.UPDATER_IMAGE }}:${{ steps.metadata.outputs.version }}
+
+      - name: Validate image manifest
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)[matrix.target]['containerimage.digest'] }}
+        run: |
+          IMAGE="${UPDATER_IMAGE}@${IMAGE_DIGEST}"
+          IMAGE_LAYERS=$(docker buildx imagetools inspect --raw "$IMAGE" | jq '.layers | length')
+          echo "$IMAGE contains $IMAGE_LAYERS layers"
+          [[ $IMAGE_LAYERS -lt 126 ]]
+
+          TAG_DIGEST=$(docker buildx imagetools inspect "${UPDATER_IMAGE}:${{ steps.metadata.outputs.version }}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+          [[ "$TAG_DIGEST" == "$IMAGE_DIGEST" ]]
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -235,13 +235,14 @@ jobs:
       - name: Validate image manifest
         env:
           IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)[matrix.target]['containerimage.digest'] }}
+          IMAGE_TAG: ${{ steps.metadata.outputs.version }}
         run: |
           IMAGE="${UPDATER_IMAGE}@${IMAGE_DIGEST}"
           IMAGE_LAYERS=$(docker buildx imagetools inspect --raw "$IMAGE" | jq '.layers | length')
           echo "$IMAGE contains $IMAGE_LAYERS layers"
           [[ $IMAGE_LAYERS -lt 126 ]]
 
-          TAG_DIGEST=$(docker buildx imagetools inspect "${UPDATER_IMAGE}:${{ steps.metadata.outputs.version }}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+          TAG_DIGEST=$(docker buildx imagetools inspect "${UPDATER_IMAGE}:${IMAGE_TAG}" --format '{{json .Manifest.Digest}}' | jq -r '.')
           [[ "$TAG_DIGEST" == "$IMAGE_DIGEST" ]]
 
       - name: Generate artifact attestation

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
         run: |
-          MATRIX=$(jq -c '[.[] | select(.target != "updater-core")]' <<< "$BAKE_MATRIX")
+          MATRIX=$(jq -c '[.[] | select(.target != "updater-core" and (.target | endswith("-raw") | not))]' <<< "$BAKE_MATRIX")
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
       - name: Find affected ecosystems
@@ -113,7 +113,6 @@ jobs:
       DATE_VERSION: ${{ needs.date-version.outputs.date }}
       DEPENDABOT_UPDATER_VERSION: ""
       UPDATER_IMAGE: ghcr.io/dependabot/dependabot-updater-${{ matrix.target }}
-      VALIDATION_IMAGE: ghcr.io/dependabot/dependabot-updater-${{ matrix.target }}:validation-${{ github.run_id }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -130,28 +129,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build ecosystem image for validation
-        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
-        with:
-          source: .
-          targets: ${{ matrix.target }}
-          provenance: false
-          set: |
-            ${{ matrix.target }}.output=type=docker
-            ${{ matrix.target }}.tags=${{ env.VALIDATION_IMAGE }}
-
-      - name: Validate ecosystem image
-        env:
-          IMAGE: ${{ env.VALIDATION_IMAGE }}
-        run: |
-          docker run --rm "$IMAGE" \
-            bash -lc "cd /home/dependabot/dependabot-updater && bundle check"
-
-          IMAGE_LAYERS=$(docker history -q "$IMAGE" | wc -l | sed -e 's/ //g')
-          echo "$IMAGE contains $IMAGE_LAYERS layers"
-          [[ $IMAGE_LAYERS -lt 126 ]]
-
-      - name: Build and push ecosystem image
+      - name: Build and push validated ecosystem image
         id: build
         uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
@@ -161,8 +139,26 @@ jobs:
           set: |
             ${{ matrix.target }}.output=type=registry
             ${{ matrix.target }}.tags=${{ env.UPDATER_IMAGE }}:${{ env.COMMIT_SHA }}
-            ${{ matrix.target }}.tags+=${{ env.UPDATER_IMAGE }}:latest
-            ${{ matrix.target }}.tags+=${{ env.UPDATER_IMAGE }}:${{ env.DATE_VERSION }}
+
+      - name: Validate and promote image manifest
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)[matrix.target]['containerimage.digest'] }}
+        run: |
+          IMAGE="${UPDATER_IMAGE}@${IMAGE_DIGEST}"
+          IMAGE_LAYERS=$(docker buildx imagetools inspect --raw "$IMAGE" | jq '.layers | length')
+          echo "$IMAGE contains $IMAGE_LAYERS layers"
+          [[ $IMAGE_LAYERS -lt 126 ]]
+
+          docker buildx imagetools create \
+            --prefer-index=false \
+            --tag "${UPDATER_IMAGE}:latest" \
+            --tag "${UPDATER_IMAGE}:${DATE_VERSION}" \
+            "$IMAGE"
+
+          for tag in "$COMMIT_SHA" latest "$DATE_VERSION"; do
+            TAG_DIGEST=$(docker buildx imagetools inspect "${UPDATER_IMAGE}:${tag}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+            [[ "$TAG_DIGEST" == "$IMAGE_DIGEST" ]]
+          done
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2

--- a/Dockerfile.validation
+++ b/Dockerfile.validation
@@ -1,0 +1,4 @@
+# syntax=docker.io/docker/dockerfile:1.20
+FROM ecosystem-image
+
+RUN bash -lc "cd /home/dependabot/dependabot-updater && bundle check"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -95,13 +95,13 @@ target "updater-core-publish" {
   ]
 }
 
-target "ecosystem" {
-  name = item.image
+target "_ecosystem" {
+  name = "${item.image}-raw"
   matrix = {
     item = ECOSYSTEMS
   }
 
-  description = "Published ${item.name} ecosystem image"
+  description = "Build input for the ${item.name} ecosystem image"
   context     = "."
   dockerfile  = item.dockerfile
   contexts = merge(
@@ -109,11 +109,29 @@ target "ecosystem" {
       (UPDATER_CORE_IMAGE) = "target:updater-core"
     },
     item.name == "pre_commit" ? {
-      "${UPDATER_IMAGE_PREFIX}gomod:latest"   = "target:gomod"
-      "${UPDATER_IMAGE_PREFIX}bundler:latest" = "target:bundler"
-      "${UPDATER_IMAGE_PREFIX}pub:latest"     = "target:pub"
+      "${UPDATER_IMAGE_PREFIX}gomod:latest"   = "target:gomod-raw"
+      "${UPDATER_IMAGE_PREFIX}bundler:latest" = "target:bundler-raw"
+      "${UPDATER_IMAGE_PREFIX}pub:latest"     = "target:pub-raw"
     } : {}
   )
+  cache-from = [
+    { type = "gha", scope = item.name },
+    { type = "registry", ref = "${UPDATER_IMAGE_PREFIX}${item.image}:latest" },
+  ]
+}
+
+target "ecosystem" {
+  name = item.image
+  matrix = {
+    item = ECOSYSTEMS
+  }
+
+  description = "Validated ${item.name} ecosystem image"
+  context     = "."
+  dockerfile  = "Dockerfile.validation"
+  contexts = {
+    ecosystem-image = "target:${item.image}-raw"
+  }
   cache-from = [
     { type = "gha", scope = item.name },
     { type = "registry", ref = "${UPDATER_IMAGE_PREFIX}${item.image}:latest" },

--- a/script/resolve-image-matrix
+++ b/script/resolve-image-matrix
@@ -30,7 +30,11 @@ if [[ "$(jq -r 'index("shared") != null' <<< "$changed_targets")" == "true" ]]; 
 fi
 changed_targets=$(jq -c '[.[] | select(. != "shared")]' <<< "$changed_targets")
 
-targets=$(jq -c '[.[] | select(.target != "updater-core") | .target]' <<< "$BAKE_MATRIX")
+targets=$(
+  jq -c \
+    '[.[] | select(.target != "updater-core" and (.target | endswith("-raw") | not)) | .target]' \
+    <<< "$BAKE_MATRIX"
+)
 unknown_targets=$(jq -cn --argjson changed "$changed_targets" --argjson targets "$targets" '$changed - $targets')
 
 if [[ "$(jq 'length' <<< "$unknown_targets")" -ne 0 ]]; then
@@ -42,7 +46,10 @@ jq -c \
   --arg force_all "$force_all" \
   --argjson changed "$changed_targets" \
   '
-    [.[] | select(.target != "updater-core")] as $matrix
+    [
+      .[]
+      | select(.target != "updater-core" and (.target | endswith("-raw") | not))
+    ] as $matrix
     | if $force_all == "true" then
         {
           reason: "force-all",

--- a/script/test-image-build-matrix
+++ b/script/test-image-build-matrix
@@ -7,7 +7,9 @@ cd "$(dirname "$0")/.."
 matrix='[
   {"target":"updater-core","dockerfile":"Dockerfile.updater-core"},
   {"target":"bundler","dockerfile":"bundler/Dockerfile"},
+  {"target":"bundler-raw","dockerfile":"bundler/Dockerfile"},
   {"target":"nuget","dockerfile":"nuget/Dockerfile"},
+  {"target":"nuget-raw","dockerfile":"nuget/Dockerfile"},
   {"target":"pre-commit","dockerfile":"pre_commit/Dockerfile"}
 ]'
 


### PR DESCRIPTION
> **Stack 2/8** · Base: #16154 · Next: #16156

### What are you trying to accomplish?

Replace the two complete image builds used for validation and publication with one validated Bake graph.

Each ecosystem now has:

1. A raw target that builds the existing ecosystem Dockerfile without exporting it.
2. A generic validation wrapper that runs `bundle check`.
3. A single registry export after validation succeeds.

Images are initially pushed under the immutable commit tag. The remote manifest layer count is checked before `latest` and the date tag are moved to the same digest.

### Anything you want to highlight for special attention from reviewers?

This adds one validation layer but removes the expensive Docker-output exporter. The profiled workflow spent 1,021 aggregate BuildKit seconds exporting 17.82 GiB of images solely for validation.

### How will you know you've accomplished your goal?

- A Bundler build completed through the wrapper with `bundle check` before the sole exporter.
- A warm rebuild cached every build instruction and exported in under a second locally.
- The final image passed `bundle check` and remained below the existing layer limit.
- No publishing workflow contains a `type=docker` exporter.

**Rollback:** restore the validation build/run steps and the original direct ecosystem Bake targets.

### Checklist

- [ ] Complete test suite passes in CI.
- [x] Targeted Bake, image, shell, and workflow checks pass.
- [x] Commit messages are descriptive.
- [x] The change and rollback are documented.
