### PR TITLE
Build updater-core once per image workflow

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -192,8 +192,6 @@ jobs:
         run: |
           gh pr checkout "$PR"
           [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
-          git fetch origin main
-          git merge origin/main --ff-only
           git submodule update --init --recursive
 
       - name: Set up Docker Buildx
@@ -275,8 +273,6 @@ jobs:
         run: |
           gh pr checkout "$PR"
           [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
-          git fetch origin main
-          git merge origin/main --ff-only
           git submodule update --init --recursive
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -181,7 +181,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ needs.approval.outputs.base_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
@@ -260,7 +260,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          ref: ${{ needs.approval.outputs.base_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -181,6 +181,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: ${{ needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
@@ -259,6 +260,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+          ref: ${{ needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -160,10 +160,84 @@ jobs:
             jq -r '.promote[]? | "- `\(.target)`"' <<< "$RESULT"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  build-updater-core:
+    runs-on: ubuntu-latest
+    needs: approval
+    if: startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN')
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      pull-requests: read
+      attestations: write
+      artifact-metadata: write
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+    env:
+      DEPENDABOT_UPDATER_VERSION: ${{ needs.approval.outputs.head_sha }}
+      UPDATER_CORE_IMAGE: ghcr.io/dependabot/dependabot-updater-core
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Preserve build definition
+        run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+
+      - name: Checkout approved pull request
+        env:
+          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+          PR: ${{ needs.approval.outputs.pr }}
+        run: |
+          gh pr checkout "$PR"
+          [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
+          git fetch origin main
+          git merge origin/main --ff-only
+          git submodule update --init --recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push updater-core
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          files: ${{ runner.temp }}/docker-bake.hcl
+          targets: updater-core-context
+          provenance: false
+          vars: |
+            UPDATER_CORE_CONTEXT_VERSION=${{ env.DEPENDABOT_UPDATER_VERSION }}
+          set: |
+            updater-core-context.output=type=registry
+            updater-core-context.tags=${{ env.UPDATER_CORE_IMAGE }}:${{ env.DEPENDABOT_UPDATER_VERSION }}
+
+      - name: Resolve updater-core digest
+        id: digest
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)['updater-core-context']['containerimage.digest'] }}
+        run: echo "digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.UPDATER_CORE_IMAGE }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: true
+
   push-updater-images:
     runs-on: ubuntu-latest
     needs:
       - approval
+      - build-updater-core
       - prepare
     if: startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN')
     strategy:
@@ -177,8 +251,9 @@ jobs:
       attestations: write
       artifact-metadata: write
     env:
-      DEPENDABOT_UPDATER_VERSION: ${{ github.sha }}
+      DEPENDABOT_UPDATER_VERSION: ${{ needs.approval.outputs.head_sha }}
       ECOSYSTEM: ${{ matrix.target }}
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
       UPDATER_IMAGE: ghcr.io/dependabot/dependabot-updater-${{ matrix.target }}
     steps:
       - name: Checkout code
@@ -193,22 +268,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      - name: Prepare tag (forks)
+      - name: Checkout approved pull request
         env:
-          APPROVAL_DECISION: ${{ needs.approval.outputs.decision }}
+          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+          PR: ${{ needs.approval.outputs.pr }}
         run: |
-          gh pr checkout ${{ inputs.pr }}
-
-          # Ensure the commit we've checked out matches our expected SHA from when we checked the PR's approval status above.
-          # This is a security measure to prevent any unreviewed commits from getting pulled into this action workflow.
-          # The format is "APPROVED:OPEN:<PR_COMMIT_SHA>", so compare the end of the string to the current commit.
-          [[ "$APPROVAL_DECISION" =~ $(git rev-parse HEAD)$ ]]
-
+          gh pr checkout "$PR"
+          [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
           git fetch origin main
           git merge origin/main --ff-only
           git submodule update --init --recursive
-          echo "DEPENDABOT_UPDATER_VERSION=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
-        if: github.event_name == 'workflow_dispatch'
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -228,6 +297,8 @@ jobs:
           files: ${{ runner.temp }}/docker-bake.hcl
           targets: ${{ matrix.target }}
           provenance: false
+          vars: |
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
           set: |
             ${{ matrix.target }}.output=type=registry
             ${{ matrix.target }}.tags=${{ env.UPDATER_IMAGE }}:${{ steps.metadata.outputs.version }}

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   date-version:
     runs-on: ubuntu-latest
-    if: github.repository == 'dependabot/dependabot-core'
+    if: github.repository == 'dependabot/dependabot-core' && github.ref == 'refs/heads/main'
     outputs:
       date: ${{ steps.date.outputs.DATE_BASED_VERSION }}
     steps:
@@ -25,9 +25,64 @@ jobs:
           DATE_BASED_VERSION="v2.0.$(date +%Y%m%d%H%M%S)"
           echo "DATE_BASED_VERSION=$DATE_BASED_VERSION" >> "$GITHUB_OUTPUT"
 
+  build-updater-core:
+    runs-on: ubuntu-latest
+    if: github.repository == 'dependabot/dependabot-core' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      attestations: write
+      artifact-metadata: write
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+      UPDATER_CORE_IMAGE: ghcr.io/dependabot/dependabot-updater-core
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push updater-core
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          targets: updater-core-context
+          provenance: false
+          set: |
+            updater-core-context.output=type=registry
+            updater-core-context.tags=${{ env.UPDATER_CORE_IMAGE }}:ecosystem-${{ env.COMMIT_SHA }}
+
+      - name: Resolve updater-core digest
+        id: digest
+        env:
+          CONTEXT_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)['updater-core-context']['containerimage.digest'] }}
+        run: echo "digest=$CONTEXT_DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Generate ecosystem updater-core attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.UPDATER_CORE_IMAGE }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: true
+
   prepare:
     runs-on: ubuntu-latest
-    if: github.repository == 'dependabot/dependabot-core'
+    if: github.repository == 'dependabot/dependabot-core' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
     outputs:
@@ -96,6 +151,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs:
+      - build-updater-core
       - date-version
       - prepare
     permissions:
@@ -112,6 +168,7 @@ jobs:
       COMMIT_SHA: ${{ github.sha }}
       DATE_VERSION: ${{ needs.date-version.outputs.date }}
       DEPENDABOT_UPDATER_VERSION: ""
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
       UPDATER_IMAGE: ghcr.io/dependabot/dependabot-updater-${{ matrix.target }}
     steps:
       - name: Checkout code
@@ -136,6 +193,8 @@ jobs:
           source: .
           targets: ${{ matrix.target }}
           provenance: false
+          vars: |
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
           set: |
             ${{ matrix.target }}.output=type=registry
             ${{ matrix.target }}.tags=${{ env.UPDATER_IMAGE }}:${{ env.COMMIT_SHA }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,6 +6,14 @@ variable "UPDATER_CORE_IMAGE" {
   default = "ghcr.io/dependabot/dependabot-updater-core"
 }
 
+variable "UPDATER_CORE_CONTEXT" {
+  default = "target:updater-core"
+}
+
+variable "UPDATER_CORE_CONTEXT_VERSION" {
+  default = ""
+}
+
 variable "UPDATER_CORE_VERSION_TAG" {
   default = ""
 }
@@ -56,15 +64,17 @@ target "_updater-core" {
   context    = "."
   dockerfile = "Dockerfile.updater-core"
   args = {
-    USER_UID                    = "1000"
-    USER_GID                    = "1000"
-    DEPENDABOT_UPDATER_VERSION = DEPENDABOT_UPDATER_VERSION
+    USER_UID = "1000"
+    USER_GID = "1000"
   }
 }
 
 target "updater-core" {
   inherits    = ["_updater-core"]
   description = "Updater-core base for ecosystem images"
+  args = {
+    DEPENDABOT_UPDATER_VERSION = DEPENDABOT_UPDATER_VERSION
+  }
   cache-from = [
     { type = "gha", scope = "updater-core" },
     { type = "registry", ref = "${UPDATER_CORE_IMAGE}:latest" },
@@ -78,7 +88,8 @@ target "updater-core-publish" {
   inherits    = ["_updater-core"]
   description = "Published updater-core image"
   args = {
-    BUILDKIT_INLINE_CACHE = "1"
+    BUILDKIT_INLINE_CACHE        = "1"
+    DEPENDABOT_UPDATER_VERSION = DEPENDABOT_UPDATER_VERSION
   }
   cache-from = [
     { type = "registry", ref = "${UPDATER_CORE_IMAGE}:latest" },
@@ -95,6 +106,21 @@ target "updater-core-publish" {
   ]
 }
 
+target "updater-core-context" {
+  inherits    = ["_updater-core"]
+  description = "Updater-core image consumed by published ecosystem images"
+  args = {
+    BUILDKIT_INLINE_CACHE        = "1"
+    DEPENDABOT_UPDATER_VERSION = UPDATER_CORE_CONTEXT_VERSION
+  }
+  cache-from = [
+    { type = "registry", ref = "${UPDATER_CORE_IMAGE}:latest" },
+  ]
+  cache-to = [
+    { type = "inline" },
+  ]
+}
+
 target "_ecosystem" {
   name = "${item.image}-raw"
   matrix = {
@@ -106,7 +132,7 @@ target "_ecosystem" {
   dockerfile  = item.dockerfile
   contexts = merge(
     {
-      (UPDATER_CORE_IMAGE) = "target:updater-core"
+      (UPDATER_CORE_IMAGE) = UPDATER_CORE_CONTEXT
     },
     item.name == "pre_commit" ? {
       "${UPDATER_IMAGE_PREFIX}gomod:latest"   = "target:gomod-raw"


### PR DESCRIPTION
> **Stack 3/8** · Base: #16155 · Next: #16157

### What are you trying to accomplish?

Build updater-core once per image workflow and pass its immutable digest to every ecosystem build.

The existing metadata contract is preserved:

- The standalone published core image keeps `DEPENDABOT_UPDATER_VERSION=development`.
- Main ecosystem images consume a separate core context with the existing empty version value.
- Branch images consume a core context carrying the exact approved head SHA.

The standalone core publisher remains responsible for `updater-core:latest`, including version-only main commits.

### Anything you want to highlight for special attention from reviewers?

Branch jobs now always check out and build the exact approved PR head. They no longer merge a moving `main` into that head after approval.

### How will you know you've accomplished your goal?

- Both core metadata variants were built in one shared solve and retained their previous environment values.
- A digest-injected Bundler build contained no updater-core target or updater-core `RUN` instruction.
- The branch workflow verifies the checked-out head before building.
- Workflow and Bake target graphs parse successfully.

**Rollback:** restore `target:updater-core` as the ecosystem context and remove the per-workflow core job.

### Checklist

- [ ] Complete test suite passes in CI.
- [x] Targeted core variant, digest-context, shell, and workflow checks pass.
- [x] Commit messages are descriptive.
- [x] The change and rollback are documented.
