### PR TITLE
Move image build caches to GHCR

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -213,6 +213,7 @@ jobs:
           targets: updater-core-context
           provenance: false
           vars: |
+            BUILD_CACHE_WRITE=false
             UPDATER_CORE_CONTEXT_VERSION=${{ env.DEPENDABOT_UPDATER_VERSION }}
           set: |
             updater-core-context.output=type=registry
@@ -296,6 +297,7 @@ jobs:
           targets: ${{ matrix.target }}
           provenance: false
           vars: |
+            BUILD_CACHE_WRITE=false
             UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
           set: |
             ${{ matrix.target }}.output=type=registry

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -62,6 +62,8 @@ jobs:
           source: .
           targets: updater-core-context
           provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=true
           set: |
             updater-core-context.output=type=registry
             updater-core-context.tags=${{ env.UPDATER_CORE_IMAGE }}:ecosystem-${{ env.COMMIT_SHA }}
@@ -194,6 +196,7 @@ jobs:
           targets: ${{ matrix.target }}
           provenance: false
           vars: |
+            BUILD_CACHE_WRITE=true
             UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
           set: |
             ${{ matrix.target }}.output=type=registry

--- a/.github/workflows/images-updater-core.yml
+++ b/.github/workflows/images-updater-core.yml
@@ -49,6 +49,8 @@ jobs:
           source: .
           targets: updater-core-publish
           provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=true
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2

--- a/.github/workflows/images-updater-core.yml
+++ b/.github/workflows/images-updater-core.yml
@@ -50,7 +50,7 @@ jobs:
           targets: updater-core-publish
           provenance: false
           vars: |
-            BUILD_CACHE_WRITE=true
+            BUILD_CACHE_WRITE=${{ github.ref == 'refs/heads/main' }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,6 +22,17 @@ variable "UPDATER_IMAGE_PREFIX" {
   default = "ghcr.io/dependabot/dependabot-updater-"
 }
 
+# Main builds overwrite one cache tag per target. Branch builds import these
+# caches without updating them, preventing pull request builds from evicting
+# the shared main-branch working set.
+variable "BUILD_CACHE_IMAGE" {
+  default = "ghcr.io/dependabot/dependabot-build-cache"
+}
+
+variable "BUILD_CACHE_WRITE" {
+  default = false
+}
+
 variable "ECOSYSTEMS" {
   default = [
     { name = "bazel", image = "bazel", dockerfile = "bazel/Dockerfile" },
@@ -76,12 +87,18 @@ target "updater-core" {
     DEPENDABOT_UPDATER_VERSION = DEPENDABOT_UPDATER_VERSION
   }
   cache-from = [
-    { type = "gha", scope = "updater-core" },
+    { type = "registry", ref = "${BUILD_CACHE_IMAGE}:updater-core" },
     { type = "registry", ref = "${UPDATER_CORE_IMAGE}:latest" },
   ]
-  cache-to = [
-    { type = "gha", mode = "max", scope = "updater-core" },
-  ]
+  cache-to = BUILD_CACHE_WRITE ? [
+    {
+      type           = "registry"
+      ref            = "${BUILD_CACHE_IMAGE}:updater-core"
+      mode           = "max"
+      image-manifest = true
+      oci-mediatypes = true
+    },
+  ] : []
 }
 
 target "updater-core-publish" {
@@ -92,11 +109,21 @@ target "updater-core-publish" {
     DEPENDABOT_UPDATER_VERSION = DEPENDABOT_UPDATER_VERSION
   }
   cache-from = [
+    { type = "registry", ref = "${BUILD_CACHE_IMAGE}:updater-core-publish" },
     { type = "registry", ref = "${UPDATER_CORE_IMAGE}:latest" },
   ]
-  cache-to = [
-    { type = "inline" },
-  ]
+  cache-to = concat(
+    [{ type = "inline" }],
+    BUILD_CACHE_WRITE ? [
+      {
+        type           = "registry"
+        ref            = "${BUILD_CACHE_IMAGE}:updater-core-publish"
+        mode           = "max"
+        image-manifest = true
+        oci-mediatypes = true
+      },
+    ] : []
+  )
   tags = [
     "${UPDATER_CORE_IMAGE}:latest",
     notequal("", UPDATER_CORE_VERSION_TAG) ? "${UPDATER_CORE_IMAGE}:${UPDATER_CORE_VERSION_TAG}" : "",
@@ -114,11 +141,21 @@ target "updater-core-context" {
     DEPENDABOT_UPDATER_VERSION = UPDATER_CORE_CONTEXT_VERSION
   }
   cache-from = [
+    { type = "registry", ref = "${BUILD_CACHE_IMAGE}:updater-core-context" },
     { type = "registry", ref = "${UPDATER_CORE_IMAGE}:latest" },
   ]
-  cache-to = [
-    { type = "inline" },
-  ]
+  cache-to = concat(
+    [{ type = "inline" }],
+    BUILD_CACHE_WRITE ? [
+      {
+        type           = "registry"
+        ref            = "${BUILD_CACHE_IMAGE}:updater-core-context"
+        mode           = "max"
+        image-manifest = true
+        oci-mediatypes = true
+      },
+    ] : []
+  )
 }
 
 target "_ecosystem" {
@@ -141,7 +178,7 @@ target "_ecosystem" {
     } : {}
   )
   cache-from = [
-    { type = "gha", scope = item.name },
+    { type = "registry", ref = "${BUILD_CACHE_IMAGE}:${item.image}" },
     { type = "registry", ref = "${UPDATER_IMAGE_PREFIX}${item.image}:latest" },
   ]
 }
@@ -159,10 +196,19 @@ target "ecosystem" {
     ecosystem-image = "target:${item.image}-raw"
   }
   cache-from = [
-    { type = "gha", scope = item.name },
+    { type = "registry", ref = "${BUILD_CACHE_IMAGE}:${item.image}" },
     { type = "registry", ref = "${UPDATER_IMAGE_PREFIX}${item.image}:latest" },
   ]
-  cache-to = [
-    { type = "gha", mode = "max", scope = item.name },
-  ]
+  cache-to = concat(
+    [{ type = "inline" }],
+    BUILD_CACHE_WRITE ? [
+      {
+        type           = "registry"
+        ref            = "${BUILD_CACHE_IMAGE}:${item.image}"
+        mode           = "max"
+        image-manifest = true
+        oci-mediatypes = true
+      },
+    ] : []
+  )
 }


### PR DESCRIPTION
> **Stack 4/8** · Base: #16156 · Next: #16158

### What are you trying to accomplish?

Move BuildKit's max-mode cache from the saturated GitHub Actions cache to one GHCR cache repository with a tag per target.

Main builds read and write:

```text
ghcr.io/dependabot/dependabot-build-cache:<target>
```

Approved branch builds import the main cache but cannot overwrite it. Published images retain inline cache metadata as a secondary fallback.

### Anything you want to highlight for special attention from reviewers?

The measured Actions cache held 10.63 GB while the final images alone totalled 17.82 GiB. Only 22 of 34 scopes remained shortly after a full run.

### How will you know you've accomplished your goal?

- HCL resolves main targets to registry plus inline exporters.
- Branch mode resolves to read-only registry imports plus inline image metadata.
- A clean Buildx builder imported a locally hosted registry cache and reused every Bundler helper layer.
- Cache export failures remain fatal; only a missing first-run cache import is tolerated by BuildKit.

**Rollback:** restore the GHA cache entries in `docker-bake.hcl`.

### Checklist

- [ ] Complete test suite passes in CI.
- [x] Targeted clean-builder registry-cache, shell, and workflow checks pass.
- [x] Commit messages are descriptive.
- [x] The change and rollback are documented.
