### PR TITLE
Build and promote only affected images

### DIFF
--- a/.github/image-filters.yml
+++ b/.github/image-filters.yml
@@ -10,6 +10,7 @@ shared: &shared
   - common/**
   - docker-bake.hcl
   - omnibus/**
+  - script/promote-image-tags
   - script/resolve-image-matrix
   - updater/**
   - '*/.bundle/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
           bundler-cache: true
       - run: ./bin/lint
       - run: ./script/test-image-build-matrix
+      - run: ./script/test-promote-image-tags
       # yamllint is installed in GitHub Actions base runner image: https://github.com/adrienverge/yamllint/pull/588
       - run: yamllint .
 

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -76,11 +76,10 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-      proposed_build_count: ${{ steps.proposed.outputs.build_count }}
-      proposed_build_matrix: ${{ steps.proposed.outputs.build_matrix }}
-      proposed_promote_count: ${{ steps.proposed.outputs.promote_count }}
-      proposed_promote_matrix: ${{ steps.proposed.outputs.promote_matrix }}
+      build_count: ${{ steps.selection.outputs.build_count }}
+      build_matrix: ${{ steps.selection.outputs.build_matrix }}
+      promote_count: ${{ steps.selection.outputs.promote_count }}
+      promote_matrix: ${{ steps.selection.outputs.promote_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -112,12 +111,6 @@ jobs:
           [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
           git fetch origin "$BASE_REF"
 
-      - name: Generate publication matrix
-        id: publication-bake-matrix
-        uses: docker/bake-action/subaction/matrix@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
-        with:
-          target: ecosystem
-
       - name: Find affected ecosystems
         id: changes
         continue-on-error: true
@@ -128,30 +121,24 @@ jobs:
           ref: ${{ needs.approval.outputs.head_sha }}
           filters: ${{ runner.temp }}/image-filters.yml
 
-      - name: Remove internal targets
-        id: matrix
-        env:
-          BAKE_MATRIX: ${{ steps.publication-bake-matrix.outputs.matrix }}
-        run: |
-          MATRIX=$(jq -c '[.[] | select(.target != "updater-core" and (.target | endswith("-raw") | not))]' <<< "$BAKE_MATRIX")
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve proposed image matrix
-        id: proposed
-        continue-on-error: true
+      - name: Resolve image matrix
+        id: selection
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
           CHANGED_TARGETS: ${{ steps.changes.outputs.changes || '[]' }}
           FORCE_ALL: ${{ inputs.force_all || steps.changes.outcome != 'success' }}
         run: |
-          RESULT=$("$RUNNER_TEMP/resolve-image-matrix")
+          if ! RESULT=$("$RUNNER_TEMP/resolve-image-matrix"); then
+            echo "::warning::Image selection failed; building every ecosystem"
+            RESULT=$(CHANGED_TARGETS='[]' FORCE_ALL=true "$RUNNER_TEMP/resolve-image-matrix")
+          fi
           echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_matrix=$(jq -c '.build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_count=$(jq -r '.promote_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_matrix=$(jq -c '.promote' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
 
           {
-            echo "## Proposed image selection"
+            echo "## Image selection"
             echo
             echo "Build: $(jq -r '.build_count' <<< "$RESULT")"
             jq -r '.build[]? | "- `\(.target)`"' <<< "$RESULT"
@@ -162,8 +149,12 @@ jobs:
 
   build-updater-core:
     runs-on: ubuntu-latest
-    needs: approval
-    if: startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN')
+    needs:
+      - approval
+      - prepare
+    if: >-
+      startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
+      needs.prepare.outputs.build_count != '0'
     permissions:
       contents: read
       id-token: write
@@ -239,11 +230,13 @@ jobs:
       - approval
       - build-updater-core
       - prepare
-    if: startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN')
+    if: >-
+      startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
+      needs.prepare.outputs.build_count != '0'
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+        include: ${{ fromJSON(needs.prepare.outputs.build_matrix) }}
     permissions:
       contents: read
       id-token: write
@@ -340,3 +333,57 @@ jobs:
             echo ".dependabot set-ecosystem-version staging * $DEPENDABOT_UPDATER_VERSION"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  promote-unchanged-images:
+    runs-on: ubuntu-latest
+    needs:
+      - approval
+      - prepare
+    if: >-
+      startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
+      needs.prepare.outputs.promote_count != '0'
+    permissions:
+      attestations: read
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.promote_matrix) }}
+    env:
+      APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+      IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
+      TARGET: ${{ matrix.target }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote existing image digest
+        run: |
+          echo "## Promoted unchanged image" >> "$GITHUB_STEP_SUMMARY"
+          TARGETS_JSON=$(jq -cn --arg target "$TARGET" '[{target: $target}]')
+          TAGS_JSON=$(jq -cn --arg tag "$APPROVED_HEAD_SHA" '[$tag]')
+          export TARGETS_JSON TAGS_JSON
+          script/promote-image-tags
+
+          {
+            echo
+            echo "deploy for $TARGET"
+            echo "\`\`\`"
+            echo ".dependabot set-ecosystem-version staging $TARGET $APPROVED_HEAD_SHA"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify existing artifact attestation
+        run: gh attestation verify "oci://${IMAGE_PREFIX}${TARGET}:${APPROVED_HEAD_SHA}" --owner dependabot

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -397,6 +397,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: ${{ needs.approval.outputs.base_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -80,6 +80,7 @@ jobs:
       build_matrix: ${{ steps.selection.outputs.build_matrix }}
       promote_count: ${{ steps.selection.outputs.promote_count }}
       promote_matrix: ${{ steps.selection.outputs.promote_matrix }}
+      source_tag: ${{ steps.source.outputs.source_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -100,6 +101,37 @@ jobs:
         with:
           files: ${{ runner.temp }}/docker-bake.hcl
           target: ecosystem
+
+      - name: Verify base image tags
+        id: source
+        env:
+          BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
+          SOURCE_TAG: ${{ needs.approval.outputs.base_sha }}
+        run: |
+          AVAILABLE=true
+          MISSING=()
+          while read -r target; do
+            image="ghcr.io/dependabot/dependabot-updater-${target}:${SOURCE_TAG}"
+            if ! docker buildx imagetools inspect "$image" > /dev/null 2>&1; then
+              AVAILABLE=false
+              MISSING+=("$target")
+            fi
+          done < <(
+            jq -r '
+              .[].target
+              | select(
+                  . != "python-runtime" and
+                  . != "updater-core" and
+                  (endswith("-raw") | not)
+                )
+            ' <<< "$BAKE_MATRIX"
+          )
+
+          echo "available=$AVAILABLE" >> "$GITHUB_OUTPUT"
+          echo "source_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
+          if [[ "$AVAILABLE" != "true" ]]; then
+            printf 'Missing base image tags: %s\n' "${MISSING[*]}"
+          fi
 
       - name: Checkout approved pull request
         env:
@@ -126,7 +158,12 @@ jobs:
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
           CHANGED_TARGETS: ${{ steps.changes.outputs.changes || '[]' }}
-          FORCE_ALL: ${{ inputs.force_all || steps.changes.outcome != 'success' }}
+          FORCE_ALL: >-
+            ${{
+              inputs.force_all ||
+              steps.changes.outcome != 'success' ||
+              steps.source.outputs.available != 'true'
+            }}
         run: |
           if ! RESULT=$("$RUNNER_TEMP/resolve-image-matrix"); then
             echo "::warning::Image selection failed; building every ecosystem"
@@ -353,6 +390,7 @@ jobs:
     env:
       APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
       IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
+      SOURCE_TAG: ${{ needs.prepare.outputs.source_tag }}
       TARGET: ${{ matrix.target }}
     steps:
       - name: Checkout code

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -73,6 +73,7 @@ jobs:
     needs: approval
     if: startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN')
     permissions:
+      attestations: read
       contents: read
       pull-requests: read
     outputs:
@@ -115,6 +116,11 @@ jobs:
             if ! docker buildx imagetools inspect "$image" > /dev/null 2>&1; then
               AVAILABLE=false
               MISSING+=("$target")
+              continue
+            fi
+            if ! gh attestation verify "oci://${image}" --owner dependabot > /dev/null 2>&1; then
+              AVAILABLE=false
+              MISSING+=("$target (attestation)")
             fi
           done < <(
             jq -r '

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -23,7 +23,7 @@ on: # yamllint disable-line rule:truthy
 permissions: {}
 
 concurrency:
-  group: branch-images-${{ github.event.pull_request.number || inputs.pr }}-${{ github.event.pull_request.head.sha || github.sha }}
+  group: branch-images-${{ github.event.pull_request.number || inputs.pr }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -397,7 +397,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ needs.approval.outputs.base_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -22,6 +22,10 @@ on: # yamllint disable-line rule:truthy
         default: false
 permissions: {}
 
+concurrency:
+  group: branch-images-${{ github.event.pull_request.number || inputs.pr }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: false
+
 jobs:
   approval:
     # Skip when triggered by pull request events on PR's from forks because the GITHUB_TOKEN on
@@ -81,7 +85,7 @@ jobs:
       build_matrix: ${{ steps.selection.outputs.build_matrix }}
       promote_count: ${{ steps.selection.outputs.promote_count }}
       promote_matrix: ${{ steps.selection.outputs.promote_matrix }}
-      source_tag: ${{ steps.source.outputs.source_tag }}
+      source_tag: ${{ steps.base-source.outputs.source_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -103,11 +107,30 @@ jobs:
           files: ${{ runner.temp }}/docker-bake.hcl
           target: ecosystem
 
+      - name: Checkout approved pull request
+        env:
+          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+          BASE_REF: ${{ needs.approval.outputs.base_ref }}
+          PR: ${{ needs.approval.outputs.pr }}
+        run: |
+          gh pr checkout "$PR"
+          [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
+          git fetch origin "$BASE_REF"
+
+      - name: Resolve immutable base source
+        id: base-source
+        env:
+          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+          BASE_REF: ${{ needs.approval.outputs.base_ref }}
+        run: |
+          SOURCE_TAG=$(git merge-base "$APPROVED_HEAD_SHA" "origin/$BASE_REF")
+          echo "source_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Verify base image tags
         id: source
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
-          SOURCE_TAG: ${{ needs.approval.outputs.base_sha }}
+          SOURCE_TAG: ${{ steps.base-source.outputs.source_tag }}
         run: |
           AVAILABLE=true
           MISSING=()
@@ -134,20 +157,9 @@ jobs:
           )
 
           echo "available=$AVAILABLE" >> "$GITHUB_OUTPUT"
-          echo "source_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
           if [[ "$AVAILABLE" != "true" ]]; then
             printf 'Missing base image tags: %s\n' "${MISSING[*]}"
           fi
-
-      - name: Checkout approved pull request
-        env:
-          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
-          BASE_REF: ${{ needs.approval.outputs.base_ref }}
-          PR: ${{ needs.approval.outputs.pr }}
-        run: |
-          gh pr checkout "$PR"
-          [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
-          git fetch origin "$BASE_REF"
 
       - name: Find affected ecosystems
         id: changes
@@ -395,6 +407,7 @@ jobs:
         include: ${{ fromJSON(needs.prepare.outputs.promote_matrix) }}
     env:
       APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+      FAIL_ON_CONFLICT: true
       IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
       SOURCE_TAG: ${{ needs.prepare.outputs.source_tag }}
       TARGET: ${{ matrix.target }}

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -94,6 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'dependabot/dependabot-core' && github.ref == 'refs/heads/main'
     permissions:
+      attestations: read
       contents: read
     outputs:
       build_count: ${{ steps.selection.outputs.build_count }}
@@ -127,6 +128,7 @@ jobs:
         if: github.event_name == 'push'
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_TAG: ${{ github.event.before }}
         run: |
           AVAILABLE=true
@@ -136,6 +138,11 @@ jobs:
             if ! docker buildx imagetools inspect "$image" > /dev/null 2>&1; then
               AVAILABLE=false
               MISSING+=("$target")
+              continue
+            fi
+            if ! gh attestation verify "oci://${image}" --owner dependabot > /dev/null 2>&1; then
+              AVAILABLE=false
+              MISSING+=("$target (attestation)")
             fi
           done < <(
             jq -r '

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -27,7 +27,11 @@ jobs:
 
   build-updater-core:
     runs-on: ubuntu-latest
-    if: github.repository == 'dependabot/dependabot-core' && github.ref == 'refs/heads/main'
+    needs: prepare
+    if: >-
+      github.repository == 'dependabot/dependabot-core' &&
+      github.ref == 'refs/heads/main' &&
+      needs.prepare.outputs.build_count != '0'
     permissions:
       contents: read
       id-token: write
@@ -88,11 +92,10 @@ jobs:
     permissions:
       contents: read
     outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-      proposed_build_count: ${{ steps.proposed.outputs.build_count }}
-      proposed_build_matrix: ${{ steps.proposed.outputs.build_matrix }}
-      proposed_promote_count: ${{ steps.proposed.outputs.promote_count }}
-      proposed_promote_matrix: ${{ steps.proposed.outputs.promote_matrix }}
+      build_count: ${{ steps.selection.outputs.build_count }}
+      build_matrix: ${{ steps.selection.outputs.build_matrix }}
+      promote_count: ${{ steps.selection.outputs.promote_count }}
+      promote_matrix: ${{ steps.selection.outputs.promote_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -106,14 +109,6 @@ jobs:
         with:
           target: ecosystem
 
-      - name: Remove internal targets
-        id: matrix
-        env:
-          BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
-        run: |
-          MATRIX=$(jq -c '[.[] | select(.target != "updater-core" and (.target | endswith("-raw") | not))]' <<< "$BAKE_MATRIX")
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-
       - name: Find affected ecosystems
         id: changes
         if: github.event_name == 'push'
@@ -125,22 +120,24 @@ jobs:
           ref: ${{ github.sha }}
           filters: .github/image-filters.yml
 
-      - name: Resolve proposed image matrix
-        id: proposed
-        continue-on-error: true
+      - name: Resolve image matrix
+        id: selection
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
           CHANGED_TARGETS: ${{ steps.changes.outputs.changes || '[]' }}
           FORCE_ALL: ${{ github.event_name != 'push' || steps.changes.outcome != 'success' }}
         run: |
-          RESULT=$(script/resolve-image-matrix)
+          if ! RESULT=$(script/resolve-image-matrix); then
+            echo "::warning::Image selection failed; building every ecosystem"
+            RESULT=$(CHANGED_TARGETS='[]' FORCE_ALL=true script/resolve-image-matrix)
+          fi
           echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_matrix=$(jq -c '.build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_count=$(jq -r '.promote_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_matrix=$(jq -c '.promote' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
 
           {
-            echo "## Proposed image selection"
+            echo "## Image selection"
             echo
             echo "Build: $(jq -r '.build_count' <<< "$RESULT")"
             jq -r '.build[]? | "- `\(.target)`"' <<< "$RESULT"
@@ -156,6 +153,7 @@ jobs:
       - build-updater-core
       - date-version
       - prepare
+    if: needs.prepare.outputs.build_count != '0'
     permissions:
       contents: read
       id-token: write
@@ -165,7 +163,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+        include: ${{ fromJSON(needs.prepare.outputs.build_matrix) }}
     env:
       COMMIT_SHA: ${{ github.sha }}
       DATE_VERSION: ${{ needs.date-version.outputs.date }}
@@ -244,3 +242,56 @@ jobs:
             echo "$UPDATER_IMAGE:$COMMIT_SHA"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  promote-unchanged-image:
+    name: Promote unchanged
+    runs-on: ubuntu-latest
+    needs:
+      - date-version
+      - prepare
+    if: needs.prepare.outputs.promote_count != '0'
+    permissions:
+      attestations: read
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.promote_matrix) }}
+    env:
+      BACKUP_REGISTRY: "dependabot-acr-apim-production.azure-api.net"
+      COMMIT_SHA: ${{ github.sha }}
+      DATE_VERSION: ${{ needs.date-version.outputs.date }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
+      TARGET: ${{ matrix.target }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote existing image digest
+        run: |
+          echo "## Promoted unchanged image" >> "$GITHUB_STEP_SUMMARY"
+          TARGETS_JSON=$(jq -cn --arg target "$TARGET" '[{target: $target}]')
+          TAGS_JSON=$(jq -cn --arg commit "$COMMIT_SHA" --arg date "$DATE_VERSION" '[$commit, $date]')
+          export TARGETS_JSON TAGS_JSON
+          script/promote-image-tags
+
+      - name: Verify existing artifact attestation
+        run: gh attestation verify "oci://${IMAGE_PREFIX}${TARGET}:${COMMIT_SHA}" --owner dependabot
+
+      - name: Pull promoted tags through backup registry
+        run: |
+          docker pull "${BACKUP_REGISTRY}/${IMAGE_PREFIX}${TARGET}:$COMMIT_SHA"
+          docker pull "${BACKUP_REGISTRY}/${IMAGE_PREFIX}${TARGET}:$DATE_VERSION"

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -10,6 +10,10 @@ on: # yamllint disable-line rule:truthy
   workflow_dispatch:
 permissions: {}
 
+concurrency:
+  group: latest-images-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   date-version:
     runs-on: ubuntu-latest
@@ -96,6 +100,7 @@ jobs:
       build_matrix: ${{ steps.selection.outputs.build_matrix }}
       promote_count: ${{ steps.selection.outputs.promote_count }}
       promote_matrix: ${{ steps.selection.outputs.promote_matrix }}
+      source_tag: ${{ steps.source.outputs.source_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -103,11 +108,51 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Verify current main tip
+        if: github.event_name == 'push'
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          git fetch origin main
+          [[ "$(git rev-parse origin/main)" == "$EXPECTED_SHA" ]]
+
       - name: Generate ecosystem matrix
         id: bake-matrix
         uses: docker/bake-action/subaction/matrix@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
           target: ecosystem
+
+      - name: Verify predecessor image tags
+        id: source
+        if: github.event_name == 'push'
+        env:
+          BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
+          SOURCE_TAG: ${{ github.event.before }}
+        run: |
+          AVAILABLE=true
+          MISSING=()
+          while read -r target; do
+            image="ghcr.io/dependabot/dependabot-updater-${target}:${SOURCE_TAG}"
+            if ! docker buildx imagetools inspect "$image" > /dev/null 2>&1; then
+              AVAILABLE=false
+              MISSING+=("$target")
+            fi
+          done < <(
+            jq -r '
+              .[].target
+              | select(
+                  . != "python-runtime" and
+                  . != "updater-core" and
+                  (endswith("-raw") | not)
+                )
+            ' <<< "$BAKE_MATRIX"
+          )
+
+          echo "available=$AVAILABLE" >> "$GITHUB_OUTPUT"
+          echo "source_tag=$SOURCE_TAG" >> "$GITHUB_OUTPUT"
+          if [[ "$AVAILABLE" != "true" ]]; then
+            printf 'Missing predecessor image tags: %s\n' "${MISSING[*]}"
+          fi
 
       - name: Find affected ecosystems
         id: changes
@@ -125,7 +170,12 @@ jobs:
         env:
           BAKE_MATRIX: ${{ steps.bake-matrix.outputs.matrix }}
           CHANGED_TARGETS: ${{ steps.changes.outputs.changes || '[]' }}
-          FORCE_ALL: ${{ github.event_name != 'push' || steps.changes.outcome != 'success' }}
+          FORCE_ALL: >-
+            ${{
+              github.event_name != 'push' ||
+              steps.changes.outcome != 'success' ||
+              steps.source.outputs.available != 'true'
+            }}
         run: |
           if ! RESULT=$(script/resolve-image-matrix); then
             echo "::warning::Image selection failed; building every ecosystem"
@@ -264,6 +314,7 @@ jobs:
       DATE_VERSION: ${{ needs.date-version.outputs.date }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
+      SOURCE_TAG: ${{ needs.prepare.outputs.source_tag }}
       TARGET: ${{ matrix.target }}
     steps:
       - name: Checkout code

--- a/bin/lint
+++ b/bin/lint
@@ -15,9 +15,11 @@ shellcheck \
   ./script/ci-test-updater \
   ./script/dependabot \
   ./script/generate-coverage-report \
+  ./script/promote-image-tags \
   ./script/resolve-image-matrix \
   ./script/setup \
   ./script/test-image-build-matrix \
+  ./script/test-promote-image-tags \
   ./script/updater-e2e \
   ./updater/bin/run \
   "$@"

--- a/script/promote-image-tags
+++ b/script/promote-image-tags
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${IMAGE_PREFIX:-}" ]]; then
+  echo "IMAGE_PREFIX must contain the image name prefix" >&2
+  exit 1
+fi
+
+targets_json="${TARGETS_JSON:-[]}"
+tags_json="${TAGS_JSON:-[]}"
+source_tag="${SOURCE_TAG:-latest}"
+
+if ! jq -e 'type == "array" and all(.[]; (.target | type) == "string")' <<< "$targets_json" > /dev/null; then
+  echo "TARGETS_JSON must be an array of target objects" >&2
+  exit 1
+fi
+
+if ! jq -e 'type == "array" and length > 0 and all(.[]; type == "string" and length > 0)' <<< "$tags_json" > /dev/null; then
+  echo "TAGS_JSON must be a non-empty array of tags" >&2
+  exit 1
+fi
+
+mapfile -t targets < <(jq -r '.[].target' <<< "$targets_json")
+mapfile -t tags < <(jq -r '.[]' <<< "$tags_json")
+
+for target in "${targets[@]}"; do
+  if [[ ! "$target" =~ ^[a-z0-9][a-z0-9.-]*$ ]]; then
+    echo "Invalid image target: $target" >&2
+    exit 1
+  fi
+
+  image="${IMAGE_PREFIX}${target}"
+  source_digest=$(
+    docker buildx imagetools inspect \
+      "${image}:${source_tag}" \
+      --format '{{json .Manifest.Digest}}' |
+      jq -er 'select(type == "string" and startswith("sha256:"))'
+  )
+
+  create_args=(buildx imagetools create --prefer-index=false)
+  for tag in "${tags[@]}"; do
+    create_args+=(--tag "${image}:${tag}")
+  done
+  create_args+=("${image}@${source_digest}")
+
+  docker "${create_args[@]}"
+
+  for tag in "${tags[@]}"; do
+    promoted_digest=$(
+      docker buildx imagetools inspect \
+        "${image}:${tag}" \
+        --format '{{json .Manifest.Digest}}' |
+        jq -er 'select(type == "string" and startswith("sha256:"))'
+    )
+    if [[ "$promoted_digest" != "$source_digest" ]]; then
+      echo "${image}:${tag} resolved to $promoted_digest instead of $source_digest" >&2
+      exit 1
+    fi
+  done
+
+  echo -e "${target}\t${source_digest}"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "- \`${image}@${source_digest}\`" >> "$GITHUB_STEP_SUMMARY"
+  fi
+done

--- a/script/promote-image-tags
+++ b/script/promote-image-tags
@@ -9,10 +9,16 @@ fi
 
 targets_json="${TARGETS_JSON:-[]}"
 tags_json="${TAGS_JSON:-[]}"
+fail_on_conflict="${FAIL_ON_CONFLICT:-false}"
 source_tag="${SOURCE_TAG:-}"
 
 if [[ -z "$source_tag" ]]; then
   echo "SOURCE_TAG must identify the immutable source image tag" >&2
+  exit 1
+fi
+
+if [[ "$fail_on_conflict" != "true" && "$fail_on_conflict" != "false" ]]; then
+  echo "FAIL_ON_CONFLICT must be true or false" >&2
   exit 1
 fi
 
@@ -42,6 +48,22 @@ for target in "${targets[@]}"; do
       --format '{{json .Manifest.Digest}}' |
       jq -er 'select(type == "string" and startswith("sha256:"))'
   )
+
+  if [[ "$fail_on_conflict" == "true" ]]; then
+    for tag in "${tags[@]}"; do
+      existing_digest=$(
+        docker buildx imagetools inspect \
+          "${image}:${tag}" \
+          --format '{{json .Manifest.Digest}}' 2> /dev/null |
+          jq -er 'select(type == "string" and startswith("sha256:"))' ||
+          true
+      )
+      if [[ -n "$existing_digest" && "$existing_digest" != "$source_digest" ]]; then
+        echo "${image}:${tag} already resolves to conflicting digest $existing_digest" >&2
+        exit 1
+      fi
+    done
+  fi
 
   create_args=(buildx imagetools create --prefer-index=false)
   for tag in "${tags[@]}"; do

--- a/script/promote-image-tags
+++ b/script/promote-image-tags
@@ -9,7 +9,12 @@ fi
 
 targets_json="${TARGETS_JSON:-[]}"
 tags_json="${TAGS_JSON:-[]}"
-source_tag="${SOURCE_TAG:-latest}"
+source_tag="${SOURCE_TAG:-}"
+
+if [[ -z "$source_tag" ]]; then
+  echo "SOURCE_TAG must identify the immutable source image tag" >&2
+  exit 1
+fi
 
 if ! jq -e 'type == "array" and all(.[]; (.target | type) == "string")' <<< "$targets_json" > /dev/null; then
   echo "TARGETS_JSON must be an array of target objects" >&2

--- a/script/resolve-image-matrix
+++ b/script/resolve-image-matrix
@@ -37,7 +37,7 @@ targets=$(
 )
 unknown_targets=$(jq -cn --argjson changed "$changed_targets" --argjson targets "$targets" '$changed - $targets')
 
-if [[ "$(jq 'length' <<< "$unknown_targets")" -ne 0 ]]; then
+if [[ "$force_all" != "true" && "$(jq 'length' <<< "$unknown_targets")" -ne 0 ]]; then
   echo "CHANGED_TARGETS contains unknown targets: $(jq -c '.' <<< "$unknown_targets")" >&2
   exit 1
 fi

--- a/script/test-image-build-matrix
+++ b/script/test-image-build-matrix
@@ -36,6 +36,14 @@ assert_equal '["nuget","pre-commit"]' "$(jq -c '[.build[].target] | sort' <<< "$
 result=$(
   BAKE_MATRIX="$matrix" \
   CHANGED_TARGETS='[]' \
+  script/resolve-image-matrix
+)
+assert_equal '0' "$(jq -r '.build_count' <<< "$result")" "empty build count"
+assert_equal '3' "$(jq -r '.promote_count' <<< "$result")" "empty promotion count"
+
+result=$(
+  BAKE_MATRIX="$matrix" \
+  CHANGED_TARGETS='[]' \
   FORCE_ALL=true \
   script/resolve-image-matrix
 )
@@ -56,6 +64,14 @@ if BAKE_MATRIX="$matrix" CHANGED_TARGETS='["unknown"]' script/resolve-image-matr
   exit 1
 fi
 
+result=$(
+  BAKE_MATRIX="$matrix" \
+  CHANGED_TARGETS='["unknown"]' \
+  FORCE_ALL=true \
+  script/resolve-image-matrix
+)
+assert_equal '3' "$(jq -r '.build_count' <<< "$result")" "fallback build count"
+
 bake_targets=$(
   docker buildx bake --print ecosystem 2> /dev/null |
     jq -c '.group.ecosystem.targets | map(select(. != "updater-core")) | sort'
@@ -71,7 +87,7 @@ assert_equal "$bake_targets" "$filter_targets" "filter and Bake targets"
 ruby -ryaml -e '
   filters = YAML.safe_load_file(ARGV.fetch(0), aliases: true)
   expected = {
-    "shared" => ["script/resolve-image-matrix"],
+    "shared" => ["script/promote-image-tags", "script/resolve-image-matrix"],
     "conda" => ["python/**"],
     "gradle" => ["maven/**"],
     "helm" => ["docker/**"],

--- a/script/test-promote-image-tags
+++ b/script/test-promote-image-tags
@@ -21,6 +21,7 @@ chmod +x "$tmpdir/docker"
 DOCKER_LOG="$tmpdir/docker.log" \
 GITHUB_STEP_SUMMARY="$tmpdir/summary.md" \
 IMAGE_PREFIX="registry.example/dependabot-updater-" \
+SOURCE_TAG="source-sha" \
 TARGETS_JSON='[{"target":"bundler"}]' \
 TAGS_JSON='["commit-sha","date-tag"]' \
 PATH="$tmpdir:$PATH" \
@@ -37,6 +38,7 @@ grep -q $'^bundler\tsha256:0123456789abcdef$' "$tmpdir/output"
 grep -q 'registry.example/dependabot-updater-bundler@sha256:0123456789abcdef' "$tmpdir/summary.md"
 
 if IMAGE_PREFIX="registry.example/" \
+  SOURCE_TAG="source-sha" \
   TARGETS_JSON='[{"target":"invalid/target"}]' \
   TAGS_JSON='["tag"]' \
   PATH="$tmpdir:$PATH" \

--- a/script/test-promote-image-tags
+++ b/script/test-promote-image-tags
@@ -11,6 +11,9 @@ cat > "$tmpdir/docker" <<'EOF'
 #!/bin/sh
 printf '%s\n' "$*" >> "$DOCKER_LOG"
 case "$*" in
+  *"imagetools inspect"*"conflict-tag"*)
+    printf '%s\n' '"sha256:fedcba9876543210"'
+    ;;
   *"imagetools inspect"*)
     printf '%s\n' '"sha256:0123456789abcdef"'
     ;;
@@ -36,6 +39,18 @@ create_call=$(grep 'imagetools create' "$tmpdir/docker.log")
 [[ "$(wc -l < "$tmpdir/docker.log")" -eq 4 ]]
 grep -q $'^bundler\tsha256:0123456789abcdef$' "$tmpdir/output"
 grep -q 'registry.example/dependabot-updater-bundler@sha256:0123456789abcdef' "$tmpdir/summary.md"
+
+if DOCKER_LOG="$tmpdir/docker.log" \
+  FAIL_ON_CONFLICT=true \
+  IMAGE_PREFIX="registry.example/dependabot-updater-" \
+  SOURCE_TAG="source-sha" \
+  TARGETS_JSON='[{"target":"bundler"}]' \
+  TAGS_JSON='["conflict-tag"]' \
+  PATH="$tmpdir:$PATH" \
+  script/promote-image-tags > /dev/null 2>&1; then
+  echo "conflicting destination tag should fail" >&2
+  exit 1
+fi
 
 if IMAGE_PREFIX="registry.example/" \
   SOURCE_TAG="source-sha" \

--- a/script/test-promote-image-tags
+++ b/script/test-promote-image-tags
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat > "$tmpdir/docker" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+case "$*" in
+  *"imagetools inspect"*)
+    printf '%s\n' '"sha256:0123456789abcdef"'
+    ;;
+esac
+EOF
+chmod +x "$tmpdir/docker"
+
+DOCKER_LOG="$tmpdir/docker.log" \
+GITHUB_STEP_SUMMARY="$tmpdir/summary.md" \
+IMAGE_PREFIX="registry.example/dependabot-updater-" \
+TARGETS_JSON='[{"target":"bundler"}]' \
+TAGS_JSON='["commit-sha","date-tag"]' \
+PATH="$tmpdir:$PATH" \
+script/promote-image-tags > "$tmpdir/output"
+
+create_call=$(grep 'imagetools create' "$tmpdir/docker.log")
+[[ "$create_call" == *"--prefer-index=false"* ]]
+[[ "$create_call" == *"--tag registry.example/dependabot-updater-bundler:commit-sha"* ]]
+[[ "$create_call" == *"--tag registry.example/dependabot-updater-bundler:date-tag"* ]]
+[[ "$create_call" == *"registry.example/dependabot-updater-bundler@sha256:0123456789abcdef"* ]]
+
+[[ "$(wc -l < "$tmpdir/docker.log")" -eq 4 ]]
+grep -q $'^bundler\tsha256:0123456789abcdef$' "$tmpdir/output"
+grep -q 'registry.example/dependabot-updater-bundler@sha256:0123456789abcdef' "$tmpdir/summary.md"
+
+if IMAGE_PREFIX="registry.example/" \
+  TARGETS_JSON='[{"target":"invalid/target"}]' \
+  TAGS_JSON='["tag"]' \
+  PATH="$tmpdir:$PATH" \
+  script/promote-image-tags > /dev/null 2>&1; then
+  echo "invalid target should fail" >&2
+  exit 1
+fi


### PR DESCRIPTION
> **Stack 5/8** · Base: #16157 · Next: #16159

### What are you trying to accomplish?

Consume the dependency-aware selection from #16154.

- Affected images are built and validated normally.
- Unchanged main images copy the immutable predecessor-commit manifest to the new commit/date tags.
- Branch images copy the immutable base-commit manifest to the exact approved SHA.
- Copied tags preserve the original digest and its original provenance.

The copy helper always uses `docker buildx imagetools create --prefer-index=false`; the default index-wrapping behavior would change the digest.

### Anything you want to highlight for special attention from reviewers?

No new build attestation is minted for an unchanged image. The copied tag continues to verify against the attestation for the build that produced those bytes.

Main image publication is serialized. The prepare job verifies that every predecessor tag exists; an incomplete or skipped predecessor publication forces a full rebuild. Superseded main runs fail before they can move mutable tags.

### How will you know you've accomplished your goal?

- NuGet-only selection resolves to one build and 32 promotions.
- Empty selection resolves to zero builds and 33 promotions.
- Missing predecessor/base tags resolve to a forced full build.
- A real local registry test preserved one manifest digest across source, commit, and date tags.
- Existing GHCR attestations verify by the copied digest.
- The full-build escape hatch remains available.

**Rollback:** point the workflow matrix back at the full Bake matrix and stop the promotion jobs.

### Checklist

- [ ] Complete test suite passes in CI.
- [x] Targeted selector, promotion, attestation, shell, and workflow checks pass.
- [x] Commit messages are descriptive.
- [x] The change and rollback are documented.
