### PR TITLE
Reuse published dependencies for pre-commit

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -81,7 +81,9 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      build_precommit: ${{ steps.selection.outputs.build_precommit }}
       build_count: ${{ steps.selection.outputs.build_count }}
+      generic_build_count: ${{ steps.selection.outputs.generic_build_count }}
       build_matrix: ${{ steps.selection.outputs.build_matrix }}
       promote_count: ${{ steps.selection.outputs.promote_count }}
       promote_matrix: ${{ steps.selection.outputs.promote_matrix }}
@@ -187,8 +189,10 @@ jobs:
             echo "::warning::Image selection failed; building every ecosystem"
             RESULT=$(CHANGED_TARGETS='[]' FORCE_ALL=true "$RUNNER_TEMP/resolve-image-matrix")
           fi
+          echo "build_precommit=$(jq -r '.build_precommit' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
-          echo "build_matrix=$(jq -c '.build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "generic_build_count=$(jq -r '.generic_build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "build_matrix=$(jq -c '.generic_build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_count=$(jq -r '.promote_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_matrix=$(jq -c '.promote' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
 
@@ -209,7 +213,7 @@ jobs:
       - prepare
     if: >-
       startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
-      needs.prepare.outputs.build_count != '0'
+      needs.prepare.outputs.generic_build_count != '0'
     permissions:
       contents: read
       id-token: write
@@ -445,3 +449,111 @@ jobs:
 
       - name: Verify existing artifact attestation
         run: gh attestation verify "oci://${IMAGE_PREFIX}${TARGET}:${APPROVED_HEAD_SHA}" --owner dependabot
+
+  push-precommit-image:
+    runs-on: ubuntu-latest
+    needs:
+      - approval
+      - build-updater-core
+      - prepare
+      - promote-unchanged-images
+      - push-updater-images
+    if: >-
+      always() &&
+      startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
+      needs.build-updater-core.result == 'success' &&
+      needs.prepare.result == 'success' &&
+      needs.prepare.outputs.build_precommit == 'true' &&
+      (needs.promote-unchanged-images.result == 'success' || needs.promote-unchanged-images.result == 'skipped') &&
+      (needs.push-updater-images.result == 'success' || needs.push-updater-images.result == 'skipped')
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      pull-requests: read
+      attestations: write
+      artifact-metadata: write
+    env:
+      DEPENDABOT_UPDATER_VERSION: ${{ needs.approval.outputs.head_sha }}
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
+      UPDATER_IMAGE: ghcr.io/dependabot/dependabot-updater-pre-commit
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Preserve build definition
+        run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Checkout approved pull request
+        env:
+          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+          PR: ${{ needs.approval.outputs.pr }}
+        run: |
+          gh pr checkout "$PR"
+          [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
+          git fetch origin main
+          git merge origin/main --ff-only
+          git submodule update --init --recursive
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push validated pre-commit image
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          files: ${{ runner.temp }}/docker-bake.hcl
+          targets: pre-commit
+          provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=false
+            PRE_COMMIT_BUNDLER_CONTEXT=docker-image://ghcr.io/dependabot/dependabot-updater-bundler:${{ env.DEPENDABOT_UPDATER_VERSION }}
+            PRE_COMMIT_GOMOD_CONTEXT=docker-image://ghcr.io/dependabot/dependabot-updater-gomod:${{ env.DEPENDABOT_UPDATER_VERSION }}
+            PRE_COMMIT_PUB_CONTEXT=docker-image://ghcr.io/dependabot/dependabot-updater-pub:${{ env.DEPENDABOT_UPDATER_VERSION }}
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
+          set: |
+            pre-commit.output=type=registry
+            pre-commit.tags=${{ env.UPDATER_IMAGE }}:${{ env.DEPENDABOT_UPDATER_VERSION }}
+
+      - name: Validate image manifest
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)['pre-commit']['containerimage.digest'] }}
+        run: |
+          IMAGE="${UPDATER_IMAGE}@${IMAGE_DIGEST}"
+          IMAGE_LAYERS=$(docker buildx imagetools inspect --raw "$IMAGE" | jq '.layers | length')
+          echo "$IMAGE contains $IMAGE_LAYERS layers"
+          [[ $IMAGE_LAYERS -lt 126 ]]
+
+          TAG_DIGEST=$(docker buildx imagetools inspect "${UPDATER_IMAGE}:${DEPENDABOT_UPDATER_VERSION}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+          [[ "$TAG_DIGEST" == "$IMAGE_DIGEST" ]]
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.UPDATER_IMAGE }}
+          subject-digest: ${{ fromJSON(steps.build.outputs.metadata)['pre-commit']['containerimage.digest'] }}
+          push-to-registry: true
+          create-storage-record: true
+
+      - name: Set summary
+        run: |
+          {
+            echo "pre-commit updater uploaded with tag \`$DEPENDABOT_UPDATER_VERSION\`"
+            echo "\`\`\`"
+            echo "$UPDATER_IMAGE:$DEPENDABOT_UPDATER_VERSION"
+            echo "\`\`\`"
+            echo "deploy for pre-commit"
+            echo "\`\`\`"
+            echo ".dependabot set-ecosystem-version staging pre-commit $DEPENDABOT_UPDATER_VERSION"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -483,7 +483,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          ref: ${{ needs.approval.outputs.base_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -213,7 +213,7 @@ jobs:
       - prepare
     if: >-
       startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
-      needs.prepare.outputs.generic_build_count != '0'
+      needs.prepare.outputs.build_count != '0'
     permissions:
       contents: read
       id-token: write
@@ -291,7 +291,7 @@ jobs:
       - prepare
     if: >-
       startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
-      needs.prepare.outputs.build_count != '0'
+      needs.prepare.outputs.generic_build_count != '0'
     strategy:
       fail-fast: false
       matrix:
@@ -483,6 +483,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+          ref: ${{ needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -497,8 +497,6 @@ jobs:
         run: |
           gh pr checkout "$PR"
           [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
-          git fetch origin main
-          git merge origin/main --ff-only
           git submodule update --init --recursive
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -97,7 +97,9 @@ jobs:
       attestations: read
       contents: read
     outputs:
+      build_precommit: ${{ steps.selection.outputs.build_precommit }}
       build_count: ${{ steps.selection.outputs.build_count }}
+      generic_build_count: ${{ steps.selection.outputs.generic_build_count }}
       build_matrix: ${{ steps.selection.outputs.build_matrix }}
       promote_count: ${{ steps.selection.outputs.promote_count }}
       promote_matrix: ${{ steps.selection.outputs.promote_matrix }}
@@ -188,8 +190,10 @@ jobs:
             echo "::warning::Image selection failed; building every ecosystem"
             RESULT=$(CHANGED_TARGETS='[]' FORCE_ALL=true script/resolve-image-matrix)
           fi
+          echo "build_precommit=$(jq -r '.build_precommit' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
-          echo "build_matrix=$(jq -c '.build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "generic_build_count=$(jq -r '.generic_build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "build_matrix=$(jq -c '.generic_build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_count=$(jq -r '.promote_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_matrix=$(jq -c '.promote' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
 
@@ -210,7 +214,7 @@ jobs:
       - build-updater-core
       - date-version
       - prepare
-    if: needs.prepare.outputs.build_count != '0'
+    if: needs.prepare.outputs.generic_build_count != '0'
     permissions:
       contents: read
       id-token: write
@@ -353,3 +357,108 @@ jobs:
         run: |
           docker pull "${BACKUP_REGISTRY}/${IMAGE_PREFIX}${TARGET}:$COMMIT_SHA"
           docker pull "${BACKUP_REGISTRY}/${IMAGE_PREFIX}${TARGET}:$DATE_VERSION"
+
+  push-precommit-image:
+    name: Deploy pre-commit
+    runs-on: ubuntu-latest
+    needs:
+      - build-updater-core
+      - date-version
+      - prepare
+      - promote-unchanged-image
+      - push-updater-image
+    if: >-
+      always() &&
+      needs.build-updater-core.result == 'success' &&
+      needs.date-version.result == 'success' &&
+      needs.prepare.result == 'success' &&
+      needs.prepare.outputs.build_precommit == 'true' &&
+      (needs.promote-unchanged-image.result == 'success' || needs.promote-unchanged-image.result == 'skipped') &&
+      (needs.push-updater-image.result == 'success' || needs.push-updater-image.result == 'skipped')
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      attestations: write
+      artifact-metadata: write
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+      DATE_VERSION: ${{ needs.date-version.outputs.date }}
+      DEPENDABOT_UPDATER_VERSION: ""
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
+      UPDATER_IMAGE: ghcr.io/dependabot/dependabot-updater-pre-commit
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push validated pre-commit image
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          targets: pre-commit
+          provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=true
+            PRE_COMMIT_BUNDLER_CONTEXT=docker-image://ghcr.io/dependabot/dependabot-updater-bundler:${{ env.COMMIT_SHA }}
+            PRE_COMMIT_GOMOD_CONTEXT=docker-image://ghcr.io/dependabot/dependabot-updater-gomod:${{ env.COMMIT_SHA }}
+            PRE_COMMIT_PUB_CONTEXT=docker-image://ghcr.io/dependabot/dependabot-updater-pub:${{ env.COMMIT_SHA }}
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
+          set: |
+            pre-commit.output=type=registry
+            pre-commit.tags=${{ env.UPDATER_IMAGE }}:${{ env.COMMIT_SHA }}
+
+      - name: Validate and promote image manifest
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)['pre-commit']['containerimage.digest'] }}
+        run: |
+          IMAGE="${UPDATER_IMAGE}@${IMAGE_DIGEST}"
+          IMAGE_LAYERS=$(docker buildx imagetools inspect --raw "$IMAGE" | jq '.layers | length')
+          echo "$IMAGE contains $IMAGE_LAYERS layers"
+          [[ $IMAGE_LAYERS -lt 126 ]]
+
+          docker buildx imagetools create \
+            --prefer-index=false \
+            --tag "${UPDATER_IMAGE}:latest" \
+            --tag "${UPDATER_IMAGE}:${DATE_VERSION}" \
+            "$IMAGE"
+
+          for tag in "$COMMIT_SHA" latest "$DATE_VERSION"; do
+            TAG_DIGEST=$(docker buildx imagetools inspect "${UPDATER_IMAGE}:${tag}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+            [[ "$TAG_DIGEST" == "$IMAGE_DIGEST" ]]
+          done
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.UPDATER_IMAGE }}
+          subject-digest: ${{ fromJSON(steps.build.outputs.metadata)['pre-commit']['containerimage.digest'] }}
+          push-to-registry: true
+          create-storage-record: true
+
+      - name: Pull images through backup registry
+        run: |
+          docker pull "${BACKUP_REGISTRY}/${UPDATER_IMAGE}:$COMMIT_SHA"
+          docker pull "${BACKUP_REGISTRY}/${UPDATER_IMAGE}:latest"
+          docker pull "${BACKUP_REGISTRY}/${UPDATER_IMAGE}:$DATE_VERSION"
+
+      - name: Set summary
+        run: |
+          {
+            echo "pre-commit updater uploaded with tag \`$COMMIT_SHA\`"
+            echo "\`\`\`"
+            echo "$UPDATER_IMAGE:$COMMIT_SHA"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -33,6 +33,18 @@ variable "BUILD_CACHE_WRITE" {
   default = false
 }
 
+variable "PRE_COMMIT_BUNDLER_CONTEXT" {
+  default = "target:bundler-raw"
+}
+
+variable "PRE_COMMIT_GOMOD_CONTEXT" {
+  default = "target:gomod-raw"
+}
+
+variable "PRE_COMMIT_PUB_CONTEXT" {
+  default = "target:pub-raw"
+}
+
 variable "ECOSYSTEMS" {
   default = [
     { name = "bazel", image = "bazel", dockerfile = "bazel/Dockerfile" },
@@ -172,9 +184,9 @@ target "_ecosystem" {
       (UPDATER_CORE_IMAGE) = UPDATER_CORE_CONTEXT
     },
     item.name == "pre_commit" ? {
-      "${UPDATER_IMAGE_PREFIX}gomod:latest"   = "target:gomod-raw"
-      "${UPDATER_IMAGE_PREFIX}bundler:latest" = "target:bundler-raw"
-      "${UPDATER_IMAGE_PREFIX}pub:latest"     = "target:pub-raw"
+      "${UPDATER_IMAGE_PREFIX}gomod:latest"   = PRE_COMMIT_GOMOD_CONTEXT
+      "${UPDATER_IMAGE_PREFIX}bundler:latest" = PRE_COMMIT_BUNDLER_CONTEXT
+      "${UPDATER_IMAGE_PREFIX}pub:latest"     = PRE_COMMIT_PUB_CONTEXT
     } : {}
   )
   cache-from = [

--- a/script/resolve-image-matrix
+++ b/script/resolve-image-matrix
@@ -50,35 +50,42 @@ jq -c \
       .[]
       | select(.target != "updater-core" and (.target | endswith("-raw") | not))
     ] as $matrix
-    | if $force_all == "true" then
-        {
-          reason: "force-all",
-          build: $matrix,
-          promote: [],
-          build_count: ($matrix | length),
-          promote_count: 0
-        }
-      else
-        {
-          reason: "changed-targets",
-          build: [
-            $matrix[] as $item
-            | select($changed | index($item.target))
-            | $item
-          ],
-          promote: [
-            $matrix[] as $item
-            | select(($changed | index($item.target)) | not)
-            | $item
-          ],
-          build_count: ([
-            $matrix[] as $item
-            | select($changed | index($item.target))
-          ] | length),
-          promote_count: ([
-            $matrix[] as $item
-            | select(($changed | index($item.target)) | not)
-          ] | length)
-        }
-      end
+    | (
+        if $force_all == "true" then
+          {
+            reason: "force-all",
+            build: $matrix,
+            promote: [],
+            build_count: ($matrix | length),
+            promote_count: 0
+          }
+        else
+          {
+            reason: "changed-targets",
+            build: [
+              $matrix[] as $item
+              | select($changed | index($item.target))
+              | $item
+            ],
+            promote: [
+              $matrix[] as $item
+              | select(($changed | index($item.target)) | not)
+              | $item
+            ],
+            build_count: ([
+              $matrix[] as $item
+              | select($changed | index($item.target))
+            ] | length),
+            promote_count: ([
+              $matrix[] as $item
+              | select(($changed | index($item.target)) | not)
+            ] | length)
+          }
+        end
+      )
+    | . + {
+        build_precommit: any(.build[]; .target == "pre-commit"),
+        generic_build: [.build[] | select(.target != "pre-commit")],
+        generic_build_count: ([.build[] | select(.target != "pre-commit")] | length)
+      }
   ' <<< "$BAKE_MATRIX"

--- a/script/test-image-build-matrix
+++ b/script/test-image-build-matrix
@@ -32,6 +32,9 @@ result=$(
 assert_equal '2' "$(jq -r '.build_count' <<< "$result")" "filtered build count"
 assert_equal '1' "$(jq -r '.promote_count' <<< "$result")" "filtered promotion count"
 assert_equal '["nuget","pre-commit"]' "$(jq -c '[.build[].target] | sort' <<< "$result")" "filtered targets"
+assert_equal 'true' "$(jq -r '.build_precommit' <<< "$result")" "pre-commit build flag"
+assert_equal '1' "$(jq -r '.generic_build_count' <<< "$result")" "generic build count"
+assert_equal '["nuget"]' "$(jq -c '[.generic_build[].target]' <<< "$result")" "generic targets"
 
 result=$(
   BAKE_MATRIX="$matrix" \
@@ -40,6 +43,7 @@ result=$(
 )
 assert_equal '0' "$(jq -r '.build_count' <<< "$result")" "empty build count"
 assert_equal '3' "$(jq -r '.promote_count' <<< "$result")" "empty promotion count"
+assert_equal 'false' "$(jq -r '.build_precommit' <<< "$result")" "empty pre-commit build flag"
 
 result=$(
   BAKE_MATRIX="$matrix" \
@@ -49,6 +53,7 @@ result=$(
 )
 assert_equal '3' "$(jq -r '.build_count' <<< "$result")" "forced build count"
 assert_equal '0' "$(jq -r '.promote_count' <<< "$result")" "forced promotion count"
+assert_equal '2' "$(jq -r '.generic_build_count' <<< "$result")" "forced generic build count"
 
 result=$(
   BAKE_MATRIX="$matrix" \


### PR DESCRIPTION
> **Stack 6/8** · Base: #16158 · Next: #16160

### What are you trying to accomplish?

Build pre-commit only after its Bundler, Go Modules, and Pub dependency tags exist for the same commit.

The dedicated pre-commit job consumes those immutable image contexts instead of expanding nested Bake targets. This removes duplicate dependency builds and their cache exporters from the pre-commit job.

### Anything you want to highlight for special attention from reviewers?

The job accepts skipped generic/promotion dependencies when the complementary path produced the required tags, but it refuses to run after any failed dependency job.

### How will you know you've accomplished your goal?

- The detached Bake graph contains only `pre-commit-raw` and `pre-commit`.
- A full pre-commit image built from published dependency images.
- The build log contained no nested Bundler, Go Modules, Pub, or dependency-cache exporters.
- The final image passed `bundle check`.

**Rollback:** restore the three `target:*` contexts in the pre-commit Bake target and return it to the generic matrix.

### Checklist

- [ ] Complete test suite passes in CI.
- [x] Targeted pre-commit image, Bake, shell, and workflow checks pass.
- [x] Commit messages are descriptive.
- [x] The change and rollback are documented.
