### PR TITLE
Publish Docker images from one build

### DIFF
--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -236,9 +236,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
-        run: |
-          cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
-          cp script/promote-image-tags "$RUNNER_TEMP/promote-image-tags"
+        run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
 
       - name: Checkout approved pull request
         env:
@@ -427,7 +425,9 @@ jobs:
           persist-credentials: false
 
       - name: Preserve build definition
-        run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+        run: |
+          cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+          cp script/promote-image-tags "$RUNNER_TEMP/promote-image-tags"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -415,6 +415,7 @@ jobs:
       DEPENDABOT_UPDATER_VERSION: ${{ needs.approval.outputs.head_sha }}
       DOCKER_COMPOSE_IMAGE: ghcr.io/dependabot/dependabot-updater-docker-compose
       DOCKER_IMAGE: ghcr.io/dependabot/dependabot-updater-docker
+      FAIL_ON_CONFLICT: true
       IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
       UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
     steps:

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -81,6 +81,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      build_docker_family: ${{ steps.selection.outputs.build_docker_family }}
       build_precommit: ${{ steps.selection.outputs.build_precommit }}
       build_count: ${{ steps.selection.outputs.build_count }}
       generic_build_count: ${{ steps.selection.outputs.generic_build_count }}
@@ -189,6 +190,7 @@ jobs:
             echo "::warning::Image selection failed; building every ecosystem"
             RESULT=$(CHANGED_TARGETS='[]' FORCE_ALL=true "$RUNNER_TEMP/resolve-image-matrix")
           fi
+          echo "build_docker_family=$(jq -r '.build_docker_family' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_precommit=$(jq -r '.build_precommit' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "generic_build_count=$(jq -r '.generic_build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
@@ -390,6 +392,123 @@ jobs:
             echo "deploy for all ecosystems"
             echo "\`\`\`"
             echo ".dependabot set-ecosystem-version staging * $DEPENDABOT_UPDATER_VERSION"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  push-docker-images:
+    runs-on: ubuntu-latest
+    needs:
+      - approval
+      - build-updater-core
+      - prepare
+    if: >-
+      startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
+      needs.prepare.outputs.build_docker_family == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      pull-requests: read
+      attestations: write
+      artifact-metadata: write
+    env:
+      DEPENDABOT_UPDATER_VERSION: ${{ needs.approval.outputs.head_sha }}
+      DOCKER_COMPOSE_IMAGE: ghcr.io/dependabot/dependabot-updater-docker-compose
+      DOCKER_IMAGE: ghcr.io/dependabot/dependabot-updater-docker
+      IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Preserve build definition
+        run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Checkout approved pull request
+        env:
+          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+          PR: ${{ needs.approval.outputs.pr }}
+        run: |
+          gh pr checkout "$PR"
+          [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
+          git fetch origin main
+          git merge origin/main --ff-only
+          git submodule update --init --recursive
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push validated Docker image
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          files: ${{ runner.temp }}/docker-bake.hcl
+          targets: docker
+          provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=false
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
+          set: |
+            docker.output=type=registry
+            docker.tags=${{ env.DOCKER_IMAGE }}:${{ env.DEPENDABOT_UPDATER_VERSION }}
+
+      - name: Validate and publish both image names
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)['docker']['containerimage.digest'] }}
+        run: |
+          IMAGE="${DOCKER_IMAGE}@${IMAGE_DIGEST}"
+          IMAGE_LAYERS=$(docker buildx imagetools inspect --raw "$IMAGE" | jq '.layers | length')
+          echo "$IMAGE contains $IMAGE_LAYERS layers"
+          [[ $IMAGE_LAYERS -lt 126 ]]
+
+          COMMIT_DIGEST=$(docker buildx imagetools inspect "${DOCKER_IMAGE}:${DEPENDABOT_UPDATER_VERSION}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+          [[ "$COMMIT_DIGEST" == "$IMAGE_DIGEST" ]]
+
+          TARGETS_JSON='[{"target":"docker-compose"}]'
+          TAGS_JSON=$(jq -cn --arg tag "$DEPENDABOT_UPDATER_VERSION" '[$tag]')
+          SOURCE_TARGET=docker
+          SOURCE_TAG="$DEPENDABOT_UPDATER_VERSION"
+          export TARGETS_JSON TAGS_JSON SOURCE_TARGET SOURCE_TAG
+          script/promote-image-tags
+
+      - name: Generate Docker artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.DOCKER_IMAGE }}
+          subject-digest: ${{ fromJSON(steps.build.outputs.metadata)['docker']['containerimage.digest'] }}
+          push-to-registry: true
+          create-storage-record: true
+
+      - name: Generate Docker Compose artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.DOCKER_COMPOSE_IMAGE }}
+          subject-digest: ${{ fromJSON(steps.build.outputs.metadata)['docker']['containerimage.digest'] }}
+          push-to-registry: true
+          create-storage-record: true
+
+      - name: Set summary
+        run: |
+          {
+            echo "Docker updater images uploaded with tag \`$DEPENDABOT_UPDATER_VERSION\`"
+            echo "\`\`\`"
+            echo "$DOCKER_IMAGE:$DEPENDABOT_UPDATER_VERSION"
+            echo "$DOCKER_COMPOSE_IMAGE:$DEPENDABOT_UPDATER_VERSION"
+            echo "\`\`\`"
+            echo "deploy for both Docker ecosystems"
+            echo "\`\`\`"
+            echo ".dependabot set-ecosystem-version staging docker $DEPENDABOT_UPDATER_VERSION"
+            echo ".dependabot set-ecosystem-version staging docker-compose $DEPENDABOT_UPDATER_VERSION"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -417,6 +417,7 @@ jobs:
       DOCKER_IMAGE: ghcr.io/dependabot/dependabot-updater-docker
       FAIL_ON_CONFLICT: true
       IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
+      STAGING_TAG: ${{ format('{0}-docker-source', needs.approval.outputs.head_sha) }}
       UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
     steps:
       - name: Checkout code
@@ -462,7 +463,7 @@ jobs:
             UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
           set: |
             docker.output=type=registry
-            docker.tags=${{ env.DOCKER_IMAGE }}:${{ env.DEPENDABOT_UPDATER_VERSION }}
+            docker.tags=${{ env.DOCKER_IMAGE }}:${{ env.STAGING_TAG }}
 
       - name: Validate and publish both image names
         env:
@@ -473,14 +474,32 @@ jobs:
           echo "$IMAGE contains $IMAGE_LAYERS layers"
           [[ $IMAGE_LAYERS -lt 126 ]]
 
-          COMMIT_DIGEST=$(docker buildx imagetools inspect "${DOCKER_IMAGE}:${DEPENDABOT_UPDATER_VERSION}" --format '{{json .Manifest.Digest}}' | jq -r '.')
-          [[ "$COMMIT_DIGEST" == "$IMAGE_DIGEST" ]]
+          STAGING_DIGEST=$(docker buildx imagetools inspect "${DOCKER_IMAGE}:${STAGING_TAG}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+          [[ "$STAGING_DIGEST" == "$IMAGE_DIGEST" ]]
 
-          TARGETS_JSON='[{"target":"docker-compose"}]'
+          for destination in "$DOCKER_IMAGE" "$DOCKER_COMPOSE_IMAGE"; do
+            EXISTING_DIGEST=$(
+              docker buildx imagetools inspect \
+                "${destination}:${DEPENDABOT_UPDATER_VERSION}" \
+                --format '{{json .Manifest.Digest}}' 2> /dev/null |
+                jq -er 'select(type == "string" and startswith("sha256:"))' ||
+                true
+            )
+            if [[ -n "$EXISTING_DIGEST" && "$EXISTING_DIGEST" != "$IMAGE_DIGEST" ]]; then
+              echo "${destination}:${DEPENDABOT_UPDATER_VERSION} already resolves to conflicting digest $EXISTING_DIGEST"
+              exit 1
+            fi
+          done
+
+          TARGETS_JSON='[{"target":"docker"}]'
           TAGS_JSON=$(jq -cn --arg tag "$DEPENDABOT_UPDATER_VERSION" '[$tag]')
           SOURCE_TARGET=docker
-          SOURCE_TAG="$DEPENDABOT_UPDATER_VERSION"
+          SOURCE_TAG="$STAGING_TAG"
           export TARGETS_JSON TAGS_JSON SOURCE_TARGET SOURCE_TAG
+          "$RUNNER_TEMP/promote-image-tags"
+
+          TARGETS_JSON='[{"target":"docker-compose"}]'
+          export TARGETS_JSON
           "$RUNNER_TEMP/promote-image-tags"
 
       - name: Generate Docker artifact attestation

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -423,6 +423,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+          ref: ${{ needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: |

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -423,7 +423,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          ref: ${{ needs.approval.outputs.base_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: |

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -236,7 +236,9 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
-        run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+        run: |
+          cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+          cp script/promote-image-tags "$RUNNER_TEMP/promote-image-tags"
 
       - name: Checkout approved pull request
         env:
@@ -437,8 +439,6 @@ jobs:
         run: |
           gh pr checkout "$PR"
           [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
-          git fetch origin main
-          git merge origin/main --ff-only
           git submodule update --init --recursive
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -479,7 +479,7 @@ jobs:
           SOURCE_TARGET=docker
           SOURCE_TAG="$DEPENDABOT_UPDATER_VERSION"
           export TARGETS_JSON TAGS_JSON SOURCE_TARGET SOURCE_TAG
-          script/promote-image-tags
+          "$RUNNER_TEMP/promote-image-tags"
 
       - name: Generate Docker artifact attestation
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -97,6 +97,7 @@ jobs:
       attestations: read
       contents: read
     outputs:
+      build_docker_family: ${{ steps.selection.outputs.build_docker_family }}
       build_precommit: ${{ steps.selection.outputs.build_precommit }}
       build_count: ${{ steps.selection.outputs.build_count }}
       generic_build_count: ${{ steps.selection.outputs.generic_build_count }}
@@ -190,6 +191,7 @@ jobs:
             echo "::warning::Image selection failed; building every ecosystem"
             RESULT=$(CHANGED_TARGETS='[]' FORCE_ALL=true script/resolve-image-matrix)
           fi
+          echo "build_docker_family=$(jq -r '.build_docker_family' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_precommit=$(jq -r '.build_precommit' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "generic_build_count=$(jq -r '.generic_build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
@@ -301,6 +303,116 @@ jobs:
             echo "updater uploaded with tag \`$COMMIT_SHA\`"
             echo "\`\`\`"
             echo "$UPDATER_IMAGE:$COMMIT_SHA"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  push-docker-images:
+    name: Deploy Docker images
+    runs-on: ubuntu-latest
+    needs:
+      - build-updater-core
+      - date-version
+      - prepare
+    if: needs.prepare.outputs.build_docker_family == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      attestations: write
+      artifact-metadata: write
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+      DATE_VERSION: ${{ needs.date-version.outputs.date }}
+      DEPENDABOT_UPDATER_VERSION: ""
+      DOCKER_COMPOSE_IMAGE: ghcr.io/dependabot/dependabot-updater-docker-compose
+      DOCKER_IMAGE: ghcr.io/dependabot/dependabot-updater-docker
+      IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push validated Docker image
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          targets: docker
+          provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=true
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
+          set: |
+            docker.output=type=registry
+            docker.tags=${{ env.DOCKER_IMAGE }}:${{ env.COMMIT_SHA }}
+
+      - name: Validate and publish both image names
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)['docker']['containerimage.digest'] }}
+        run: |
+          IMAGE="${DOCKER_IMAGE}@${IMAGE_DIGEST}"
+          IMAGE_LAYERS=$(docker buildx imagetools inspect --raw "$IMAGE" | jq '.layers | length')
+          echo "$IMAGE contains $IMAGE_LAYERS layers"
+          [[ $IMAGE_LAYERS -lt 126 ]]
+
+          COMMIT_DIGEST=$(docker buildx imagetools inspect "${DOCKER_IMAGE}:${COMMIT_SHA}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+          [[ "$COMMIT_DIGEST" == "$IMAGE_DIGEST" ]]
+
+          TARGETS_JSON='[{"target":"docker"}]'
+          TAGS_JSON=$(jq -cn --arg latest latest --arg date "$DATE_VERSION" '[$latest, $date]')
+          SOURCE_TAG="$COMMIT_SHA"
+          export TARGETS_JSON TAGS_JSON SOURCE_TAG
+          script/promote-image-tags
+
+          TARGETS_JSON='[{"target":"docker-compose"}]'
+          TAGS_JSON=$(jq -cn --arg commit "$COMMIT_SHA" --arg latest latest --arg date "$DATE_VERSION" '[$commit, $latest, $date]')
+          SOURCE_TARGET=docker
+          export TARGETS_JSON TAGS_JSON SOURCE_TARGET
+          script/promote-image-tags
+
+      - name: Generate Docker artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.DOCKER_IMAGE }}
+          subject-digest: ${{ fromJSON(steps.build.outputs.metadata)['docker']['containerimage.digest'] }}
+          push-to-registry: true
+          create-storage-record: true
+
+      - name: Generate Docker Compose artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.DOCKER_COMPOSE_IMAGE }}
+          subject-digest: ${{ fromJSON(steps.build.outputs.metadata)['docker']['containerimage.digest'] }}
+          push-to-registry: true
+          create-storage-record: true
+
+      - name: Pull images through backup registry
+        run: |
+          for image in "$DOCKER_IMAGE" "$DOCKER_COMPOSE_IMAGE"; do
+            docker pull "${BACKUP_REGISTRY}/${image}:$COMMIT_SHA"
+            docker pull "${BACKUP_REGISTRY}/${image}:latest"
+            docker pull "${BACKUP_REGISTRY}/${image}:$DATE_VERSION"
+          done
+
+      - name: Set summary
+        run: |
+          {
+            echo "Docker updater images uploaded with tag \`$COMMIT_SHA\`"
+            echo "\`\`\`"
+            echo "$DOCKER_IMAGE:$COMMIT_SHA"
+            echo "$DOCKER_COMPOSE_IMAGE:$COMMIT_SHA"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/script/promote-image-tags
+++ b/script/promote-image-tags
@@ -10,7 +10,9 @@ fi
 targets_json="${TARGETS_JSON:-[]}"
 tags_json="${TAGS_JSON:-[]}"
 fail_on_conflict="${FAIL_ON_CONFLICT:-false}"
+source_image_prefix="${SOURCE_IMAGE_PREFIX:-$IMAGE_PREFIX}"
 source_tag="${SOURCE_TAG:-}"
+source_target="${SOURCE_TARGET:-}"
 
 if [[ -z "$source_tag" ]]; then
   echo "SOURCE_TAG must identify the immutable source image tag" >&2
@@ -35,6 +37,11 @@ fi
 mapfile -t targets < <(jq -r '.[].target' <<< "$targets_json")
 mapfile -t tags < <(jq -r '.[]' <<< "$tags_json")
 
+if [[ -n "$source_target" && "${#targets[@]}" -ne 1 ]]; then
+  echo "SOURCE_TARGET can only be used with one destination target" >&2
+  exit 1
+fi
+
 for target in "${targets[@]}"; do
   if [[ ! "$target" =~ ^[a-z0-9][a-z0-9.-]*$ ]]; then
     echo "Invalid image target: $target" >&2
@@ -42,9 +49,15 @@ for target in "${targets[@]}"; do
   fi
 
   image="${IMAGE_PREFIX}${target}"
+  resolved_source_target="${source_target:-$target}"
+  if [[ ! "$resolved_source_target" =~ ^[a-z0-9][a-z0-9.-]*$ ]]; then
+    echo "Invalid source image target: $resolved_source_target" >&2
+    exit 1
+  fi
+  source_image="${source_image_prefix}${resolved_source_target}"
   source_digest=$(
     docker buildx imagetools inspect \
-      "${image}:${source_tag}" \
+      "${source_image}:${source_tag}" \
       --format '{{json .Manifest.Digest}}' |
       jq -er 'select(type == "string" and startswith("sha256:"))'
   )
@@ -69,7 +82,7 @@ for target in "${targets[@]}"; do
   for tag in "${tags[@]}"; do
     create_args+=(--tag "${image}:${tag}")
   done
-  create_args+=("${image}@${source_digest}")
+  create_args+=("${source_image}@${source_digest}")
 
   docker "${create_args[@]}"
 

--- a/script/resolve-image-matrix
+++ b/script/resolve-image-matrix
@@ -51,6 +51,17 @@ jq -c \
       | select(.target != "updater-core" and (.target | endswith("-raw") | not))
     ] as $matrix
     | (
+        $changed +
+        (
+          if ($changed | index("docker")) or ($changed | index("docker-compose")) then
+            ["docker", "docker-compose"]
+          else
+            []
+          end
+        )
+        | unique
+      ) as $effective_changed
+    | (
         if $force_all == "true" then
           {
             reason: "force-all",
@@ -64,28 +75,35 @@ jq -c \
             reason: "changed-targets",
             build: [
               $matrix[] as $item
-              | select($changed | index($item.target))
+              | select($effective_changed | index($item.target))
               | $item
             ],
             promote: [
               $matrix[] as $item
-              | select(($changed | index($item.target)) | not)
+              | select(($effective_changed | index($item.target)) | not)
               | $item
             ],
             build_count: ([
               $matrix[] as $item
-              | select($changed | index($item.target))
+              | select($effective_changed | index($item.target))
             ] | length),
             promote_count: ([
               $matrix[] as $item
-              | select(($changed | index($item.target)) | not)
+              | select(($effective_changed | index($item.target)) | not)
             ] | length)
           }
         end
       )
     | . + {
+        build_docker_family: any(.build[]; .target == "docker" or .target == "docker-compose"),
         build_precommit: any(.build[]; .target == "pre-commit"),
-        generic_build: [.build[] | select(.target != "pre-commit")],
-        generic_build_count: ([.build[] | select(.target != "pre-commit")] | length)
+        generic_build: [
+          .build[]
+          | select(.target != "docker" and .target != "docker-compose" and .target != "pre-commit")
+        ],
+        generic_build_count: ([
+          .build[]
+          | select(.target != "docker" and .target != "docker-compose" and .target != "pre-commit")
+        ] | length)
       }
   ' <<< "$BAKE_MATRIX"

--- a/script/test-image-build-matrix
+++ b/script/test-image-build-matrix
@@ -77,6 +77,20 @@ result=$(
 )
 assert_equal '3' "$(jq -r '.build_count' <<< "$result")" "fallback build count"
 
+alias_matrix='[
+  {"target":"docker","dockerfile":"docker/Dockerfile"},
+  {"target":"docker-compose","dockerfile":"docker/Dockerfile"},
+  {"target":"nuget","dockerfile":"nuget/Dockerfile"}
+]'
+result=$(
+  BAKE_MATRIX="$alias_matrix" \
+  CHANGED_TARGETS='["docker-compose"]' \
+  script/resolve-image-matrix
+)
+assert_equal 'true' "$(jq -r '.build_docker_family' <<< "$result")" "Docker family build flag"
+assert_equal '["docker","docker-compose"]' "$(jq -c '[.build[].target] | sort' <<< "$result")" "Docker family targets"
+assert_equal '0' "$(jq -r '.generic_build_count' <<< "$result")" "Docker family generic count"
+
 bake_targets=$(
   docker buildx bake --print ecosystem 2> /dev/null |
     jq -c '.group.ecosystem.targets | map(select(. != "updater-core")) | sort'

--- a/script/test-promote-image-tags
+++ b/script/test-promote-image-tags
@@ -52,6 +52,21 @@ if DOCKER_LOG="$tmpdir/docker.log" \
   exit 1
 fi
 
+: > "$tmpdir/docker.log"
+DOCKER_LOG="$tmpdir/docker.log" \
+IMAGE_PREFIX="registry.example/dependabot-updater-" \
+SOURCE_TARGET="docker" \
+SOURCE_TAG="commit-sha" \
+TARGETS_JSON='[{"target":"docker-compose"}]' \
+TAGS_JSON='["commit-sha","latest"]' \
+PATH="$tmpdir:$PATH" \
+script/promote-image-tags > /dev/null
+
+alias_create_call=$(grep 'imagetools create' "$tmpdir/docker.log")
+[[ "$alias_create_call" == *"--tag registry.example/dependabot-updater-docker-compose:commit-sha"* ]]
+[[ "$alias_create_call" == *"--tag registry.example/dependabot-updater-docker-compose:latest"* ]]
+[[ "$alias_create_call" == *"registry.example/dependabot-updater-docker@sha256:0123456789abcdef"* ]]
+
 if IMAGE_PREFIX="registry.example/" \
   SOURCE_TAG="source-sha" \
   TARGETS_JSON='[{"target":"invalid/target"}]' \


### PR DESCRIPTION
> **Stack 7/8** · Base: #16159 · Next: #16161

### What are you trying to accomplish?

Build the shared Docker/Docker Compose image once, then publish the exact digest under both package names.

The resolver treats either target as the complete Docker family. A dedicated job builds and validates the Docker target, copies the digest to Docker Compose, and creates an attestation for each package name.

### Anything you want to highlight for special attention from reviewers?

The branch workflow snapshots the promotion helper before checking out the approved PR. The helper therefore runs with package-write credentials from trusted workflow code, while PR Dockerfile content remains isolated inside BuildKit.

### How will you know you've accomplished your goal?

- Selecting Docker Compose selects both logical images but schedules no generic build.
- A cross-repository local registry copy retained the exact source digest.
- The Docker image built and passed `bundle check`.
- No Docker Compose Bake target appeared in the Docker build log.

**Rollback:** return Docker and Docker Compose to separate generic matrix builds.

### Checklist

- [ ] Complete test suite passes in CI.
- [x] Targeted Docker build, cross-repository copy, shell, and workflow checks pass.
- [x] Commit messages are descriptive.
- [x] The change and rollback are documented.
