### PR TITLE
Share runtime layers between Pip and UV

### DIFF
--- a/.github/ci-filters.yml
+++ b/.github/ci-filters.yml
@@ -113,6 +113,7 @@ opentofu:
   - 'opentofu/**'
 uv:
   - *shared
+  - 'python/**'
   - 'uv/**'
 helm:
   - *shared

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -83,9 +83,12 @@ jobs:
     outputs:
       build_docker_family: ${{ steps.selection.outputs.build_docker_family }}
       build_precommit: ${{ steps.selection.outputs.build_precommit }}
+      build_python_family: ${{ steps.selection.outputs.build_python_family }}
       build_count: ${{ steps.selection.outputs.build_count }}
       generic_build_count: ${{ steps.selection.outputs.generic_build_count }}
       build_matrix: ${{ steps.selection.outputs.build_matrix }}
+      python_build_count: ${{ steps.selection.outputs.python_build_count }}
+      python_build_matrix: ${{ steps.selection.outputs.python_build_matrix }}
       promote_count: ${{ steps.selection.outputs.promote_count }}
       promote_matrix: ${{ steps.selection.outputs.promote_matrix }}
       source_tag: ${{ steps.base-source.outputs.source_tag }}
@@ -192,9 +195,12 @@ jobs:
           fi
           echo "build_docker_family=$(jq -r '.build_docker_family' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_precommit=$(jq -r '.build_precommit' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "build_python_family=$(jq -r '.build_python_family' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "generic_build_count=$(jq -r '.generic_build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_matrix=$(jq -c '.generic_build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "python_build_count=$(jq -r '.python_build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "python_build_matrix=$(jq -c '.python_build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_count=$(jq -r '.promote_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_matrix=$(jq -c '.promote' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
 
@@ -392,6 +398,195 @@ jobs:
             echo "deploy for all ecosystems"
             echo "\`\`\`"
             echo ".dependabot set-ecosystem-version staging * $DEPENDABOT_UPDATER_VERSION"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build-python-runtime:
+    runs-on: ubuntu-latest
+    needs:
+      - approval
+      - build-updater-core
+      - prepare
+    if: >-
+      startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
+      needs.prepare.outputs.build_python_family == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      pull-requests: read
+      attestations: write
+      artifact-metadata: write
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+    env:
+      DEPENDABOT_UPDATER_VERSION: ${{ needs.approval.outputs.head_sha }}
+      PYTHON_RUNTIME_IMAGE: ghcr.io/dependabot/dependabot-updater-python-runtime
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Preserve build definition
+        run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+
+      - name: Checkout approved pull request
+        env:
+          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+          PR: ${{ needs.approval.outputs.pr }}
+        run: |
+          gh pr checkout "$PR"
+          [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
+          git fetch origin main
+          git merge origin/main --ff-only
+          git submodule update --init --recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Python runtime
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          files: ${{ runner.temp }}/docker-bake.hcl
+          targets: python-runtime
+          provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=false
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
+          set: |
+            python-runtime.output=type=registry
+            python-runtime.tags=${{ env.PYTHON_RUNTIME_IMAGE }}:${{ env.DEPENDABOT_UPDATER_VERSION }}
+
+      - name: Resolve Python runtime digest
+        id: digest
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)['python-runtime']['containerimage.digest'] }}
+        run: |
+          TAG_DIGEST=$(docker buildx imagetools inspect "${PYTHON_RUNTIME_IMAGE}:${DEPENDABOT_UPDATER_VERSION}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+          [[ "$TAG_DIGEST" == "$IMAGE_DIGEST" ]]
+          echo "digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.PYTHON_RUNTIME_IMAGE }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: true
+
+  push-python-images:
+    runs-on: ubuntu-latest
+    needs:
+      - approval
+      - build-python-runtime
+      - build-updater-core
+      - prepare
+    if: >-
+      startsWith(needs.approval.outputs.decision, 'APPROVED:OPEN') &&
+      needs.prepare.outputs.python_build_count != '0'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      pull-requests: read
+      attestations: write
+      artifact-metadata: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.python_build_matrix) }}
+    env:
+      DEPENDABOT_UPDATER_VERSION: ${{ needs.approval.outputs.head_sha }}
+      ECOSYSTEM: ${{ matrix.target }}
+      PYTHON_RUNTIME_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-python-runtime@${{ needs.build-python-runtime.outputs.digest }}
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
+      UPDATER_IMAGE: ghcr.io/dependabot/dependabot-updater-${{ matrix.target }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Preserve build definition
+        run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Checkout approved pull request
+        env:
+          APPROVED_HEAD_SHA: ${{ needs.approval.outputs.head_sha }}
+          PR: ${{ needs.approval.outputs.pr }}
+        run: |
+          gh pr checkout "$PR"
+          [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
+          git fetch origin main
+          git merge origin/main --ff-only
+          git submodule update --init --recursive
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push validated Python image
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          files: ${{ runner.temp }}/docker-bake.hcl
+          targets: ${{ matrix.target }}
+          provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=false
+            PYTHON_RUNTIME_CONTEXT=${{ env.PYTHON_RUNTIME_CONTEXT }}
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
+          set: |
+            ${{ matrix.target }}.output=type=registry
+            ${{ matrix.target }}.tags=${{ env.UPDATER_IMAGE }}:${{ env.DEPENDABOT_UPDATER_VERSION }}
+
+      - name: Validate image manifest
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)[matrix.target]['containerimage.digest'] }}
+        run: |
+          IMAGE="${UPDATER_IMAGE}@${IMAGE_DIGEST}"
+          IMAGE_LAYERS=$(docker buildx imagetools inspect --raw "$IMAGE" | jq '.layers | length')
+          echo "$IMAGE contains $IMAGE_LAYERS layers"
+          [[ $IMAGE_LAYERS -lt 126 ]]
+
+          TAG_DIGEST=$(docker buildx imagetools inspect "${UPDATER_IMAGE}:${DEPENDABOT_UPDATER_VERSION}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+          [[ "$TAG_DIGEST" == "$IMAGE_DIGEST" ]]
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.UPDATER_IMAGE }}
+          subject-digest: ${{ fromJSON(steps.build.outputs.metadata)[matrix.target]['containerimage.digest'] }}
+          push-to-registry: true
+          create-storage-record: true
+
+      - name: Set summary
+        run: |
+          {
+            echo "Python updater uploaded with tag \`$DEPENDABOT_UPDATER_VERSION\`"
+            echo "\`\`\`"
+            echo "$UPDATER_IMAGE:$DEPENDABOT_UPDATER_VERSION"
+            echo "\`\`\`"
+            echo "deploy for $ECOSYSTEM"
+            echo "\`\`\`"
+            echo ".dependabot set-ecosystem-version staging $ECOSYSTEM $DEPENDABOT_UPDATER_VERSION"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -439,8 +439,6 @@ jobs:
         run: |
           gh pr checkout "$PR"
           [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
-          git fetch origin main
-          git merge origin/main --ff-only
           git submodule update --init --recursive
 
       - name: Set up Docker Buildx
@@ -531,8 +529,6 @@ jobs:
         run: |
           gh pr checkout "$PR"
           [[ "$(git rev-parse HEAD)" == "$APPROVED_HEAD_SHA" ]]
-          git fetch origin main
-          git merge origin/main --ff-only
           git submodule update --init --recursive
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -428,6 +428,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: ${{ needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
@@ -515,6 +516,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+          ref: ${{ needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"

--- a/.github/workflows/images-branch.yml
+++ b/.github/workflows/images-branch.yml
@@ -428,7 +428,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ needs.approval.outputs.base_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"
@@ -516,7 +516,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-          ref: ${{ needs.approval.outputs.base_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || needs.approval.outputs.base_sha }}
 
       - name: Preserve build definition
         run: cp docker-bake.hcl "$RUNNER_TEMP/docker-bake.hcl"

--- a/.github/workflows/images-latest.yml
+++ b/.github/workflows/images-latest.yml
@@ -99,9 +99,12 @@ jobs:
     outputs:
       build_docker_family: ${{ steps.selection.outputs.build_docker_family }}
       build_precommit: ${{ steps.selection.outputs.build_precommit }}
+      build_python_family: ${{ steps.selection.outputs.build_python_family }}
       build_count: ${{ steps.selection.outputs.build_count }}
       generic_build_count: ${{ steps.selection.outputs.generic_build_count }}
       build_matrix: ${{ steps.selection.outputs.build_matrix }}
+      python_build_count: ${{ steps.selection.outputs.python_build_count }}
+      python_build_matrix: ${{ steps.selection.outputs.python_build_matrix }}
       promote_count: ${{ steps.selection.outputs.promote_count }}
       promote_matrix: ${{ steps.selection.outputs.promote_matrix }}
       source_tag: ${{ steps.source.outputs.source_tag }}
@@ -193,9 +196,12 @@ jobs:
           fi
           echo "build_docker_family=$(jq -r '.build_docker_family' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_precommit=$(jq -r '.build_precommit' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "build_python_family=$(jq -r '.build_python_family' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_count=$(jq -r '.build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "generic_build_count=$(jq -r '.generic_build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "build_matrix=$(jq -c '.generic_build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "python_build_count=$(jq -r '.python_build_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
+          echo "python_build_matrix=$(jq -c '.python_build' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_count=$(jq -r '.promote_count' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
           echo "promote_matrix=$(jq -c '.promote' <<< "$RESULT")" >> "$GITHUB_OUTPUT"
 
@@ -305,6 +311,207 @@ jobs:
             echo "$UPDATER_IMAGE:$COMMIT_SHA"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  build-python-runtime:
+    runs-on: ubuntu-latest
+    needs:
+      - build-updater-core
+      - prepare
+    if: needs.prepare.outputs.build_python_family == 'true'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      attestations: write
+      artifact-metadata: write
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+      PYTHON_RUNTIME_IMAGE: ghcr.io/dependabot/dependabot-updater-python-runtime
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Python runtime
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          targets: python-runtime
+          provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=true
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
+          set: |
+            python-runtime.cache-to+=type=inline
+            python-runtime.output=type=registry
+            python-runtime.tags=${{ env.PYTHON_RUNTIME_IMAGE }}:${{ env.COMMIT_SHA }}
+
+      - name: Resolve Python runtime digest
+        id: digest
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)['python-runtime']['containerimage.digest'] }}
+        run: |
+          TAG_DIGEST=$(docker buildx imagetools inspect "${PYTHON_RUNTIME_IMAGE}:${COMMIT_SHA}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+          [[ "$TAG_DIGEST" == "$IMAGE_DIGEST" ]]
+          echo "digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.PYTHON_RUNTIME_IMAGE }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: true
+
+  push-python-images:
+    name: Deploy Python
+    runs-on: ubuntu-latest
+    needs:
+      - build-python-runtime
+      - build-updater-core
+      - date-version
+      - prepare
+    if: needs.prepare.outputs.python_build_count != '0'
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+      attestations: write
+      artifact-metadata: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.python_build_matrix) }}
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+      DATE_VERSION: ${{ needs.date-version.outputs.date }}
+      DEPENDABOT_UPDATER_VERSION: ""
+      PYTHON_RUNTIME_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-python-runtime@${{ needs.build-python-runtime.outputs.digest }}
+      UPDATER_CORE_CONTEXT: docker-image://ghcr.io/dependabot/dependabot-updater-core@${{ needs.build-updater-core.outputs.digest }}
+      UPDATER_IMAGE: ghcr.io/dependabot/dependabot-updater-${{ matrix.target }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push validated Python image
+        id: build
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          source: .
+          targets: ${{ matrix.target }}
+          provenance: false
+          vars: |
+            BUILD_CACHE_WRITE=true
+            PYTHON_RUNTIME_CONTEXT=${{ env.PYTHON_RUNTIME_CONTEXT }}
+            UPDATER_CORE_CONTEXT=${{ env.UPDATER_CORE_CONTEXT }}
+          set: |
+            ${{ matrix.target }}.output=type=registry
+            ${{ matrix.target }}.tags=${{ env.UPDATER_IMAGE }}:${{ env.COMMIT_SHA }}
+
+      - name: Validate and promote image manifest
+        env:
+          IMAGE_DIGEST: ${{ fromJSON(steps.build.outputs.metadata)[matrix.target]['containerimage.digest'] }}
+        run: |
+          IMAGE="${UPDATER_IMAGE}@${IMAGE_DIGEST}"
+          IMAGE_LAYERS=$(docker buildx imagetools inspect --raw "$IMAGE" | jq '.layers | length')
+          echo "$IMAGE contains $IMAGE_LAYERS layers"
+          [[ $IMAGE_LAYERS -lt 126 ]]
+
+          docker buildx imagetools create \
+            --prefer-index=false \
+            --tag "${UPDATER_IMAGE}:latest" \
+            --tag "${UPDATER_IMAGE}:${DATE_VERSION}" \
+            "$IMAGE"
+
+          for tag in "$COMMIT_SHA" latest "$DATE_VERSION"; do
+            TAG_DIGEST=$(docker buildx imagetools inspect "${UPDATER_IMAGE}:${tag}" --format '{{json .Manifest.Digest}}' | jq -r '.')
+            [[ "$TAG_DIGEST" == "$IMAGE_DIGEST" ]]
+          done
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.UPDATER_IMAGE }}
+          subject-digest: ${{ fromJSON(steps.build.outputs.metadata)[matrix.target]['containerimage.digest'] }}
+          push-to-registry: true
+          create-storage-record: true
+
+      - name: Pull images through backup registry
+        run: |
+          docker pull "${BACKUP_REGISTRY}/${UPDATER_IMAGE}:$COMMIT_SHA"
+          docker pull "${BACKUP_REGISTRY}/${UPDATER_IMAGE}:latest"
+          docker pull "${BACKUP_REGISTRY}/${UPDATER_IMAGE}:$DATE_VERSION"
+
+      - name: Set summary
+        run: |
+          {
+            echo "Python updater uploaded with tag \`$COMMIT_SHA\`"
+            echo "\`\`\`"
+            echo "$UPDATER_IMAGE:$COMMIT_SHA"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  promote-python-runtime:
+    runs-on: ubuntu-latest
+    needs:
+      - build-python-runtime
+      - prepare
+      - push-python-images
+    if: needs.prepare.outputs.build_python_family == 'true'
+    permissions:
+      contents: read
+      packages: write
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+      IMAGE_PREFIX: ghcr.io/dependabot/dependabot-updater-
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote validated Python runtime
+        run: |
+          TARGETS_JSON='[{"target":"python-runtime"}]'
+          TAGS_JSON='["latest"]'
+          SOURCE_TAG="$COMMIT_SHA"
+          export TARGETS_JSON TAGS_JSON SOURCE_TAG
+          script/promote-image-tags
 
   push-docker-images:
     name: Deploy Docker images

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -14,6 +14,14 @@ variable "UPDATER_CORE_CONTEXT_VERSION" {
   default = ""
 }
 
+variable "PYTHON_RUNTIME_IMAGE" {
+  default = "ghcr.io/dependabot/dependabot-updater-python-runtime"
+}
+
+variable "PYTHON_RUNTIME_CONTEXT" {
+  default = "target:python-runtime"
+}
+
 variable "UPDATER_CORE_VERSION_TAG" {
   default = ""
 }
@@ -170,6 +178,28 @@ target "updater-core-context" {
   )
 }
 
+target "python-runtime" {
+  context     = "."
+  dockerfile  = "python/Dockerfile.runtime"
+  description = "Shared runtime for Pip and UV ecosystem images"
+  contexts = {
+    (UPDATER_CORE_IMAGE) = UPDATER_CORE_CONTEXT
+  }
+  cache-from = [
+    { type = "registry", ref = "${BUILD_CACHE_IMAGE}:python-runtime" },
+    { type = "registry", ref = "${PYTHON_RUNTIME_IMAGE}:latest" },
+  ]
+  cache-to = BUILD_CACHE_WRITE ? [
+    {
+      type           = "registry"
+      ref            = "${BUILD_CACHE_IMAGE}:python-runtime"
+      mode           = "max"
+      image-manifest = true
+      oci-mediatypes = true
+    },
+  ] : []
+}
+
 target "_ecosystem" {
   name = "${item.image}-raw"
   matrix = {
@@ -183,6 +213,9 @@ target "_ecosystem" {
     {
       (UPDATER_CORE_IMAGE) = UPDATER_CORE_CONTEXT
     },
+    item.name == "python" || item.name == "uv" ? {
+      (PYTHON_RUNTIME_IMAGE) = PYTHON_RUNTIME_CONTEXT
+    } : {},
     item.name == "pre_commit" ? {
       "${UPDATER_IMAGE_PREFIX}gomod:latest"   = PRE_COMMIT_GOMOD_CONTEXT
       "${UPDATER_IMAGE_PREFIX}bundler:latest" = PRE_COMMIT_BUNDLER_CONTEXT

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -29,8 +29,8 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
   PATH="/usr/local/.pyenv/bin:$PATH"
 RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
 USER dependabot
-ENV REQUESTS_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
-ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/opt"
 RUN git -c advice.detachedHead=false clone https://github.com/pyenv/pyenv.git --branch $PYENV_VERSION --single-branch --depth=1 /usr/local/.pyenv
 
@@ -127,29 +127,14 @@ RUN PYENV_VERSION=$PY_3_14 pyenv exec python --version | grep "Python $PY_3_14" 
 RUN bash /opt/python/helpers/build $PY_3_14
 # This is the default Python, so no need to tar it
 
-FROM python-core
-# Install C-libs needed to build users' Python packages. Please document why each package is needed.
-USER root
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends \
-    # Used by pycurl
-    libcurl4-openssl-dev \
-    # Used by mysqlclient
-    libmysqlclient-dev \
-    pkg-config \
-    # Used by psycopg Postgres Client
-    libpq-dev \
-    # Used by python zoneinfo core lib
-    tzdata \
-    # Needed to build `gssapi`/`krb5`
-    libkrb5-dev \
-    # Used by pycairo and pygobject
-    libcairo2-dev \
-    libgirepository-2.0-dev \
-  && rm -rf /var/lib/apt/lists/*
-
-USER dependabot
+FROM ghcr.io/dependabot/dependabot-updater-python-runtime
+ARG PY_3_14
+ARG PY_3_13
+ARG PY_3_12
+ARG PY_3_11
+ARG PY_3_10
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+  SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 COPY --chown=dependabot:dependabot --parents python common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
@@ -165,23 +150,6 @@ COPY --from=python-3.14 $PYENV_ROOT/versions/ $PYENV_ROOT/versions/
 COPY --from=python-3.14 /opt/python/ /opt/python/
 
 RUN pyenv global $PY_3_14
-
-USER root
-
-# Install Rust
-ENV RUSTUP_HOME=/opt/rust \
-  CARGO_HOME=/opt/rust \
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
-  PATH="${PATH}:/opt/rust/bin"
-RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
-
-USER dependabot
-
-COPY --from=rust /usr/local/rustup $RUSTUP_HOME
-COPY --from=rust /usr/local/cargo $CARGO_HOME
-
-# Configure cargo to use Git CLI so the Git shim works
-RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml
 
 COPY --chown=dependabot:dependabot --parents cargo common $DEPENDABOT_HOME/
 

--- a/python/Dockerfile.runtime
+++ b/python/Dockerfile.runtime
@@ -1,0 +1,66 @@
+# syntax=docker.io/docker/dockerfile:1.20
+# Keep this version in sync with python/Dockerfile and uv/Dockerfile.
+# https://github.com/pyenv/pyenv/releases
+ARG PYENV_VERSION=v2.6.16
+
+FROM docker.io/library/rust:latest AS rust
+
+FROM ghcr.io/dependabot/dependabot-updater-core
+ARG PYENV_VERSION
+
+USER root
+
+# Install C libraries needed to build users' Python packages.
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
+    # Used by pycurl
+    libcurl4-openssl-dev \
+    # Used by mysqlclient
+    libmysqlclient-dev \
+    pkg-config \
+    # Used by psycopg Postgres Client
+    libpq-dev \
+    # Used by Python's zoneinfo core library
+    tzdata \
+    # Needed to build gssapi/krb5
+    libkrb5-dev \
+    # Used by pycairo and pygobject
+    libcairo2-dev \
+    libgirepository-2.0-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PYENV_ROOT=/usr/local/.pyenv \
+  PATH="/usr/local/.pyenv/bin:$PATH"
+
+RUN mkdir -p "$PYENV_ROOT" && chown dependabot:dependabot "$PYENV_ROOT"
+
+USER dependabot
+
+ENV DEPENDABOT_NATIVE_HELPERS_PATH=/opt
+
+RUN git -c advice.detachedHead=false clone \
+  https://github.com/pyenv/pyenv.git \
+  --branch "$PYENV_VERSION" \
+  --single-branch \
+  --depth=1 \
+  "$PYENV_ROOT"
+
+RUN mkdir "$PYENV_ROOT/versions"
+
+USER root
+
+ENV RUSTUP_HOME=/opt/rust \
+  CARGO_HOME=/opt/rust \
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
+  PATH="${PATH}:/opt/rust/bin"
+
+RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
+
+USER dependabot
+
+COPY --from=rust /usr/local/rustup $RUSTUP_HOME
+COPY --from=rust /usr/local/cargo $CARGO_HOME
+
+# Configure Cargo to use Git CLI so the Git shim works.
+RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml

--- a/python/README.md
+++ b/python/README.md
@@ -8,7 +8,7 @@ We rely on `pyenv` to manage Python's versions.
 
 Updating the list of known versions might be tricky, here are the steps:
 
-1. Update the `pyenv` version in [`Dockerfile.runtime`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile.runtime) and the ecosystem [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile). You may use a commit hash if a new `pyenv` version is not released yet.
+1. Update the `pyenv` version in the shared [`Dockerfile.runtime`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile.runtime), the Pip [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile), and the UV [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile). You may use a commit hash if a new `pyenv` version is not released yet.
 2. Update the `pyenv global` version in the `Dockerfile`. We always use the latest (and greatest) Python version.
 3. Update the list of known Python versions in [`language_version_manager.rb`](https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/language_version_manager.rb).
 4. Fix any broken tests.

--- a/python/README.md
+++ b/python/README.md
@@ -8,7 +8,7 @@ We rely on `pyenv` to manage Python's versions.
 
 Updating the list of known versions might be tricky, here are the steps:
 
-1. Update the `pyenv` version in the [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile), you may use a commit hash if a new `pyenv` version is not released yet.
+1. Update the `pyenv` version in [`Dockerfile.runtime`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile.runtime) and the ecosystem [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile). You may use a commit hash if a new `pyenv` version is not released yet.
 2. Update the `pyenv global` version in the `Dockerfile`. We always use the latest (and greatest) Python version.
 3. Update the list of known Python versions in [`language_version_manager.rb`](https://github.com/dependabot/dependabot-core/blob/main/python/lib/dependabot/python/language_version_manager.rb).
 4. Fix any broken tests.

--- a/script/_common
+++ b/script/_common
@@ -1,6 +1,8 @@
 # shellcheck shell=bash
 export UPDATER_CORE_IMAGE="ghcr.io/dependabot/dependabot-updater-core"
 export UPDATER_CORE_LOCAL_IMAGE="dependabot-updater-core-local"
+export PYTHON_RUNTIME_IMAGE="ghcr.io/dependabot/dependabot-updater-python-runtime"
+export PYTHON_RUNTIME_LOCAL_IMAGE="dependabot-updater-python-runtime-local"
 export UPDATER_IMAGE="ghcr.io/dependabot/dependabot-updater-"
 export DOCKER_BUILDKIT=1
 
@@ -140,18 +142,71 @@ function docker_build() {
     return 1
   fi
 
+  local -a core_context_args=()
+  if [[ -n "$core_oci_layout" ]]; then
+    core_context_args=(--build-context "$UPDATER_CORE_IMAGE=oci-layout://$core_oci_layout")
+  else
+    # Works around upstream bug https://github.com/moby/buildkit/issues/6956
+    # Remove when the bug is resolved.
+    core_context_args=(--build-context "$UPDATER_CORE_IMAGE=docker-image://$UPDATER_CORE_LOCAL_IMAGE")
+  fi
+
   # We don't sign the updater image with Notary, so disable Docker Content Trust for remaining builds
   unset DOCKER_CONTENT_TRUST
+
+  local python_runtime_oci_tempdir=""
+  local python_runtime_oci_layout=""
+  local python_runtime_output_mode="load"
+  local -a python_runtime_output_args=()
+  local -a python_runtime_context_args=()
+  if [[ "$ECOSYSTEM" == "python" || "$ECOSYSTEM" == "uv" ]]; then
+    if [[ -n "$BUILDX_GHA_CACHE" ]]; then
+      python_runtime_oci_tempdir=$(mktemp -d)
+      python_runtime_oci_layout="$python_runtime_oci_tempdir/image"
+      python_runtime_output_mode="oci"
+      python_runtime_output_args=(--output "type=oci,dest=${python_runtime_oci_layout},tar=false")
+    fi
+
+    PYTHON_RUNTIME_BUILD=$(
+      _build_cmd_and_cache_args "python-runtime" "$PYTHON_RUNTIME_IMAGE" "$python_runtime_output_mode"
+    )
+
+    # shellcheck disable=SC2086  # word-splitting is intentional for build args
+    if ! $PYTHON_RUNTIME_BUILD \
+      $DOCKER_BUILD_ARGS \
+      "${core_context_args[@]}" \
+      "${python_runtime_output_args[@]}" \
+      -t "$PYTHON_RUNTIME_IMAGE" \
+      -t "$PYTHON_RUNTIME_LOCAL_IMAGE" \
+      -f python/Dockerfile.runtime \
+      .; then
+      [[ -z "$python_runtime_oci_tempdir" ]] || rm -rf "$python_runtime_oci_tempdir"
+      [[ -z "$core_oci_tempdir" ]] || rm -rf "$core_oci_tempdir"
+      return 1
+    fi
+
+    if [[ -n "$python_runtime_oci_layout" ]]; then
+      python_runtime_context_args=(
+        --build-context "$PYTHON_RUNTIME_IMAGE=oci-layout://$python_runtime_oci_layout"
+      )
+    else
+      python_runtime_context_args=(
+        --build-context "$PYTHON_RUNTIME_IMAGE=docker-image://$PYTHON_RUNTIME_LOCAL_IMAGE"
+      )
+    fi
+  fi
 
   # pre_commit depends on go_modules and bundler images, so build them first
   # Use a guard variable to prevent infinite recursion when called recursively
   if [[ "$ECOSYSTEM" == "pre_commit" && -z "$BUILDING_DEPENDENCY" ]]; then
     echo "Building pre_commit dependencies: go_modules and bundler..."
     if ! BUILDING_DEPENDENCY=1 docker_build "go_modules"; then
+      [[ -z "$python_runtime_oci_tempdir" ]] || rm -rf "$python_runtime_oci_tempdir"
       [[ -z "$core_oci_tempdir" ]] || rm -rf "$core_oci_tempdir"
       return 1
     fi
     if ! BUILDING_DEPENDENCY=1 docker_build "bundler"; then
+      [[ -z "$python_runtime_oci_tempdir" ]] || rm -rf "$python_runtime_oci_tempdir"
       [[ -z "$core_oci_tempdir" ]] || rm -rf "$core_oci_tempdir"
       return 1
     fi
@@ -165,14 +220,7 @@ function docker_build() {
   DOCKERFILE_PATH=$(get_dockerfile_path)
 
   ECOSYSTEM_BUILD=$(_build_cmd_and_cache_args "$ECOSYSTEM" "$UPDATER_IMAGE_NAME")
-  local -a ecosystem_context_args=()
-  if [[ -n "$core_oci_layout" ]]; then
-    ecosystem_context_args=(--build-context "$UPDATER_CORE_IMAGE=oci-layout://$core_oci_layout")
-  else
-    # Works around upstream bug https://github.com/moby/buildkit/issues/6956
-    # Remove when the bug is resolved.
-    ecosystem_context_args=(--build-context "$UPDATER_CORE_IMAGE=docker-image://$UPDATER_CORE_LOCAL_IMAGE")
-  fi
+  local -a ecosystem_context_args=("${core_context_args[@]}" "${python_runtime_context_args[@]}")
 
   # shellcheck disable=SC2086  # word-splitting is intentional for build args
   if ! $ECOSYSTEM_BUILD \
@@ -181,10 +229,14 @@ function docker_build() {
     -t "$UPDATER_IMAGE_NAME" \
     -f "$DOCKERFILE_PATH" \
     .; then
+    [[ -z "$python_runtime_oci_tempdir" ]] || rm -rf "$python_runtime_oci_tempdir"
     [[ -z "$core_oci_tempdir" ]] || rm -rf "$core_oci_tempdir"
     return 1
   fi
 
+  if [[ -n "$python_runtime_oci_tempdir" ]]; then
+    rm -rf "$python_runtime_oci_tempdir"
+  fi
   if [[ -n "$core_oci_tempdir" ]]; then
     rm -rf "$core_oci_tempdir"
   fi

--- a/script/resolve-image-matrix
+++ b/script/resolve-image-matrix
@@ -32,7 +32,15 @@ changed_targets=$(jq -c '[.[] | select(. != "shared")]' <<< "$changed_targets")
 
 targets=$(
   jq -c \
-    '[.[] | select(.target != "updater-core" and (.target | endswith("-raw") | not)) | .target]' \
+    '[
+      .[]
+      | select(
+          .target != "python-runtime" and
+          .target != "updater-core" and
+          (.target | endswith("-raw") | not)
+        )
+      | .target
+    ]' \
     <<< "$BAKE_MATRIX"
 )
 unknown_targets=$(jq -cn --argjson changed "$changed_targets" --argjson targets "$targets" '$changed - $targets')
@@ -48,7 +56,11 @@ jq -c \
   '
     [
       .[]
-      | select(.target != "updater-core" and (.target | endswith("-raw") | not))
+      | select(
+          .target != "python-runtime" and
+          .target != "updater-core" and
+          (.target | endswith("-raw") | not)
+        )
     ] as $matrix
     | (
         $changed +
@@ -97,13 +109,28 @@ jq -c \
     | . + {
         build_docker_family: any(.build[]; .target == "docker" or .target == "docker-compose"),
         build_precommit: any(.build[]; .target == "pre-commit"),
+        build_python_family: any(.build[]; .target == "pip" or .target == "uv"),
+        python_build: [.build[] | select(.target == "pip" or .target == "uv")],
+        python_build_count: ([.build[] | select(.target == "pip" or .target == "uv")] | length),
         generic_build: [
           .build[]
-          | select(.target != "docker" and .target != "docker-compose" and .target != "pre-commit")
+          | select(
+              .target != "docker" and
+              .target != "docker-compose" and
+              .target != "pip" and
+              .target != "pre-commit" and
+              .target != "uv"
+            )
         ],
         generic_build_count: ([
           .build[]
-          | select(.target != "docker" and .target != "docker-compose" and .target != "pre-commit")
+          | select(
+              .target != "docker" and
+              .target != "docker-compose" and
+              .target != "pip" and
+              .target != "pre-commit" and
+              .target != "uv"
+            )
         ] | length)
       }
   ' <<< "$BAKE_MATRIX"

--- a/script/test-image-build-matrix
+++ b/script/test-image-build-matrix
@@ -91,9 +91,24 @@ assert_equal 'true' "$(jq -r '.build_docker_family' <<< "$result")" "Docker fami
 assert_equal '["docker","docker-compose"]' "$(jq -c '[.build[].target] | sort' <<< "$result")" "Docker family targets"
 assert_equal '0' "$(jq -r '.generic_build_count' <<< "$result")" "Docker family generic count"
 
+python_matrix='[
+  {"target":"python-runtime","dockerfile":"python/Dockerfile.runtime"},
+  {"target":"pip","dockerfile":"python/Dockerfile"},
+  {"target":"uv","dockerfile":"uv/Dockerfile"}
+]'
+result=$(
+  BAKE_MATRIX="$python_matrix" \
+  CHANGED_TARGETS='["uv"]' \
+  script/resolve-image-matrix
+)
+assert_equal 'true' "$(jq -r '.build_python_family' <<< "$result")" "Python family build flag"
+assert_equal '["uv"]' "$(jq -c '[.python_build[].target]' <<< "$result")" "Python family targets"
+assert_equal '0' "$(jq -r '.generic_build_count' <<< "$result")" "Python family generic count"
+assert_equal '1' "$(jq -r '.promote_count' <<< "$result")" "Python family promotion count"
+
 bake_targets=$(
   docker buildx bake --print ecosystem 2> /dev/null |
-    jq -c '.group.ecosystem.targets | map(select(. != "updater-core")) | sort'
+    jq -c '.group.ecosystem.targets | map(select(. != "python-runtime" and . != "updater-core")) | sort'
 )
 filter_targets=$(
   ruby -ryaml -rjson -e '

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -128,29 +128,12 @@ RUN PYENV_VERSION=$PY_3_14 pyenv exec python --version | grep "Python $PY_3_14" 
 RUN bash /opt/python/helpers/build $PY_3_14
 # This is the default Python, so no need to tar it
 
-FROM python-core
-# Install C-libs needed to build users' Python packages. Please document why each package is needed.
-USER root
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends \
-    # Used by pycurl
-    libcurl4-openssl-dev \
-    # Used by mysqlclient
-    libmysqlclient-dev \
-    pkg-config \
-    # Used by psycopg Postgres Client
-    libpq-dev \
-    # Used by python zoneinfo core lib
-    tzdata \
-    # Needed to build `gssapi`/`krb5`
-    libkrb5-dev \
-    # Used by pycairo and pygobject
-    libcairo2-dev \
-    libgirepository-2.0-dev \
-  && rm -rf /var/lib/apt/lists/*
-
-USER dependabot
+FROM ghcr.io/dependabot/dependabot-updater-python-runtime
+ARG PY_3_14
+ARG PY_3_13
+ARG PY_3_12
+ARG PY_3_11
+ARG PY_3_10
 
 COPY --chown=dependabot:dependabot --parents uv python common $DEPENDABOT_HOME/
 COPY --chown=dependabot:dependabot updater $DEPENDABOT_HOME/dependabot-updater
@@ -166,23 +149,6 @@ COPY --from=python-3.14 $PYENV_ROOT/versions/ $PYENV_ROOT/versions/
 COPY --from=python-3.14 /opt/python/ /opt/python/
 
 RUN pyenv global $PY_3_14
-
-USER root
-
-# Install Rust
-ENV RUSTUP_HOME=/opt/rust \
-  CARGO_HOME=/opt/rust \
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
-  PATH="${PATH}:/opt/rust/bin"
-RUN mkdir -p "$RUSTUP_HOME" && chown dependabot:dependabot "$RUSTUP_HOME"
-
-USER dependabot
-
-COPY --from=rust /usr/local/rustup $RUSTUP_HOME
-COPY --from=rust /usr/local/cargo $CARGO_HOME
-
-# Configure cargo to use Git CLI so the Git shim works
-RUN mkdir -p ~/.cargo && printf "[net]\ngit-fetch-with-cli = true\n" >> ~/.cargo/config.toml
 
 # Install uv by copying from the official image
 COPY --from=uv /uv /uvx /usr/local/bin/

--- a/uv/README.md
+++ b/uv/README.md
@@ -8,7 +8,7 @@ We rely on `pyenv` to manage Python's versions.
 
 Updating the list of known versions might be tricky, here are the steps:
 
-1. Update the `pyenv` version in the shared [`Dockerfile.runtime`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile.runtime) and the UV [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile). You may use a commit hash if a new `pyenv` version is not released yet.
+1. Update the `pyenv` version in the shared [`Dockerfile.runtime`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile.runtime), the Pip [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile), and the UV [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile). You may use a commit hash if a new `pyenv` version is not released yet.
 2. Update the `pyenv global` version in the `Dockerfile`. We always use the latest (and greatest) Python version.
 3. Update the list of known Python versions in [`language_version_manager.rb`](https://github.com/dependabot/dependabot-core/blob/main/uv/lib/dependabot/uv/language_version_manager.rb).
 4. Fix any broken tests.

--- a/uv/README.md
+++ b/uv/README.md
@@ -8,7 +8,7 @@ We rely on `pyenv` to manage Python's versions.
 
 Updating the list of known versions might be tricky, here are the steps:
 
-1. Update the `pyenv` version in the [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile), you may use a commit hash if a new `pyenv` version is not released yet.
+1. Update the `pyenv` version in the shared [`Dockerfile.runtime`](https://github.com/dependabot/dependabot-core/blob/main/python/Dockerfile.runtime) and the UV [`Dockerfile`](https://github.com/dependabot/dependabot-core/blob/main/uv/Dockerfile). You may use a commit hash if a new `pyenv` version is not released yet.
 2. Update the `pyenv global` version in the `Dockerfile`. We always use the latest (and greatest) Python version.
 3. Update the list of known Python versions in [`language_version_manager.rb`](https://github.com/dependabot/dependabot-core/blob/main/uv/lib/dependabot/uv/language_version_manager.rb).
 4. Fix any broken tests.
@@ -30,4 +30,3 @@ Updating the list of known versions might be tricky, here are the steps:
    ```
 
 [core-repo]: https://github.com/dependabot/dependabot-core
-


### PR DESCRIPTION
> **Stack 8/8** · Base: #16160

### What are you trying to accomplish?

Share the final pyenv, native-library, and Rust foundation used by Pip and UV.

The helper build stages remain based directly on updater-core so their package installation environment is unchanged. A separate internal runtime is built once, and the validated Pip/UV jobs consume its immutable digest.

The selector excludes the internal runtime from public image promotion and schedules dedicated Pip/UV jobs only when those images are affected.

### Anything you want to highlight for special attention from reviewers?

The runtime's `latest` tag is promoted only after all selected Pip/UV images succeed. Main builds write the runtime cache; branch builds are read-only. Local `script/build python|uv` builds and injects the current runtime for both legacy Docker and OCI Buildx paths.

The first GHCR runtime package version should be made public so unauthenticated local cache imports do not warn.

### How will you know you've accomplished your goal?

- Pip and UV built through both Bake and the repository's `script/build` entry point.
- All five Python versions, Rust, UV, and `bundle check` were verified.
- 67 Python helper tests and both language spec files passed.
- Pip and UV environment variables match the current published images.
- Final local sizes remained close to the existing images while sharing a 624 MB foundation.

**Rollback:** restore the native-library/Rust sections to each ecosystem Dockerfile and remove the runtime target/jobs.

### Checklist

- [ ] Complete test suite passes in CI.
- [x] Targeted helper, language, image, shell, Bake, and workflow checks pass.
- [x] Commit messages are descriptive.
- [x] Documentation and rollback are included.
