### PR TITLE
Type Julia RegistryClient helper results

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 700
+# Offense count: 674
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -295,8 +295,6 @@ Sorbet/ForbidTUntyped:
     - "hex/lib/dependabot/hex/update_checker/latest_version_finder.rb"
     - "julia/lib/dependabot/julia/file_parser.rb"
     - "julia/lib/dependabot/julia/file_updater.rb"
-    - "julia/lib/dependabot/julia/package/package_details_fetcher.rb"
-    - "julia/lib/dependabot/julia/registry_client.rb"
     - "julia/lib/dependabot/julia/update_checker.rb"
     - "nix/lib/dependabot/nix/file_parser.rb"
     - "nix/lib/dependabot/nix/flake_nix_parser.rb"

--- a/julia/lib/dependabot/julia/file_fetcher.rb
+++ b/julia/lib/dependabot/julia/file_fetcher.rb
@@ -33,30 +33,18 @@ module Dependabot
       sig { params(temp_dir: T.any(Pathname, String)).returns(T::Array[Dependabot::DependencyFile]) }
       def fetch_files_using_julia_helper(temp_dir)
         workspace_info = registry_client.find_workspace_project_files(temp_dir.to_s)
-        validate_workspace_info!(workspace_info)
+        if workspace_info.is_a?(Dependabot::Julia::RegistryClient::Result::Failure)
+          raise Dependabot::DependencyFileNotFound, "No Project.toml or JuliaProject.toml found."
+        end
 
-        project_files = T.cast(workspace_info["project_files"], T::Array[String])
-        manifest_path = T.cast(workspace_info["manifest_file"], String)
+        project_files = workspace_info.project_files
+        manifest_path = workspace_info.manifest_file
 
         fetched_files = fetch_all_project_files(project_files, temp_dir.to_s)
         raise Dependabot::DependencyFileNotFound, "No Project.toml or JuliaProject.toml found." if fetched_files.empty?
 
         fetch_manifest_file(fetched_files, manifest_path, project_files, temp_dir.to_s)
         fetched_files
-      end
-
-      sig { params(workspace_info: T::Hash[String, Object]).void }
-      def validate_workspace_info!(workspace_info)
-        # Only domain errors ("no project file found") reach here; helper
-        # crashes raise from RegistryClient rather than being misreported as
-        # a missing Project.toml.
-        error_value = T.cast(workspace_info["error"], T.nilable(String))
-        has_error = !error_value.nil?
-        project_files = T.cast(workspace_info["project_files"], T.nilable(T::Array[String]))
-        no_projects = project_files.nil? || project_files.empty?
-        return unless has_error || no_projects
-
-        raise Dependabot::DependencyFileNotFound, "No Project.toml or JuliaProject.toml found."
       end
 
       sig { params(project_files: T::Array[String], base_dir: String).returns(T::Array[Dependabot::DependencyFile]) }

--- a/julia/lib/dependabot/julia/file_parser.rb
+++ b/julia/lib/dependabot/julia/file_parser.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "tempfile"
@@ -114,22 +114,20 @@ module Dependabot
         # a sibling member) resolve by path within the workspace, never from a
         # registry, so they must not be treated as updatable dependencies.
         workspace_package_uuids = parsed_projects.filter_map do |_, result|
-          T.cast(result["uuid"], T.nilable(String))
+          result.uuid
         end
 
         parsed_projects.each do |proj_file, result|
-          parsed_deps = T.cast(result["dependencies"] || [], T::Array[T.untyped])
           merge_dependencies_from_list(
-            parsed_deps,
+            result.dependencies,
             ["deps"],
             proj_file.name,
             dependencies_map,
             workspace_package_uuids
           )
 
-          parsed_weak_deps = T.cast(result["weak_dependencies"] || [], T::Array[T.untyped])
           merge_dependencies_from_list(
-            parsed_weak_deps,
+            result.weak_dependencies,
             ["weakdeps"],
             proj_file.name,
             dependencies_map,
@@ -171,34 +169,34 @@ module Dependabot
 
         result = parse_manifest_content(T.must(manifest.content))
 
-        if result["error"]
-          Dependabot.logger.warn("Failed to parse Julia manifest: #{result['error']}")
+        if result.is_a?(Dependabot::Julia::RegistryClient::Result::Failure)
+          Dependabot.logger.warn("Failed to parse Julia manifest: #{result.message}")
           return {}
         end
 
-        deps = T.cast(result["dependencies"] || [], T::Array[T.untyped])
-        deps.each_with_object({}) do |dep_info, map|
-          dep_hash = T.cast(dep_info, T::Hash[String, T.untyped])
-          uuid = T.cast(dep_hash["uuid"], T.nilable(String))
-          version = T.cast(dep_hash["version"], T.nilable(String)).to_s
-          next if uuid.nil? || version.empty?
+        result.dependencies.each_with_object({}) do |dependency, map|
+          next if dependency.version.empty?
 
-          map[uuid] = version
+          map[dependency.uuid] = dependency.version
         end
       end
 
-      sig { params(content: String).returns(T::Hash[String, T.untyped]) }
+      sig do
+        params(content: String)
+          .returns(T.any(
+                     Dependabot::Julia::RegistryClient::Result::Manifest,
+                     Dependabot::Julia::RegistryClient::Result::Failure
+                   ))
+      end
       def parse_manifest_content(content)
-        result = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
         Dir.mktmpdir("julia_manifest") do |temp_dir|
           # Written under a fixed name: version-suffixed manifests
           # (Manifest-v1.11.toml) would otherwise be skipped by Pkg when the
           # helper's Julia version doesn't match.
           manifest_path = File.join(temp_dir, "Manifest.toml")
           File.write(manifest_path, content)
-          result = registry_client.parse_manifest(manifest_path)
+          registry_client.parse_manifest(manifest_path)
         end
-        T.must(result)
       end
 
       sig { returns(T.nilable(Dependabot::DependencyFile)) }
@@ -208,7 +206,10 @@ module Dependabot
         end
       end
 
-      sig { params(proj_file: Dependabot::DependencyFile).returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig do
+        params(proj_file: Dependabot::DependencyFile)
+          .returns(T.nilable(Dependabot::Julia::RegistryClient::Result::Project))
+      end
       def parse_project_file(proj_file)
         temp_dir = Dir.mktmpdir("julia_project")
         # File names like "../Project.toml" (a workspace root fetched from a
@@ -224,7 +225,7 @@ module Dependabot
         begin
           result = registry_client.parse_project(project_path: project_path)
 
-          return nil if result["error"]
+          return nil if result.is_a?(Dependabot::Julia::RegistryClient::Result::Failure)
 
           result
         ensure
@@ -234,7 +235,7 @@ module Dependabot
 
       sig do
         params(
-          dep_list: T::Array[T.untyped],
+          dep_list: T::Array[Dependabot::Julia::RegistryClient::Result::ProjectDependency],
           groups: T::Array[String],
           file_name: String,
           dependencies_map: T::Hash[String, Dependabot::Dependency],
@@ -242,13 +243,12 @@ module Dependabot
         ).void
       end
       def merge_dependencies_from_list(dep_list, groups, file_name, dependencies_map, workspace_package_uuids)
-        dep_list.each do |dep_info|
-          dep_hash = T.cast(dep_info, T::Hash[String, T.untyped])
-          name = T.cast(dep_hash["name"], String)
+        dep_list.each do |dependency|
+          name = dependency.name
           next if name == "julia" # Skip Julia version requirement
 
-          uuid = T.cast(dep_hash["uuid"], T.nilable(String))
-          requirement_string = T.cast(dep_hash["requirement"], T.nilable(String))
+          uuid = dependency.uuid
+          requirement_string = dependency.requirement
 
           next if skip_dependency?(uuid, requirement_string, file_name, workspace_package_uuids)
 
@@ -279,7 +279,7 @@ module Dependabot
               version: nil,
               requirements: [new_requirement],
               package_manager: "julia",
-              metadata: uuid ? { julia_uuid: uuid } : {}
+              metadata: { julia_uuid: uuid }
             )
           end
         end

--- a/julia/lib/dependabot/julia/file_updater.rb
+++ b/julia/lib/dependabot/julia/file_updater.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "toml-rb"
@@ -70,7 +70,9 @@ module Dependabot
           write_all_temporary_files(updated_project_files, actual_manifest)
           result = call_julia_helper
 
-          return handle_julia_helper_error_multi(result, actual_manifest, updated_project_files) if result["error"]
+          if result.is_a?(Dependabot::Julia::RegistryClient::Result::Failure)
+            return handle_julia_helper_error_multi(result, actual_manifest, updated_project_files)
+          end
 
           build_updated_files_multi(updated_files, updated_project_files, actual_manifest, result)
         end
@@ -147,7 +149,14 @@ module Dependabot
         File.write(manifest_path, actual_manifest.content)
       end
 
-      sig { returns(T::Hash[String, T.untyped]) }
+      sig do
+        returns(
+          T.any(
+            Dependabot::Julia::RegistryClient::Result::ManifestUpdate,
+            Dependabot::Julia::RegistryClient::Result::Failure
+          )
+        )
+      end
       def call_julia_helper
         registry_client.update_manifest(
           project_path: Dir.pwd,
@@ -157,13 +166,13 @@ module Dependabot
 
       sig do
         params(
-          result: T::Hash[String, T.untyped],
+          result: Dependabot::Julia::RegistryClient::Result::Failure,
           actual_manifest: Dependabot::DependencyFile,
           updated_project_files: T::Array[T::Hash[Symbol, T.untyped]]
         ).returns(T::Array[Dependabot::DependencyFile])
       end
       def handle_julia_helper_error_multi(result, actual_manifest, updated_project_files)
-        error_message = result["error"]
+        error_message = result.message
         manifest_path = actual_manifest.name
 
         is_resolver_error = resolver_error?(error_message)
@@ -212,7 +221,7 @@ module Dependabot
           updated_files: T::Array[Dependabot::DependencyFile],
           updated_project_files: T::Array[T::Hash[Symbol, T.untyped]],
           actual_manifest: Dependabot::DependencyFile,
-          result: T::Hash[String, T.untyped]
+          result: Dependabot::Julia::RegistryClient::Result::ManifestUpdate
         ).void
       end
       def build_updated_files_multi(updated_files, updated_project_files, actual_manifest, result)
@@ -225,16 +234,10 @@ module Dependabot
           updated_files << updated_file(file: file, content: content)
         end
 
-        return unless result["manifest_content"]
-
-        updated_manifest_content = result["manifest_content"]
+        updated_manifest_content = result.manifest_content
         return unless updated_manifest_content != actual_manifest.content
 
-        manifest_for_update = if result["manifest_path"]
-                                manifest_file_for_path(result["manifest_path"])
-                              else
-                                actual_manifest
-                              end
+        manifest_for_update = manifest_file_for_path(result.manifest_path)
         updated_files << updated_file(file: manifest_for_update, content: updated_manifest_content)
       end
 

--- a/julia/lib/dependabot/julia/metadata_finder.rb
+++ b/julia/lib/dependabot/julia/metadata_finder.rb
@@ -30,10 +30,9 @@ module Dependabot
       def source_url_from_julia_helper
         uuid = T.cast(dependency.metadata[:julia_uuid], T.nilable(String))
         result = registry_client.find_package_source_url(dependency.name, uuid)
-        error = T.cast(result["error"], T.nilable(T.any(String, T::Boolean)))
-        return nil if error
+        return nil if result.is_a?(Dependabot::Julia::RegistryClient::Result::Failure)
 
-        T.cast(result["source_url"], T.nilable(String))
+        result.source_url
       rescue StandardError => e
         Dependabot.logger.warn("Failed to get source URL from Julia helper: #{e.message}")
         nil

--- a/julia/lib/dependabot/julia/package/package_details_fetcher.rb
+++ b/julia/lib/dependabot/julia/package/package_details_fetcher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "time"
@@ -89,35 +89,41 @@ module Dependabot
         def fetch_release_dates_batch(registry_client, available_versions, uuid)
           return {} if available_versions.empty?
 
-          packages_versions = [{
-            name: dependency.name,
-            uuid: uuid || "",
-            versions: available_versions
-          }]
+          packages_versions = [
+            RegistryClient::Result::PackageVersionsRequest.new(
+              name: dependency.name,
+              uuid: uuid || "",
+              versions: available_versions
+            )
+          ]
 
           result = registry_client.batch_fetch_version_release_dates(packages_versions)
-          dates_for_package = result[dependency.name] || {}
+          return {} if result.is_a?(RegistryClient::Result::Failure)
+
+          dates_for_package = result.packages[dependency.name]
+          return {} unless dates_for_package.is_a?(RegistryClient::Result::ReleaseDates)
 
           convert_dates_to_time_objects(dates_for_package)
         end
 
         sig do
           params(
-            dates_hash: T::Hash[String, T.untyped]
+            release_dates: RegistryClient::Result::ReleaseDates
           ).returns(T::Hash[String, T.nilable(Time)])
         end
-        def convert_dates_to_time_objects(dates_hash)
-          dates_hash.transform_values do |date_value|
-            convert_single_date(date_value)
+        def convert_dates_to_time_objects(release_dates)
+          release_dates.dates.transform_values do |result|
+            next if result.is_a?(RegistryClient::Result::Failure)
+
+            convert_single_date(result.release_date)
           end
         end
 
-        sig { params(date_value: T.untyped).returns(T.nilable(Time)) }
+        sig { params(date_value: T.nilable(String)).returns(T.nilable(Time)) }
         def convert_single_date(date_value)
           return nil if date_value.nil?
-          return nil if date_value.is_a?(Hash) && date_value["error"]
 
-          Time.parse(date_value.to_s)
+          Time.parse(date_value)
         rescue ArgumentError, TypeError
           nil
         end

--- a/julia/lib/dependabot/julia/registry_client.rb
+++ b/julia/lib/dependabot/julia/registry_client.rb
@@ -1,5 +1,5 @@
 # Julia Registry Client with DependabotHelper.jl integration
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "time"
@@ -10,6 +10,7 @@ require "dependabot/credential"
 require "dependabot/julia/version"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
+require_relative "registry_client/result"
 
 module Dependabot
   module Julia
@@ -36,20 +37,17 @@ module Dependabot
           function: "get_latest_version",
           args: args
         )
+        parsed_result = Result::Version.from_object(result, context: "latest version result")
 
         # Check if the result itself contains an error (package not found)
-        if result["error"]
+        if parsed_result.is_a?(Result::Failure)
           Dependabot.logger.warn(
-            "Failed to fetch latest version for #{package_name}: #{result['error']}"
+            "Failed to fetch latest version for #{package_name}: #{parsed_result.message}"
           )
           return nil
         end
 
-        # Extract version from the result structure
-        # The Julia helper returns version directly in the result
-        return nil unless result["version"]
-
-        Gem::Version.new(result["version"])
+        Gem::Version.new(parsed_result.version)
       end
 
       sig { params(package_name: String, package_uuid: T.nilable(String)).returns(T.nilable(Gem::Version)) }
@@ -64,26 +62,30 @@ module Dependabot
           function: "get_latest_version_with_custom_registries",
           args: args
         )
+        parsed_result = Result::Version.from_object(result, context: "custom registry latest version result")
 
         # Check if the result itself contains an error (package not found)
-        if result["error"]
+        if parsed_result.is_a?(Result::Failure)
           Dependabot.logger.warn(
-            "Failed to fetch latest version with custom registries for #{package_name}: #{result['error']}"
+            "Failed to fetch latest version with custom registries for #{package_name}: #{parsed_result.message}"
           )
           return nil
         end
 
-        # Extract version from the result structure
-        return nil unless result["version"]
-
-        Gem::Version.new(result["version"])
+        Gem::Version.new(parsed_result.version)
       end
 
-      sig { params(package_name: String, package_uuid: String).returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig do
+        params(package_name: String, package_uuid: String)
+          .returns(T.any(Result::PackageMetadata, Result::Failure))
+      end
       def fetch_package_metadata(package_name, package_uuid)
-        call_julia_helper(
-          function: "get_package_metadata",
-          args: { package_name: package_name, package_uuid: package_uuid }
+        Result::PackageMetadata.from_object(
+          call_julia_helper(
+            function: "get_package_metadata",
+            args: { package_name: package_name, package_uuid: package_uuid }
+          ),
+          context: "package metadata result"
         )
       end
 
@@ -91,55 +93,48 @@ module Dependabot
         params(
           project_path: String,
           manifest_path: T.nilable(String)
-        ).returns(T::Hash[String, T.untyped])
+        ).returns(T.any(Result::Project, Result::Failure))
       end
       def parse_project(project_path:, manifest_path: nil)
         args = { project_path: project_path }
         args[:manifest_path] = manifest_path if manifest_path
 
-        call_julia_helper(
-          function: "parse_project",
-          args: args
+        Result::Project.from_object(
+          call_julia_helper(
+            function: "parse_project",
+            args: args
+          )
         )
       end
 
-      sig { params(manifest_path: String).returns(T::Hash[String, T.untyped]) }
+      sig { params(manifest_path: String).returns(T.any(Result::Manifest, Result::Failure)) }
       def parse_manifest(manifest_path)
-        call_julia_helper(
-          function: "parse_manifest",
-          args: { manifest_path: manifest_path }
+        Result::Manifest.from_object(
+          call_julia_helper(
+            function: "parse_manifest",
+            args: { manifest_path: manifest_path }
+          )
         )
       end
 
-      sig { params(directory: String).returns(T::Hash[String, String]) }
+      sig { params(directory: String).returns(T.any(Result::EnvironmentFiles, Result::Failure)) }
       def find_environment_files(directory)
-        result = call_julia_helper(
-          function: "find_environment_files",
-          args: { directory: directory }
+        Result::EnvironmentFiles.from_object(
+          call_julia_helper(
+            function: "find_environment_files",
+            args: { directory: directory }
+          )
         )
-
-        return {} if result["error"]
-
-        {
-          "project_file" => result["project_file"],
-          "manifest_file" => result["manifest_file"]
-        }
       end
 
-      sig { params(directory: String).returns(T::Hash[String, T.untyped]) }
+      sig { params(directory: String).returns(T.any(Result::WorkspaceFiles, Result::Failure)) }
       def find_workspace_project_files(directory)
-        result = call_julia_helper(
-          function: "find_workspace_project_files",
-          args: { directory: directory }
+        Result::WorkspaceFiles.from_object(
+          call_julia_helper(
+            function: "find_workspace_project_files",
+            args: { directory: directory }
+          )
         )
-
-        return { "error" => result["error"] } if result["error"]
-
-        {
-          "project_files" => result["project_files"] || [],
-          "manifest_file" => result["manifest_file"] || "",
-          "workspace_root" => result["workspace_root"] || ""
-        }
       end
 
       sig do
@@ -158,18 +153,24 @@ module Dependabot
             uuid: uuid
           }
         )
+        parsed_result = Result::Version.from_object(result, context: "manifest version result")
 
-        result["version"] unless result["error"]
+        parsed_result.version unless parsed_result.is_a?(Result::Failure)
       end
 
-      sig { params(package_name: String, package_uuid: T.nilable(String)).returns(T::Hash[String, T.untyped]) }
+      sig do
+        params(package_name: String, package_uuid: T.nilable(String))
+          .returns(T.any(Result::Source, Result::Failure))
+      end
       def find_package_source_url(package_name, package_uuid = nil)
         args = { package_name: package_name }
         args[:package_uuid] = package_uuid if package_uuid
 
-        call_julia_helper(
-          function: "find_package_source_url",
-          args: args
+        Result::Source.from_object(
+          call_julia_helper(
+            function: "find_package_source_url",
+            args: args
+          )
         )
       end
 
@@ -177,15 +178,17 @@ module Dependabot
         params(
           project_path: String,
           updates: T::Hash[String, T::Hash[String, String]]
-        ).returns(T::Hash[String, T.untyped])
+        ).returns(T.any(Result::ManifestUpdate, Result::Failure))
       end
       def update_manifest(project_path:, updates:)
-        call_julia_helper(
-          function: "update_manifest",
-          args: {
-            project_path: project_path,
-            updates: updates
-          }
+        Result::ManifestUpdate.from_object(
+          call_julia_helper(
+            function: "update_manifest",
+            args: {
+              project_path: project_path,
+              updates: updates
+            }
+          )
         )
       end
 
@@ -199,14 +202,16 @@ module Dependabot
             package_uuid: package_uuid
           }
         )
+        parsed_result = Result::ReleaseDate.from_object(result, context: "version release date result")
 
         # Check if the result contains an error
-        return nil if result["error"]
+        return nil if parsed_result.is_a?(Result::Failure)
 
         # Parse the release date if available
-        return nil unless result["release_date"]
+        release_date = parsed_result.release_date
+        return nil unless release_date
 
-        Time.parse(result["release_date"])
+        Time.parse(release_date)
       rescue ArgumentError => e
         Dependabot.logger.warn("Failed to parse release date for #{package_name} v#{version}: #{e.message}")
         nil
@@ -224,18 +229,17 @@ module Dependabot
           function: "get_available_versions",
           args: args
         )
+        parsed_result = Result::AvailableVersions.from_object(result, context: "available versions result")
 
         # Check if the result contains an error
-        if result["error"]
-          Dependabot.logger.warn("Failed to fetch available versions for #{package_name}: #{result['error']}")
+        if parsed_result.is_a?(Result::Failure)
+          Dependabot.logger.warn(
+            "Failed to fetch available versions for #{package_name}: #{parsed_result.message}"
+          )
           return []
         end
 
-        # Extract versions array from the result
-        versions = result["versions"]
-        return [] unless versions.is_a?(Array)
-
-        versions.map(&:to_s)
+        parsed_result.versions
       end
 
       sig { params(package_name: String, package_uuid: T.nilable(String)).returns(T::Array[String]) }
@@ -250,78 +254,83 @@ module Dependabot
           function: "get_available_versions_with_custom_registries",
           args: args
         )
+        parsed_result = Result::AvailableVersions.from_object(
+          result,
+          context: "custom registry available versions result"
+        )
 
         # Check if the result contains an error
-        if result["error"]
+        if parsed_result.is_a?(Result::Failure)
           Dependabot.logger.warn(
-            "Failed to fetch available versions with custom registries for #{package_name}: #{result['error']}"
+            "Failed to fetch available versions with custom registries for #{package_name}: #{parsed_result.message}"
           )
           return []
         end
 
-        # Extract versions array from the result
-        versions = result["versions"]
-        return [] unless versions.is_a?(Array)
-
-        versions.map(&:to_s)
+        parsed_result.versions
       end
 
       # ============================================================================
       # BATCH OPERATIONS
       # ============================================================================
 
-      sig { params(dependencies: T::Array[Dependabot::Dependency]).returns(T::Hash[String, T.untyped]) }
+      sig do
+        params(dependencies: T::Array[Dependabot::Dependency])
+          .returns(T.any(Result::PackageInfoBatch, Result::Failure))
+      end
       def batch_fetch_package_info(dependencies)
-        return {} if dependencies.empty?
+        return Result::PackageInfoBatch.new(packages: {}) if dependencies.empty?
 
         packages = dependencies.map do |dep|
           {
             name: dep.name,
-            uuid: dep.metadata[:julia_uuid] || ""
+            uuid: T.cast(dep.metadata[:julia_uuid], T.nilable(String)) || ""
           }
         end
 
-        call_julia_helper(
-          function: "batch_get_package_info",
-          args: { packages: packages }
+        Result::PackageInfoBatch.from_object(
+          call_julia_helper(
+            function: "batch_get_package_info",
+            args: { packages: packages }
+          )
         )
       end
 
       sig do
         params(
-          packages_versions: T::Array[T::Hash[Symbol, T.untyped]]
-        ).returns(T::Hash[String, T::Hash[String, T.nilable(String)]])
+          packages_versions: T::Array[Result::PackageVersionsRequest]
+        ).returns(T.any(Result::ReleaseDatesBatch, Result::Failure))
       end
       def batch_fetch_version_release_dates(packages_versions)
-        return {} if packages_versions.empty?
+        return Result::ReleaseDatesBatch.new(packages: {}) if packages_versions.empty?
 
-        result = call_julia_helper(
-          function: "batch_get_version_release_dates",
-          args: { packages_versions: packages_versions }
+        Result::ReleaseDatesBatch.from_object(
+          call_julia_helper(
+            function: "batch_get_version_release_dates",
+            args: { packages_versions: packages_versions.map(&:to_h) }
+          )
         )
-
-        # Convert the result to a more Ruby-friendly format
-        result.transform_values do |dates|
-          next dates if dates.is_a?(Hash) && dates["error"]
-
-          dates.is_a?(Hash) ? dates : {}
-        end
       end
 
-      sig { params(dependencies: T::Array[Dependabot::Dependency]).returns(T::Hash[String, T.untyped]) }
+      sig do
+        params(dependencies: T::Array[Dependabot::Dependency])
+          .returns(T.any(Result::AvailableVersionsBatch, Result::Failure))
+      end
       def batch_fetch_available_versions(dependencies)
-        return {} if dependencies.empty?
+        return Result::AvailableVersionsBatch.new(packages: {}) if dependencies.empty?
 
         packages = dependencies.map do |dep|
           {
             name: dep.name,
-            uuid: dep.metadata[:julia_uuid] || ""
+            uuid: T.cast(dep.metadata[:julia_uuid], T.nilable(String)) || ""
           }
         end
 
-        call_julia_helper(
-          function: "batch_get_available_versions",
-          args: { packages: packages }
+        Result::AvailableVersionsBatch.from_object(
+          call_julia_helper(
+            function: "batch_get_available_versions",
+            args: { packages: packages }
+          )
         )
       end
 
@@ -341,23 +350,20 @@ module Dependabot
       sig do
         params(
           function: String,
-          args: T::Hash[Symbol, T.untyped]
-        ).returns(T::Hash[String, T.untyped])
+          args: Object
+        ).returns(Object)
       end
       def call_julia_helper(function:, args:)
         # Use the main julia helpers directory as project (contains Project.toml with DependabotHelper in [sources])
         julia_project_dir = File.dirname(julia_helper_script)
         julia_command = "julia --project=#{julia_project_dir} #{julia_helper_script}"
 
-        T.cast(
-          SharedHelpers.run_helper_subprocess(
-            command: julia_command,
-            function: function,
-            args: args,
-            env: julia_env,
-            allow_unsafe_shell_command: true
-          ),
-          T::Hash[String, T.untyped]
+        SharedHelpers.run_helper_subprocess(
+          command: julia_command,
+          function: function,
+          args: args,
+          env: julia_env,
+          allow_unsafe_shell_command: true
         )
       end
 
@@ -414,12 +420,13 @@ module Dependabot
         token = credential["token"]
         return unless token
 
-        host = URI.parse(credential.fetch("url")).host
+        host = URI.parse(T.cast(credential.fetch("url"), String)).host
         return unless host
 
         auth_dir = File.join(julia_user_depot, "servers", host)
         FileUtils.mkdir_p(auth_dir)
-        File.write(File.join(auth_dir, "auth.toml"), TomlRB.dump({ "access_token" => token }))
+        auth_toml = T.cast(TomlRB.dump({ "access_token" => token }), String)
+        File.write(File.join(auth_dir, "auth.toml"), auth_toml)
       rescue URI::InvalidURIError => e
         Dependabot.logger.warn("Invalid julia_registry URL: #{e.message}")
       end

--- a/julia/lib/dependabot/julia/registry_client.rb
+++ b/julia/lib/dependabot/julia/registry_client.rb
@@ -10,12 +10,13 @@ require "dependabot/credential"
 require "dependabot/julia/version"
 require "dependabot/shared_helpers"
 require "dependabot/errors"
-require_relative "registry_client/result"
 
 module Dependabot
   module Julia
     class RegistryClient
       extend T::Sig
+
+      require_relative "registry_client/result"
 
       sig do
         params(credentials: T::Array[Dependabot::Credential], custom_registries: T::Array[T::Hash[Symbol, String]]).void

--- a/julia/lib/dependabot/julia/registry_client/result.rb
+++ b/julia/lib/dependabot/julia/registry_client/result.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "sorbet-runtime"
+require "dependabot/julia/registry_client"
 
 module Dependabot
   module Julia
@@ -98,11 +99,12 @@ module Dependabot
           const :message, String
         end
 
-        sig { params(hash: ObjectHash, context: String).returns(T.nilable(Failure)) }
-        def self.failure_from(hash, context)
-          return unless hash.key?("error")
+        sig { params(hash: ObjectHash, _context: String).returns(T.nilable(Failure)) }
+        def self.failure_from(hash, _context)
+          error = hash["error"]
+          return unless hash.length == 1 && error.is_a?(String)
 
-          Failure.new(message: ValueParser.string(hash, "error", context))
+          Failure.new(message: error)
         end
 
         class Version < T::ImmutableStruct

--- a/julia/lib/dependabot/julia/registry_client/result.rb
+++ b/julia/lib/dependabot/julia/registry_client/result.rb
@@ -1,0 +1,561 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+module Dependabot
+  module Julia
+    class RegistryClient
+      module Result
+        extend T::Sig
+
+        ObjectHash = T.type_alias { T::Hash[String, Object] }
+
+        module ValueParser
+          extend T::Sig
+
+          sig { params(value: Object, context: String).returns(ObjectHash) }
+          def self.object_hash(value, context)
+            raise TypeError, "#{context} must be an object" unless value.is_a?(Hash)
+
+            result = T.let({}, ObjectHash)
+            value.each do |raw_key, raw_value|
+              key = T.cast(raw_key, Object)
+              raise TypeError, "#{context} keys must be strings" unless key.is_a?(String)
+
+              result[key] = T.cast(raw_value, Object)
+            end
+            result
+          end
+
+          sig { params(hash: ObjectHash, key: String, context: String).returns(Object) }
+          def self.value(hash, key, context)
+            raise TypeError, "#{context} #{key} is required" unless hash.key?(key)
+
+            hash[key]
+          end
+
+          sig { params(hash: ObjectHash, key: String, context: String).returns(String) }
+          def self.string(hash, key, context)
+            string_value(value(hash, key, context), "#{context} #{key}")
+          end
+
+          sig { params(hash: ObjectHash, key: String, context: String).returns(T.nilable(String)) }
+          def self.nilable_string(hash, key, context)
+            optional_string_value(value(hash, key, context), "#{context} #{key}")
+          end
+
+          sig { params(hash: ObjectHash, key: String, context: String).returns(T.nilable(String)) }
+          def self.optional_string(hash, key, context)
+            optional_string_value(hash[key], "#{context} #{key}")
+          end
+
+          sig { params(value: Object, context: String).returns(String) }
+          def self.string_value(value, context)
+            return value if value.is_a?(String)
+
+            raise TypeError, "#{context} must be a string"
+          end
+
+          sig { params(value: Object, context: String).returns(T.nilable(String)) }
+          def self.optional_string_value(value, context)
+            return if value.nil?
+            return value if value.is_a?(String)
+
+            raise TypeError, "#{context} must be a string or nil"
+          end
+
+          sig { params(value: Object, context: String).returns(T::Array[String]) }
+          def self.string_array(value, context)
+            raise TypeError, "#{context} must be an array" unless value.is_a?(Array)
+
+            value.map do |item|
+              string_value(T.cast(item, Object), "#{context} entry")
+            end
+          end
+
+          sig { params(value: Object, context: String).returns(T::Array[ObjectHash]) }
+          def self.object_array(value, context)
+            raise TypeError, "#{context} must be an array" unless value.is_a?(Array)
+
+            value.map do |item|
+              object_hash(T.cast(item, Object), "#{context} entry")
+            end
+          end
+
+          sig { params(value: Object, context: String).returns(T::Hash[String, String]) }
+          def self.string_map(value, context)
+            result = T.let({}, T::Hash[String, String])
+            object_hash(value, context).each do |key, raw_value|
+              result[key] = string_value(raw_value, "#{context} #{key}")
+            end
+            result
+          end
+        end
+        private_constant :ValueParser
+
+        class Failure < T::ImmutableStruct
+          const :message, String
+        end
+
+        sig { params(hash: ObjectHash, context: String).returns(T.nilable(Failure)) }
+        def self.failure_from(hash, context)
+          return unless hash.key?("error")
+
+          Failure.new(message: ValueParser.string(hash, "error", context))
+        end
+
+        class Version < T::ImmutableStruct
+          extend T::Sig
+
+          const :version, String
+          const :package_uuid, T.nilable(String), default: nil
+
+          sig { params(value: Object, context: String).returns(T.any(Version, Failure)) }
+          def self.from_object(value, context:)
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            new(
+              version: ValueParser.string(hash, "version", context),
+              package_uuid: ValueParser.optional_string(hash, "package_uuid", context)
+            )
+          end
+
+          sig { params(value: Object, context: String).returns(T.any(Version, Failure)) }
+          def self.from_batch_value(value, context:)
+            return new(version: value) if value.is_a?(String)
+
+            from_object(value, context: context)
+          end
+        end
+
+        class PackageMetadata < T::ImmutableStruct
+          extend T::Sig
+
+          const :name, String
+          const :uuid, String
+          const :latest_version, String
+          const :available_versions, T::Array[String]
+
+          sig { params(value: Object, context: String).returns(T.any(PackageMetadata, Failure)) }
+          def self.from_object(value, context:)
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            new(
+              name: ValueParser.string(hash, "name", context),
+              uuid: ValueParser.string(hash, "uuid", context),
+              latest_version: ValueParser.string(hash, "latest_version", context),
+              available_versions: ValueParser.string_array(
+                ValueParser.value(hash, "available_versions", context),
+                "#{context} available_versions"
+              )
+            )
+          end
+        end
+
+        class ProjectDependency < T::ImmutableStruct
+          extend T::Sig
+
+          const :name, String
+          const :uuid, String
+          const :requirement, T.nilable(String), default: nil
+
+          sig { params(value: Object).returns(ProjectDependency) }
+          def self.from_object(value)
+            context = "project dependency"
+            hash = ValueParser.object_hash(value, context)
+
+            new(
+              name: ValueParser.string(hash, "name", context),
+              uuid: ValueParser.string(hash, "uuid", context),
+              requirement: ValueParser.optional_string(hash, "requirement", context)
+            )
+          end
+        end
+
+        class Project < T::ImmutableStruct
+          extend T::Sig
+
+          const :name, T.nilable(String)
+          const :version, T.nilable(String)
+          const :uuid, T.nilable(String)
+          const :julia_version, String
+          const :dependencies, T::Array[ProjectDependency]
+          const :weak_dependencies, T::Array[ProjectDependency]
+          const :project_path, String
+
+          sig { params(value: Object).returns(T.any(Project, Failure)) }
+          def self.from_object(value)
+            context = "project result"
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            new(
+              name: ValueParser.nilable_string(hash, "name", context),
+              version: ValueParser.nilable_string(hash, "version", context),
+              uuid: ValueParser.nilable_string(hash, "uuid", context),
+              julia_version: ValueParser.string(hash, "julia_version", context),
+              dependencies: parse_dependencies(hash, "dependencies", context),
+              weak_dependencies: parse_dependencies(hash, "weak_dependencies", context),
+              project_path: ValueParser.string(hash, "project_path", context)
+            )
+          end
+
+          sig do
+            params(
+              hash: ObjectHash,
+              key: String,
+              context: String
+            ).returns(T::Array[ProjectDependency])
+          end
+          def self.parse_dependencies(hash, key, context)
+            ValueParser.object_array(
+              ValueParser.value(hash, key, context),
+              "#{context} #{key}"
+            ).map { |dependency| ProjectDependency.from_object(dependency) }
+          end
+          private_class_method :parse_dependencies
+        end
+
+        class ManifestDependency < T::ImmutableStruct
+          extend T::Sig
+
+          const :name, String
+          const :uuid, String
+          const :version, String
+          const :tree_hash, String
+          const :repo_url, String
+          const :repo_rev, String
+          const :path, String
+          const :dependencies, T::Hash[String, String]
+
+          sig { params(value: Object).returns(ManifestDependency) }
+          def self.from_object(value)
+            context = "manifest dependency"
+            hash = ValueParser.object_hash(value, context)
+            raw_dependencies = hash["dependencies"]
+            dependencies = if raw_dependencies.nil?
+                             {}
+                           else
+                             ValueParser.string_map(raw_dependencies, "#{context} dependencies")
+                           end
+
+            new(
+              name: ValueParser.string(hash, "name", context),
+              uuid: ValueParser.string(hash, "uuid", context),
+              version: ValueParser.string(hash, "version", context),
+              tree_hash: ValueParser.string(hash, "tree_hash", context),
+              repo_url: ValueParser.string(hash, "repo_url", context),
+              repo_rev: ValueParser.string(hash, "repo_rev", context),
+              path: ValueParser.string(hash, "path", context),
+              dependencies: dependencies
+            )
+          end
+        end
+
+        class Manifest < T::ImmutableStruct
+          extend T::Sig
+
+          const :dependencies, T::Array[ManifestDependency]
+          const :manifest_path, String
+
+          sig { params(value: Object).returns(T.any(Manifest, Failure)) }
+          def self.from_object(value)
+            context = "manifest result"
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            dependencies = ValueParser.object_array(
+              ValueParser.value(hash, "dependencies", context),
+              "#{context} dependencies"
+            ).map { |dependency| ManifestDependency.from_object(dependency) }
+
+            new(
+              dependencies: dependencies,
+              manifest_path: ValueParser.string(hash, "manifest_path", context)
+            )
+          end
+        end
+
+        class EnvironmentFiles < T::ImmutableStruct
+          extend T::Sig
+
+          const :project_file, String
+          const :manifest_file, String
+
+          sig { params(value: Object).returns(T.any(EnvironmentFiles, Failure)) }
+          def self.from_object(value)
+            context = "environment files result"
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            new(
+              project_file: ValueParser.string(hash, "project_file", context),
+              manifest_file: ValueParser.string(hash, "manifest_file", context)
+            )
+          end
+        end
+
+        class WorkspaceFiles < T::ImmutableStruct
+          extend T::Sig
+
+          const :project_files, T::Array[String]
+          const :manifest_file, String
+          const :workspace_root, String
+
+          sig { params(value: Object).returns(T.any(WorkspaceFiles, Failure)) }
+          def self.from_object(value)
+            context = "workspace files result"
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            new(
+              project_files: ValueParser.string_array(
+                ValueParser.value(hash, "project_files", context),
+                "#{context} project_files"
+              ),
+              manifest_file: ValueParser.string(hash, "manifest_file", context),
+              workspace_root: ValueParser.string(hash, "workspace_root", context)
+            )
+          end
+        end
+
+        class Source < T::ImmutableStruct
+          extend T::Sig
+
+          const :source_url, String
+          const :source_type, String
+          const :package_uuid, String
+
+          sig { params(value: Object).returns(T.any(Source, Failure)) }
+          def self.from_object(value)
+            context = "package source result"
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            new(
+              source_url: ValueParser.string(hash, "source_url", context),
+              source_type: ValueParser.string(hash, "source_type", context),
+              package_uuid: ValueParser.string(hash, "package_uuid", context)
+            )
+          end
+        end
+
+        class ManifestUpdate < T::ImmutableStruct
+          extend T::Sig
+
+          const :manifest_content, String
+          const :manifest_path, String
+
+          sig { params(value: Object).returns(T.any(ManifestUpdate, Failure)) }
+          def self.from_object(value)
+            context = "manifest update result"
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            new(
+              manifest_content: ValueParser.string(hash, "manifest_content", context),
+              manifest_path: ValueParser.string(hash, "manifest_path", context)
+            )
+          end
+        end
+
+        class AvailableVersions < T::ImmutableStruct
+          extend T::Sig
+
+          const :versions, T::Array[String]
+
+          sig { params(value: Object, context: String).returns(T.any(AvailableVersions, Failure)) }
+          def self.from_object(value, context:)
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            new(
+              versions: ValueParser.string_array(
+                ValueParser.value(hash, "versions", context),
+                "#{context} versions"
+              )
+            )
+          end
+
+          sig { params(value: Object, context: String).returns(T.any(AvailableVersions, Failure)) }
+          def self.from_batch_value(value, context:)
+            return new(versions: ValueParser.string_array(value, context)) if value.is_a?(Array)
+
+            from_object(value, context: context)
+          end
+        end
+
+        class ReleaseDate < T::ImmutableStruct
+          extend T::Sig
+
+          const :release_date, T.nilable(String)
+
+          sig { params(value: Object, context: String).returns(T.any(ReleaseDate, Failure)) }
+          def self.from_object(value, context:)
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            new(release_date: ValueParser.nilable_string(hash, "release_date", context))
+          end
+
+          sig { params(value: Object, context: String).returns(T.any(ReleaseDate, Failure)) }
+          def self.from_batch_value(value, context:)
+            return new(release_date: nil) if value.nil?
+            return new(release_date: value) if value.is_a?(String)
+
+            from_object(value, context: context)
+          end
+        end
+
+        class PackageInfo < T::ImmutableStruct
+          extend T::Sig
+
+          const :available_versions, T.any(AvailableVersions, Failure)
+          const :latest_version, T.any(Version, Failure)
+          const :metadata, T.nilable(T.any(PackageMetadata, Failure)), default: nil
+
+          sig { params(value: Object, context: String).returns(T.any(PackageInfo, Failure)) }
+          def self.from_object(value, context:)
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            metadata = if hash.key?("metadata")
+                         PackageMetadata.from_object(
+                           ValueParser.value(hash, "metadata", context),
+                           context: "#{context} metadata"
+                         )
+                       end
+
+            new(
+              available_versions: AvailableVersions.from_batch_value(
+                ValueParser.value(hash, "available_versions", context),
+                context: "#{context} available_versions"
+              ),
+              latest_version: Version.from_batch_value(
+                ValueParser.value(hash, "latest_version", context),
+                context: "#{context} latest_version"
+              ),
+              metadata: metadata
+            )
+          end
+        end
+
+        class PackageInfoBatch < T::ImmutableStruct
+          extend T::Sig
+
+          const :packages, T::Hash[String, T.any(PackageInfo, Failure)]
+
+          sig { params(value: Object).returns(T.any(PackageInfoBatch, Failure)) }
+          def self.from_object(value)
+            context = "batch package info result"
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            packages = T.let({}, T::Hash[String, T.any(PackageInfo, Failure)])
+            hash.each do |name, raw_info|
+              packages[name] = PackageInfo.from_object(raw_info, context: "#{context} #{name}")
+            end
+            new(packages: packages)
+          end
+        end
+
+        class ReleaseDates < T::ImmutableStruct
+          extend T::Sig
+
+          const :dates, T::Hash[String, T.any(ReleaseDate, Failure)]
+
+          sig { params(value: Object, context: String).returns(T.any(ReleaseDates, Failure)) }
+          def self.from_object(value, context:)
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            dates = T.let({}, T::Hash[String, T.any(ReleaseDate, Failure)])
+            hash.each do |version, raw_date|
+              dates[version] = ReleaseDate.from_batch_value(raw_date, context: "#{context} #{version}")
+            end
+            new(dates: dates)
+          end
+        end
+
+        class ReleaseDatesBatch < T::ImmutableStruct
+          extend T::Sig
+
+          const :packages, T::Hash[String, T.any(ReleaseDates, Failure)]
+
+          sig { params(value: Object).returns(T.any(ReleaseDatesBatch, Failure)) }
+          def self.from_object(value)
+            context = "batch release dates result"
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            packages = T.let({}, T::Hash[String, T.any(ReleaseDates, Failure)])
+            hash.each do |name, raw_dates|
+              packages[name] = ReleaseDates.from_object(raw_dates, context: "#{context} #{name}")
+            end
+            new(packages: packages)
+          end
+        end
+
+        class AvailableVersionsBatch < T::ImmutableStruct
+          extend T::Sig
+
+          const :packages, T::Hash[String, T.any(AvailableVersions, Failure)]
+
+          sig { params(value: Object).returns(T.any(AvailableVersionsBatch, Failure)) }
+          def self.from_object(value)
+            context = "batch available versions result"
+            hash = ValueParser.object_hash(value, context)
+            failure = Result.failure_from(hash, context)
+            return failure if failure
+
+            packages = T.let({}, T::Hash[String, T.any(AvailableVersions, Failure)])
+            hash.each do |name, raw_versions|
+              packages[name] = AvailableVersions.from_object(
+                raw_versions,
+                context: "#{context} #{name}"
+              )
+            end
+            new(packages: packages)
+          end
+        end
+
+        class PackageVersionsRequest < T::ImmutableStruct
+          extend T::Sig
+
+          const :name, String
+          const :uuid, String
+          const :versions, T::Array[String]
+
+          sig { returns(T::Hash[Symbol, Object]) }
+          def to_h
+            T.let(
+              {
+                name: name,
+                uuid: uuid,
+                versions: versions
+              },
+              T::Hash[Symbol, Object]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/julia/spec/dependabot/julia/file_fetcher_spec.rb
+++ b/julia/spec/dependabot/julia/file_fetcher_spec.rb
@@ -68,11 +68,13 @@ RSpec.describe Dependabot::Julia::FileFetcher do
       before do
         allow(registry_client).to receive(:find_workspace_project_files)
           .with("/tmp/test")
-          .and_return({
-            "project_files" => ["/tmp/test/Project.toml"],
-            "manifest_file" => "/tmp/test/Manifest.toml",
-            "workspace_root" => "/tmp/test"
-          })
+          .and_return(
+            Dependabot::Julia::RegistryClient::Result::WorkspaceFiles.new(
+              project_files: ["/tmp/test/Project.toml"],
+              manifest_file: "/tmp/test/Manifest.toml",
+              workspace_root: "/tmp/test"
+            )
+          )
 
         allow(file_fetcher_instance).to receive(:fetch_file_if_present)
           .with("Project.toml")
@@ -94,11 +96,13 @@ RSpec.describe Dependabot::Julia::FileFetcher do
       before do
         allow(registry_client).to receive(:find_workspace_project_files)
           .with("/tmp/test")
-          .and_return({
-            "project_files" => ["/tmp/test/Project.toml"],
-            "manifest_file" => "",
-            "workspace_root" => "/tmp/test"
-          })
+          .and_return(
+            Dependabot::Julia::RegistryClient::Result::WorkspaceFiles.new(
+              project_files: ["/tmp/test/Project.toml"],
+              manifest_file: "",
+              workspace_root: "/tmp/test"
+            )
+          )
 
         allow(file_fetcher_instance).to receive(:fetch_file_if_present)
           .with("Project.toml")
@@ -128,15 +132,17 @@ RSpec.describe Dependabot::Julia::FileFetcher do
       before do
         allow(registry_client).to receive(:find_workspace_project_files)
           .with("/tmp/test")
-          .and_return({
-            "project_files" => [
-              "/tmp/test/Project.toml",
-              "/tmp/test/docs/Project.toml",
-              "/tmp/test/test/Project.toml"
-            ],
-            "manifest_file" => "/tmp/test/Manifest.toml",
-            "workspace_root" => "/tmp/test"
-          })
+          .and_return(
+            Dependabot::Julia::RegistryClient::Result::WorkspaceFiles.new(
+              project_files: [
+                "/tmp/test/Project.toml",
+                "/tmp/test/docs/Project.toml",
+                "/tmp/test/test/Project.toml"
+              ],
+              manifest_file: "/tmp/test/Manifest.toml",
+              workspace_root: "/tmp/test"
+            )
+          )
 
         allow(file_fetcher_instance).to receive(:fetch_file_if_present)
           .with("Project.toml")
@@ -178,11 +184,13 @@ RSpec.describe Dependabot::Julia::FileFetcher do
       before do
         allow(registry_client).to receive(:find_workspace_project_files)
           .with("/tmp/test")
-          .and_return({
-            "project_files" => ["/tmp/test/Project.toml"],
-            "manifest_file" => "/tmp/test/Manifest-v1.12.toml",
-            "workspace_root" => "/tmp/test"
-          })
+          .and_return(
+            Dependabot::Julia::RegistryClient::Result::WorkspaceFiles.new(
+              project_files: ["/tmp/test/Project.toml"],
+              manifest_file: "/tmp/test/Manifest-v1.12.toml",
+              workspace_root: "/tmp/test"
+            )
+          )
 
         allow(file_fetcher_instance).to receive(:fetch_file_if_present)
           .with("Project.toml")
@@ -204,7 +212,9 @@ RSpec.describe Dependabot::Julia::FileFetcher do
       before do
         allow(registry_client).to receive(:find_workspace_project_files)
           .with("/tmp/test")
-          .and_return({ "error" => "No project file found", "project_files" => [] })
+          .and_return(
+            Dependabot::Julia::RegistryClient::Result::Failure.new(message: "No project file found")
+          )
       end
 
       it "raises an error" do

--- a/julia/spec/dependabot/julia/file_updater_spec.rb
+++ b/julia/spec/dependabot/julia/file_updater_spec.rb
@@ -255,10 +255,10 @@ RSpec.describe Dependabot::Julia::FileUpdater do
 
       before do
         allow(registry_client_double).to receive(:update_manifest).and_return(
-          {
-            "manifest_content" => updated_manifest_content,
-            "manifest_path" => "Manifest.toml"
-          }
+          Dependabot::Julia::RegistryClient::Result::ManifestUpdate.new(
+            manifest_content: updated_manifest_content,
+            manifest_path: "Manifest.toml"
+          )
         )
       end
 
@@ -303,10 +303,10 @@ RSpec.describe Dependabot::Julia::FileUpdater do
 
       before do
         allow(registry_client_double).to receive(:update_manifest).and_return(
-          {
-            "manifest_content" => updated_manifest_content,
-            "manifest_path" => "../Manifest.toml"
-          }
+          Dependabot::Julia::RegistryClient::Result::ManifestUpdate.new(
+            manifest_content: updated_manifest_content,
+            manifest_path: "../Manifest.toml"
+          )
         )
       end
 
@@ -337,10 +337,10 @@ RSpec.describe Dependabot::Julia::FileUpdater do
 
       before do
         allow(registry_client_double).to receive(:update_manifest).and_return(
-          {
-            "manifest_content" => updated_manifest_content,
-            "manifest_path" => "Manifest-v1.12.toml"
-          }
+          Dependabot::Julia::RegistryClient::Result::ManifestUpdate.new(
+            manifest_content: updated_manifest_content,
+            manifest_path: "Manifest-v1.12.toml"
+          )
         )
       end
 
@@ -356,9 +356,9 @@ RSpec.describe Dependabot::Julia::FileUpdater do
     context "when Julia helper returns a resolver error" do
       before do
         allow(registry_client_double).to receive(:update_manifest).and_return(
-          {
-            "error" => "Unsatisfiable requirements detected for package JSON"
-          }
+          Dependabot::Julia::RegistryClient::Result::Failure.new(
+            message: "Unsatisfiable requirements detected for package JSON"
+          )
         )
       end
 

--- a/julia/spec/dependabot/julia/package/package_details_fetcher_spec.rb
+++ b/julia/spec/dependabot/julia/package/package_details_fetcher_spec.rb
@@ -49,19 +49,26 @@ RSpec.describe Dependabot::Julia::Package::PackageDetailsFetcher do
 
       # Mock the batch operation for release dates
       allow(registry_client).to receive(:batch_fetch_version_release_dates)
-        .with([{
-          name: "Example",
-          uuid: "7876af07-990d-54b4-ab0e-23690620f79a",
-          versions: available_versions
-        }])
-        .and_return({
-          "Example" => {
-            "0.5.0" => release_date1.to_s,
-            "0.5.1" => release_date2.to_s,
-            "0.5.2" => nil,
-            "0.5.3" => release_date2.to_s
-          }
-        })
+        .and_return(
+          Dependabot::Julia::RegistryClient::Result::ReleaseDatesBatch.new(
+            packages: {
+              "Example" => Dependabot::Julia::RegistryClient::Result::ReleaseDates.new(
+                dates: {
+                  "0.5.0" => Dependabot::Julia::RegistryClient::Result::ReleaseDate.new(
+                    release_date: release_date1.to_s
+                  ),
+                  "0.5.1" => Dependabot::Julia::RegistryClient::Result::ReleaseDate.new(
+                    release_date: release_date2.to_s
+                  ),
+                  "0.5.2" => Dependabot::Julia::RegistryClient::Result::ReleaseDate.new(release_date: nil),
+                  "0.5.3" => Dependabot::Julia::RegistryClient::Result::ReleaseDate.new(
+                    release_date: release_date2.to_s
+                  )
+                }
+              )
+            }
+          )
+        )
     end
 
     it "returns an array of PackageRelease objects" do

--- a/julia/spec/dependabot/julia/registry_client_batch_integration_spec.rb
+++ b/julia/spec/dependabot/julia/registry_client_batch_integration_spec.rb
@@ -32,14 +32,13 @@ RSpec.describe Dependabot::Julia::RegistryClient, :julia_helpers do
 
         result = client.batch_fetch_package_info(dependencies)
 
-        expect(result).to be_a(Hash)
-        expect(result["Example"]).to be_a(Hash)
-        expect(result["Example"]["available_versions"]).to be_an(Array)
-        expect(result["Example"]["latest_version"]).to be_a(String)
-
-        expect(result["JSON"]).to be_a(Hash)
-        expect(result["JSON"]["available_versions"]).to be_an(Array)
-        expect(result["JSON"]["latest_version"]).to be_a(String)
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::PackageInfoBatch)
+        expect(result.packages.fetch("Example")).to be_a(
+          Dependabot::Julia::RegistryClient::Result::PackageInfo
+        )
+        expect(result.packages.fetch("JSON")).to be_a(
+          Dependabot::Julia::RegistryClient::Result::PackageInfo
+        )
       end
     end
 
@@ -64,39 +63,34 @@ RSpec.describe Dependabot::Julia::RegistryClient, :julia_helpers do
 
         result = client.batch_fetch_available_versions(dependencies)
 
-        expect(result).to be_a(Hash)
-        expect(result["Example"]).to have_key("versions")
-        expect(result["Example"]["versions"]).to be_an(Array)
-        expect(result["Example"]["versions"]).not_to be_empty
-
-        expect(result["JSON"]).to have_key("versions")
-        expect(result["JSON"]["versions"]).to be_an(Array)
-        expect(result["JSON"]["versions"]).not_to be_empty
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::AvailableVersionsBatch)
+        expect(result.packages.fetch("Example").versions).not_to be_empty
+        expect(result.packages.fetch("JSON").versions).not_to be_empty
       end
     end
 
     describe "batch_get_version_release_dates" do
       it "successfully fetches release dates for multiple packages" do
         packages_versions = [
-          {
+          Dependabot::Julia::RegistryClient::Result::PackageVersionsRequest.new(
             name: "Example",
             uuid: "7876af07-990d-54b4-ab0e-23690620f79a",
             versions: ["0.5.3", "0.5.4"]
-          },
-          {
+          ),
+          Dependabot::Julia::RegistryClient::Result::PackageVersionsRequest.new(
             name: "JSON",
             uuid: "682c06a0-de6a-54ab-a142-c8b1cf79cde6",
             versions: ["0.21.0", "0.21.1"]
-          }
+          )
         ]
 
         result = client.batch_fetch_version_release_dates(packages_versions)
 
-        expect(result).to be_a(Hash)
-        expect(result["Example"]).to be_a(Hash)
-        expect(result["Example"]["0.5.3"]).to eq("2019-07-17T05:33:46")
-        expect(result["JSON"]).to be_a(Hash)
-        expect(result["JSON"]["0.21.0"]).to eq("2019-07-16T19:58:10")
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::ReleaseDatesBatch)
+        example_dates = result.packages.fetch("Example")
+        json_dates = result.packages.fetch("JSON")
+        expect(example_dates.dates.fetch("0.5.3").release_date).to eq("2019-07-17T05:33:46")
+        expect(json_dates.dates.fetch("0.21.0").release_date).to eq("2019-07-16T19:58:10")
       end
     end
 
@@ -131,7 +125,7 @@ RSpec.describe Dependabot::Julia::RegistryClient, :julia_helpers do
           result = client.batch_fetch_package_info(dependencies)
         end.not_to raise_error
 
-        expect(result.keys.length).to eq(3)
+        expect(result.packages.length).to eq(3)
       end
     end
   end

--- a/julia/spec/dependabot/julia/registry_client_batch_spec.rb
+++ b/julia/spec/dependabot/julia/registry_client_batch_spec.rb
@@ -73,6 +73,23 @@ RSpec.describe Dependabot::Julia::RegistryClient do
         expect(missing.available_versions).to be_a(Dependabot::Julia::RegistryClient::Result::Failure)
         expect(missing.available_versions.message).to eq("No versions found")
       end
+
+      it "allows a package named error" do
+        allow(client).to receive(:call_julia_helper).and_return(
+          {
+            "error" => {
+              "available_versions" => ["1.0.0"],
+              "latest_version" => "1.0.0"
+            }
+          }
+        )
+
+        result = client.batch_fetch_package_info([dependencies.first])
+        package_info = result.packages.fetch("error")
+
+        expect(package_info).to be_a(Dependabot::Julia::RegistryClient::Result::PackageInfo)
+        expect(package_info.latest_version).to have_attributes(version: "1.0.0")
+      end
     end
 
     describe "#batch_fetch_available_versions" do
@@ -117,6 +134,18 @@ RSpec.describe Dependabot::Julia::RegistryClient do
           Dependabot::Julia::RegistryClient::Result::Failure
         )
         expect(result.packages.fetch("Missing").message).to eq("No versions found")
+      end
+
+      it "allows a package named error" do
+        allow(client).to receive(:call_julia_helper).and_return(
+          {
+            "error" => { "versions" => ["1.0.0"] }
+          }
+        )
+
+        result = client.batch_fetch_available_versions([dependencies.first])
+
+        expect(result.packages.fetch("error")).to have_attributes(versions: ["1.0.0"])
       end
     end
 
@@ -165,6 +194,25 @@ RSpec.describe Dependabot::Julia::RegistryClient do
         expect(dates.dates.fetch("0.5.1")).to have_attributes(release_date: nil)
         expect(dates.dates.fetch("0.5.2")).to be_a(Dependabot::Julia::RegistryClient::Result::Failure)
         expect(dates.dates.fetch("0.5.2").message).to eq("Date unavailable")
+      end
+
+      it "allows a package named error" do
+        allow(client).to receive(:call_julia_helper).and_return(
+          {
+            "error" => { "1.0.0" => "2023-01-01T00:00:00Z" }
+          }
+        )
+
+        request = Dependabot::Julia::RegistryClient::Result::PackageVersionsRequest.new(
+          name: "error",
+          uuid: "11111111-1111-1111-1111-111111111111",
+          versions: ["1.0.0"]
+        )
+        result = client.batch_fetch_version_release_dates([request])
+        dates = result.packages.fetch("error")
+
+        expect(dates).to be_a(Dependabot::Julia::RegistryClient::Result::ReleaseDates)
+        expect(dates.dates.fetch("1.0.0")).to have_attributes(release_date: "2023-01-01T00:00:00Z")
       end
     end
   end

--- a/julia/spec/dependabot/julia/registry_client_batch_spec.rb
+++ b/julia/spec/dependabot/julia/registry_client_batch_spec.rb
@@ -39,8 +39,39 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "returns empty hash when dependencies list is empty" do
         result = client.batch_fetch_package_info([])
 
-        expect(result).to be_a(Hash)
-        expect(result).to be_empty
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::PackageInfoBatch)
+        expect(result.packages).to be_empty
+      end
+
+      it "parses successful and failed package fields" do
+        allow(client).to receive(:call_julia_helper).and_return(
+          {
+            "Example" => {
+              "available_versions" => ["0.5.4", "0.5.5"],
+              "latest_version" => "0.5.5",
+              "metadata" => {
+                "name" => "Example",
+                "uuid" => "7876af07-990d-54b4-ab0e-23690620f79a",
+                "latest_version" => "0.5.5",
+                "available_versions" => ["0.5.4", "0.5.5"]
+              }
+            },
+            "Missing" => {
+              "available_versions" => { "error" => "No versions found" },
+              "latest_version" => { "error" => "Package not found" }
+            }
+          }
+        )
+
+        result = client.batch_fetch_package_info(dependencies)
+
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::PackageInfoBatch)
+        example = result.packages.fetch("Example")
+        missing = result.packages.fetch("Missing")
+        expect(example).to be_a(Dependabot::Julia::RegistryClient::Result::PackageInfo)
+        expect(example.latest_version).to have_attributes(version: "0.5.5")
+        expect(missing.available_versions).to be_a(Dependabot::Julia::RegistryClient::Result::Failure)
+        expect(missing.available_versions.message).to eq("No versions found")
       end
     end
 
@@ -67,8 +98,25 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "returns empty hash when dependencies list is empty" do
         result = client.batch_fetch_available_versions([])
 
-        expect(result).to be_a(Hash)
-        expect(result).to be_empty
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::AvailableVersionsBatch)
+        expect(result.packages).to be_empty
+      end
+
+      it "preserves per-package failures" do
+        allow(client).to receive(:call_julia_helper).and_return(
+          {
+            "Example" => { "versions" => ["0.5.4", "0.5.5"] },
+            "Missing" => { "error" => "No versions found" }
+          }
+        )
+
+        result = client.batch_fetch_available_versions(dependencies)
+
+        expect(result.packages.fetch("Example")).to have_attributes(versions: ["0.5.4", "0.5.5"])
+        expect(result.packages.fetch("Missing")).to be_a(
+          Dependabot::Julia::RegistryClient::Result::Failure
+        )
+        expect(result.packages.fetch("Missing").message).to eq("No versions found")
       end
     end
 
@@ -91,8 +139,32 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "returns empty hash structure when packages_versions is empty" do
         result = client.batch_fetch_version_release_dates([])
 
-        expect(result).to be_a(Hash)
-        expect(result).to be_empty
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::ReleaseDatesBatch)
+        expect(result.packages).to be_empty
+      end
+
+      it "parses dates, missing dates, and per-version failures" do
+        allow(client).to receive(:call_julia_helper).and_return(
+          {
+            "Example" => {
+              "0.5.0" => "2023-01-01T00:00:00Z",
+              "0.5.1" => nil,
+              "0.5.2" => { "error" => "Date unavailable" }
+            }
+          }
+        )
+
+        requests = packages_versions.map do |package|
+          Dependabot::Julia::RegistryClient::Result::PackageVersionsRequest.new(**package)
+        end
+        result = client.batch_fetch_version_release_dates(requests)
+        dates = result.packages.fetch("Example")
+
+        expect(dates).to be_a(Dependabot::Julia::RegistryClient::Result::ReleaseDates)
+        expect(dates.dates.fetch("0.5.0")).to have_attributes(release_date: "2023-01-01T00:00:00Z")
+        expect(dates.dates.fetch("0.5.1")).to have_attributes(release_date: nil)
+        expect(dates.dates.fetch("0.5.2")).to be_a(Dependabot::Julia::RegistryClient::Result::Failure)
+        expect(dates.dates.fetch("0.5.2").message).to eq("Date unavailable")
       end
     end
   end

--- a/julia/spec/dependabot/julia/registry_client_spec.rb
+++ b/julia/spec/dependabot/julia/registry_client_spec.rb
@@ -24,12 +24,9 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "returns both project and manifest file paths" do
         result = registry_client.find_environment_files(directory)
 
-        expect(result).to eq(
-          {
-            "project_file" => "/tmp/test_project/Project.toml",
-            "manifest_file" => "/tmp/test_project/Manifest.toml"
-          }
-        )
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::EnvironmentFiles)
+        expect(result.project_file).to eq("/tmp/test_project/Project.toml")
+        expect(result.manifest_file).to eq("/tmp/test_project/Manifest.toml")
       end
     end
 
@@ -47,8 +44,9 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "returns both paths even if manifest doesn't exist yet" do
         result = registry_client.find_environment_files(directory)
 
-        expect(result["project_file"]).to eq("/tmp/test_project/Project.toml")
-        expect(result["manifest_file"]).to eq("/tmp/test_project/Manifest.toml")
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::EnvironmentFiles)
+        expect(result.project_file).to eq("/tmp/test_project/Project.toml")
+        expect(result.manifest_file).to eq("/tmp/test_project/Manifest.toml")
       end
     end
 
@@ -66,8 +64,9 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "returns project in subdirectory and manifest in parent" do
         result = registry_client.find_environment_files(directory)
 
-        expect(result["project_file"]).to eq("/tmp/test_project/SubPackage/Project.toml")
-        expect(result["manifest_file"]).to eq("/tmp/test_project/Manifest.toml")
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::EnvironmentFiles)
+        expect(result.project_file).to eq("/tmp/test_project/SubPackage/Project.toml")
+        expect(result.manifest_file).to eq("/tmp/test_project/Manifest.toml")
       end
     end
 
@@ -81,10 +80,11 @@ RSpec.describe Dependabot::Julia::RegistryClient do
         })
       end
 
-      it "returns empty hash" do
+      it "returns a typed failure" do
         result = registry_client.find_environment_files(directory)
 
-        expect(result).to eq({})
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::Failure)
+        expect(result.message).to eq("No Project.toml found")
       end
     end
 
@@ -116,8 +116,9 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "handles Julia-prefixed file names" do
         result = registry_client.find_environment_files(directory)
 
-        expect(result["project_file"]).to eq("/tmp/test_project/JuliaProject.toml")
-        expect(result["manifest_file"]).to eq("/tmp/test_project/JuliaManifest.toml")
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::EnvironmentFiles)
+        expect(result.project_file).to eq("/tmp/test_project/JuliaProject.toml")
+        expect(result.manifest_file).to eq("/tmp/test_project/JuliaManifest.toml")
       end
     end
 
@@ -135,8 +136,170 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "returns version-specific manifest path" do
         result = registry_client.find_environment_files(directory)
 
-        expect(result["project_file"]).to eq("/tmp/test_project/Project.toml")
-        expect(result["manifest_file"]).to eq("/tmp/test_project/Manifest-v1.12.toml")
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::EnvironmentFiles)
+        expect(result.project_file).to eq("/tmp/test_project/Project.toml")
+        expect(result.manifest_file).to eq("/tmp/test_project/Manifest-v1.12.toml")
+      end
+    end
+  end
+
+  describe "typed helper results" do
+    describe "#parse_project" do
+      let(:project_path) { "/tmp/test_project/Project.toml" }
+
+      it "parses dependencies and tolerates unknown fields" do
+        allow(registry_client).to receive(:call_julia_helper).and_return(
+          {
+            "name" => "TestProject",
+            "version" => "1.0.0",
+            "uuid" => "11111111-1111-1111-1111-111111111111",
+            "julia_version" => "1.10",
+            "dependencies" => [
+              {
+                "name" => "Example",
+                "uuid" => "7876af07-990d-54b4-ab0e-23690620f79a",
+                "requirement" => "0.5",
+                "ignored" => true
+              }
+            ],
+            "weak_dependencies" => [],
+            "project_path" => project_path,
+            "ignored" => "value"
+          }
+        )
+
+        result = registry_client.parse_project(project_path: project_path)
+
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::Project)
+        expect(result.name).to eq("TestProject")
+        expect(result.dependencies.first).to have_attributes(
+          name: "Example",
+          uuid: "7876af07-990d-54b4-ab0e-23690620f79a",
+          requirement: "0.5"
+        )
+      end
+
+      it "returns a typed failure for an expected helper error" do
+        allow(registry_client).to receive(:call_julia_helper).and_return(
+          { "error" => "Failed to parse project" }
+        )
+
+        result = registry_client.parse_project(project_path: project_path)
+
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::Failure)
+        expect(result.message).to eq("Failed to parse project")
+      end
+
+      it "raises for a malformed dependency" do
+        allow(registry_client).to receive(:call_julia_helper).and_return(
+          {
+            "name" => nil,
+            "version" => nil,
+            "uuid" => nil,
+            "julia_version" => "",
+            "dependencies" => [{ "name" => 123, "uuid" => "uuid" }],
+            "weak_dependencies" => [],
+            "project_path" => project_path
+          }
+        )
+
+        expect { registry_client.parse_project(project_path: project_path) }
+          .to raise_error(TypeError, /project dependency name must be a string/)
+      end
+    end
+
+    describe "#parse_manifest" do
+      it "parses manifest dependencies" do
+        allow(registry_client).to receive(:call_julia_helper).and_return(
+          {
+            "dependencies" => [
+              {
+                "name" => "Example",
+                "uuid" => "7876af07-990d-54b4-ab0e-23690620f79a",
+                "version" => "0.5.5",
+                "tree_hash" => "abc123",
+                "repo_url" => "",
+                "repo_rev" => "",
+                "path" => "",
+                "dependencies" => { "Test" => "uuid" }
+              }
+            ],
+            "manifest_path" => "/tmp/Manifest.toml"
+          }
+        )
+
+        result = registry_client.parse_manifest("/tmp/Manifest.toml")
+
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::Manifest)
+        expect(result.dependencies.first).to have_attributes(
+          name: "Example",
+          version: "0.5.5",
+          dependencies: { "Test" => "uuid" }
+        )
+      end
+    end
+
+    describe "#fetch_package_metadata" do
+      it "returns typed package metadata" do
+        allow(registry_client).to receive(:call_julia_helper).and_return(
+          {
+            "name" => "Example",
+            "uuid" => "7876af07-990d-54b4-ab0e-23690620f79a",
+            "latest_version" => "0.5.5",
+            "available_versions" => ["0.5.4", "0.5.5"]
+          }
+        )
+
+        result = registry_client.fetch_package_metadata(
+          "Example",
+          "7876af07-990d-54b4-ab0e-23690620f79a"
+        )
+
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::PackageMetadata)
+        expect(result.latest_version).to eq("0.5.5")
+      end
+    end
+
+    describe "#find_package_source_url" do
+      it "returns a typed source" do
+        allow(registry_client).to receive(:call_julia_helper).and_return(
+          {
+            "source_url" => "https://github.com/JuliaLang/Example.jl",
+            "source_type" => "github",
+            "package_uuid" => "7876af07-990d-54b4-ab0e-23690620f79a"
+          }
+        )
+
+        result = registry_client.find_package_source_url(
+          "Example",
+          "7876af07-990d-54b4-ab0e-23690620f79a"
+        )
+
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::Source)
+        expect(result.source_url).to eq("https://github.com/JuliaLang/Example.jl")
+      end
+    end
+
+    describe "#update_manifest" do
+      it "returns a typed manifest update" do
+        allow(registry_client).to receive(:call_julia_helper).and_return(
+          {
+            "result" => "success",
+            "manifest_content" => "manifest",
+            "manifest_path" => "Manifest.toml",
+            "updated_manifest" => {}
+          }
+        )
+
+        result = registry_client.update_manifest(
+          project_path: "/tmp/test_project",
+          updates: { "uuid" => { "name" => "Example", "version" => "0.5.5" } }
+        )
+
+        expect(result).to have_attributes(
+          manifest_content: "manifest",
+          manifest_path: "Manifest.toml"
+        )
       end
     end
   end

--- a/julia/spec/integration/julia_helper_spec.rb
+++ b/julia/spec/integration/julia_helper_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Dependabot::Julia::RegistryClient do
           metadata = registry_client.fetch_package_metadata(package_name, package_uuid)
 
           # If metadata works but fetch_latest_version doesn't, that's unexpected
-          if metadata && metadata["latest_version"]
-            raise "fetch_latest_version returned nil, but metadata shows latest_version: #{metadata['latest_version']}"
+          if metadata.is_a?(Dependabot::Julia::RegistryClient::Result::PackageMetadata)
+            raise "fetch_latest_version returned nil, but metadata shows latest_version: #{metadata.latest_version}"
           end
 
           # Otherwise, the package might not be in the registry (expected case)
@@ -36,20 +36,17 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "fetches actual source URL" do
         result = registry_client.find_package_source_url(package_name, package_uuid)
 
-        expect(result).to be_a(Hash)
-        expect(result["source_url"]).to be_a(String)
-        expect(result["source_url"]).to include("github.com")
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::Source)
+        expect(result.source_url).to include("github.com")
       end
 
       it "fetches package metadata" do
         result = registry_client.fetch_package_metadata(package_name, package_uuid)
 
-        expect(result).to be_a(Hash)
-        # The metadata returns direct package info, not nested under "result"
-        expect(result).to have_key("name")
-        expect(result).to have_key("uuid")
-        expect(result).to have_key("latest_version")
-        expect(result["latest_version"]).to match(/\d+\.\d+\.\d+/)
+        expect(result).to be_a(Dependabot::Julia::RegistryClient::Result::PackageMetadata)
+        expect(result.name).to eq(package_name)
+        expect(result.uuid).to eq(package_uuid)
+        expect(result.latest_version).to match(/\d+\.\d+\.\d+/)
       end
     end
 
@@ -79,19 +76,6 @@ RSpec.describe Dependabot::Julia::RegistryClient do
       it "get_latest_version works via registry client" do
         result = registry_client.fetch_latest_version(package_name, package_uuid)
         expect(result).to be_a(Gem::Version).or(be_nil)
-      end
-
-      it "get_latest_version works directly" do
-        # Test the Julia helper function directly
-        args = { package_name: package_name, package_uuid: package_uuid }
-        result = registry_client.send(:call_julia_helper, function: "get_latest_version", args: args)
-
-        # The result should contain version directly (not nested under "result")
-        expect(result).to have_key("version")
-        expect(result["version"]).to match(/\d+\.\d+\.\d+/)
-
-        version = Gem::Version.new(result["version"])
-        expect(version).to be_a(Gem::Version)
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

`RegistryClient` treated every Julia helper response as `T::Hash[String, T.untyped]`. This change adds immutable result types and parses each raw `Object` at the Ruby boundary. Julia callers now use typed fields instead of indexing helper response hashes.

Expected domain failures remain values through a shared `Failure` result. Malformed payloads raise `TypeError`, while subprocess failures keep their existing error handling. The Julia helper JSON format is unchanged.

The change moves `RegistryClient`, `FileParser`, `FileUpdater`, and `PackageDetailsFetcher` to `# typed: strong`. Julia's semantic untyped usage falls from 60 to 4.

### Anything you want to highlight for special attention from reviewers?

Batch calls can return partial failures. Their result types keep failures at the package or version that caused them rather than failing the whole batch.

The parser is local to Julia. This avoids adding shared response machinery before another ecosystem needs the same pattern. No semantic coverage ratchet is included.

### How will you know you've accomplished your goal?

The old and new code use the same helper payloads and caller fallbacks. The following checks pass:

- `bundle exec srb tc`
- `bundle exec tapioca gem --verify`
- Julia RuboCop: 37 files, no offenses
- Julia RSpec: 273 examples, 0 failures

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
