### PR TITLE
Group Excon EOF errors by call site

### DIFF
--- a/updater/lib/dependabot/base_command.rb
+++ b/updater/lib/dependabot/base_command.rb
@@ -9,6 +9,7 @@ require "dependabot/service"
 require "dependabot/logger"
 require "dependabot/logger/formats"
 require "dependabot/environment"
+require "dependabot/sentry/error_fingerprint"
 
 module Dependabot
   class RunFailure < StandardError; end
@@ -67,12 +68,14 @@ module Dependabot
 
     sig { params(err: StandardError).void }
     def handle_unknown_error(err)
-      fingerprint = (if err.respond_to?(:sentry_context)
-                       T.cast(
-                         err,
-                         Dependabot::HasSentryContext
-                       ).sentry_context[:fingerprint]
-                     end)
+      fingerprint = if err.respond_to?(:sentry_context)
+                      T.cast(
+                        err,
+                        Dependabot::HasSentryContext
+                      ).sentry_context[:fingerprint]
+                    else
+                      Dependabot::Sentry::ErrorFingerprint.for(error: err, package_manager: job.package_manager)
+                    end
 
       error_details = {
         ErrorAttributes::CLASS => err.class.to_s,

--- a/updater/lib/dependabot/sentry/error_fingerprint.rb
+++ b/updater/lib/dependabot/sentry/error_fingerprint.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "excon"

--- a/updater/lib/dependabot/sentry/error_fingerprint.rb
+++ b/updater/lib/dependabot/sentry/error_fingerprint.rb
@@ -1,0 +1,57 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "excon"
+require "sorbet-runtime"
+
+module Dependabot
+  module Sentry
+    module ErrorFingerprint
+      extend T::Sig
+
+      CALL_SITE_PATTERN = %r{
+        (?<path>[^/]+/lib/dependabot/[^:]+\.rb):\d+:in\s+[`'](?<method>[^`']+)
+      }x
+      REGISTRY_CLIENT_PATH = "common/lib/dependabot/registry_client.rb"
+
+      sig do
+        params(
+          error: StandardError,
+          package_manager: T.nilable(String)
+        ).returns(T.nilable(T::Array[String]))
+      end
+      def self.for(error:, package_manager:)
+        return unless eof_socket_error?(error)
+
+        [
+          "excon-eof",
+          package_manager || "unknown-package-manager",
+          dependabot_call_site(error) || "unknown-call-site"
+        ]
+      end
+
+      sig { params(error: StandardError).returns(T::Boolean) }
+      private_class_method def self.eof_socket_error?(error)
+        return false unless error.is_a?(Excon::Error::Socket)
+
+        case error.socket_error
+        when EOFError then true
+        else false
+        end
+      end
+
+      sig { params(error: StandardError).returns(T.nilable(String)) }
+      private_class_method def self.dependabot_call_site(error)
+        error.backtrace&.each do |frame|
+          match = frame.match(CALL_SITE_PATTERN)
+          next unless match
+          next if match[:path] == REGISTRY_CLIENT_PATH
+
+          return "#{match[:path]}:#{match[:method]}"
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/updater/lib/dependabot/service.rb
+++ b/updater/lib/dependabot/service.rb
@@ -9,6 +9,7 @@ require "dependabot/api_client"
 require "dependabot/errors"
 require "dependabot/opentelemetry"
 require "dependabot/experiments"
+require "dependabot/sentry/error_fingerprint"
 require "dependabot/workflow_summary"
 require "github_api/dependency_submission"
 
@@ -212,11 +213,17 @@ module Dependabot
       # some GHES versions do not support reporting errors to the service
       return unless Experiments.enabled?(:record_update_job_unknown_error)
 
+      fingerprint = if error.respond_to?(:sentry_context)
+                      T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint]
+                    else
+                      Dependabot::Sentry::ErrorFingerprint.for(error: error, package_manager: job&.package_manager)
+                    end
+
       error_details = {
         ErrorAttributes::CLASS => error.class.to_s,
         ErrorAttributes::MESSAGE => error.message,
         ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
-        ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint] : nil, # rubocop:disable Layout/LineLength
+        ErrorAttributes::FINGERPRINT => fingerprint,
         ErrorAttributes::PACKAGE_MANAGER => job&.package_manager,
         ErrorAttributes::JOB_ID => job&.id,
         ErrorAttributes::DEPENDENCIES => dependency&.name || job&.dependencies,

--- a/updater/lib/dependabot/update_files_command.rb
+++ b/updater/lib/dependabot/update_files_command.rb
@@ -94,7 +94,7 @@ module Dependabot
 
     private
 
-    # rubocop:disable Metrics/AbcSize, Layout/LineLength, Metrics/MethodLength, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
     sig { params(error: StandardError).void }
     def handle_parser_error(error)
       # This happens if the repo gets removed after a job gets kicked off.
@@ -127,7 +127,14 @@ module Dependabot
             ErrorAttributes::CLASS => error.class.to_s,
             ErrorAttributes::MESSAGE => error.message,
             ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
-            ErrorAttributes::FINGERPRINT => error.respond_to?(:sentry_context) ? T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint] : nil,
+            ErrorAttributes::FINGERPRINT => (if error.respond_to?(:sentry_context)
+                                               T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint]
+                                             else
+                                               Dependabot::Sentry::ErrorFingerprint.for(
+                                                 error: error,
+                                                 package_manager: job.package_manager
+                                               )
+                                             end),
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,
             ErrorAttributes::DEPENDENCIES => job.dependencies,
@@ -159,7 +166,7 @@ module Dependabot
         error_details: error_detail
       )
     end
-    # rubocop:enable Metrics/AbcSize, Layout/LineLength, Metrics/MethodLength, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     sig { params(error: Dependabot::DependencyFileNotParseable).void }
     def handle_dependency_file_not_parseable_error(error)

--- a/updater/lib/dependabot/update_graph_command.rb
+++ b/updater/lib/dependabot/update_graph_command.rb
@@ -83,6 +83,11 @@ module Dependabot
             ErrorAttributes::BACKTRACE => error.backtrace&.join("\n"),
             ErrorAttributes::FINGERPRINT => (if error.respond_to?(:sentry_context)
                                                T.cast(error, Dependabot::HasSentryContext).sentry_context[:fingerprint]
+                                             else
+                                               Dependabot::Sentry::ErrorFingerprint.for(
+                                                 error: error,
+                                                 package_manager: job.package_manager
+                                               )
                                              end),
             ErrorAttributes::PACKAGE_MANAGER => job.package_manager,
             ErrorAttributes::JOB_ID => job.id,

--- a/updater/lib/dependabot/updater/error_handler.rb
+++ b/updater/lib/dependabot/updater/error_handler.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "dependabot/errors"
+require "dependabot/sentry/error_fingerprint"
 require "dependabot/updater/errors"
 require "dependabot/updater/security_update_helpers"
 require "octokit"
@@ -277,7 +278,7 @@ module Dependabot
           return fingerprint.map { |value| T.cast(value, Object).to_s } if fingerprint.is_a?(Array)
         end
 
-        nil
+        Dependabot::Sentry::ErrorFingerprint.for(error: error, package_manager: job.package_manager)
       end
     end
   end

--- a/updater/spec/dependabot/sentry/error_fingerprint_spec.rb
+++ b/updater/spec/dependabot/sentry/error_fingerprint_spec.rb
@@ -1,0 +1,53 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "dependabot/sentry/error_fingerprint"
+
+RSpec.describe Dependabot::Sentry::ErrorFingerprint do
+  describe ".for" do
+    subject(:fingerprint) do
+      described_class.for(error: error, package_manager: package_manager)
+    end
+
+    let(:package_manager) { "pip" }
+
+    context "with an EOF-backed Excon socket error" do
+      let(:error) do
+        Excon::Error::Socket.new(EOFError.new).tap do |socket_error|
+          socket_error.set_backtrace(
+            [
+              "/vendor/ruby/gems/excon/lib/excon/socket.rb:90:in 'readline'",
+              "/home/dependabot/common/lib/dependabot/registry_client.rb:32:in 'get'",
+              "/home/dependabot/python/lib/dependabot/python/package/package_details_fetcher.rb:445:" \
+              "in 'registry_response_for_dependency'"
+            ]
+          )
+        end
+      end
+
+      it "groups by package manager and the first non-client Dependabot call site" do
+        expect(fingerprint).to eq(
+          [
+            "excon-eof",
+            "pip",
+            "python/lib/dependabot/python/package/package_details_fetcher.rb:registry_response_for_dependency"
+          ]
+        )
+      end
+    end
+
+    context "with another socket error" do
+      let(:error) { Excon::Error::Socket.new(Errno::ECONNRESET.new) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with an unrelated error" do
+      let(:error) { StandardError.new }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/updater/spec/dependabot/service_spec.rb
+++ b/updater/spec/dependabot/service_spec.rb
@@ -11,6 +11,7 @@ require "dependabot/errors"
 require "dependabot/pull_request_creator"
 require "dependabot/service"
 require "dependabot/experiments"
+require "dependabot/shared_helpers"
 
 RSpec.describe Dependabot::Service do
   subject(:service) { described_class.new(client: mock_client) }
@@ -390,6 +391,61 @@ RSpec.describe Dependabot::Service do
             Dependabot::ErrorAttributes::MESSAGE => "Something went wrong",
             Dependabot::ErrorAttributes::JOB_ID => job.id,
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => job.package_manager
+          )
+        )
+    end
+
+    it "groups EOF socket errors by package manager and Dependabot call site" do
+      job = instance_double(
+        Dependabot::Job,
+        id: 1234,
+        package_manager: "pip",
+        repo_private?: false,
+        repo_owner: "foo",
+        dependencies: nil,
+        dependency_groups: nil,
+        security_updates_only?: false
+      )
+      error = Excon::Error::Socket.new(EOFError.new).tap do |socket_error|
+        socket_error.set_backtrace(
+          [
+            "/home/dependabot/common/lib/dependabot/registry_client.rb:32:in 'get'",
+            "/home/dependabot/python/lib/dependabot/python/package/package_details_fetcher.rb:445:" \
+            "in 'registry_response_for_dependency'"
+          ]
+        )
+      end
+
+      service.capture_exception(error: error, job: job)
+
+      expect(mock_client)
+        .to have_received(:record_update_job_unknown_error)
+        .with(
+          error_type: "unknown_error",
+          error_details: hash_including(
+            Dependabot::ErrorAttributes::FINGERPRINT => [
+              "excon-eof",
+              "pip",
+              "python/lib/dependabot/python/package/package_details_fetcher.rb:registry_response_for_dependency"
+            ]
+          )
+        )
+    end
+
+    it "preserves an existing fingerprint" do
+      error = Dependabot::SharedHelpers::HelperSubprocessFailed.new(
+        message: "Something went wrong",
+        error_context: { fingerprint: "existing-fingerprint" }
+      )
+
+      service.capture_exception(error: error)
+
+      expect(mock_client)
+        .to have_received(:record_update_job_unknown_error)
+        .with(
+          error_type: "unknown_error",
+          error_details: hash_including(
+            Dependabot::ErrorAttributes::FINGERPRINT => ["existing-fingerprint"]
           )
         )
     end

--- a/updater/spec/dependabot/update_files_command_spec.rb
+++ b/updater/spec/dependabot/update_files_command_spec.rb
@@ -174,6 +174,34 @@ RSpec.describe Dependabot::UpdateFilesCommand do
         perform_job
         Dependabot::Experiments.reset!
       end
+
+      context "with an EOF socket error" do
+        let(:error) do
+          Excon::Error::Socket.new(EOFError.new).tap do |socket_error|
+            socket_error.set_backtrace(
+              [
+                "/home/dependabot/common/lib/dependabot/registry_client.rb:32:in 'get'",
+                "/home/dependabot/bundler/lib/dependabot/bundler/file_parser.rb:100:in 'parse'"
+              ]
+            )
+          end
+        end
+
+        it "records the call-site fingerprint with the duplicate unknown error" do
+          expect(service).to receive(:record_update_job_unknown_error).with(
+            error_type: "update_files_error",
+            error_details: hash_including(
+              Dependabot::ErrorAttributes::FINGERPRINT => [
+                "excon-eof",
+                "bundler",
+                "bundler/lib/dependabot/bundler/file_parser.rb:parse"
+              ]
+            )
+          )
+
+          perform_job
+        end
+      end
     end
 
     context "with an update files error (ghes)" do

--- a/updater/spec/dependabot/update_graph_command_spec.rb
+++ b/updater/spec/dependabot/update_graph_command_spec.rb
@@ -210,6 +210,34 @@ RSpec.describe Dependabot::UpdateGraphCommand do
         perform_job
         Dependabot::Experiments.reset!
       end
+
+      context "with an EOF socket error" do
+        let(:error) do
+          Excon::Error::Socket.new(EOFError.new).tap do |socket_error|
+            socket_error.set_backtrace(
+              [
+                "/home/dependabot/common/lib/dependabot/registry_client.rb:32:in 'get'",
+                "/home/dependabot/bundler/lib/dependabot/bundler/file_parser.rb:100:in 'parse'"
+              ]
+            )
+          end
+        end
+
+        it "records the call-site fingerprint with the duplicate unknown error" do
+          expect(service).to receive(:record_update_job_unknown_error).with(
+            error_type: "unknown_update_graph_error",
+            error_details: hash_including(
+              Dependabot::ErrorAttributes::FINGERPRINT => [
+                "excon-eof",
+                "bundler",
+                "bundler/lib/dependabot/bundler/file_parser.rb:parse"
+              ]
+            )
+          )
+
+          perform_job
+        end
+      end
     end
 
     context "with an update graph error (ghes)" do

--- a/updater/spec/dependabot/updater/error_handler_spec.rb
+++ b/updater/spec/dependabot/updater/error_handler_spec.rb
@@ -165,6 +165,46 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
       end
     end
 
+    context "with an EOF socket error (cloud)" do
+      let(:error) do
+        Excon::Error::Socket.new(EOFError.new).tap do |socket_error|
+          socket_error.set_backtrace(
+            [
+              "/home/dependabot/common/lib/dependabot/registry_client.rb:32:in 'get'",
+              "/home/dependabot/bundler/lib/dependabot/bundler/package/package_details_fetcher.rb:100:" \
+              "in 'package_json_response'"
+            ]
+          )
+        end
+      end
+
+      before do
+        Dependabot::Experiments.register(:record_update_job_unknown_error, true)
+        allow(mock_service).to receive(:capture_exception)
+        allow(mock_service).to receive(:record_update_job_error)
+        allow(Dependabot.logger).to receive(:error)
+      end
+
+      after do
+        Dependabot::Experiments.reset!
+      end
+
+      it "records a package manager and call-site fingerprint" do
+        expect(mock_service).to receive(:record_update_job_unknown_error).with(
+          error_type: "unknown_error",
+          error_details: hash_including(
+            Dependabot::ErrorAttributes::FINGERPRINT => [
+              "excon-eof",
+              "bundler",
+              "bundler/lib/dependabot/bundler/package/package_details_fetcher.rb:package_json_response"
+            ]
+          )
+        )
+
+        handle_dependency_error
+      end
+    end
+
     context "with a handled unknown error (ghes)" do
       let(:error) do
         StandardError.new("There are bees everywhere").tap do |err|
@@ -245,7 +285,7 @@ RSpec.describe Dependabot::Updater::ErrorHandler do
             Dependabot::ErrorAttributes::BACKTRACE => "****** ERROR 8335 -- 101",
             Dependabot::ErrorAttributes::MESSAGE => "the kernal is full of bees",
             Dependabot::ErrorAttributes::CLASS => "Dependabot::SharedHelpers::HelperSubprocessFailed",
-            Dependabot::ErrorAttributes::FINGERPRINT => anything,
+            Dependabot::ErrorAttributes::FINGERPRINT => ["123456789"],
             Dependabot::ErrorAttributes::PACKAGE_MANAGER => "bundler",
             Dependabot::ErrorAttributes::JOB_ID => "123123",
             Dependabot::ErrorAttributes::DEPENDENCIES => [],


### PR DESCRIPTION
### What are you trying to accomplish?

Group `Excon::Error::Socket` failures backed by `EOFError` using the package manager and first non-registry-client Dependabot call site. This prevents unrelated registry EOF failures from being collapsed into one Sentry issue while preserving existing custom fingerprints and grouping behavior for every other error.

### Anything you want to highlight for special attention from reviewers?

The new fingerprint is deliberately a fallback only for EOF-backed Excon socket errors. Existing `sentry_context` fingerprints retain their previous handling across service and command-specific error-reporting paths.

### How will you know you have accomplished your goal?

Focused updater coverage verifies the new grouping, existing fingerprint preservation, unchanged behavior for unrelated and non-EOF socket errors, and consistent fingerprints in command-specific unknown-error reports.

Validation:

- `bin/test --workdir updater bundler rspec spec/dependabot/sentry/error_fingerprint_spec.rb spec/dependabot/service_spec.rb spec/dependabot/updater/error_handler_spec.rb spec/dependabot/update_files_command_spec.rb spec/dependabot/update_graph_command_spec.rb` (141 examples, 0 failures)
- Focused RuboCop for all changed production and spec files

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.