### PR TITLE
Fix grouped PR refresh crash when no directory produces a change

### DIFF
--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -173,10 +173,15 @@ module Dependabot
               T::Array[Dependabot::DependencyChange]
             )
 
-            # merge the changes together into one
-            dependency_change = T.let(T.must(dependency_changes.first), Dependabot::DependencyChange)
-            dependency_change.merge_changes!(T.must(dependency_changes[1..-1])) if dependency_changes.count > 1
-            @dependency_change = T.let(dependency_change, T.nilable(Dependabot::DependencyChange))
+            # `filter_map` drops directories that produced no change, so the array is empty
+            # when nothing could update across every directory. Return nil like the
+            # single-directory branch above (the caller logs and closes out) instead of
+            # `T.must`-ing `first` on an empty array, which raised `TypeError: Passed nil`.
+            first_change = dependency_changes.first
+            if first_change && dependency_changes.count > 1
+              first_change.merge_changes!(T.must(dependency_changes[1..-1]))
+            end
+            @dependency_change = T.let(first_change, T.nilable(Dependabot::DependencyChange))
           end
 
           # Apply GroupDependencySelector filtering to ensure only group-eligible dependencies

--- a/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_multi_dir_spec.rb
+++ b/updater/spec/dependabot/updater/operations/refresh_group_update_pull_request_multi_dir_spec.rb
@@ -239,5 +239,46 @@ RSpec.describe Dependabot::Updater::Operations::RefreshGroupUpdatePullRequest do
       duplicates = name_dir_pairs.tally.select { |_pair, count| count > 1 }
       expect(duplicates).to be_empty, "Found duplicate (name, directory) pairs: #{duplicates.keys.inspect}"
     end
+
+    context "when no directory produces a change" do
+      before do
+        # Re-register an update checker whose updates are missing a previous version and
+        # leave requirements unchanged. compile_all_dependency_changes_for then fails its
+        # all_have_previous_version? check and returns nil for every directory, so the
+        # multi-directory filter_map collapses to an empty array (the crash condition).
+        Dependabot::UpdateCheckers.register(
+          "terraform",
+          Class.new(Dependabot::UpdateCheckers::Base) do
+            define_method(:latest_version) { Gem::Version.new("5.0.0") }
+            define_method(:latest_resolvable_version) { Gem::Version.new("5.0.0") }
+            define_method(:latest_resolvable_version_with_no_unlock) { Gem::Version.new("5.0.0") }
+            define_method(:lowest_security_fix_version) { nil }
+            define_method(:lowest_resolvable_security_fix_version) { nil }
+            define_method(:updated_requirements) { dependency.requirements }
+            define_method(:up_to_date?) { false }
+            define_method(:requirements_unlocked_or_can_be?) { true }
+            define_method(:can_update?) { |**_kwargs| true }
+            define_method(:updated_dependencies) do |**_kwargs|
+              [Dependabot::Dependency.new(
+                name: dependency.name,
+                version: "5.0.0",
+                requirements: dependency.requirements,
+                previous_version: nil,
+                previous_requirements: dependency.requirements,
+                package_manager: "terraform",
+                directory: dependency.directory
+              )]
+            end
+          end
+        )
+      end
+
+      it "completes without raising and does not open or update a PR" do
+        expect(mock_service).not_to receive(:create_pull_request)
+        expect(mock_service).not_to receive(:update_pull_request)
+
+        expect { refresh_operation.perform }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Refreshing an existing grouped-update PR that spans multiple directories crashes with `TypeError: Passed nil into T.must` when none of the directories can produce an update.

`RefreshGroupUpdatePullRequest#dependency_change` has two paths:

- **Single-directory** returns `nil` when nothing can update, and the caller already handles that by logging "Nothing could update" and returning cleanly.
- **Multi-directory** builds the changes with `filter_map`, which drops directories that produced no change. When every directory is filtered out the array is empty, and `T.must(dependency_changes.first)` becomes `T.must(nil)` and raises — so the whole job fails instead of completing as a no-op.

This makes the multi-directory branch symmetric with the single-directory one: return `nil` when nothing could update, so the existing caller logs and closes out gracefully.

### Anything you want to highlight for special attention from reviewers?

- **Scope:** this PR hardens the **refresh** operation only. `CreateGroupUpdatePullRequest` contains the same latent `filter_map` + `T.must` pattern and is being addressed in a separate change; this PR is a defensive fix to keep the two operations symmetric.
- The fix deliberately keeps behavior identical to the single-directory path: a "nothing could update" refresh logs and returns without touching the existing PR. PR-closure semantics (empty group, removed dependencies) are unchanged.
- The bug is latent and dates back to when Sorbet types were first added to group update creation; the multi-directory path is the only one that goes through `filter_map`.

### How will you know you've accomplished your goal?

Added a regression test covering a multi-directory refresh where every directory is filtered out: it drives the public `#perform`, reproduces the `TypeError` on the unfixed code, now returns `nil` and no longer raises. Existing specs for the operation continue to pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
