### PR TITLE
Handle nil GitHub contents responses in ChangelogFinder

### DIFF
--- a/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
+++ b/common/lib/dependabot/metadata_finders/base/changelog_finder.rb
@@ -434,14 +434,14 @@ module Dependabot
 
         sig do
           params(
-            response: T.any(Sawyer::Resource, T::Array[Sawyer::Resource]),
+            response: T.nilable(T.any(Sawyer::Resource, T::Array[T.nilable(Sawyer::Resource)])),
             source_url: String
           )
             .returns(T::Array[ChangelogFile])
         end
         def github_changelog_files(response, source_url:)
           resources = response.is_a?(Array) ? response : [response]
-          resources.filter_map do |resource|
+          resources.compact.filter_map do |resource|
             type = sawyer_string(resource, :type, source_url: source_url)
             next unless CHANGELOG_FILE_TYPES.include?(type)
 

--- a/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
+++ b/common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb
@@ -313,6 +313,46 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
         end
       end
 
+      context "when the contents response is nil" do
+        # Sawyer decodes an empty response body to nil, so Octokit#contents
+        # hands back nil rather than a resource or an array of resources.
+        let(:github_response) { nil }
+
+        before do
+          stub_request(:get, github_url + "?ref=v1.4.0")
+            .to_return(status: github_status,
+                       body: github_response,
+                       headers: { "Content-Type" => "application/json" })
+        end
+
+        it "does not raise an error" do
+          expect { changelog_url }.not_to raise_error
+        end
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when the contents response contains a nil entry" do
+        let(:github_response) do
+          files = JSON.parse(fixture("github", "business_files.json"))
+          JSON.dump(files + [nil])
+        end
+
+        it "ignores the nil entry and still finds the changelog" do
+          expect(changelog_url)
+            .to eq("https://github.com/gocardless/business/blob/master/CHANGELOG.md")
+        end
+      end
+
+      context "when the contents response contains no nils" do
+        let(:github_response) { fixture("github", "business_files.json") }
+
+        it "still finds the changelog" do
+          expect(changelog_url)
+            .to eq("https://github.com/gocardless/business/blob/master/CHANGELOG.md")
+        end
+      end
+
       context "with a file containing changelog name in the middle" do
         let(:github_response) do
           fixture("github", "business_files_with_misleading_release_doc.json")
@@ -937,6 +977,15 @@ RSpec.describe Dependabot::MetadataFinders::Base::ChangelogFinder do
           finder.changelog_text
           expect(WebMock).to have_requested(:get, github_url).once
           expect(WebMock).to have_requested(:get, github_changelog_url).once
+        end
+
+        context "when the contents response contains a nil entry" do
+          let(:github_contents_response) do
+            files = JSON.parse(fixture("github", "business_files.json"))
+            JSON.dump(files + [nil])
+          end
+
+          it { is_expected.to eq(expected_pruned_changelog) }
         end
 
         context "when dealing with non-standard characters" do


### PR DESCRIPTION
Fixes Sentry [`DELTAFORCE-1K1X`](https://github.sentry.io/issues/?query=DELTAFORCE-1K1X) (~4.3k events, ~430 users, status *escalating*).

## The bug

`Octokit#contents` returns `nil` when the GitHub API responds with an empty or `null` body. In `ChangelogFinder` that nil flowed unguarded into `github_changelog_files`:

```ruby
def github_changelog_files(response, source_url:)
  resources = response.is_a?(Array) ? response : [response]  # nil -> [nil]
  resources.filter_map do |resource|
    type = sawyer_string(resource, :type, source_url: source_url)  # boom
```

`sawyer_string`'s sig requires a non-nil `Sawyer::Resource`, so `nil -> [nil] -> sawyer_string(nil)` violates it.

**Why one nil produces two Sentry reports.** Dependabot's Sorbet call-validation handler is non-raising — `Dependabot::Sorbet::Runtime::InformationalError` reports to Sentry and lets execution continue. So a single nil trips the sig twice and files two separate signatures, which is why they show up in near-equal pairs in the aggregate event data:

| Signature | Caller | Events |
| --- | --- | --- |
| `Parameter 'response': Expected T.any(Sawyer::Resource, T::Array[Sawyer::Resource]), got NilClass` | `changelog_finder.rb:354` | 493 |
| `Parameter 'resource': Expected Sawyer::Resource, got NilClass` | `changelog_finder.rb:445` (def `:462`) | 423 |

**Guard asymmetry.** There are three call sites of `github_changelog_files`, and only one of them guarded against a non-array response:

| Line | Source | Guarded? |
| --- | --- | --- |
| 149 | `suggested_source_client.contents` | ❌ |
| 336 | `fetch_github_file_list` directory branch | ✅ `if response.is_a?(Array)` |
| 354 | `github_files_at` | ❌ — dominant source |

## The fix

Normalize once at the boundary rather than patching each caller, so all three call sites are covered and both nil shapes are handled — a nil response, and an array containing nil elements:

```ruby
response: T.nilable(T.any(Sawyer::Resource, T::Array[T.nilable(Sawyer::Resource)]))
...
resources.compact.filter_map do |resource|
```

Widening the sig stops the `'response'` report; `.compact` stops the `'resource'` report. `sawyer_string` / `sawyer_optional_string` / `sawyer_optional_integer` keep requiring a non-nil `Sawyer::Resource` — deliberately unchanged.

The now-redundant `if response.is_a?(Array)` guard on line 336 is left in place to keep the diff surgical.

**Impact.** Returning `[]` for a nil listing is the correct behaviour here. This is changelog/metadata lookup, so the worst case is slightly degraded PR description metadata — never a failed dependency update.

## Origin

Introduced in #15919 ("Type common metadata boundaries", `18e27cc8`, merged 2026-08-18), which replaced an untyped `files += github_client.contents(...)` with strict typed extraction. #15954 (`f220428b`) only added `source_url:` and shifted line numbers; it neither caused nor fixed this.

### Note on the Sentry "first seen" date

The issue's *first seen 2026-08-31* is largely a **re-grouping artifact, not the regression date**. `sorbet-runtime` was bumped 0.6.13371 → 0.6.13449 on 2026-08-30 (`87109f8f`, dependabot[bot]), and the Sorbet culprit path embeds the gem version — so every Sorbet issue in the project split into a new group at that boundary (`1FXH`→`1K1Y`, `1FXK`→`1K1Z`, and this one). Events at the older line numbering (caller 442 / def 459) confirm the bug was already firing on Aug 18–19. Real regression age is ~2.5 weeks, not 4 days.

## Tests

Added to `common/spec/dependabot/metadata_finders/base/changelog_finder_spec.rb`, in the existing WebMock idiom:

1. `#changelog_url` — contents response is nil → no error raised, degrades to no changelog found.
2. `#changelog_url` — response array contains a nil entry → nil skipped, changelog still found.
3. `#changelog_url` — response array with no nils → control case, unchanged.
4. `#changelog_text` — response array contains a nil entry → full pruned changelog text still extracted, proving `.compact` drops only the nil.

## Validation

⚠️ **RSpec was not run locally and I am not claiming these specs pass.** This host has no container runtime and only Ruby 3.1.2/3.2.2, while `dependabot-common` requires `>= 3.3.0` (`.ruby-version` is 4.0.5), so `bundle install` cannot resolve. CI is the first real execution of these specs.

What I *was* able to run, isolated from the local RVM environment:

- **Sorbet — passes.** `sorbet 0.6.13449` (exact `updater/Gemfile.lock` pin) run against the committed `sorbet/rbi/gems` RBIs: `No errors! Great job.` This confirms the widened sig type-checks and that `.compact` narrows to `T::Array[Sawyer::Resource]`, satisfying `sawyer_string`.
- **RuboCop — passes, no offenses** on both changed files. Used the `updater/Gemfile.lock` pins `rubocop 1.90.0` / `rubocop-ast 1.50.0` / `rubocop-performance 1.27.0` / `rubocop-rspec 3.10.2`. `rubocop-sorbet` had to be `0.13.2` rather than the pinned `0.15.0`, which requires Ruby >= 3.3.
- **Stub-shape verification.** Since I could not run RSpec, I verified the assumptions behind the new stubs with a standalone script against real `octokit` + `sawyer`: a 200 with an empty body yields `contents == nil` (exactly the production input), a JSON array containing `null` yields `[Sawyer::Resource, ..., nil]`, and `.compact` drops only the nil while keeping all 10 valid resources including `CHANGELOG.md`.
- `ruby -c` clean on both files.

## Follow-up (not in this PR)

Two sibling issues show the same "strict sigs layered over untyped API responses" pattern from the same typing series and are worth auditing separately:

- `DELTAFORCE-1K1Y` — `T.must` on nil, ~8,970 events
- `DELTAFORCE-1K1Z` — `T.cast` expected `Hash`, got `String` (`"rfce"`), ~2,253 events