### PR TITLE
Type Python and UV library detection metadata

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 674
+# Offense count: 662
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"

--- a/python/lib/dependabot/python/file_parser/pyproject_document.rb
+++ b/python/lib/dependabot/python/file_parser/pyproject_document.rb
@@ -98,6 +98,11 @@ module Dependabot
           const :url, T.nilable(String), default: nil
         end
 
+        class ProjectMetadata < T::ImmutableStruct
+          const :name, T.nilable(String), default: nil
+          const :description, T.nilable(String), default: nil
+        end
+
         sig { params(data: PyprojectValueParser::ObjectHash).void }
         def initialize(data)
           @data = data
@@ -105,16 +110,40 @@ module Dependabot
 
         sig { params(file: Dependabot::DependencyFile).returns(PyprojectDocument) }
         def self.from_file(file)
-          content = T.must(file.content)
-          parsed = T.cast(TomlRB.parse(content), Object)
-          new(PyprojectValueParser.object_hash(parsed, "pyproject.toml"))
+          from_content(T.must(file.content))
         rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
           raise Dependabot::DependencyFileNotParseable, file.path
+        end
+
+        sig { params(content: String).returns(PyprojectDocument) }
+        def self.from_content(content)
+          parsed = T.cast(TomlRB.parse(content), Object)
+          new(PyprojectValueParser.object_hash(parsed, "pyproject.toml"))
         end
 
         sig { returns(T::Boolean) }
         def poetry?
           !poetry_root.nil?
+        end
+
+        sig { returns(T::Boolean) }
+        def project?
+          !section(@data, "project", "project").nil?
+        end
+
+        sig { returns(T.nilable(ProjectMetadata)) }
+        def poetry_metadata
+          metadata_from(poetry_root, "tool.poetry")
+        end
+
+        sig { returns(T.nilable(ProjectMetadata)) }
+        def project_metadata
+          metadata_from(section(@data, "project", "project"), "project")
+        end
+
+        sig { returns(T.nilable(ProjectMetadata)) }
+        def build_system_metadata
+          metadata_from(section(@data, "build-system", "build-system"), "build-system")
         end
 
         sig { returns(T::Boolean) }
@@ -199,6 +228,19 @@ module Dependabot
         end
 
         private
+
+        sig do
+          params(data: T.nilable(PyprojectValueParser::ObjectHash), context: String)
+            .returns(T.nilable(ProjectMetadata))
+        end
+        def metadata_from(data, context)
+          return unless data
+
+          ProjectMetadata.new(
+            name: PyprojectValueParser.optional_string(data["name"], "#{context}.name"),
+            description: PyprojectValueParser.optional_string(data["description"], "#{context}.description")
+          )
+        end
 
         sig { returns(T.nilable(PyprojectValueParser::ObjectHash)) }
         def poetry_root

--- a/python/lib/dependabot/python/update_checker.rb
+++ b/python/lib/dependabot/python/update_checker.rb
@@ -2,12 +2,13 @@
 # frozen_string_literal: true
 
 require "excon"
-require "toml-rb"
+require "json"
 require "sorbet-runtime"
 
 require "dependabot/dependency"
 require "dependabot/dependency_requirement"
 require "dependabot/errors"
+require "dependabot/python/file_parser"
 require "dependabot/python/name_normaliser"
 require "dependabot/python/requirement_parser"
 require "dependabot/python/requirement"
@@ -28,6 +29,8 @@ module Dependabot
       require_relative "update_checker/pip_version_resolver"
       require_relative "update_checker/requirements_updater"
       require_relative "update_checker/latest_version_finder"
+
+      PyprojectDocument = FileParser::PyprojectDocument
 
       MAIN_PYPI_INDEXES = %w(
         https://pypi.python.org/simple/
@@ -248,7 +251,7 @@ module Dependabot
         # For hybrid projects with both [tool.poetry] and [project] sections but no lockfile,
         # use the requirements resolver to handle PEP 621 dependencies
         # For pure Poetry projects, use Poetry resolver even without lockfile
-        return :poetry if poetry_based? && (poetry_lock || !standard_details)
+        return :poetry if poetry_based? && (poetry_lock || !pyproject_document.project?)
 
         :requirements
       end
@@ -395,7 +398,7 @@ module Dependabot
 
       sig { returns(T::Boolean) }
       def poetry_based?
-        updating_pyproject? && !poetry_details.nil?
+        updating_pyproject? && pyproject_document.poetry?
       end
 
       sig { returns(T::Boolean) }
@@ -410,22 +413,41 @@ module Dependabot
       def check_pypi_for_library_match
         return false unless updating_pyproject?
 
-        library_details_temp = library_details
-        return false unless library_details_temp && !library_details_temp["name"].nil?
+        metadata = library_details
+        name = metadata&.name
+        return false unless name
 
-        has_library_metadata = !library_details_temp["description"].nil?
+        local_description = metadata.description
+        has_library_metadata = !local_description.nil?
 
-        response = Dependabot::RegistryClient.get(
-          url: "https://pypi.org/pypi/#{normalised_name(library_details_temp['name'])}/json/"
-        )
-        return has_library_metadata unless response.status == 200
+        begin
+          response = Dependabot::RegistryClient.get(
+            url: "https://pypi.org/pypi/#{normalised_name(name)}/json/"
+          )
+          return has_library_metadata unless response.status == 200
 
-        local_description = library_details_temp["description"]
-        return true if local_description.nil?
+          return true if local_description.nil?
 
-        (JSON.parse(response.body)["info"] || {})["summary"] == local_description
-      rescue Excon::Error::Timeout, Excon::Error::Socket, URI::InvalidURIError
-        has_library_metadata
+          pypi_summary(response.body) == local_description
+        rescue Excon::Error::Timeout, Excon::Error::Socket, URI::InvalidURIError
+          has_library_metadata
+        end
+      end
+
+      sig { params(body: String).returns(T.nilable(String)) }
+      def pypi_summary(body)
+        metadata = T.cast(JSON.parse(body), Object)
+        raise TypeError, "PyPI metadata must be an object" unless metadata.is_a?(Hash)
+
+        info = T.cast(metadata["info"], Object)
+        return if info.nil?
+        raise TypeError, "PyPI info must be an object" unless info.is_a?(Hash)
+
+        summary = T.cast(info["summary"], Object)
+        return if summary.nil?
+        return summary if summary.is_a?(String)
+
+        raise TypeError, "PyPI info.summary must be a string"
       end
 
       sig { returns(T::Boolean) }
@@ -483,43 +505,21 @@ module Dependabot
         dependency_files.find { |f| f.name == "poetry.lock" }
       end
 
-      sig { returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig { returns(T.nilable(PyprojectDocument::ProjectMetadata)) }
       def library_details
         @library_details ||= T.let(
-          poetry_details || standard_details || build_system_details,
-          T.nilable(T::Hash[String, T.untyped])
+          pyproject_document.poetry_metadata ||
+            pyproject_document.project_metadata ||
+            pyproject_document.build_system_metadata,
+          T.nilable(PyprojectDocument::ProjectMetadata)
         )
       end
 
-      sig { returns(T.nilable(T::Hash[String, T.untyped])) }
-      def poetry_details
-        @poetry_details ||= T.let(
-          toml_content.dig("tool", "poetry"),
-          T.nilable(T::Hash[String, T.untyped])
-        )
-      end
-
-      sig { returns(T.nilable(T::Hash[String, T.untyped])) }
-      def standard_details
-        @standard_details ||= T.let(
-          toml_content["project"],
-          T.nilable(T::Hash[String, T.untyped])
-        )
-      end
-
-      sig { returns(T.nilable(T::Hash[String, T.untyped])) }
-      def build_system_details
-        @build_system_details ||= T.let(
-          toml_content["build-system"],
-          T.nilable(T::Hash[String, T.untyped])
-        )
-      end
-
-      sig { returns(T::Hash[String, T.untyped]) }
-      def toml_content
-        @toml_content ||= T.let(
-          TomlRB.parse(T.must(pyproject).content),
-          T.nilable(T::Hash[String, T.untyped])
+      sig { returns(PyprojectDocument) }
+      def pyproject_document
+        @pyproject_document ||= T.let(
+          PyprojectDocument.from_content(T.must(T.must(pyproject).content)),
+          T.nilable(PyprojectDocument)
         )
       end
 

--- a/python/spec/dependabot/python/file_parser/pyproject_document_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pyproject_document_spec.rb
@@ -131,4 +131,116 @@ RSpec.describe Dependabot::Python::FileParser::PyprojectDocument do
         .to raise_error(TypeError, "tool.uv.workspace.members must contain only strings")
     end
   end
+
+  describe "library metadata" do
+    let(:content) do
+      <<~TOML
+        [tool.poetry]
+        name = "poetry-project"
+        description = "Poetry description"
+
+        [project]
+        name = "standard-project"
+        description = "Project description"
+
+        [build-system]
+        name = "build-project"
+        description = "Build description"
+      TOML
+    end
+
+    it "returns typed metadata for each section" do
+      expect(document.poetry_metadata).to have_attributes(
+        name: "poetry-project", description: "Poetry description"
+      )
+      expect(document.project_metadata).to have_attributes(
+        name: "standard-project", description: "Project description"
+      )
+      expect(document.build_system_metadata).to have_attributes(
+        name: "build-project", description: "Build description"
+      )
+    end
+
+    context "with an empty project section" do
+      let(:content) { "[project]" }
+
+      it "distinguishes a present section from a missing one" do
+        expect(document).to be_project
+        expect(document).not_to be_pep621
+        expect(document.project_metadata).to have_attributes(name: nil, description: nil)
+        expect(document.poetry_metadata).to be_nil
+        expect(document.build_system_metadata).to be_nil
+      end
+    end
+
+    context "without metadata sections" do
+      let(:content) { "" }
+
+      it "returns no metadata" do
+        expect(document).not_to be_project
+        expect(document.poetry_metadata).to be_nil
+        expect(document.project_metadata).to be_nil
+        expect(document.build_system_metadata).to be_nil
+      end
+    end
+
+    context "with a non-string name" do
+      let(:content) { "[project]\nname = 123" }
+
+      it "raises a contextual error when the metadata is read" do
+        expect(document).to be_project
+        expect { document.project_metadata }.to raise_error(TypeError, "project.name must be a string")
+      end
+    end
+
+    context "with a non-table metadata section" do
+      let(:content) { "project = 123" }
+
+      it "rejects the malformed section" do
+        expect { document.project_metadata }.to raise_error(TypeError, "project must be an object")
+      end
+    end
+
+    context "with a non-string description" do
+      let(:content) do
+        <<~TOML
+          [tool.poetry]
+          name = "valid-project"
+
+          [project]
+          description = false
+        TOML
+      end
+
+      it "validates only the requested metadata section" do
+        expect(document.poetry_metadata).to have_attributes(name: "valid-project", description: nil)
+        expect { document.project_metadata }
+          .to raise_error(TypeError, "project.description must be a string")
+      end
+    end
+
+    context "with unknown metadata fields" do
+      let(:content) { "[project]\nname = \"example\"\nextra = { nested = [1, false] }" }
+
+      it "reads known fields without validating unrelated fields" do
+        expect(document.project_metadata).to have_attributes(name: "example", description: nil)
+      end
+    end
+  end
+
+  describe ".from_content" do
+    it "parses the same document without a dependency file" do
+      expect(described_class.from_content(content).poetry_dependencies("dependencies"))
+        .to eq(document.poetry_dependencies("dependencies"))
+    end
+
+    it "preserves native TOML syntax errors" do
+      expect { described_class.from_content("[project\n") }.to raise_error(TomlRB::ParseError)
+    end
+
+    it "preserves native duplicate-key errors" do
+      expect { described_class.from_content("[project]\nname = \"one\"\nname = \"two\"") }
+        .to raise_error(TomlRB::ValueOverwriteError)
+    end
+  end
 end

--- a/python/spec/dependabot/python/update_checker_spec.rb
+++ b/python/spec/dependabot/python/update_checker_spec.rb
@@ -86,6 +86,219 @@ RSpec.describe Dependabot::Python::UpdateChecker do
 
   it_behaves_like "an update checker"
 
+  describe "#requirements_update_strategy" do
+    subject(:strategy) { checker.requirements_update_strategy }
+
+    let(:dependency_files) { [pyproject] }
+    let(:dependency_requirements) do
+      [{ file: "pyproject.toml", requirement: "==2.0.0", groups: [], source: nil }]
+    end
+    let(:pyproject) { Dependabot::DependencyFile.new(name: "pyproject.toml", content: project_content) }
+    let(:project_content) do
+      <<~TOML
+        [project]
+        name = "example_project"
+        description = "Example library"
+      TOML
+    end
+    let(:project_url) { "https://pypi.org/pypi/example-project/json/" }
+    let(:project_response) { { info: { summary: "Example library" } }.to_json }
+    let(:project_status) { 200 }
+
+    before do
+      stub_request(:get, project_url).to_return(status: project_status, body: project_response)
+    end
+
+    it "widens matching library requirements and caches the result" do
+      2.times { expect(checker.requirements_update_strategy).to eq(Dependabot::RequirementsUpdateStrategy::WidenRanges) }
+      expect(a_request(:get, project_url)).to have_been_made.once
+    end
+
+    context "with a different summary" do
+      let(:project_response) { { info: { summary: "Another project" } }.to_json }
+
+      it "bumps application requirements and caches the result" do
+        2.times { expect(checker.requirements_update_strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersions) }
+        expect(a_request(:get, project_url)).to have_been_made.once
+      end
+    end
+
+    [{}, { info: nil }, { info: {} }, { info: { summary: nil } }, { info: { summary: "" } }].each do |response|
+      context "with PyPI metadata #{response.inspect}" do
+        let(:project_response) { response.to_json }
+
+        it "does not identify a matching library" do
+          expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersions)
+        end
+      end
+    end
+
+    context "with malformed JSON" do
+      let(:project_response) { "not JSON" }
+
+      it "propagates the parse error" do
+        expect { strategy }.to raise_error(JSON::ParserError)
+      end
+    end
+
+    context "with a non-object PyPI response" do
+      let(:project_response) { "[]" }
+
+      it "rejects the malformed response" do
+        expect { strategy }.to raise_error(TypeError, "PyPI metadata must be an object")
+      end
+    end
+
+    context "with a non-object info field" do
+      let(:project_response) { { info: false }.to_json }
+
+      it "rejects the malformed info field" do
+        expect { strategy }.to raise_error(TypeError, "PyPI info must be an object")
+      end
+    end
+
+    context "with a non-string summary" do
+      let(:project_response) { { info: { summary: 123 } }.to_json }
+
+      it "rejects the malformed summary" do
+        expect { strategy }.to raise_error(TypeError, "PyPI info.summary must be a string")
+      end
+    end
+
+    context "without a local description" do
+      let(:project_content) { "[project]\nname = \"example_project\"" }
+      let(:project_response) { "not JSON" }
+
+      it "accepts a published project without parsing unused metadata" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::WidenRanges)
+      end
+
+      context "when the project is not published" do
+        let(:project_status) { 404 }
+
+        it "does not classify it as a library" do
+          expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersions)
+        end
+      end
+    end
+
+    context "without a local name" do
+      let(:project_content) { "[project]\ndescription = \"Example library\"" }
+
+      it "does not request PyPI metadata" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersions)
+        expect(a_request(:get, project_url)).not_to have_been_made
+      end
+    end
+
+    context "with a non-string local name" do
+      let(:project_content) { "[project]\nname = 123" }
+
+      it "rejects the malformed name before making a request" do
+        expect { strategy }.to raise_error(TypeError, "project.name must be a string")
+        expect(a_request(:get, project_url)).not_to have_been_made
+      end
+    end
+
+    context "with a non-string local description" do
+      let(:project_content) { "[project]\nname = \"example_project\"\ndescription = false" }
+
+      it "rejects the malformed description" do
+        expect { strategy }.to raise_error(TypeError, "project.description must be a string")
+      end
+    end
+
+    context "with a non-200 PyPI response" do
+      let(:project_status) { 503 }
+      let(:project_response) { "not JSON" }
+
+      it "uses the presence of a local description" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::WidenRanges)
+      end
+    end
+
+    context "when the request times out" do
+      before do
+        stub_request(:get, project_url).to_raise(Excon::Error::Timeout.new("connection timeout"))
+      end
+
+      it "uses the presence of a local description" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::WidenRanges)
+      end
+    end
+
+    context "with Poetry and project metadata" do
+      let(:project_content) do
+        <<~TOML
+          [tool.poetry]
+          name = "example_project"
+          description = "Example library"
+
+          [project]
+          name = 123
+        TOML
+      end
+
+      it "prefers Poetry without reading the unselected metadata" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::WidenRanges)
+      end
+
+      context "when the Poetry table is empty" do
+        let(:project_content) { "[tool.poetry]\n[project]\nname = \"example_project\"" }
+
+        it "does not fall through to project metadata" do
+          expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersions)
+          expect(a_request(:get, project_url)).not_to have_been_made
+        end
+      end
+    end
+
+    context "with only build-system metadata" do
+      let(:project_content) do
+        <<~TOML
+          [build-system]
+          name = "example_project"
+          description = "Example library"
+        TOML
+      end
+
+      it "retains the build-system metadata fallback" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::WidenRanges)
+      end
+
+      context "with an empty project table" do
+        let(:project_content) { "[project]\n#{super()}" }
+
+        it "does not fall through to build-system metadata" do
+          expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersions)
+          expect(a_request(:get, project_url)).not_to have_been_made
+        end
+      end
+    end
+
+    context "with an explicit update strategy" do
+      let(:requirements_update_strategy) { Dependabot::RequirementsUpdateStrategy::LockfileOnly }
+      let(:project_content) { "not TOML" }
+
+      it "skips library detection" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::LockfileOnly)
+        expect(a_request(:get, project_url)).not_to have_been_made
+      end
+    end
+
+    context "when updating a requirements file" do
+      let(:dependency_requirements) do
+        [{ file: "requirements.txt", requirement: "==2.0.0", groups: [], source: nil }]
+      end
+      let(:project_content) { "not TOML" }
+
+      it "does not inspect unrelated project metadata" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersions)
+        expect(a_request(:get, project_url)).not_to have_been_made
+      end
+    end
+  end
+
   describe "#can_update?" do
     subject { checker.can_update?(requirements_to_unlock: :own) }
 
@@ -487,6 +700,23 @@ RSpec.describe Dependabot::Python::UpdateChecker do
             .and_return(Gem::Version.new("2.5.0"))
           expect(checker.latest_resolvable_version)
             .to eq(Gem::Version.new("2.5.0"))
+        end
+      end
+
+      context "when Poetry has an empty project table and no lockfile" do
+        let(:dependency_files) { [pyproject] }
+        let(:pyproject) do
+          Dependabot::DependencyFile.new(name: "pyproject.toml", content: "[tool.poetry]\n[project]\n")
+        end
+
+        it "selects the requirements resolver based on table presence" do
+          resolver = instance_double(
+            described_class::PipVersionResolver,
+            latest_resolvable_version: Gem::Version.new("2.5.0")
+          )
+          allow(described_class::PipVersionResolver).to receive(:new).and_return(resolver)
+
+          expect(checker.latest_resolvable_version).to eq(Gem::Version.new("2.5.0"))
         end
       end
 

--- a/uv/lib/dependabot/uv/update_checker.rb
+++ b/uv/lib/dependabot/uv/update_checker.rb
@@ -228,11 +228,11 @@ module Dependabot
         requirement_files.any? { |f| f.end_with?("requirements.txt") }
       end
 
-      sig { override.returns(T.nilable(T::Hash[String, T.untyped])) }
+      sig { override.returns(T.nilable(PyprojectDocument::ProjectMetadata)) }
       def library_details
         @library_details ||= T.let(
-          standard_details || build_system_details,
-          T.nilable(T::Hash[String, T.untyped])
+          pyproject_document.project_metadata || pyproject_document.build_system_metadata,
+          T.nilable(PyprojectDocument::ProjectMetadata)
         )
       end
 

--- a/uv/spec/dependabot/uv/update_checker_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker_spec.rb
@@ -80,6 +80,76 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
 
   it_behaves_like "an update checker"
 
+  describe "#requirements_update_strategy" do
+    subject(:strategy) { checker.requirements_update_strategy }
+
+    let(:dependency_files) { [pyproject] }
+    let(:dependency_requirements) do
+      [{ file: "pyproject.toml", requirement: "==2.0.0", groups: [], source: nil }]
+    end
+    let(:pyproject) { Dependabot::DependencyFile.new(name: "pyproject.toml", content: project_content) }
+    let(:project_content) do
+      <<~TOML
+        [tool.poetry]
+        name = 123
+
+        [project]
+        name = "example"
+        description = "Example library"
+      TOML
+    end
+    let(:project_url) { "https://pypi.org/pypi/example/json/" }
+
+    before do
+      stub_request(:get, project_url)
+        .to_return(status: 200, body: { info: { summary: "Example library" } }.to_json)
+    end
+
+    it "uses project metadata and ignores Poetry metadata" do
+      expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::WidenRanges)
+    end
+
+    context "with only Poetry metadata" do
+      let(:project_content) { "[tool.poetry]\nname = 123" }
+
+      it "does not use Poetry for library detection" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersions)
+        expect(a_request(:get, project_url)).not_to have_been_made
+      end
+    end
+
+    context "with build-system metadata and no project table" do
+      let(:project_content) do
+        <<~TOML
+          [build-system]
+          name = "example"
+          description = "Example library"
+        TOML
+      end
+
+      it "retains the build-system metadata fallback" do
+        expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::WidenRanges)
+      end
+
+      context "with an empty project table" do
+        let(:project_content) { "[project]\n#{super()}" }
+
+        it "does not fall through to the build-system metadata" do
+          expect(strategy).to eq(Dependabot::RequirementsUpdateStrategy::BumpVersions)
+          expect(a_request(:get, project_url)).not_to have_been_made
+        end
+      end
+    end
+
+    context "with malformed project metadata" do
+      let(:project_content) { "[project]\nname = \"example\"\ndescription = 123" }
+
+      it "uses the same type errors as Python library detection" do
+        expect { strategy }.to raise_error(TypeError, "project.description must be a string")
+      end
+    end
+  end
+
   describe "#can_update?" do
     subject { checker.can_update?(requirements_to_unlock: :own) }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Use typed pyproject metadata for library detection in Python and UV. `PyprojectDocument` now exposes optional string `name` and `description` fields, and the Python checker reads PyPI's `info.summary` through a typed helper. This removes 12 `T.untyped` annotations across the two checkers.

### Anything you want to highlight for special attention from reviewers?

Python still prefers Poetry, project, then build-system metadata. UV still ignores Poetry metadata. Empty tables remain distinct from missing tables, including when choosing the Poetry resolver. Missing descriptions, network fallbacks, and cached library decisions keep their existing behavior.

Wrongly typed consumed metadata now raises a contextual `TypeError`. This is intentional: malformed names, descriptions, and PyPI summaries were previously handled inconsistently. Unknown fields remain allowed, and unselected metadata is not validated. TOML syntax errors retain each caller's existing handling.

The types cover fields already used by library detection, not a complete pyproject schema. The build-system metadata fallback is existing Dependabot behavior. Resolver interfaces stay outside this change, so both checker files remain `typed: strict`.

This PR is independent of the UV version-config change. Both reduce the existing RuboCop offense count; preserve both reductions when merging.

### How will you know you've accomplished your goal?

Repository-wide Sorbet and targeted RuboCop passed in containers. The relevant Python and UV document, parser, and checker suites passed all 394 examples, including new cases for malformed metadata, table precedence, empty-table resolver selection, and cached PyPI decisions. I did not run the complete repository suite.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
