### PR TITLE
Type UV dynamic version configuration reads

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 662
+# Offense count: 660
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -367,7 +367,6 @@ Sorbet/ForbidTUntyped:
     - "uv/lib/dependabot/uv/file_updater/compile_file_updater.rb"
     - "uv/lib/dependabot/uv/file_updater/lock_file_error_handler.rb"
     - "uv/lib/dependabot/uv/file_updater/lock_file_updater.rb"
-    - "uv/lib/dependabot/uv/file_updater/version_config_parser.rb"
     - "uv/lib/dependabot/uv/update_checker.rb"
     - "vcpkg/lib/dependabot/vcpkg/file_parser.rb"
     - "vcpkg/lib/dependabot/vcpkg/file_updater.rb"

--- a/uv/lib/dependabot/uv/file_updater/version_config_parser.rb
+++ b/uv/lib/dependabot/uv/file_updater/version_config_parser.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "toml-rb"
@@ -12,6 +12,8 @@ module Dependabot
     class FileUpdater < Dependabot::FileUpdaters::Base
       class VersionConfigParser
         extend T::Sig
+
+        ObjectHash = T.type_alias { T::Hash[String, Object] }
 
         class VersionConfig < T::Struct
           extend T::Sig
@@ -32,7 +34,7 @@ module Dependabot
           @pyproject_content = pyproject_content
           @base_path = base_path
           @repo_root = repo_root
-          @parsed_pyproject = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
+          @parsed_pyproject = T.let(nil, T.nilable(ObjectHash))
         end
 
         sig { returns(VersionConfig) }
@@ -56,13 +58,44 @@ module Dependabot
         sig { returns(String) }
         attr_reader :repo_root
 
-        sig { returns(T::Hash[String, T.untyped]) }
+        sig { returns(ObjectHash) }
         def parsed_pyproject
           return @parsed_pyproject unless @parsed_pyproject.nil?
 
-          @parsed_pyproject = TomlRB.parse(pyproject_content)
+          @parsed_pyproject = object_hash(T.cast(TomlRB.parse(pyproject_content), Object))
         rescue TomlRB::ParseError, TomlRB::ValueOverwriteError
           @parsed_pyproject = {}
+        end
+
+        sig { params(value: Object).returns(ObjectHash) }
+        def object_hash(value)
+          raise TypeError, "Version configuration must be a table" unless value.is_a?(Hash)
+
+          result = T.let({}, ObjectHash)
+          value.each do |raw_key, raw_value|
+            key = T.cast(raw_key, Object)
+            raise TypeError, "Version configuration keys must be strings" unless key.is_a?(String)
+
+            result[key] = T.cast(raw_value, Object)
+          end
+          result
+        end
+
+        sig { params(path: T::Array[String]).returns(Object) }
+        def config_value(path)
+          value = T.let(parsed_pyproject, Object)
+          path.each do |key|
+            return nil if value.nil?
+
+            value = object_hash(value)[key]
+          end
+          value
+        end
+
+        sig { params(path: T::Array[String]).returns(T.nilable(ObjectHash)) }
+        def config_table(path)
+          value = config_value(path)
+          object_hash(value) if value.is_a?(Hash)
         end
 
         sig { returns(T::Array[String]) }
@@ -82,8 +115,8 @@ module Dependabot
 
         sig { returns(T::Array[String]) }
         def setuptools_scm_write_paths
-          scm_config = parsed_pyproject.dig("tool", "setuptools_scm")
-          return [] unless scm_config.is_a?(Hash)
+          scm_config = config_table(%w(tool setuptools_scm))
+          return [] unless scm_config
 
           paths = []
 
@@ -98,8 +131,8 @@ module Dependabot
 
         sig { returns(T::Array[String]) }
         def hatch_vcs_build_hook_write_paths
-          vcs_hook = parsed_pyproject.dig("tool", "hatch", "build", "hooks", "vcs")
-          return [] unless vcs_hook.is_a?(Hash)
+          vcs_hook = config_table(%w(tool hatch build hooks vcs))
+          return [] unless vcs_hook
 
           paths = []
 
@@ -111,8 +144,8 @@ module Dependabot
 
         sig { returns(T::Array[String]) }
         def hatch_version_source_paths
-          hatch_version = parsed_pyproject.dig("tool", "hatch", "version")
-          return [] unless hatch_version.is_a?(Hash)
+          hatch_version = config_table(%w(tool hatch version))
+          return [] unless hatch_version
 
           paths = []
 
@@ -124,14 +157,14 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def extract_fallback_version
-          scm_config = parsed_pyproject.dig("tool", "setuptools_scm")
-          if scm_config.is_a?(Hash)
+          scm_config = config_table(%w(tool setuptools_scm))
+          if scm_config
             fallback = scm_config["fallback_version"]
             return fallback if fallback.is_a?(String)
           end
 
-          raw_options = parsed_pyproject.dig("tool", "hatch", "version", "raw-options")
-          if raw_options.is_a?(Hash)
+          raw_options = config_table(%w(tool hatch version raw-options))
+          if raw_options
             fallback = raw_options["fallback_version"]
             return fallback if fallback.is_a?(String)
           end
@@ -141,7 +174,7 @@ module Dependabot
 
         sig { returns(T.nilable(String)) }
         def extract_package_name
-          name = parsed_pyproject.dig("project", "name")
+          name = config_value(%w(project name))
           return name if name.is_a?(String)
 
           nil

--- a/uv/spec/dependabot/uv/file_updater/version_config_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_updater/version_config_parser_spec.rb
@@ -195,5 +195,174 @@ RSpec.describe Dependabot::Uv::FileUpdater::VersionConfigParser do
         expect(config.write_paths).to contain_exactly("src/new/_version.py", "src/old/_version.py")
       end
     end
+
+    context "with both fallback version sources" do
+      let(:fallback_version) { "1.2.3" }
+      let(:pyproject_content) do
+        <<~TOML
+          [tool.setuptools_scm]
+          fallback_version = #{fallback_version.to_json}
+
+          [tool.hatch.version.raw-options]
+          fallback_version = "9.0.0"
+        TOML
+      end
+
+      it "prefers the setuptools-scm fallback" do
+        expect(config.fallback_version).to eq("1.2.3")
+      end
+
+      context "when the setuptools-scm fallback is empty" do
+        let(:fallback_version) { "" }
+
+        it "keeps the empty fallback" do
+          expect(config.fallback_version).to eq("")
+        end
+      end
+
+      context "when the setuptools-scm fallback is not a string" do
+        let(:fallback_version) { 123 }
+
+        it "uses the Hatch fallback" do
+          expect(config.fallback_version).to eq("9.0.0")
+        end
+      end
+    end
+
+    context "with non-string optional values" do
+      let(:pyproject_content) do
+        <<~TOML
+          [project]
+          name = 123
+
+          [tool.setuptools_scm]
+          version_file = 123
+          write_to = false
+          fallback_version = ["1.0.0"]
+
+          [tool.hatch.build.hooks.vcs]
+          version-file = ["_version.py"]
+
+          [tool.hatch.version]
+          path = 123
+
+          [tool.hatch.version.raw-options]
+          fallback_version = 456
+        TOML
+      end
+
+      it "ignores the invalid optional values" do
+        expect(config).to have_attributes(
+          write_paths: [],
+          source_paths: [],
+          fallback_version: nil,
+          package_name: nil
+        )
+      end
+    end
+
+    context "with a non-table setuptools-scm configuration" do
+      let(:pyproject_content) do
+        <<~TOML
+          [tool]
+          setuptools_scm = false
+
+          [tool.hatch.version.raw-options]
+          fallback_version = "9.0.0"
+        TOML
+      end
+
+      it "ignores that section without dropping other configuration" do
+        expect(config.write_paths).to be_empty
+        expect(config.fallback_version).to eq("9.0.0")
+      end
+    end
+
+    context "with duplicate paths across build backends" do
+      let(:pyproject_content) do
+        <<~TOML
+          [tool.setuptools_scm]
+          version_file = "src/_version.py"
+          write_to = "src/_version.py"
+
+          [tool.hatch.build.hooks.vcs]
+          version-file = "src/hatch_version.py"
+
+          [tool.hatch.version]
+          path = ".release-manifest.json"
+        TOML
+      end
+
+      it "keeps the first occurrence of each output path in order" do
+        expect(config.write_paths).to eq(["src/_version.py", "src/hatch_version.py"])
+        expect(config.source_paths).to eq([".release-manifest.json"])
+      end
+    end
+
+    context "with an empty document" do
+      let(:pyproject_content) { "" }
+
+      it "returns an empty configuration" do
+        expect(config).to have_attributes(
+          write_paths: [],
+          source_paths: [],
+          fallback_version: nil,
+          package_name: nil
+        )
+      end
+    end
+
+    context "with unrelated configuration" do
+      let(:pyproject_content) do
+        <<~TOML
+          [project]
+          name = "example"
+
+          [tool.unrelated]
+          options = [1, false, { key = "value" }]
+        TOML
+      end
+
+      it "ignores unknown sections" do
+        expect(config.package_name).to eq("example")
+        expect(config).not_to be_dynamic_version
+      end
+
+      it "parses the TOML only once" do
+        allow(TomlRB).to receive(:parse).and_call_original
+
+        parser.parse
+        parser.parse
+
+        expect(TomlRB).to have_received(:parse).with(pyproject_content).once
+      end
+    end
+
+    context "with duplicate TOML keys" do
+      let(:pyproject_content) do
+        <<~TOML
+          [project]
+          name = "one"
+          name = "two"
+        TOML
+      end
+
+      it "returns an empty configuration" do
+        expect(config).to have_attributes(
+          write_paths: [],
+          source_paths: [],
+          fallback_version: nil,
+          package_name: nil
+        )
+      end
+    end
+
+    context "with a non-table intermediate section" do
+      let(:pyproject_content) { 'tool = "invalid"' }
+
+      it "raises instead of treating the document as empty" do
+        expect { config }.to raise_error(TypeError)
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Make `VersionConfigParser` `typed: strong` by checking TOML values before reading them. The parser still returns the existing `VersionConfig`; its two `T.untyped` annotations are gone.

### Anything you want to highlight for special attention from reviewers?

The supported fields are the setuptools-scm and Hatch settings already used by this reader and its fixtures. Invalid TOML still produces an empty config, non-string optional values are still ignored, and malformed intermediate tables still raise. Fallback precedence, path handling, and workspace behavior are unchanged.

The parsing stays local because the existing Python document parser has different error handling.

### How will you know you've accomplished your goal?

Container checks passed: repository-wide Sorbet, RuboCop on both changed Ruby files, and all 119 examples in the version-config and lock-file-updater specs. The added cases cover fallback precedence, malformed and missing values, duplicate paths, and cached parsing.

Sorbet reports no untyped usages in this reader. The existing RuboCop offense baseline drops by two. I ran the relevant suites, not the complete repository suite.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
