### PR TITLE
Use typed package.json reads in npm and Yarn

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 660
+# Offense count: 656
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -301,7 +301,6 @@ Sorbet/ForbidTUntyped:
     - "nix/lib/dependabot/nix/package/package_details_fetcher.rb"
     - "nix/lib/dependabot/nix/update_checker/versioned_branch_finder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_files_filterer.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/npm_relationship_resolver.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/yarn_relationship_resolver.rb"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_files_filterer.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_files_filterer.rb
@@ -1,7 +1,8 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/utils"
+require "dependabot/package/npm_package_json"
 require "dependabot/npm_and_yarn/file_parser/lockfile_parser"
 require "sorbet-runtime"
 
@@ -88,7 +89,7 @@ module Dependabot
         return false unless ["yarn.lock", "package-lock.json", "pnpm-lock.yaml", "bun.lock", "npm-shrinkwrap.json"]
                             .include?(lockfile.name)
 
-        return false unless parsed_root_package_json["workspaces"] || dependency_files.any? do |file|
+        return false unless root_package_json_document.workspaces? || dependency_files.any? do |file|
           file.name.end_with?("pnpm-workspace.yaml") && File.dirname(file.name) == File.dirname(lockfile.name)
         end
 
@@ -115,14 +116,14 @@ module Dependabot
         )
       end
 
-      sig { returns(T::Hash[String, T.untyped]) }
-      def parsed_root_package_json
-        @parsed_root_package_json ||= T.let(
+      sig { returns(Dependabot::Package::NpmPackageJson) }
+      def root_package_json_document
+        @root_package_json_document ||= T.let(
           begin
             package = T.must(dependency_files.find { |f| f.name == "package.json" })
-            JSON.parse(T.must(package.content))
+            Dependabot::Package::NpmPackageJson.from_file(package)
           end,
-          T.nilable(T::Hash[String, T.untyped])
+          T.nilable(Dependabot::Package::NpmPackageJson)
         )
       end
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -5,6 +5,7 @@
 
 require "cgi/escape"
 require "dependabot/dependency"
+require "dependabot/package/npm_package_json"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/shared_helpers"
@@ -99,7 +100,7 @@ module Dependabot
       def package_manager_helper
         @package_manager_helper ||= T.let(
           PackageManagerHelper.new(
-            Dependabot::Package::NpmPackageManagerConfig.from_package_json(parsed_package_json),
+            package_json_document.package_manager_config,
             lockfiles,
             registry_config_files,
             credentials
@@ -126,9 +127,9 @@ module Dependabot
         }
       end
 
-      sig { returns(T.untyped) }
-      def parsed_package_json
-        JSON.parse(T.must(package_json.content))
+      sig { returns(Dependabot::Package::NpmPackageJson) }
+      def package_json_document
+        Dependabot::Package::NpmPackageJson.from_file(package_json)
       rescue JSON::ParserError
         raise Dependabot::DependencyFileNotParseable, package_json.path
       end
@@ -227,16 +228,14 @@ module Dependabot
         dependency_set = DependencySet.new
 
         package_files.each do |file|
-          json = JSON.parse(T.must(file.content))
+          manifest = Dependabot::Package::NpmPackageJson.from_file(file)
 
           # TODO: Currently, Dependabot can't handle flat dependency files
           # (and will error at the FileUpdater stage, because the
           # UpdateChecker doesn't take account of flat resolution).
-          next if json["flat"]
+          next if manifest.flat?
 
-          self.class.each_dependency(json) do |name, requirement, type|
-            next unless requirement.is_a?(String)
-
+          manifest.each_dependency do |name, requirement, type|
             # Skip dependencies using Yarn workspace cross-references as requirements
             next if requirement.start_with?("workspace:", "catalog:")
 
@@ -295,7 +294,7 @@ module Dependabot
       end
 
       sig do
-        params(file: DependencyFile, type: T.untyped, name: String, requirement: String)
+        params(file: DependencyFile, type: String, name: String, requirement: String)
           .returns(T.nilable(Dependency))
       end
       def build_dependency(file:, type:, name:, requirement:)
@@ -454,7 +453,7 @@ module Dependabot
       def workspace_package_names
         @workspace_package_names ||= T.let(
           package_files.filter_map do |f|
-            JSON.parse(T.must(f.content))["name"]
+            Dependabot::Package::NpmPackageJson.from_file(f).name
           end,
           T.nilable(T::Array[String])
         )

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_files_filterer_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_files_filterer_spec.rb
@@ -37,6 +37,95 @@ RSpec.describe Dependabot::NpmAndYarn::DependencyFilesFilterer do
     dependency_files.find { |f| f.name == file_name }
   end
 
+  describe "workspace manifest reads" do
+    let(:workspaces) { [] }
+    let(:root_manifest) do
+      Dependabot::DependencyFile.new(
+        name: "package.json",
+        content: JSON.dump("workspaces" => workspaces, "dependencies" => [])
+      )
+    end
+    let(:member_manifest) do
+      Dependabot::DependencyFile.new(name: "packages/member/package.json", content: "{}")
+    end
+    let(:root_lockfile) { Dependabot::DependencyFile.new(name: "package-lock.json", content: "{}") }
+    let(:dependency_files) { [root_manifest, member_manifest, root_lockfile] }
+    let(:dependency) do
+      Dependabot::Dependency.new(
+        name: "chalk",
+        version: "0.4.0",
+        requirements: [{
+          file: member_manifest.name,
+          requirement: "0.3.0",
+          groups: ["dependencies"],
+          source: nil
+        }],
+        package_manager: "npm_and_yarn"
+      )
+    end
+
+    before do
+      lockfile_parser = instance_double(Dependabot::NpmAndYarn::FileParser::LockfileParser, parse: [dependency])
+      allow(Dependabot::NpmAndYarn::FileParser::LockfileParser).to receive(:new).and_return(lockfile_parser)
+    end
+
+    it "keeps the workspace lockfile without inspecting unrelated manifest fields" do
+      expect(files_requiring_update).to contain_exactly(member_manifest, root_lockfile)
+    end
+
+    context "with an object workspace declaration" do
+      let(:workspaces) { {} }
+
+      it "keeps the root lockfile" do
+        expect(files_requiring_update).to contain_exactly(member_manifest, root_lockfile)
+      end
+    end
+
+    [nil, false].each do |value|
+      context "with workspaces set to #{value.inspect}" do
+        let(:workspaces) { value }
+
+        it "does not treat the root lockfile as a workspace lockfile" do
+          expect(files_requiring_update).to eq([member_manifest])
+        end
+      end
+    end
+
+    context "with a pnpm workspace file instead of a workspace declaration" do
+      let(:workspaces) { nil }
+      let(:dependency_files) do
+        super() + [Dependabot::DependencyFile.new(name: "pnpm-workspace.yaml", content: "packages: []")]
+      end
+
+      it "retains the pnpm workspace fallback" do
+        expect(files_requiring_update).to contain_exactly(member_manifest, root_lockfile)
+      end
+    end
+
+    context "when the nested package has its own lockfile and no root manifest" do
+      let(:root_lockfile) do
+        Dependabot::DependencyFile.new(name: "packages/member/package-lock.json", content: "{}")
+      end
+      let(:dependency_files) { [member_manifest, root_lockfile] }
+
+      it "does not attempt to read the root manifest" do
+        expect(files_requiring_update).to contain_exactly(member_manifest, root_lockfile)
+      end
+    end
+
+    context "with multiple workspace lockfiles" do
+      let(:other_lockfile) { Dependabot::DependencyFile.new(name: "yarn.lock", content: "") }
+      let(:dependency_files) { super() + [other_lockfile] }
+
+      it "decodes the root manifest once" do
+        allow(JSON).to receive(:parse).and_call_original
+
+        expect(files_requiring_update).to contain_exactly(member_manifest, root_lockfile, other_lockfile)
+        expect(JSON).to have_received(:parse).with(root_manifest.content).once
+      end
+    end
+  end
+
   describe ".files_requiring_update" do
     it do
       expect(files_requiring_update).to contain_exactly(

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -39,6 +39,114 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
   it_behaves_like "a dependency file parser"
 
+  describe ".each_dependency compatibility" do
+    it "keeps raw values and section order for updater callers" do
+      json = {
+        "dependencies" => { "first" => "1.0.0", "raw" => { "version" => "2.0.0" }, "missing" => nil },
+        "devDependencies" => { "first" => "3.0.0" }
+      }
+      yielded = []
+
+      described_class.each_dependency(json) { |name, requirement, type| yielded << [name, requirement, type] }
+
+      expect(yielded).to eq(
+        [
+          ["first", "1.0.0", "dependencies"],
+          ["raw", { "version" => "2.0.0" }, "dependencies"],
+          ["missing", nil, "dependencies"],
+          ["first", "3.0.0", "devDependencies"]
+        ]
+      )
+    end
+
+    it "allows callers to update the original dependency map during iteration" do
+      json = { "dependencies" => { "first" => "1.0.0", "second" => "2.0.0" } }
+      yielded = []
+
+      described_class.each_dependency(json) do |name, requirement, type|
+        yielded << requirement
+        json[type]["second"] = "3.0.0" if name == "first"
+      end
+
+      expect(yielded).to eq(["1.0.0", "3.0.0"])
+      expect(json["dependencies"]["second"]).to eq("3.0.0")
+    end
+  end
+
+  describe "package.json read boundaries" do
+    let(:manifest) { { "name" => "root", "dependencies" => { "chalk" => "0.3.0" } } }
+    let(:manifest_content) { JSON.dump(manifest) }
+    let(:package_file) { Dependabot::DependencyFile.new(name: "package.json", content: manifest_content) }
+    let(:files) { [package_file] }
+
+    it "parses an exact dependency without a lockfile" do
+      expect(parser.parse.map(&:name)).to eq(["chalk"])
+    end
+
+    context "with malformed dependency containers" do
+      let(:manifest) { { "dependencies" => [["chalk", "0.3.0"]] } }
+
+      it "rejects the container with file and field context" do
+        expect { parser.parse }
+          .to raise_error(TypeError, "#{package_file.path}: dependencies must be an object")
+      end
+    end
+
+    context "with a flat manifest and malformed dependencies" do
+      let(:manifest) { { "flat" => true, "dependencies" => [] } }
+
+      it "skips the manifest before inspecting dependencies" do
+        expect(parser.parse).to be_empty
+      end
+    end
+
+    context "with missing, null, and false dependency sections" do
+      let(:manifest) { { "dependencies" => nil, "devDependencies" => false } }
+
+      it "finds no dependencies" do
+        expect(parser.parse).to be_empty
+      end
+    end
+
+    context "with a workspace package" do
+      let(:manifest) { { "dependencies" => { "chalk" => "0.3.0", "member" => "1.0.0" } } }
+      let(:member_name) { "member" }
+      let(:files) do
+        [
+          package_file,
+          Dependabot::DependencyFile.new(
+            name: "packages/member/package.json",
+            content: JSON.dump("name" => member_name)
+          )
+        ]
+      end
+
+      it "excludes the workspace package from registry updates" do
+        expect(parser.parse.map(&:name)).to eq(["chalk"])
+      end
+
+      context "with a non-string workspace name" do
+        let(:member_name) { 123 }
+
+        it "does not match the dependency name" do
+          expect(parser.parse.map(&:name)).to contain_exactly("chalk", "member")
+        end
+      end
+    end
+
+    context "with invalid JSON" do
+      let(:manifest_content) { "{" }
+
+      it "preserves the parsing error for dependency extraction" do
+        expect { parser.parse }.to raise_error(JSON::ParserError)
+      end
+
+      it "preserves the file error for package-manager detection" do
+        expect { parser.ecosystem }.to raise_error(Dependabot::DependencyFileNotParseable)
+      end
+    end
+  end
+
   describe "#ecosystem" do
     let(:files) { project_dependency_files("npm6/simple") }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Use the shared reader from #16179 for npm/Yarn's root package-manager configuration, manifest dependencies, workspace package names, and workspace-aware file filtering.

`DependencyFilesFilterer` is now `typed: strong`. This layer removes four `T.untyped` annotations and lowers the existing offense count from 660 to 656.

### Anything you want to highlight for special attention from reviewers?

The public `FileParser.each_dependency` implementation is unchanged. Updater callers can still read raw values and modify their original JSON during iteration.

Empty-requirement normalization, aliases, workspace/catalog references, and support-file handling stay in the ecosystem parser. The filterer keeps its existing short circuits, workspace truthiness, pnpm fallback, and shrinkwrap support.

The selected read paths now reject malformed dependency containers with contextual errors. Non-string requirement values remain ignored. Lockfile parsing and writing are unchanged.

This PR is based on #16179; #16181 adds the Bun integration above it.

### How will you know you've accomplished your goal?

The parser, filterer, package-json-preparer, and npm-lockfile-updater suites pass all 343 examples. New cases cover iterator mutation, malformed containers, lazy reads, workspace names, and syntax-error handling. Repository-wide Sorbet, targeted RuboCop, and the existing untyped ratchet pass in containers. I did not run the complete repository suite.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
