### PR TITLE
Use typed package.json reads in Bun

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,11 +239,10 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 656
+# Offense count: 652
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
-    - "bun/lib/dependabot/bun/dependency_files_filterer.rb"
     - "bun/lib/dependabot/bun/file_fetcher.rb"
     - "bun/lib/dependabot/bun/file_fetcher/path_dependency_builder.rb"
     - "bun/lib/dependabot/bun/file_parser.rb"

--- a/bun/lib/dependabot/bun/dependency_files_filterer.rb
+++ b/bun/lib/dependabot/bun/dependency_files_filterer.rb
@@ -1,7 +1,8 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "dependabot/utils"
+require "dependabot/package/npm_package_json"
 require "dependabot/bun/file_parser/lockfile_parser"
 require "sorbet-runtime"
 
@@ -87,7 +88,7 @@ module Dependabot
       def workspaces_lockfile?(lockfile)
         return false unless ["yarn.lock", "package-lock.json", "pnpm-lock.yaml", "bun.lock"].include?(lockfile.name)
 
-        return false unless parsed_root_package_json["workspaces"] || dependency_files.any? do |file|
+        return false unless root_package_json_document.workspaces? || dependency_files.any? do |file|
           file.name.end_with?("pnpm-workspace.yaml") && File.dirname(file.name) == File.dirname(lockfile.name)
         end
 
@@ -114,14 +115,14 @@ module Dependabot
         )
       end
 
-      sig { returns(T::Hash[String, T.untyped]) }
-      def parsed_root_package_json
-        @parsed_root_package_json ||= T.let(
+      sig { returns(Dependabot::Package::NpmPackageJson) }
+      def root_package_json_document
+        @root_package_json_document ||= T.let(
           begin
             package = T.must(dependency_files.find { |f| f.name == "package.json" })
-            JSON.parse(T.must(package.content))
+            Dependabot::Package::NpmPackageJson.from_file(package)
           end,
-          T.nilable(T::Hash[String, T.untyped])
+          T.nilable(Dependabot::Package::NpmPackageJson)
         )
       end
 

--- a/bun/lib/dependabot/bun/file_parser.rb
+++ b/bun/lib/dependabot/bun/file_parser.rb
@@ -5,6 +5,7 @@
 
 require "cgi/escape"
 require "dependabot/dependency"
+require "dependabot/package/npm_package_json"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
 require "dependabot/shared_helpers"
@@ -98,7 +99,7 @@ module Dependabot
       def package_manager_helper
         @package_manager_helper ||= T.let(
           PackageManagerHelper.new(
-            Dependabot::Package::NpmPackageManagerConfig.from_package_json(parsed_package_json),
+            package_json_document.package_manager_config,
             lockfiles,
             registry_config_files,
             credentials
@@ -121,9 +122,9 @@ module Dependabot
         }
       end
 
-      sig { returns(T.untyped) }
-      def parsed_package_json
-        JSON.parse(T.must(package_json.content))
+      sig { returns(Dependabot::Package::NpmPackageJson) }
+      def package_json_document
+        Dependabot::Package::NpmPackageJson.from_file(package_json)
       rescue JSON::ParserError
         raise Dependabot::DependencyFileNotParseable, package_json.path
       end
@@ -162,16 +163,14 @@ module Dependabot
         dependency_set = DependencySet.new
 
         package_files.each do |file|
-          json = JSON.parse(T.must(file.content))
+          manifest = Dependabot::Package::NpmPackageJson.from_file(file)
 
           # TODO: Currently, Dependabot can't handle flat dependency files
           # (and will error at the FileUpdater stage, because the
           # UpdateChecker doesn't take account of flat resolution).
-          next if json["flat"]
+          next if manifest.flat?
 
-          self.class.each_dependency(json) do |name, requirement, type|
-            next unless requirement.is_a?(String)
-
+          manifest.each_dependency do |name, requirement, type|
             # Skip dependencies using Yarn workspace cross-references as requirements
             next if requirement.start_with?("workspace:", "catalog:")
 
@@ -202,7 +201,7 @@ module Dependabot
       end
 
       sig do
-        params(file: DependencyFile, type: T.untyped, name: String, requirement: String)
+        params(file: DependencyFile, type: String, name: String, requirement: String)
           .returns(T.nilable(Dependency))
       end
       def build_dependency(file:, type:, name:, requirement:)
@@ -303,7 +302,7 @@ module Dependabot
       def workspace_package_names
         @workspace_package_names ||= T.let(
           package_files.filter_map do |f|
-            JSON.parse(T.must(f.content))["name"]
+            Dependabot::Package::NpmPackageJson.from_file(f).name
           end,
           T.nilable(T::Array[String])
         )

--- a/bun/spec/dependabot/bun/dependency_files_filterer_spec.rb
+++ b/bun/spec/dependabot/bun/dependency_files_filterer_spec.rb
@@ -1,0 +1,119 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/dependency"
+require "dependabot/dependency_file"
+require "dependabot/bun/dependency_files_filterer"
+
+RSpec.describe Dependabot::Bun::DependencyFilesFilterer do
+  subject(:filterer) do
+    described_class.new(dependency_files: files, updated_dependencies: [dependency])
+  end
+
+  let(:workspaces) { [] }
+  let(:root_content) { JSON.dump("workspaces" => workspaces, "dependencies" => []) }
+  let(:root_manifest) { Dependabot::DependencyFile.new(name: "package.json", content: root_content) }
+  let(:member_manifest) do
+    Dependabot::DependencyFile.new(name: "packages/member/package.json", content: "{}")
+  end
+  let(:root_lockfile) { Dependabot::DependencyFile.new(name: "bun.lock", content: "{}") }
+  let(:files) { [root_manifest, member_manifest, root_lockfile] }
+  let(:requirement_file) { member_manifest.name }
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "chalk",
+      version: "0.4.0",
+      requirements: [{
+        file: requirement_file,
+        requirement: "0.3.0",
+        groups: ["dependencies"],
+        source: nil
+      }],
+      package_manager: "bun"
+    )
+  end
+
+  before do
+    lockfile_parser = instance_double(Dependabot::Bun::FileParser::LockfileParser, parse: [dependency])
+    allow(Dependabot::Bun::FileParser::LockfileParser).to receive(:new).and_return(lockfile_parser)
+  end
+
+  it "selects the member manifest and workspace lockfile without reading dependency values" do
+    expect(filterer.files_requiring_update).to contain_exactly(member_manifest, root_lockfile)
+  end
+
+  it "returns the manifests requiring an update" do
+    expect(filterer.package_files_requiring_update).to eq([member_manifest])
+  end
+
+  it "checks the root path when a single root lockfile tracks all dependencies" do
+    expect(filterer.paths_requiring_update_check).to eq(["."])
+  end
+
+  context "with an object workspace declaration" do
+    let(:workspaces) { {} }
+
+    it "keeps the root lockfile" do
+      expect(filterer.files_requiring_update).to contain_exactly(member_manifest, root_lockfile)
+    end
+  end
+
+  [nil, false].each do |value|
+    context "with workspaces set to #{value.inspect}" do
+      let(:workspaces) { value }
+
+      it "does not treat the root lockfile as a workspace lockfile" do
+        expect(filterer.files_requiring_update).to eq([member_manifest])
+      end
+    end
+  end
+
+  context "with a pnpm workspace file" do
+    let(:workspaces) { nil }
+    let(:files) { super() + [Dependabot::DependencyFile.new(name: "pnpm-workspace.yaml", content: "packages: []")] }
+
+    it "retains the existing workspace fallback" do
+      expect(filterer.files_requiring_update).to contain_exactly(member_manifest, root_lockfile)
+    end
+  end
+
+  context "with a root dependency" do
+    let(:requirement_file) { root_manifest.name }
+    let(:root_content) { "{" }
+
+    it "keeps the associated lockfile without parsing unrelated workspace information" do
+      expect(filterer.files_requiring_update).to contain_exactly(root_manifest, root_lockfile)
+    end
+  end
+
+  context "with a nested lockfile and no root manifest" do
+    let(:root_lockfile) { Dependabot::DependencyFile.new(name: "packages/member/bun.lock", content: "{}") }
+    let(:files) { [member_manifest, root_lockfile] }
+
+    it "selects the nested files without reading a root manifest" do
+      expect(filterer.files_requiring_update).to contain_exactly(member_manifest, root_lockfile)
+      expect(filterer.paths_requiring_update_check).to eq(["packages/member"])
+    end
+  end
+
+  context "with a root shrinkwrap" do
+    let(:root_lockfile) { Dependabot::DependencyFile.new(name: "npm-shrinkwrap.json", content: "{}") }
+
+    it "does not add npm-only workspace shrinkwrap behavior" do
+      expect(filterer.files_requiring_update).to eq([member_manifest])
+    end
+  end
+
+  context "with multiple workspace lockfiles" do
+    let(:other_lockfile) { Dependabot::DependencyFile.new(name: "yarn.lock", content: "") }
+    let(:files) { super() + [other_lockfile] }
+
+    it "decodes the root manifest once" do
+      allow(JSON).to receive(:parse).and_call_original
+
+      expect(filterer.files_requiring_update).to contain_exactly(member_manifest, root_lockfile, other_lockfile)
+      expect(JSON).to have_received(:parse).with(root_content).once
+    end
+  end
+end

--- a/bun/spec/dependabot/bun/file_parser_spec.rb
+++ b/bun/spec/dependabot/bun/file_parser_spec.rb
@@ -30,6 +30,142 @@ RSpec.describe Dependabot::Bun::FileParser do
     )
   end
 
+  describe ".each_dependency compatibility" do
+    it "keeps raw values and section order for updater callers" do
+      json = {
+        "dependencies" => { "first" => "1.0.0", "raw" => { "version" => "2.0.0" }, "missing" => nil },
+        "devDependencies" => { "first" => "3.0.0" }
+      }
+      yielded = []
+
+      described_class.each_dependency(json) { |name, requirement, type| yielded << [name, requirement, type] }
+
+      expect(yielded).to eq(
+        [
+          ["first", "1.0.0", "dependencies"],
+          ["raw", { "version" => "2.0.0" }, "dependencies"],
+          ["missing", nil, "dependencies"],
+          ["first", "3.0.0", "devDependencies"]
+        ]
+      )
+    end
+
+    it "allows callbacks to change the original dependency map" do
+      json = { "dependencies" => { "first" => "1.0.0", "second" => "2.0.0" } }
+      yielded = []
+
+      described_class.each_dependency(json) do |name, requirement, type|
+        yielded << requirement
+        json[type]["second"] = "3.0.0" if name == "first"
+      end
+
+      expect(yielded).to eq(["1.0.0", "3.0.0"])
+      expect(json["dependencies"]["second"]).to eq("3.0.0")
+    end
+  end
+
+  describe "package.json read boundaries" do
+    let(:manifest) { { "name" => "root", "dependencies" => { "chalk" => "0.3.0" } } }
+    let(:manifest_content) { JSON.dump(manifest) }
+    let(:package_file) { Dependabot::DependencyFile.new(name: "package.json", content: manifest_content) }
+    let(:files) { [package_file] }
+
+    it "parses an exact dependency without a lockfile" do
+      expect(parser.parse.map(&:name)).to eq(["chalk"])
+    end
+
+    context "with non-string and workspace/catalog requirements" do
+      let(:manifest) do
+        {
+          "dependencies" => {
+            "chalk" => "0.3.0",
+            "raw" => { "version" => "1.0.0" },
+            "missing" => nil,
+            "workspace" => "workspace:*",
+            "catalog" => "catalog:testing"
+          }
+        }
+      end
+
+      it "keeps only the registry dependency" do
+        expect(parser.parse.map(&:name)).to eq(["chalk"])
+      end
+    end
+
+    context "with an empty requirement" do
+      let(:manifest) { { "dependencies" => { "chalk" => "" } } }
+
+      it "retains wildcard normalization" do
+        dependency = parser.parse.find { |dep| dep.name == "chalk" }
+
+        expect(dependency.requirements.first.requirement_string).to eq("*")
+      end
+    end
+
+    context "with malformed dependency containers" do
+      let(:manifest) { { "dependencies" => [["chalk", "0.3.0"]] } }
+
+      it "rejects the container with file and field context" do
+        expect { parser.parse }
+          .to raise_error(TypeError, "#{package_file.path}: dependencies must be an object")
+      end
+    end
+
+    context "with a flat manifest and malformed dependencies" do
+      let(:manifest) { { "flat" => true, "dependencies" => [] } }
+
+      it "skips the manifest before inspecting dependencies" do
+        expect(parser.parse).to be_empty
+      end
+    end
+
+    context "with missing, null, and false dependency sections" do
+      let(:manifest) { { "dependencies" => nil, "devDependencies" => false } }
+
+      it "finds no dependencies" do
+        expect(parser.parse).to be_empty
+      end
+    end
+
+    context "with a workspace package" do
+      let(:manifest) { { "dependencies" => { "chalk" => "0.3.0", "member" => "1.0.0" } } }
+      let(:member_name) { "member" }
+      let(:files) do
+        [
+          package_file,
+          Dependabot::DependencyFile.new(
+            name: "packages/member/package.json",
+            content: JSON.dump("name" => member_name)
+          )
+        ]
+      end
+
+      it "excludes the workspace package from registry updates" do
+        expect(parser.parse.map(&:name)).to eq(["chalk"])
+      end
+
+      context "with a non-string workspace name" do
+        let(:member_name) { 123 }
+
+        it "does not match the dependency name" do
+          expect(parser.parse.map(&:name)).to contain_exactly("chalk", "member")
+        end
+      end
+    end
+
+    context "with invalid JSON" do
+      let(:manifest_content) { "{" }
+
+      it "preserves the parsing error for dependency extraction" do
+        expect { parser.parse }.to raise_error(JSON::ParserError)
+      end
+
+      it "preserves the file error for package-manager detection" do
+        expect { parser.ecosystem }.to raise_error(Dependabot::DependencyFileNotParseable)
+      end
+    end
+  end
+
   describe "inheritance" do
     require_common_spec "file_parsers/shared_examples_for_file_parsers"
 


### PR DESCRIPTION
### What are you trying to accomplish?

Use the shared `NpmPackageJson` reader for Bun's manifest dependencies, workspace names, package-manager configuration, and file filtering. `DependencyFilesFilterer` is now `typed: strong`, and this layer removes another four `T.untyped` annotations.

This is the top layer of the stack, based on #16180. The cumulative offense count falls from 660 to 652.

### Anything you want to highlight for special attention from reviewers?

Bun keeps its existing protocol skips, wildcard normalization, workspace behavior, and lockfile rules. The public `FileParser.each_dependency` implementation and updater logic are unchanged.

The new read paths reject malformed dependency containers while continuing to ignore non-string requirements and workspace names. The new filterer spec covers lazy reads, caching, nested files, and the distinction between Bun and npm workspace shrinkwrap handling.

### How will you know you've accomplished your goal?

The Bun parser, filterer, and updater suites pass all 49 examples. Repository-wide Sorbet, targeted RuboCop, and the parent-relative untyped ratchet also pass in containers. I did not run the complete repository suite.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
