### PR TITLE
julia: Fix suggested `[compat]` JLL packages including build numbers

### DIFF
--- a/julia/CHANGELOG.md
+++ b/julia/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Fixed suggested `[compat]` bounds for JLL packages including the build number (e.g. `Zlib_jll = "1.6.10+0"`), which Julia rejects as an invalid version specifier
 - Fixed Julia version requirement parsing to correctly handle caret (^) and tilde (~) semantics according to Julia's official specification
 - Fixed handling julia style compat version spec lists
 - Corrected test expectations for 0.0.x version semantics to match Julia Pkg behavior (0.0.5 satisfies only itself, not 0.0.6+)

--- a/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
+++ b/julia/lib/dependabot/julia/update_checker/requirements_updater.rb
@@ -10,6 +10,14 @@ module Dependabot
     class RequirementsUpdater
       extend T::Sig
 
+      # Julia compat entries only accept plain, dot-separated numeric versions
+      # of at most three parts (see Pkg's `semver_spec`), so anything a version
+      # string carries beyond "major.minor.patch" has to be dropped before it
+      # can be suggested as a bound. This matters for JLL packages, which
+      # register build metadata as part of the version ("1.6.10+0"): writing
+      # `Zlib_jll = "1.6.10+0"` into [compat] makes Pkg reject the Project.toml.
+      NUMERIC_VERSION_PREFIX = /\A\d+(?:\.\d+){0,2}/
+
       sig do
         params(
           requirements: T::Array[Dependabot::DependencyRequirement],
@@ -62,7 +70,7 @@ module Dependabot
 
         # If requirement is nil (no compat entry), use target version
         new_requirement = if current_requirement.nil?
-                            target_version.to_s
+                            exact_version_spec(target_version)
                           else
                             updated_version_requirement(current_requirement, target_version)
                           end
@@ -106,6 +114,20 @@ module Dependabot
         "#{requirement_string}#{separator}#{new_spec}"
       end
 
+      # The target version rendered as an exact compat bound, e.g. "1.6.10+0"
+      # (a JLL build) becomes "1.6.10", which still admits the build.
+      sig { params(target_version: Dependabot::Julia::Version).returns(String) }
+      def exact_version_spec(target_version)
+        version_string = target_version.to_s
+        version_string[NUMERIC_VERSION_PREFIX] || version_string
+      end
+
+      sig { params(target_version: Dependabot::Julia::Version).returns([Integer, Integer, Integer]) }
+      def compat_version_parts(target_version)
+        parts = exact_version_spec(target_version).split(".")
+        [parts[0].to_i, parts[1].to_i, parts[2].to_i]
+      end
+
       sig { params(target_version: Dependabot::Julia::Version).returns(String) }
       def simplified_version_spec(target_version)
         # Follow CompatHelper.jl's compat_version_number logic:
@@ -113,10 +135,7 @@ module Dependabot
         # - major == 0, minor > 0: use "0.minor"
         # - major == 0, minor == 0: use "0.0.patch"
         # Note: CompatHelper always returns plain versions (no ^ or ~ prefix)
-        # Coerce segments to integers (segments may be Integer or String or nil)
-        major = (target_version.segments[0] || 0).to_i
-        minor = (target_version.segments[1] || 0).to_i
-        patch = (target_version.segments[2] || 0).to_i
+        major, minor, patch = compat_version_parts(target_version)
 
         if major.positive?
           "#{major}.#{minor}"

--- a/julia/spec/dependabot/julia/requirements_updater_spec.rb
+++ b/julia/spec/dependabot/julia/requirements_updater_spec.rb
@@ -99,6 +99,66 @@ RSpec.describe Dependabot::Julia::RequirementsUpdater do
         it { is_expected.to eq("0.35.0") }
       end
 
+      # JLL packages register build metadata as part of their version
+      # ("Zlib_jll" 1.6.10+0). Julia's [compat] specifiers are numeric-only, so
+      # a suggested bound must never carry the "+build" suffix.
+      context "with a JLL target version carrying build metadata" do
+        context "when there is no compat entry" do
+          let(:requirements) { [{ requirement: nil, file: "Project.toml", groups: ["dependencies"], source: nil }] }
+          let(:target_version) { "1.6.10+0" }
+
+          it "drops the build number" do
+            expect(result).to eq("1.6.10")
+          end
+        end
+
+        context "when the existing compat entry already admits the new build" do
+          let(:requirement_string) { "1.6.10" }
+          let(:target_version) { "1.6.10+1" }
+
+          it "leaves the compat entry untouched" do
+            expect(result).to eq("1.6.10")
+          end
+        end
+
+        context "when the existing compat entry needs widening" do
+          let(:requirement_string) { "1.5.0" }
+          let(:target_version) { "2.0.1+2" }
+
+          it "appends a spec without the build number" do
+            expect(result).to eq("1.5.0, 2.0")
+          end
+        end
+
+        context "when the JLL is a 0.0.x version" do
+          let(:requirement_string) { "0.0.5" }
+          let(:target_version) { "0.0.8+3" }
+
+          it "appends a patch-level spec without the build number" do
+            expect(result).to eq("0.0.5, 0.0.8")
+          end
+        end
+
+        context "with bump_versions" do
+          let(:update_strategy) { :bump_versions }
+          let(:requirement_string) { "1.5" }
+          let(:target_version) { "1.6.10+0" }
+
+          it "bumps to a spec without the build number" do
+            expect(result).to eq("1.6")
+          end
+        end
+
+        context "with a prerelease target version" do
+          let(:requirements) { [{ requirement: nil, file: "Project.toml", groups: ["dependencies"], source: nil }] }
+          let(:target_version) { "1.6.10-rc1" }
+
+          it "drops the prerelease tag, which compat entries also reject" do
+            expect(result).to eq("1.6.10")
+          end
+        end
+      end
+
       context "with range requirement" do
         let(:requirement_string) { "0.34 - 0.35" }
         let(:target_version) { "0.36.0" }


### PR DESCRIPTION
### What are you trying to accomplish?

Julia project's do not allow packages to specify a build number in their compat bounds.  JLL packages register versions with build numbers attached, so we need to filter them out when adding compat bounds for them.

### How will you know you've accomplished your goal?

When Dependabot no longer opens PRs such as: https://github.com/JuliaPackaging/BinaryBuilder2.jl/pull/58

### Checklist

- [X] I have run the complete test suite to ensure all tests and linters pass.
- [X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [X] I have written clear and descriptive commit messages.
- [X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [X] I have ensured that the code is well-documented and easy to understand.
