### PR TITLE
Add ability to use http for private instances

### DIFF
--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -163,7 +163,8 @@ module Dependabot
         branch: T.nilable(String),
         commit: T.nilable(String),
         hostname: T.nilable(String),
-        api_endpoint: T.nilable(String)
+        api_endpoint: T.nilable(String),
+        scheme: T.nilable(String),
       ).void
     end
     def initialize(
@@ -174,7 +175,8 @@ module Dependabot
       branch: nil,
       commit: nil,
       hostname: nil,
-      api_endpoint: nil
+      api_endpoint: nil,
+      scheme: nil
     )
       if (hostname.nil? ^ api_endpoint.nil?) && (provider != "codecommit")
         msg = "Both hostname and api_endpoint must be specified if either " \
@@ -191,11 +193,12 @@ module Dependabot
       @commit = commit
       @hostname = T.let(hostname || default_hostname(provider), String)
       @api_endpoint = T.let(api_endpoint || default_api_endpoint(provider), T.nilable(String))
+      @scheme = T.let(scheme || "https", String)
     end
 
     sig { returns(String) }
     def url
-      "https://" + hostname + "/" + repo
+      "#{@scheme}://" + hostname + "/" + repo
     end
 
     sig { returns(String) }

--- a/common/lib/dependabot/source.rb
+++ b/common/lib/dependabot/source.rb
@@ -185,6 +185,10 @@ module Dependabot
         raise msg
       end
 
+      if (scheme && !%w(http https).include?(scheme))
+        raise "scheme must be either https or http"
+      end
+
       @provider = provider
       @repo = repo
       @directory = directory

--- a/common/spec/dependabot/source_spec.rb
+++ b/common/spec/dependabot/source_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe Dependabot::Source do
       specify { expect { source }.not_to raise_error }
     end
 
+    context "with htttp private instance" do
+      let(:attrs) do
+        {
+          provider: "github",
+          repo: "my/repo",
+          api_endpoint: "http://my.private.instance/api/v3/",
+          hostname: "my.private.instance",
+          scheme: "http"
+        }
+      end
+
+      specify { expect(source.url).to eq("http://my.private.instance/my/repo") }
+    end
+
     context "with a hostname but no api_endpoint" do
       let(:attrs) do
         {

--- a/common/spec/dependabot/source_spec.rb
+++ b/common/spec/dependabot/source_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe Dependabot::Source do
       specify { expect(source.url).to eq("http://my.private.instance/my/repo") }
     end
 
+    context "with invalid scheme param" do
+      let(:attrs) do
+        {
+          provider: "github",
+          repo: "my/repo",
+          api_endpoint: "https://my.private.instance/api/v3/",
+          hostname: "my.private.instance",
+          scheme: "invalid"
+        }
+      end
+
+      specify { expect { source }.to raise_error(/scheme must be either https or http/) }
+    end
+
     context "with a hostname but no api_endpoint" do
       let(:attrs) do
         {


### PR DESCRIPTION
### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? -->

There might be cases when updates are executed against self hosted instances that aren't configured with ssl termination (maybe some homelab setups etc). This allows to override the currently hardcoded "https" url scheme to make such setups work.

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->

Alternative way would be to parse `api_endpoint` and get scheme from it but it introduces potential uri parse error so it felt like introducing a bigger change to existing workflow

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->

Tests added for introduced code flows

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [ ] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ ] I have written clear and descriptive commit messages.
- [ ] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ ] I have ensured that the code is well-documented and easy to understand.
