### PR TITLE
build(deps): bump git-shim to v1.5.0

### DIFF
--- a/Dockerfile.updater-core
+++ b/Dockerfile.updater-core
@@ -156,8 +156,8 @@ ENV DEPENDABOT=true
 ENV GIT_LFS_SKIP_SMUDGE=1
 
 # Place a git shim ahead of git on the path to rewrite git arguments to use HTTPS.
-ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.4.0/git-v1.4.0-linux-${TARGETARCH}.tar.gz"
-RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && rm git-shim.tar.gz
+ARG SHIM="https://github.com/dependabot/git-shim/releases/download/v1.5.0/git-shim-v1.5.0-linux-${TARGETARCH}.tar.gz"
+RUN curl -sL $SHIM -o git-shim.tar.gz && mkdir -p ~/bin && tar -xvf git-shim.tar.gz -C ~/bin && mv ~/bin/git-shim ~/bin/git && rm git-shim.tar.gz
 
 COPY --chown=dependabot:dependabot updater/Gemfile updater/Gemfile.lock dependabot-updater/
 


### PR DESCRIPTION
### What are you trying to accomplish?

Update `dependabot/git-shim` from v1.4.0 to v1.5.0, the latest stable release. The updater still needs the shim at `/home/dependabot/bin/git` so existing Git commands continue to use its HTTPS rewriting.

### Anything you want to highlight for special attention from reviewers?

The v1.5.0 release renamed both the archive and the executable. The Dockerfile now downloads `git-shim-v1.5.0-linux-${TARGETARCH}.tar.gz`, extracts `git-shim`, and renames it to `git`. This keeps the existing PATH behavior on amd64 and arm64.

### How will you know you've accomplished your goal?

`script/build bundler` built the updater-core and Bundler images successfully. The Bundler image had 42 layers.

In the built image:

```text
executable: /home/dependabot/bin/git
command -v git: /home/dependabot/bin/git
git version 2.55.0
The Gemfile's dependencies are satisfied
```

All required CI checks pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
