### PR TITLE
build(deps): bump hcl2json to v0.6.9

### DIFF
--- a/opentofu/helpers/build
+++ b/opentofu/helpers/build
@@ -15,8 +15,8 @@ fi
 
 os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
-hcl2json_checksum="8da5a86b3caff977067c62dd190bfdf296842191b0282c7e3a7019d6cf0f6657"
-hcl2json_url="https://github.com/tmccombs/hcl2json/releases/download/v0.6.4/hcl2json_${os}_amd64"
+hcl2json_checksum="b609e37094948c0b77cd8c6c0baaf8af2bd168c685c6e3334d671cc9692c34a5"
+hcl2json_url="https://github.com/tmccombs/hcl2json/releases/download/v0.6.9/hcl2json_${os}_amd64"
 hcl2json_path="$install_dir/bin/hcl2json"
 curl -sSLfo "$hcl2json_path" "$hcl2json_url"
 echo "$hcl2json_checksum  $hcl2json_path" | sha256sum -c

--- a/terraform/helpers/build
+++ b/terraform/helpers/build
@@ -15,8 +15,8 @@ fi
 
 os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
-hcl2json_checksum="8da5a86b3caff977067c62dd190bfdf296842191b0282c7e3a7019d6cf0f6657"
-hcl2json_url="https://github.com/tmccombs/hcl2json/releases/download/v0.6.4/hcl2json_${os}_amd64"
+hcl2json_checksum="b609e37094948c0b77cd8c6c0baaf8af2bd168c685c6e3334d671cc9692c34a5"
+hcl2json_url="https://github.com/tmccombs/hcl2json/releases/download/v0.6.9/hcl2json_${os}_amd64"
 hcl2json_path="$install_dir/bin/hcl2json"
 curl -sSLfo "$hcl2json_path" "$hcl2json_url"
 echo "$hcl2json_checksum  $hcl2json_path" | sha256sum -c


### PR DESCRIPTION
### What are you trying to accomplish?

Update `tmccombs/hcl2json` from v0.6.4 to v0.6.9 in the Terraform and OpenTofu helper images. GitHub's latest-release API reports v0.6.9 with `draft: false` and `prerelease: false`.

Both helpers now use the SHA-256 checksum from the official `hcl2json_0.6.9_checksums.txt` release asset:

```text
b609e37094948c0b77cd8c6c0baaf8af2bd168c685c6e3334d671cc9692c34a5  hcl2json_linux_amd64
```

### Anything you want to highlight for special attention from reviewers?

The Terraform and OpenTofu build scripts remain separate. This PR only updates the shared version and checksum in both copies.

### How will you know you've accomplished your goal?

The Terraform parser suite passed with 99 examples and 0 failures. The OpenTofu parser suite passed with 106 examples and 0 failures.

Direct checks against both installed binaries confirmed the expected checksum. Valid HCL produced the expected JSON, while invalid HCL exited with status 1 and reported `Unclosed configuration block`.

All required CI checks pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
