### PR TITLE
build(deps): bump PowerShell to 7.6.5

### DIFF
--- a/nuget/Dockerfile
+++ b/nuget/Dockerfile
@@ -30,7 +30,7 @@ RUN URL=$([ $TARGETARCH = "arm64" ] && echo ${LIBSSL11_URL_ARM64} || echo ${LIBS
  && dpkg -i /tmp/libssl-1.1.deb \
  && rm /tmp/libssl-1.1.deb
 
-ARG POWERSHELL_VERSION=7.4.5
+ARG POWERSHELL_VERSION=7.6.5
 RUN ARCH=$([ $TARGETARCH = "arm64" ] && echo "arm64" || echo "x64") \
  && POWERSHELL_VERSION_MAJOR=$(echo $POWERSHELL_VERSION | cut -d. -f1) \
  && INSTALL_PATH=/usr/local/microsoft/powershell/${POWERSHELL_VERSION_MAJOR} \


### PR DESCRIPTION
### What are you trying to accomplish?

Update PowerShell from 7.4.5 to 7.6.5, the current stable release. This intentionally moves the NuGet image beyond the 7.4 LTS line.

### Anything you want to highlight for special attention from reviewers?

The existing architecture mapping is unchanged: Docker `amd64` downloads the PowerShell `x64` asset, while `arm64` downloads the `arm64` asset. The major-version install path, `/usr/bin/pwsh` symlink, .NET SDK versions, and libssl packages are also unchanged.

Local BuildKit downloads hit TLS EOF errors without a validation-only proxy. An unchanged 7.4.5 control build failed in the same way, while a normal container downloaded 7.6.5 successfully. The non-interactive `bin/test` command also needed a pseudo-TTY because the development container enables TTY attachment.

### How will you know you've accomplished your goal?

The NuGet image build downloaded `powershell-7.6.5-linux-x64.tar.gz`, reported `PowerShell 7.6.5`, installed the targeting packs, and exported `ghcr.io/dependabot/dependabot-updater-nuget:latest`.

The built image reports `PowerShell 7.6.5`. All PowerShell assertions passed, as did the C# test groups containing 14, 3, 10, 77, 37, and 879 tests.

All required CI checks pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
