### PR TITLE
Stop converting gitmoji emoji to shortcodes in commit messages

### DIFF
--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -338,13 +338,13 @@ module Dependabot
 
       sig { returns(String) }
       def commit_subject
-        subject = pr_name
-        return subject unless subject.length > 72
+        full = pr_name
+        return full unless full.length > 72
 
-        subject = subject.gsub(/ from [^\s]*? to [^\s]*/, "")
-        return subject unless subject.length > 72
+        without_versions = full.gsub(/ from [^\s]*? to [^\s]*/, "")
+        return without_versions unless without_versions.length > 72
 
-        T.must(subject.split(" in ").first)
+        T.must(without_versions.split(" in ").first)
       end
 
       sig { returns(String) }

--- a/common/lib/dependabot/pull_request_creator/message_builder.rb
+++ b/common/lib/dependabot/pull_request_creator/message_builder.rb
@@ -338,7 +338,7 @@ module Dependabot
 
       sig { returns(String) }
       def commit_subject
-        subject = pr_name.gsub("⬆️", ":arrow_up:").gsub("🔒", ":lock:")
+        subject = pr_name
         return subject unless subject.length > 72
 
         subject = subject.gsub(/ from [^\s]*? to [^\s]*/, "")

--- a/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/message_builder_spec.rb
@@ -3005,16 +3005,28 @@ RSpec.describe Dependabot::PullRequestCreator::MessageBuilder do
 
       let(:pr_name_prefix) { "⬆️ " }
 
-      it "uses gitmoji" do
-        expect(commit_message).to start_with(":arrow_up: Bump ")
+      it "keeps the unicode emoji in the commit subject" do
+        expect(commit_message).to start_with("⬆️ Bump ")
+      end
+
+      it "uses the same prefix as the PR title" do
+        expect(commit_message.split("\n").first).to eq(builder.pr_name)
       end
 
       context "with a security vulnerability fixed" do
         let(:vulnerabilities_fixed) { { business: [{}] } }
         let(:pr_name_prefix) { "⬆️🔒 " }
 
-        it "uses gitmoji" do
-          expect(commit_message).to start_with(":arrow_up::lock: Bump ")
+        it "keeps both unicode emoji in the commit subject" do
+          expect(commit_message).to start_with("⬆️🔒 Bump ")
+        end
+      end
+
+      context "when the prefix is already a shortcode" do
+        let(:pr_name_prefix) { ":arrow_up: " }
+
+        it "passes the shortcode through verbatim" do
+          expect(commit_message).to start_with(":arrow_up: Bump ")
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Fix #4565.

Dependabot's pull request creator rewrites `⬆️` and `🔒` into `:arrow_up:` and `:lock:` when building the commit message, while the PR title keeps the unicode version. Projects using gitmoji end up with unicode emoji in the PR title and shortcode emoji in `git log`.

This removes the rewrite so the commit subject carries whatever emojis the prefixer produces.

### Anything you want to highlight for special attention from reviewers?

I also renamed the locals in `message_builder.rb#commit_subject` to more accurately reflect what each holds.

On GitLab, [`Gitlab#commit_exists?`](https://github.com/dependabot/dependabot-core/blob/d912847173d0ef30b881ef9053a770c8d3b02177/common/lib/dependabot/pull_request_creator/gitlab.rb#L165) compares the stored commit message against the freshly generated one by exact string equality. For a gitmoji repo with an existing branch whose head commit was written as `:arrow_up: …`, that comparison stops matching after this change, so [a branch that exists without a merge request](https://github.com/dependabot/dependabot-core/blob/d912847173d0ef30b881ef9053a770c8d3b02177/common/lib/dependabot/pull_request_creator/gitlab.rb#L110-L118) will pick up one redundant duplicate commit on its next run. It self-corrects after that, and GitLab is the only provider affected.



### How will you know you've accomplished your goal?

New specs that fail against `main` pass on this branch.

### Checklist
- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.