### PR TITLE
fix(maven): preserve POM formatting during dependencyManagement injec…

### DIFF
--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -255,15 +255,13 @@ module Dependabot
         # file's formatting, indentation style, and attribute quotes on the root elements,
         # avoiding git diff noise on unrelated lines.
         if dependency_management_created
-          new_block_text = dependency_management.to_s
           # Find the character position of the true closing project tag at the literal end of the file.
           match_data = content.match(%r{</project>\s*\z})
 
           if match_data
             insert_position = match_data.begin(0)
             # Extract the baseline indentation level for the root block formatting (e.g. spaces or tabs)
-            base_indent = indentation_config[:levels][:base]
-            formatted_patch = "\n#{base_indent}#{new_block_text}\n"
+            formatted_patch = "\n#{indentation_config[:levels][:base]}#{dependency_management}\n"
 
             # place the block text right into that character boundary index position
             return T.must(content[0...insert_position]) + formatted_patch + T.must(content[insert_position..-1])

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -249,11 +249,26 @@ module Dependabot
         # Close all sections with appropriate indentation
         dependencies.add_text("\n#{indentation_config[:levels][:dependency_management]}")
         dependency_management.add_text("\n#{indentation_config[:levels][:base]}") if dependencies_created
-        project.add_text("\n") if dependency_management_created
 
-        # If dependencyManagement was created, replace entire document content with parser output
-        # Unfortunately, this might include unrelated formatting changes sometimes
-        return doc.to_s if dependency_management_created
+        # If a new dependencyManagement section was created, we use a hybrid DOM-guided
+        # text splice instead of doc.to_s. This completely preserves the original
+        # file's formatting, indentation style, and attribute quotes on the root elements,
+        # avoiding git diff noise on unrelated lines.
+        if dependency_management_created
+          new_block_text = dependency_management.to_s
+          # Find the character position of the true closing project tag at the literal end of the file.
+          match_data = content.match(%r{</project>\s*\z})
+
+          if match_data
+            insert_position = match_data.begin(0)
+            # Extract the baseline indentation level for the root block formatting (e.g. spaces or tabs)
+            base_indent = indentation_config[:levels][:base]
+            formatted_patch = "\n#{base_indent}#{new_block_text}\n"
+
+            # place the block text right into that character boundary index position
+            return T.must(content[0...insert_position]) + formatted_patch + T.must(content[insert_position..-1])
+          end
+        end
 
         # If dependencyManagement was not created, we just replace the existing dependencyManagement element
         # with the updated one, preserving the rest of the document

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -137,6 +137,44 @@ RSpec.describe Dependabot::Maven::FileUpdater do
           .to include(%(<project xmlns="http://maven.apache.org/POM/4.0.0"\n))
       end
 
+      context "when pinning a transitive dependency via a multi-line project header" do
+        let(:pom_body) { fixture("poms", "multiline_header_pom.xml") }
+        let(:dependency) do
+          Dependabot::Dependency.new(
+            name: "org.apache.zookeeper:zookeeper",
+            version: "3.7.2",
+            requirements: [{
+              file: "pom.xml",
+              requirement: "3.7.2",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            previous_requirements: [{
+              file: "pom.xml",
+              requirement: "3.4.6",
+              groups: [],
+              source: nil,
+              metadata: { packaging_type: "jar" }
+            }],
+            package_manager: "maven"
+          )
+        end
+
+        it "injects dependencyManagement without modifying the project header attributes" do
+          updated_content = updated_pom_file.content
+
+          expect(updated_content).to include("<dependencyManagement>")
+          expect(updated_content).to include("<groupId>org.apache.zookeeper</groupId>")
+
+          expect(updated_content).to include(
+            "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" \
+            "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" \
+            "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">"
+          )
+        end
+      end
+
       context "when handling dependencies with classifiers" do
         let(:dependencies) { [dependency, mockk_dependency] }
 

--- a/maven/spec/fixtures/poms/multiline_header_pom.xml
+++ b/maven/spec/fixtures/poms/multiline_header_pom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>multi-module-repro</artifactId>
+    <version>1.0.0</version>
+</project>


### PR DESCRIPTION

Bypasses REXML's full-document serialization to prevent attribute scrambling and quote transformation on the root `<project>` tag. Uses a clean string slice anchored by the trailing `</project>` tag to insert the text block, keeping all original formatting, spaces.

### What are you trying to accomplish?

<!-- Provide both a what and a _why_ for the change. -->

<!-- What issues does this affect or fix? --> #13011

### Anything you want to highlight for special attention from reviewers?

<!-- If there were multiple ways to approach the problem, why did you pick this one? -->
I considered preserving "" and '' based on the input pom and converting the pom from REXML parser but there were corner cases that were missed. This seemed to be the best approach .

### How will you know you've accomplished your goal?

<!--
  * If you've reproduced an error, can you link to, or demonstrate the reproduction?
  * If you've added a new feature, how will you demonstrate it to others?
  * If you've refactored code, how will you demonstrate that the new code is functionally equivalent to the old code?
-->
I added a test case. I also used locally by running the dependabot cli and checking the actual changes in the repo (i used the repo in issue #13011 
```
dependabot update -f job-security.yaml  --local /Users/shikhaaggarwal/github/maven_transitive_repro   --updater-image ghcr.io/dependabot/dependabot-updater-maven:latest \
--pull=false -o update-result.yaml
```
job-security.yaml
```
job:
  package-manager: "maven"
  allowed-updates:
    - update-type: "all"
  source:
    provider: "github"
    repo: "shikhahere/maven_transitive_repro"
    directory: "/"
  experiments:
    maven_transitive_dependencies: true
  security-updates-only: true
  dependencies:
    - "dnsjava:dnsjava"
  security-advisories:
    - dependency-name: "dnsjava:dnsjava"
      affected-versions:
        - ">= 0, < 3.6.0"
      patched-versions:
        - "3.6.0"
      unaffected-versions: []
```
### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [X ] I have run the complete test suite to ensure all tests and linters pass.
- [ X] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [ X] I have written clear and descriptive commit messages.
- [ X] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [ X] I have ensured that the code is well-documented and easy to understand.
