### PR TITLE
Surface unavailable cooldown dates for OpenTofu

### DIFF
--- a/opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb
+++ b/opentofu/lib/dependabot/opentofu/update_checker/latest_version_resolver.rb
@@ -5,14 +5,14 @@ require "dependabot/update_checkers/base"
 require "dependabot/opentofu/package/package_details_fetcher"
 require "sorbet-runtime"
 require "dependabot/git_commit_checker"
+require "dependabot/update_checkers/tag_cooldown_filter"
 
 module Dependabot
   module Opentofu
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       class LatestVersionResolver
         extend T::Sig
-
-        DAY_IN_SECONDS = T.let(24 * 60 * 60, Integer)
+        include Dependabot::UpdateCheckers::TagCooldownFilter
 
         sig do
           params(
@@ -29,8 +29,11 @@ module Dependabot
           @git_commit_checker = git_commit_checker
         end
 
-        sig { returns(Dependabot::Dependency) }
+        sig { override.returns(Dependabot::Dependency) }
         attr_reader :dependency
+
+        sig { override.returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
+        attr_reader :cooldown_options
 
         # Return latest version tag for the dependency, it removes tags that are in cooldown period
         # and returns the latest version tag that is not in cooldown period. If exception occurs
@@ -117,7 +120,7 @@ module Dependabot
           version_tags_in_cooldown_period = T.let([], T::Array[String])
 
           package_details_fetcher.fetch_tag_and_release_date.each do |git_tag_with_detail|
-            if check_if_version_in_cooldown_period?(T.must(git_tag_with_detail.release_date))
+            if check_if_version_in_cooldown_period?(git_tag_with_detail.release_date)
               version_tags_in_cooldown_period << git_tag_with_detail.tag
             end
           end
@@ -127,35 +130,12 @@ module Dependabot
           version_tags_in_cooldown_period
         end
 
-        sig { params(release_date: String).returns(T::Boolean) }
-        def check_if_version_in_cooldown_period?(release_date)
-          return false unless release_date.length.positive?
-
-          cooldown = @cooldown_options
-          return false unless cooldown
-
-          return false if cooldown.nil?
-
-          # Calculate the number of seconds passed since the release
-          passed_seconds = Time.now.to_i - release_date_to_seconds(release_date)
-          # Check if the release is within the cooldown period
-          passed_seconds < cooldown.default_days * DAY_IN_SECONDS
-        end
-
-        sig { params(release_date: String).returns(Integer) }
-        def release_date_to_seconds(release_date)
-          Time.parse(release_date).to_i
-        rescue ArgumentError => e
-          Dependabot.logger.error("Invalid release date format: #{release_date} and error: #{e.message}")
-          0 # Default to 360 days in seconds if parsing fails, so that it will not be in cooldown
-        end
-
         sig { returns(T.nilable(T::Array[String])) }
         def select_tags_which_in_cooldown_from_provider
           version_tags_in_cooldown_from_provider = T.let([], T::Array[String])
 
           package_details_fetcher.fetch_tag_and_release_date_from_provider.each do |git_tag_with_detail|
-            if check_if_version_in_cooldown_period?(T.must(git_tag_with_detail.release_date))
+            if check_if_version_in_cooldown_period?(git_tag_with_detail.release_date)
               version_tags_in_cooldown_from_provider << git_tag_with_detail.tag
             end
           end
@@ -170,7 +150,7 @@ module Dependabot
           version_tags_in_cooldown_from_module = T.let([], T::Array[String])
 
           package_details_fetcher.fetch_tag_and_release_date_from_module.each do |git_tag_with_detail|
-            if check_if_version_in_cooldown_period?(T.must(git_tag_with_detail.release_date))
+            if check_if_version_in_cooldown_period?(git_tag_with_detail.release_date)
               version_tags_in_cooldown_from_module << git_tag_with_detail.tag
             end
           end

--- a/opentofu/spec/dependabot/opentofu/update_checker/latest_version_resolver_spec.rb
+++ b/opentofu/spec/dependabot/opentofu/update_checker/latest_version_resolver_spec.rb
@@ -106,5 +106,10 @@ RSpec.describe Dependabot::Opentofu::UpdateChecker::LatestVersionResolver do
       release_date = (Time.now - (100 * 24 * 60 * 60)).iso8601 # 100 days ago
       expect(resolver.check_if_version_in_cooldown_period?(release_date)).to be false
     end
+
+    it "marks the dependency when the release date is unavailable" do
+      expect(resolver.check_if_version_in_cooldown_period?(nil)).to be false
+      expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Stacked on #16213.

Adopt the shared tag cooldown filter in OpenTofu so missing or unparseable publication dates mark the dependency and produce the warning introduced at the root of the stack.

### Anything you want to highlight for special attention from reviewers?

OpenTofu is deliberately isolated in this PR. Its existing fail-open update behavior remains unchanged.

### How will you know you've accomplished your goal?

The focused resolver run reports 6 examples and the same 4 pre-existing `Dependabot::Opentofu::Version` load-order failures seen on clean `main`; no new failure class or count was introduced. The added missing-date example passes.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.