### PR TITLE
Surface unavailable cooldown dates for git updates

### DIFF
--- a/common/lib/dependabot/git_commit_checker.rb
+++ b/common/lib/dependabot/git_commit_checker.rb
@@ -835,13 +835,18 @@ module Dependabot
     end
     def tag_in_cooldown_period?(tag, cooldown)
       released_at = release_date_for_tag_name(tag.name)
-      return false unless released_at
-
       cooldown_days = Dependabot::UpdateCheckers::CooldownCalculation.cooldown_days_for(
         cooldown,
         T.cast(current_version, T.nilable(Dependabot::Version)),
         T.cast(version_from_tag(tag), Dependabot::Version)
       )
+      unless released_at
+        Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+          dependency,
+          cooldown_days: cooldown_days
+        )
+        return false
+      end
 
       in_cooldown = Dependabot::UpdateCheckers::CooldownCalculation
                     .within_cooldown_window?(released_at, cooldown_days)

--- a/common/lib/dependabot/git_cooldown_date_resolver.rb
+++ b/common/lib/dependabot/git_cooldown_date_resolver.rb
@@ -41,7 +41,7 @@ module Dependabot
 
     # Resolves the best available date for a candidate tag.
     # Priority: GitHub Release published_at > tag creation date > commit date.
-    sig { params(tag_name: String, commit_sha: String).returns(Time) }
+    sig { params(tag_name: String, commit_sha: String).returns(T.nilable(Time)) }
     def resolve_candidate_date(tag_name, commit_sha)
       releases = cached_github_releases
       unless releases.empty?
@@ -71,7 +71,7 @@ module Dependabot
 
     # Returns the tag creation date for cooldown purposes (used inside bare clone).
     # Priority: tag creation date from for-each-ref > commit date fallback.
-    sig { params(tag_name: String, commit_sha: String).returns(Time) }
+    sig { params(tag_name: String, commit_sha: String).returns(T.nilable(Time)) }
     def tag_creation_date(tag_name, commit_sha)
       tag_date_str = SharedHelpers.run_shell_command(
         "git for-each-ref --format=\"%(creatordate:iso)\" \"refs/tags/#{tag_name}\"",
@@ -84,6 +84,8 @@ module Dependabot
           fingerprint: "git show --no-patch --format=\"%cd\" --date=iso <commit_sha>"
         ).strip
       end
+
+      return if tag_date_str.empty?
 
       Time.parse(tag_date_str)
     end

--- a/common/spec/dependabot/git_commit_checker_spec.rb
+++ b/common/spec/dependabot/git_commit_checker_spec.rb
@@ -1385,6 +1385,17 @@ RSpec.describe Dependabot::GitCommitChecker do
         end
       end
 
+      context "when a tag has no release date" do
+        let(:refs_with_detail) do
+          [Dependabot::GitTagWithDetail.new(tag: "v1.13.0", release_date: nil)]
+        end
+
+        it "allows the tag and marks the dependency" do
+          expect(latest_tag[:tag]).to eq("v1.13.0")
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        end
+      end
+
       context "when a GitHub Release publish date is available" do
         let(:refs_with_detail) do
           [

--- a/common/spec/dependabot/git_cooldown_date_resolver_spec.rb
+++ b/common/spec/dependabot/git_cooldown_date_resolver_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe Dependabot::GitCooldownDateResolver do
       result = resolver.tag_creation_date("v1.0.0", "abc123")
       expect(result).to eq(Time.parse(commit_date))
     end
+
+    it "returns nil when neither tag nor commit date is available" do
+      allow(Dependabot::SharedHelpers).to receive(:run_shell_command).and_return("")
+
+      expect(resolver.tag_creation_date("v1.0.0", "abc123")).to be_nil
+    end
   end
 
   describe "#github_release_published_at" do

--- a/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
+++ b/github_actions/lib/dependabot/github_actions/update_checker/latest_version_finder.rb
@@ -374,12 +374,20 @@ module Dependabot
 
         sig { params(release_date: T.nilable(String)).returns(T::Boolean) }
         def check_if_version_in_cooldown_period?(release_date)
-          return false unless release_date&.length&.positive?
-          return false unless cooldown_options
-          return false unless T.must(cooldown_options).included?(dependency.name)
+          cooldown = cooldown_options
+          return false if Dependabot::UpdateCheckers::CooldownCalculation.skip_cooldown?(
+            cooldown, dependency.name, cooldown_enabled: cooldown_enabled?
+          )
 
-          release_time = Time.parse(T.must(release_date))
-          cooldown_days = T.must(cooldown_options).default_days
+          cooldown_days = T.must(cooldown).default_days
+          release_time = parse_release_date(release_date)
+          unless release_time
+            Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+              dependency,
+              cooldown_days: cooldown_days
+            )
+            return false
+          end
 
           is_in_cooldown = Dependabot::UpdateCheckers::CooldownCalculation.within_cooldown_window?(
             release_time,
@@ -396,6 +404,16 @@ module Dependabot
         rescue StandardError => e
           Dependabot.logger.debug("Error parsing release date: #{e.message}")
           false
+        end
+
+        sig { params(release_date: T.nilable(String)).returns(T.nilable(Time)) }
+        def parse_release_date(release_date)
+          return nil if release_date.nil? || release_date.empty?
+
+          Time.parse(release_date)
+        rescue ArgumentError => e
+          Dependabot.logger.debug("Error parsing release date: #{e.message}")
+          nil
         end
 
         sig { returns(String) }

--- a/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
+++ b/github_actions/spec/dependabot/github_actions/update_checker/latest_version_finder_spec.rb
@@ -559,6 +559,28 @@ RSpec.describe namespace::LatestVersionFinder do
           expect(selected_tags).to be_empty
         end
       end
+
+      context "when a release date is unavailable" do
+        let(:git_tags_with_dates) do
+          [Dependabot::GitTagWithDetail.new(tag: "v1.0.0", release_date: nil)]
+        end
+
+        it "keeps the tag and marks the dependency" do
+          expect(selected_tags).to be_empty
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        end
+      end
+
+      context "when a release date cannot be parsed" do
+        let(:git_tags_with_dates) do
+          [Dependabot::GitTagWithDetail.new(tag: "v1.0.0", release_date: "not-a-date")]
+        end
+
+        it "keeps the tag and marks the dependency" do
+          expect(selected_tags).to be_empty
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        end
+      end
     end
   end
 

--- a/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
+++ b/pre_commit/lib/dependabot/pre_commit/update_checker/latest_version_finder.rb
@@ -273,6 +273,13 @@ module Dependabot
 
             tag_name = normalize_tag_name((tag[:tag] || "v#{tag[:version]}").to_s)
             release_date = resolve_candidate_date(tag_name, commit_sha)
+            unless release_date
+              Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+                dependency,
+                cooldown_days: T.must(@cooldown_options).default_days
+              )
+              return nil
+            end
 
             if release_in_cooldown_period?(release_date)
               filtered_count += 1

--- a/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
+++ b/pre_commit/spec/dependabot/pre_commit/update_checker/latest_version_finder_spec.rb
@@ -639,6 +639,38 @@ RSpec.describe Dependabot::PreCommit::UpdateChecker::LatestVersionFinder do
       end
     end
 
+    context "when no publication date can be resolved" do
+      let(:update_cooldown) do
+        Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+      end
+
+      it "keeps the current version and marks the dependency" do
+        latest_tag = {
+          tag: "v6.0.0",
+          version: Dependabot::PreCommit::Version.new("6.0.0"),
+          commit_sha: "latest_sha"
+        }
+
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:local_tags_for_allowed_versions_matching_existing_precision)
+          .and_return([latest_tag])
+        allow_any_instance_of(Dependabot::GitCommitChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:dependency_source_details)
+          .and_return(source_details)
+        allow(Dependabot::SharedHelpers).to receive(:in_a_temporary_directory).and_yield("/tmp/fake")
+        allow(Dir).to receive(:chdir).and_yield
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git clone --bare/, any_args).and_return("")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git for-each-ref/, hash_including(fingerprint: anything)).and_return("")
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command)
+          .with(/git show --no-patch/, hash_including(fingerprint: anything)).and_return("")
+
+        expect(finder.latest_release_version.to_s).to eq("4.4.0")
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
+
     context "when GitHub Release published_at is available" do
       let(:update_cooldown) do
         Dependabot::Package::ReleaseCooldownOptions.new(

--- a/swift/spec/dependabot/swift/update_checker_spec.rb
+++ b/swift/spec/dependabot/swift/update_checker_spec.rb
@@ -746,6 +746,33 @@ RSpec.describe Dependabot::Swift::UpdateChecker do
       end
     end
 
+    context "when the tag publication date is unavailable" do
+      let(:stubbed_git_commit_checker) do
+        Dependabot::GitCommitChecker.new(
+          dependency: cooldown_dependency,
+          credentials: github_credentials,
+          ignored_versions: [],
+          raise_on_ignored: false
+        )
+      end
+      let(:candidate_tag) do
+        Dependabot::GitRef.new(name: "2.1.0", commit_sha: "abc123")
+      end
+
+      before do
+        allow(stubbed_git_commit_checker).to receive_messages(
+          allowed_version_tags: [candidate_tag],
+          refs_for_tag_with_detail: [Dependabot::GitTagWithDetail.new(tag: "2.1.0", release_date: nil)],
+          cached_github_releases: []
+        )
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(cooldown_checker.latest_version).to eq(Dependabot::Swift::Version.new("2.1.0"))
+        expect(cooldown_dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
+
     context "when cooldown is not configured" do
       let(:cooldown_options) { nil }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Stacked on #16214.

Mark dependencies when git-backed cooldown checks cannot resolve a usable publication date. The change covers the shared `GitCommitChecker` and `GitCooldownDateResolver` paths, plus GitHub Actions, Pre-commit, and Swift integrations.

### Anything you want to highlight for special attention from reviewers?

GitHub Release publication time remains preferred, followed by tag creation time and commit time. If none are available, the existing ecosystem policy is preserved while the shared warning marker is set.

Julia is intentionally excluded and follows in its own PR.

### How will you know you've accomplished your goal?

- Common git specs: 162 examples, 0 failures.
- GitHub Actions finder: 32 examples, 0 failures.
- Pre-commit finder: 25 examples, 0 failures.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.