### PR TITLE
Warn when Bazel and Pub cooldown dates are unavailable

### DIFF
--- a/bazel/lib/dependabot/bazel/update_checker.rb
+++ b/bazel/lib/dependabot/bazel/update_checker.rb
@@ -177,7 +177,13 @@ module Dependabot
         filtered_versions = sorted_versions.reject do |version|
           details = publication_detail(version)
 
-          next false unless details&.released_at
+          unless details&.released_at
+            Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+              dependency,
+              cooldown_days: cooldown_days_for(version)
+            )
+            next false
+          end
 
           if cooldown_period?(T.must(details.released_at), version)
             Dependabot.logger.info("Skipping version #{version} due to cooldown period")
@@ -225,13 +231,20 @@ module Dependabot
 
       sig { params(release_date: Time, version_string: String).returns(T::Boolean) }
       def cooldown_period?(release_date, version_string)
+        Dependabot::UpdateCheckers::CooldownCalculation.within_cooldown_window?(
+          release_date,
+          cooldown_days_for(version_string)
+        )
+      end
+
+      sig { params(version_string: String).returns(Integer) }
+      def cooldown_days_for(version_string)
         cooldown = update_cooldown
-        return false unless cooldown
+        return 0 unless cooldown
 
         current_version = dependency.version ? version_class.new(dependency.version) : nil
         new_version = version_class.new(version_string)
-        days = Dependabot::UpdateCheckers::CooldownCalculation.cooldown_days_for(cooldown, current_version, new_version)
-        Dependabot::UpdateCheckers::CooldownCalculation.within_cooldown_window?(release_date, days)
+        Dependabot::UpdateCheckers::CooldownCalculation.cooldown_days_for(cooldown, current_version, new_version)
       end
 
       sig { returns(T::Boolean) }

--- a/bazel/spec/dependabot/bazel/update_checker_spec.rb
+++ b/bazel/spec/dependabot/bazel/update_checker_spec.rb
@@ -636,7 +636,7 @@ RSpec.describe Dependabot::Bazel::UpdateChecker do
 
       context "when cooldown is enabled" do
         before do
-          allow(checker).to receive(:should_skip_cooldown?).and_return(false)
+          allow(checker).to receive_messages(should_skip_cooldown?: false, cooldown_days_for: 1)
           allow(Dependabot.logger).to receive(:info)
 
           # Mock cooldown period check - return true for recent time, false for old time
@@ -702,6 +702,7 @@ RSpec.describe Dependabot::Bazel::UpdateChecker do
           it "returns all versions when no release dates available" do
             result = checker.send(:apply_cooldown_filter, versions)
             expect(result).to eq(versions)
+            expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
           end
         end
       end

--- a/pub/lib/dependabot/pub/update_checker/latest_version_finder.rb
+++ b/pub/lib/dependabot/pub/update_checker/latest_version_finder.rb
@@ -146,13 +146,17 @@ module Dependabot
 
         sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
         def in_cooldown_period?(release)
+          current_version = version_class.correct?(dependency.version) ? version_class.new(dependency.version) : nil
+          days = cooldown_days_for(current_version, release.version)
+
           unless release.released_at
+            Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+              dependency,
+              cooldown_days: days
+            )
             Dependabot.logger.info("Release date not available for version #{release.version}")
             return false
           end
-
-          current_version = version_class.correct?(dependency.version) ? version_class.new(dependency.version) : nil
-          days = cooldown_days_for(current_version, release.version)
 
           # Calculate the number of seconds passed since the release
           passed_seconds = Time.now.to_i - release.released_at.to_i

--- a/pub/spec/dependabot/pub/update_checker/latest_version_finder_spec.rb
+++ b/pub/spec/dependabot/pub/update_checker/latest_version_finder_spec.rb
@@ -15,9 +15,12 @@ RSpec.describe Dependabot::Pub::UpdateChecker::LatestVersionFinder do
     described_class.new(
       dependency: dependency,
       dependency_files: dependency_files,
-      credentials: credentials
+      credentials: credentials,
+      cooldown_options: cooldown_options
     )
   end
+
+  let(:cooldown_options) { nil }
 
   let(:dependency) do
     Dependabot::Dependency.new(
@@ -69,6 +72,37 @@ RSpec.describe Dependabot::Pub::UpdateChecker::LatestVersionFinder do
         expect(versions.latest_resolvable_version).to be_a(String).or be_nil
         expect(versions.latest_resolvable_version_with_no_unlock).to be_a(String).or be_nil
         expect(versions.latest_version_resolvable_with_full_unlock).to be_a(String).or be_nil
+      end
+    end
+  end
+
+  describe "#latest_version with cooldown" do
+    context "when the release date is unavailable" do
+      let(:cooldown_options) do
+        Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+      end
+      let(:release) do
+        Dependabot::Package::PackageRelease.new(
+          version: Dependabot::Pub::Version.new("1.0.0"),
+          released_at: nil
+        )
+      end
+      let(:package_details_fetcher) do
+        instance_double(
+          Dependabot::Pub::Package::PackageDetailsFetcher,
+          report: [{ "name" => dependency_name, "latest" => "1.0.0" }],
+          package_details_metadata: [release]
+        )
+      end
+
+      before do
+        allow(Dependabot::Pub::Package::PackageDetailsFetcher)
+          .to receive(:new).and_return(package_details_fetcher)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(latest_version_finder.latest_version).to eq("1.0.0")
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Stacked on #16216 and part of the #16142 cooldown-warning stack.

When a positive cooldown is configured but a registry provides no publication date, Bazel and Pub currently fail open and continue selecting the release without telling the user that cooldown could not be applied.

Mark the dependency through the shared cooldown diagnostic so the root delivery code can surface this warning in the pull request and update job:

> [!WARNING]
> Cooldown could not be applied because no publication date was available from the registry.

This is an observability change only. Both ecosystems retain their existing fail-open update behavior.

### Anything you want to highlight for special attention from reviewers?

Bazel and Pub remain bespoke integrations rather than using `PackageLatestVersionFinder`:

- Bazel filters version strings and resolves publication details through its registry client.
- Pub uses a standalone latest-version finder and computes its own SemVer-specific cooldown days.

Both paths calculate the effective cooldown before marking the dependency, so excluded dependencies and zero-day cooldowns do not produce a warning.

This is the final PR in the stack.

### How will you know you've accomplished your goal?

Verified in Docker:

- Bazel update checker: 96 examples, 0 failures.
- Pub latest-version finder: 3 examples, 0 failures.
- The final stack tip contains every path from the preserved original change.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
