### PR TITLE
Recognize unicode gitmoji commit prefixes

### DIFF
--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -19,7 +19,7 @@ module Dependabot
 
       ANGULAR_PREFIXES = %w(build chore ci docs feat fix perf refactor style test).freeze
       ESLINT_PREFIXES = %w(Breaking Build Chore Docs Fix New Update Upgrade).freeze
-      GITMOJI_PREFIXES = %w(
+      GITMOJI_SHORTCODE_PREFIXES = %w(
         alien ambulance apple arrow_down arrow_up art beers bento bookmark boom bug building_construction
         bulb busts_in_silhouette camera_flash card_file_box chart_with_upwards_trend checkered_flag children_crossing
         clown_face construction construction_worker egg fire globe_with_meridians green_apple green_heart hankey
@@ -27,6 +27,12 @@ module Dependabot
         pencil2 penguin pushpin recycle rewind robot rocket rotating_light see_no_evil sparkles speech_balloon tada
         truck twisted_rightwards_arrows whale wheelchair white_check_mark wrench zap
       ).freeze
+
+      # U+FE0F (variation selector-16) is optional in commit messages; strip it so both forms match
+      GITMOJI_UNICODE_PREFIXES = %w(
+        👽 🚑 🍎 ⬇️ ⬆️ 🎨 🍻 🍱 🔖 💥 🐛 🏗️ 💡 👥 📸 🗃️ 📈 🏁 🚸 🤡 🚧 👷 🥚 🔥 🌐 🍏 💚 💩
+        ➖ ➕ 📱 💄 🔒 🔊 📝 🔇 👌 📦 📄 ✏️ 🐧 📌 ♻️ ⏪ 🤖 🚀 🚨 🙈 ✨ 💬 🎉 🚚 🔀 🐳 ♿ ✅ 🔧 ⚡
+      ).map { |emoji| -emoji.delete("\uFE0F") }.freeze
 
       class RecentCommit < T::ImmutableStruct
         const :message, T.nilable(String)
@@ -319,9 +325,10 @@ module Dependabot
       def using_gitmoji_commit_messages?
         return false unless recent_commit_messages.any?
 
-        gitmoji_messages =
-          recent_commit_messages
-          .select { |m| GITMOJI_PREFIXES.any? { |pre| m.match?(/:#{pre}:/i) } }
+        gitmoji_messages = recent_commit_messages.select do |message|
+          GITMOJI_SHORTCODE_PREFIXES.any? { |prefix| message.match?(/:#{prefix}:/i) } ||
+            message.start_with?(*GITMOJI_UNICODE_PREFIXES)
+        end
 
         gitmoji_messages.count / recent_commit_messages.count.to_f > 0.3
       end

--- a/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
+++ b/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb
@@ -29,10 +29,13 @@ module Dependabot
       ).freeze
 
       # U+FE0F (variation selector-16) is optional in commit messages; strip it so both forms match
-      GITMOJI_UNICODE_PREFIXES = %w(
-        👽 🚑 🍎 ⬇️ ⬆️ 🎨 🍻 🍱 🔖 💥 🐛 🏗️ 💡 👥 📸 🗃️ 📈 🏁 🚸 🤡 🚧 👷 🥚 🔥 🌐 🍏 💚 💩
-        ➖ ➕ 📱 💄 🔒 🔊 📝 🔇 👌 📦 📄 ✏️ 🐧 📌 ♻️ ⏪ 🤖 🚀 🚨 🙈 ✨ 💬 🎉 🚚 🔀 🐳 ♿ ✅ 🔧 ⚡
-      ).map { |emoji| -emoji.delete("\uFE0F") }.freeze
+      GITMOJI_UNICODE_PREFIXES = T.let(
+        %w(
+          👽 🚑 🍎 ⬇️ ⬆️ 🎨 🍻 🍱 🔖 💥 🐛 🏗️ 💡 👥 📸 🗃️ 📈 🏁 🚸 🤡 🚧 👷 🥚 🔥 🌐 🍏 💚 💩
+          ➖ ➕ 📱 💄 🔒 🔊 📝 🔇 👌 📦 📄 ✏️ 🐧 📌 ♻️ ⏪ 🤖 🚀 🚨 🙈 ✨ 💬 🎉 🚚 🔀 🐳 ♿ ✅ 🔧 ⚡
+        ).map { |emoji| emoji.delete("\uFE0F").freeze }.freeze,
+        T::Array[String]
+      )
 
       class RecentCommit < T::ImmutableStruct
         const :message, T.nilable(String)
@@ -327,7 +330,7 @@ module Dependabot
 
         gitmoji_messages = recent_commit_messages.select do |message|
           GITMOJI_SHORTCODE_PREFIXES.any? { |prefix| message.match?(/:#{prefix}:/i) } ||
-            message.start_with?(*GITMOJI_UNICODE_PREFIXES)
+            GITMOJI_UNICODE_PREFIXES.any? { |prefix| message.start_with?(prefix) }
         end
 
         gitmoji_messages.count / recent_commit_messages.count.to_f > 0.3

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -490,6 +490,27 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
 
         it { is_expected.to eq("") }
       end
+
+      context "when exactly 30 percent of the commits use Gitmoji" do
+        let(:commits_response) do
+          JSON.dump(
+            [
+              { commit: { message: ":rocket: release dependency update" } },
+              { commit: { message: "⬆️ update dependency" } },
+              { commit: { message: ":bug: fix dependency issue" } },
+              { commit: { message: "refactor dependency handling" } },
+              { commit: { message: "docs: update dependency notes" } },
+              { commit: { message: "test dependency handling" } },
+              { commit: { message: "chore dependency handling" } },
+              { commit: { message: "build dependency handling" } },
+              { commit: { message: "ci dependency handling" } },
+              { commit: { message: "style dependency handling" } }
+            ]
+          )
+        end
+
+        it { is_expected.to eq("") }
+      end
     end
 
     context "when commit_message_options are provided" do

--- a/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
+++ b/common/spec/dependabot/pull_request_creator/pr_name_prefixer_spec.rb
@@ -417,9 +417,11 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
       before do
         stub_request(:get, watched_repo_url + "/commits?per_page=100")
           .to_return(status: 200,
-                     body: fixture("github", "commits_gitmoji.json"),
+                     body: commits_response,
                      headers: json_header)
       end
+
+      let(:commits_response) { fixture("github", "commits_gitmoji.json") }
 
       it { is_expected.to eq("⬆️ ") }
 
@@ -427,6 +429,66 @@ RSpec.describe Dependabot::PullRequestCreator::PrNamePrefixer do
         let(:security_fix) { true }
 
         it { is_expected.to eq("⬆️🔒 ") }
+      end
+
+      context "when the commits use Gitmoji shortcodes" do
+        let(:commits_response) do
+          JSON.dump(
+            [
+              { commit: { message: ":rocket: release dependency update" } },
+              { commit: { message: ":bug: fix dependency issue" } },
+              { commit: { message: ":memo: update changelog" } },
+              { commit: { message: "refactor dependency handling" } }
+            ]
+          )
+        end
+
+        it { is_expected.to eq("⬆️ ") }
+      end
+
+      context "when the commits use Unicode Gitmoji" do
+        let(:commits_response) do
+          JSON.dump(
+            [
+              { commit: { message: "⬆️ update dependency" } },
+              { commit: { message: "✏️ update dependency notes" } },
+              { commit: { message: "🚀 release dependency update" } },
+              { commit: { message: "refactor dependency handling" } }
+            ]
+          )
+        end
+
+        it { is_expected.to eq("⬆️ ") }
+      end
+
+      context "when the commits use Unicode Gitmoji without a variation selector" do
+        let(:commits_response) do
+          JSON.dump(
+            [
+              { commit: { message: "⬆ update dependency" } },
+              { commit: { message: "🏗 restructure dependency loading" } },
+              { commit: { message: "♻ rework dependency handling" } },
+              { commit: { message: "refactor dependency handling" } }
+            ]
+          )
+        end
+
+        it { is_expected.to eq("⬆️ ") }
+      end
+
+      context "when Unicode Gitmoji appear mid-message" do
+        let(:commits_response) do
+          JSON.dump(
+            [
+              { commit: { message: "update 🚀 dependency" } },
+              { commit: { message: "fix 🐛 dependency issue" } },
+              { commit: { message: "add ✨ dependency" } },
+              { commit: { message: "refactor dependency handling" } }
+            ]
+          )
+        end
+
+        it { is_expected.to eq("") }
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?
Fix #16190

Dependabot currently detects Gitmoji commit conventions only when commits use Gitmoji shortcodes such as `:rocket:` or `:bug:`. This misses repositories that use the corresponding Unicode emojis directly, such as `🚀` or `🐛`.

This change updates pull request name prefix detection to recognize Unicode Gitmoji prefixes alongside the existing shortcode format. This allows Dependabot to preserve the repository's Gitmoji convention when generating pull request titles.

### Anything you want to highlight for special attention from reviewers?

The existing shortcode detection remains supported. Unicode Gitmoji are matched only at the beginning of a commit message, reflecting their use as commit message prefixes.

The detection threshold remains unchanged: more than 30% of recent commit messages must use Gitmoji for the repository to be treated as using the convention.

Additional specs cover Gitmoji shortcodes, Unicode Gitmoji, and the 30% detection threshold.

### How will you know you've accomplished your goal?

The new specs verify that repositories using Unicode Gitmoji are detected and receive the expected `⬆️` pull request title prefix. They also verify that shortcode-based detection continues to work and that repositories at exactly the 30% threshold are not classified as Gitmoji repositories.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.