### PR TITLE
fix(npm_and_yarn): detect bun.lock misconfigured as npm ecosystem

### DIFF
--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -36,9 +36,6 @@ module Dependabot
       )
       PATH_DEPENDENCY_CLEAN_REGEX = /^file:|^link:/
       DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org"
-      # Bun uses its own lockfile format that this ecosystem's file updater cannot write to.
-      # Detected only to raise a clear error (see `raise_if_bun_lock_misconfigured_as_npm!`) —
-      # this ecosystem never fetches or updates `bun.lock` itself.
       BUN_LOCKFILE_NAME = "bun.lock"
 
       sig { override.params(filenames: T::Array[String]).returns(T::Boolean) }
@@ -311,12 +308,8 @@ module Dependabot
         !npm_version && !yarn_version && !pnpm_version
       end
 
-      # A `bun.lock` with no npm/yarn/pnpm lockfile means the project is managed by Bun,
-      # but `package-ecosystem: "npm"` (or `"yarn"`) routes it to this ecosystem instead of
-      # to the dedicated `"bun"` ecosystem. This ecosystem has no updater for `bun.lock`, so
-      # left unchecked it would silently open a PR that bumps `package.json` without ever
-      # updating the lockfile (dependabot/dependabot-core#14223). Fail fast with a clear,
-      # actionable error instead.
+      # Without this check, a bun-managed project misconfigured as "npm" would silently get a
+      # PR that bumps package.json without updating bun.lock (dependabot-core#14223).
       sig { void }
       def raise_if_bun_lock_misconfigured_as_npm!
         return unless no_package_manager_detected?

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -3,6 +3,7 @@
 
 require "json"
 require "sorbet-runtime"
+require "dependabot/errors"
 require "dependabot/experiments"
 require "dependabot/logger"
 require "dependabot/file_fetchers"
@@ -35,6 +36,10 @@ module Dependabot
       )
       PATH_DEPENDENCY_CLEAN_REGEX = /^file:|^link:/
       DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org"
+      # Bun uses its own lockfile format that this ecosystem's file updater cannot write to.
+      # Detected only to raise a clear error (see `raise_if_bun_lock_misconfigured_as_npm!`) —
+      # this ecosystem never fetches or updates `bun.lock` itself.
+      BUN_LOCKFILE_NAME = "bun.lock"
 
       sig { override.params(filenames: T::Array[String]).returns(T::Boolean) }
       def self.required_files_in?(filenames)
@@ -81,6 +86,8 @@ module Dependabot
 
       sig { override.returns(T::Array[DependencyFile]) }
       def fetch_files # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+        raise_if_bun_lock_misconfigured_as_npm!
+
         fetched_files = T.let([], T::Array[DependencyFile])
         fetched_files << package_json
         fetched_files << T.must(npmrc) if npmrc && !scope_overrides_npmrc?
@@ -302,6 +309,33 @@ module Dependabot
       sig { returns(T::Boolean) }
       def no_package_manager_detected?
         !npm_version && !yarn_version && !pnpm_version
+      end
+
+      # A `bun.lock` with no npm/yarn/pnpm lockfile means the project is managed by Bun,
+      # but `package-ecosystem: "npm"` (or `"yarn"`) routes it to this ecosystem instead of
+      # to the dedicated `"bun"` ecosystem. This ecosystem has no updater for `bun.lock`, so
+      # left unchecked it would silently open a PR that bumps `package.json` without ever
+      # updating the lockfile (dependabot/dependabot-core#14223). Fail fast with a clear,
+      # actionable error instead.
+      sig { void }
+      def raise_if_bun_lock_misconfigured_as_npm!
+        return unless no_package_manager_detected?
+        return unless bun_lock
+
+        raise Dependabot::MisconfiguredTooling.new(
+          "Bun",
+          "This project has a `#{BUN_LOCKFILE_NAME}` file but no `package-lock.json`, `yarn.lock` or " \
+          "`pnpm-lock.yaml`, which means it is managed by Bun. Dependabot's `npm_and_yarn` ecosystem " \
+          "cannot update `#{BUN_LOCKFILE_NAME}`. Set `package-ecosystem: \"bun\"` in your dependabot.yml " \
+          "for this directory so Dependabot can update this project's dependencies correctly."
+        )
+      end
+
+      sig { returns(T.nilable(DependencyFile)) }
+      def bun_lock
+        return @bun_lock if defined?(@bun_lock)
+
+        @bun_lock ||= T.let(fetch_file_if_present(BUN_LOCKFILE_NAME), T.nilable(DependencyFile))
       end
 
       sig { returns(T.nilable(T.any(Integer, String))) }

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_fetcher_spec.rb
@@ -261,6 +261,36 @@ RSpec.describe Dependabot::NpmAndYarn::FileFetcher do
     end
   end
 
+  context "with a bun.lock but no npm, yarn, or pnpm lockfile" do
+    before do
+      stub_request(:get, url + "?ref=sha")
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "contents_js_bun.json"),
+          headers: json_header
+        )
+      stub_request(:get, File.join(url, "package-lock.json?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(status: 404)
+      stub_request(:get, File.join(url, "bun.lock?ref=sha"))
+        .with(headers: { "Authorization" => "token token" })
+        .to_return(
+          status: 200,
+          body: fixture("github", "bun_lock_content.json"),
+          headers: json_header
+        )
+    end
+
+    it "raises MisconfiguredTooling directing the user to the bun ecosystem" do
+      expect { file_fetcher_instance.files }.to raise_error(Dependabot::MisconfiguredTooling) do |error|
+        expect(error.tool_name).to eq("Bun")
+        expect(error.tool_message).to include("bun.lock")
+        expect(error.tool_message).to include('package-ecosystem: "bun"')
+      end
+    end
+  end
+
   context "with a yarn.lock but no package-lock.json file" do
     before do
       stub_request(:get, url + "?ref=sha")


### PR DESCRIPTION
### What are you trying to accomplish?

Regarding the issue in dependabot/dependabot-core#14223, I have added a error when bun.lock is present even though the package-ecosystem is npm.

### Anything you want to highlight for special attention from reviewers?

Prevents new issues like dependabot/dependabot-core#14223 from being created due to error displays.

### How will you know you've accomplished your goal?

Added specs to verify the behavior.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
