### PR TITLE
Prototype NuGet patch-only default for selected Microsoft.Build packages

### DIFF
--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -66,6 +66,54 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
     }
 
     [Fact]
+    public async Task LimitsMicrosoftBuildFrameworkToPatchUpdatesByDefault()
+    {
+        await TestAnalyzeAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "17.8.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "17.8.5", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "17.9.1", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "18.0.0", "net8.0"),
+            ],
+            discovery: new()
+            {
+                Path = "/",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "./project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies = [
+                            new("Microsoft.Build.Framework", "17.8.0", DependencyType.PackageReference),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                    },
+                ],
+            },
+            dependencyInfo: new()
+            {
+                Name = "Microsoft.Build.Framework",
+                Version = "17.8.0",
+                IgnoredVersions = [],
+                IsVulnerable = false,
+                Vulnerabilities = [],
+            },
+            expectedResult: new()
+            {
+                UpdatedVersion = "17.8.5",
+                CanUpdate = true,
+                VersionComesFromMultiDependencyProperty = false,
+                UpdatedDependencies = [
+                    new("Microsoft.Build.Framework", "17.8.5", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                ],
+            }
+        );
+    }
+
+    [Fact]
     public async Task FindsUpdatedPeerDependencies()
     {
         await TestAnalyzeAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/AnalyzeWorkerTests.cs
@@ -114,6 +114,66 @@ public partial class AnalyzeWorkerTests : AnalyzeWorkerTestBase
     }
 
     [Fact]
+    public async Task LimitsMicrosoftBuildFrameworkToPatchUpdatesWhenSharingVersionProperty()
+    {
+        var evaluationResult = new EvaluationResult(
+            EvaluationResultType.Success,
+            "$(SharedPackageVersion)",
+            "17.8.0",
+            "SharedPackageVersion",
+            ErrorMessage: null);
+        await TestAnalyzeAsync(
+            packages:
+            [
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "17.8.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "17.8.5", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "17.9.1", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Some.Package", "18.0.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "17.8.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "17.8.5", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "17.9.1", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "18.0.0", "net8.0"),
+            ],
+            discovery: new()
+            {
+                Path = "/",
+                Projects = [
+                    new()
+                    {
+                        FilePath = "./project.csproj",
+                        TargetFrameworks = ["net8.0"],
+                        Dependencies = [
+                            new("Some.Package", "17.8.0", DependencyType.PackageReference, EvaluationResult: evaluationResult, TargetFrameworks: ["net8.0"]),
+                            new("Microsoft.Build.Framework", "17.8.0", DependencyType.PackageReference, EvaluationResult: evaluationResult, TargetFrameworks: ["net8.0"]),
+                        ],
+                        ReferencedProjectPaths = [],
+                        ImportedFiles = [],
+                        AdditionalFiles = [],
+                    },
+                ],
+            },
+            dependencyInfo: new()
+            {
+                Name = "Some.Package",
+                Version = "17.8.0",
+                IgnoredVersions = [],
+                IsVulnerable = false,
+                Vulnerabilities = [],
+            },
+            expectedResult: new()
+            {
+                UpdatedVersion = "17.8.5",
+                CanUpdate = true,
+                VersionComesFromMultiDependencyProperty = true,
+                UpdatedDependencies = [
+                    new("Some.Package", "17.8.5", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                    new("Microsoft.Build.Framework", "17.8.5", DependencyType.PackageReference, TargetFrameworks: ["net8.0"]),
+                ],
+            }
+        );
+    }
+
+    [Fact]
     public async Task FindsUpdatedPeerDependencies()
     {
         await TestAnalyzeAsync(

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/VersionFinderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/VersionFinderTests.cs
@@ -201,6 +201,84 @@ public class VersionFinderTests : TestBase
         Assert.True(result);
     }
 
+    [Theory]
+    [InlineData("Microsoft.Build.Framework")]
+    [InlineData("Microsoft.Build.Utilities.Core")]
+    [InlineData("Microsoft.Build.Tasks.Core")]
+    [InlineData("Microsoft.Build")]
+    public void VersionFilter_PatchOnlyDefaultPackage_PatchVersionReturnsTrue(string dependencyName)
+    {
+        var filter = CreateVersionFilter(dependencyName);
+
+        var result = filter(NuGetVersion.Parse("17.8.3"));
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("17.9.0")]
+    [InlineData("18.0.0")]
+    public void VersionFilter_PatchOnlyDefaultPackage_MajorOrMinorVersionReturnsFalse(string candidateVersion)
+    {
+        var filter = CreateVersionFilter("Microsoft.Build.Framework");
+
+        var result = filter(NuGetVersion.Parse(candidateVersion));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void VersionFilter_PatchOnlyDefaultPackage_NameComparisonIsCaseInsensitive()
+    {
+        var filter = CreateVersionFilter("microsoft.build.framework");
+
+        var result = filter(NuGetVersion.Parse("17.9.0"));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void VersionFilter_PatchOnlyDefaultPackage_UnclassifiedVersionReturnsTrue()
+    {
+        var filter = CreateVersionFilter("Microsoft.Build.Framework", dependencyVersion: "17.8.0-alpha");
+
+        var result = filter(NuGetVersion.Parse("17.8.0-beta"));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void VersionFilter_NonPatchOnlyDefaultPackage_MajorVersionReturnsTrue()
+    {
+        var filter = CreateVersionFilter("Some.Dependency");
+
+        var result = filter(NuGetVersion.Parse("18.0.0"));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void VersionFilter_PatchOnlyDefaultPackage_ExplicitIgnoreStillApplies()
+    {
+        var filter = CreateVersionFilter(
+            "Microsoft.Build.Framework",
+            ignoredVersions: [Requirement.Parse("17.8.3")]);
+
+        var result = filter(NuGetVersion.Parse("17.8.3"));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void VersionFilter_PatchOnlyDefaultPackage_VulnerableDependencyMajorVersionReturnsTrue()
+    {
+        var filter = CreateVersionFilter("Microsoft.Build.Framework", isVulnerable: true);
+
+        var result = filter(NuGetVersion.Parse("18.0.0"));
+
+        Assert.True(result);
+    }
+
     [Fact]
     public async Task TargetFrameworkIsConsideredForUpdatedVersions()
     {
@@ -526,5 +604,23 @@ public class VersionFinderTests : TestBase
         Assert.NotNull(versionsResult);
         var versions = versionsResult.GetVersions();
         Assert.Empty(versions);
+    }
+
+    private static Func<NuGetVersion, bool> CreateVersionFilter(
+        string dependencyName,
+        bool isVulnerable = false,
+        ImmutableArray<Requirement>? ignoredVersions = null,
+        string dependencyVersion = "17.8.0")
+    {
+        var dependencyInfo = new DependencyInfo
+        {
+            Name = dependencyName,
+            Version = dependencyVersion,
+            IsVulnerable = isVulnerable,
+            IgnoredVersions = ignoredVersions ?? [],
+            Vulnerabilities = [],
+        };
+
+        return VersionFinder.CreateVersionFilter(dependencyInfo, VersionRange.Parse(dependencyInfo.Version));
     }
 }

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/VersionFinderTests.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core.Test/Analyze/VersionFinderTests.cs
@@ -280,6 +280,33 @@ public class VersionFinderTests : TestBase
     }
 
     [Fact]
+    public async Task GetVersionsByNameAsync_PatchOnlyDefaultPackage_ReturnsPatchVersionsOnly()
+    {
+        using var tempDir = new TemporaryDirectory();
+        await UpdateWorkerTestBase.MockNuGetPackagesInDirectory(
+            [
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "17.8.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "17.8.3", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "17.9.0", "net8.0"),
+                MockNuGetPackage.CreateSimplePackage("Microsoft.Build.Framework", "18.0.0", "net8.0"),
+            ],
+            tempDir.DirectoryPath);
+        var projectTfms = new[] { "net8.0" }.Select(NuGetFramework.Parse).ToImmutableArray();
+        var nugetContext = new NuGetContext(tempDir.DirectoryPath);
+
+        var versionResult = await VersionFinder.GetVersionsByNameAsync(
+            projectTfms,
+            "Microsoft.Build.Framework",
+            NuGetVersion.Parse("17.8.0"),
+            nugetContext,
+            new TestLogger(),
+            CancellationToken.None);
+
+        var actual = versionResult.GetVersions().Select(v => v.ToString()).ToArray();
+        AssertEx.Equal(["17.8.3"], actual);
+    }
+
+    [Fact]
     public async Task TargetFrameworkIsConsideredForUpdatedVersions()
     {
         // arrange

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/AnalyzeWorker.cs
@@ -247,7 +247,7 @@ public partial class AnalyzeWorker : IAnalyzeWorker
             dependencyInfo.Version,
             versionResult,
             projectFrameworks,
-            findLowestVersion: dependencyInfo.IsVulnerable,
+            isVulnerable: dependencyInfo.IsVulnerable,
             nugetContext,
             logger,
             cancellationToken);
@@ -258,19 +258,28 @@ public partial class AnalyzeWorker : IAnalyzeWorker
         string versionString,
         VersionResult versionResult,
         ImmutableArray<NuGetFramework> projectFrameworks,
-        bool findLowestVersion,
+        bool isVulnerable,
         NuGetContext nugetContext,
         ILogger logger,
         CancellationToken cancellationToken)
     {
         var versions = versionResult.GetVersions();
+        var currentVersion = VersionRange.Parse(versionString).MinVersion;
+        versions = versions
+            .Where(version => VersionFinder.IsVersionAllowedByPatchOnlyDefault(
+                packageIds,
+                currentVersion,
+                version,
+                isVulnerable))
+            .ToImmutableArray();
+
         if (versions.Length == 0)
         {
             // if absolutely nothing was found, then we can't update
             return null;
         }
 
-        var orderedVersions = findLowestVersion
+        var orderedVersions = isVulnerable
             ? versions.OrderBy(v => v) // If we are fixing a vulnerability, then we want the lowest version that is safe.
             : versions.OrderByDescending(v => v); // If we are just updating versions, then we want the highest version possible.
 

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
@@ -66,7 +66,14 @@ internal static class VersionFinder
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        var versionFilter = CreateVersionFilter(currentVersion);
+        var defaultVersionFilter = CreateVersionFilter(currentVersion);
+        Func<NuGetVersion, bool> versionFilter = version =>
+            defaultVersionFilter(version) &&
+            IsVersionAllowedByPatchOnlyDefault(
+                [dependencyInfo.Name],
+                currentVersion,
+                version,
+                dependencyInfo.IsVulnerable);
 
         return GetVersionsAsync(projectTfms, dependencyInfo, currentVersion, versionFilter, currentTime, nugetContext, logger, cancellationToken);
     }
@@ -257,11 +264,11 @@ internal static class VersionFinder
                 }
             }
 
-            // This deliberately narrow prototype default reduces update churn for Microsoft.Build packages.
-            var isIgnoredByPatchOnlyDefault = !dependencyInfo.IsVulnerable
-                && currentVersion is not null
-                && PatchOnlyDefaultPackageNames.Contains(dependencyInfo.Name)
-                && versionBumpType is VersionBumpType.Major or VersionBumpType.Minor;
+            var isAllowedByPatchOnlyDefault = IsVersionAllowedByPatchOnlyDefault(
+                [dependencyInfo.Name],
+                currentVersion,
+                version,
+                dependencyInfo.IsVulnerable);
 
             return versionGreaterThanCurrent
                 && rangeSatisfies
@@ -270,8 +277,25 @@ internal static class VersionFinder
                 && !isVulnerableVersion
                 && isSafeVersion
                 && !isIgnoredByType
-                && !isIgnoredByPatchOnlyDefault;
+                && isAllowedByPatchOnlyDefault;
         };
+    }
+
+    // This deliberately narrow prototype default reduces update churn for Microsoft.Build packages.
+    internal static bool IsVersionAllowedByPatchOnlyDefault(
+        IEnumerable<string> dependencyNames,
+        NuGetVersion? currentVersion,
+        NuGetVersion candidateVersion,
+        bool isVulnerable)
+    {
+        if (isVulnerable ||
+            currentVersion is null ||
+            !dependencyNames.Any(PatchOnlyDefaultPackageNames.Contains))
+        {
+            return true;
+        }
+
+        return GetVersionBumpType(currentVersion, candidateVersion) is not VersionBumpType.Major and not VersionBumpType.Minor;
     }
 
     private static VersionBumpType GetVersionBumpType(NuGetVersion currentVersion, NuGetVersion candidateVersion)

--- a/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
+++ b/nuget/helpers/lib/NuGetUpdater/NuGetUpdater.Core/Analyze/VersionFinder.cs
@@ -16,6 +16,21 @@ namespace NuGetUpdater.Core.Analyze;
 
 internal static class VersionFinder
 {
+    private static readonly ImmutableHashSet<string> PatchOnlyDefaultPackageNames = ImmutableHashSet.Create(
+        StringComparer.OrdinalIgnoreCase,
+        "Microsoft.Build.Framework",
+        "Microsoft.Build.Utilities.Core",
+        "Microsoft.Build.Tasks.Core",
+        "Microsoft.Build");
+
+    private enum VersionBumpType
+    {
+        Major,
+        Minor,
+        Patch,
+        Other,
+    }
+
     public static Task<VersionResult> GetVersionsByNameAsync(
         ImmutableArray<NuGetFramework> projectTfms,
         string dependencyName,
@@ -216,25 +231,25 @@ internal static class VersionFinder
             var isIgnoredVersion = dependencyInfo.IgnoredVersions.Any(i => i.IsSatisfiedBy(version));
             var isVulnerableVersion = dependencyInfo.Vulnerabilities.Any(v => v.IsVulnerable(version));
             var isSafeVersion = !safeVersions.Any() || safeVersions.Any(s => s.IsSatisfiedBy(version));
+            var versionBumpType = currentVersion is null
+                ? VersionBumpType.Other
+                : GetVersionBumpType(currentVersion, version);
 
             var isIgnoredByType = false;
             if (currentVersion is not null)
             {
-                var isMajorBump = version.Major > currentVersion.Major;
-                var isMinorBump = version.Major == currentVersion.Major && version.Minor > currentVersion.Minor;
-                var isPatchBump = version.Major == currentVersion.Major && version.Minor == currentVersion.Minor && version.Patch > currentVersion.Patch;
                 foreach (var ignoreType in dependencyInfo.IgnoredUpdateTypes)
                 {
                     switch (ignoreType)
                     {
                         case ConditionUpdateType.SemVerPatch:
-                            isIgnoredByType = isIgnoredByType || isPatchBump || isMinorBump || isMajorBump;
+                            isIgnoredByType = isIgnoredByType || versionBumpType is VersionBumpType.Patch or VersionBumpType.Minor or VersionBumpType.Major;
                             break;
                         case ConditionUpdateType.SemVerMinor:
-                            isIgnoredByType = isIgnoredByType || isMinorBump || isMajorBump;
+                            isIgnoredByType = isIgnoredByType || versionBumpType is VersionBumpType.Minor or VersionBumpType.Major;
                             break;
                         case ConditionUpdateType.SemVerMajor:
-                            isIgnoredByType = isIgnoredByType || isMajorBump;
+                            isIgnoredByType = isIgnoredByType || versionBumpType is VersionBumpType.Major;
                             break;
                         default:
                             break;
@@ -242,14 +257,43 @@ internal static class VersionFinder
                 }
             }
 
+            // This deliberately narrow prototype default reduces update churn for Microsoft.Build packages.
+            var isIgnoredByPatchOnlyDefault = !dependencyInfo.IsVulnerable
+                && currentVersion is not null
+                && PatchOnlyDefaultPackageNames.Contains(dependencyInfo.Name)
+                && versionBumpType is VersionBumpType.Major or VersionBumpType.Minor;
+
             return versionGreaterThanCurrent
                 && rangeSatisfies
                 && prereleaseTypeMatches
                 && !isIgnoredVersion
                 && !isVulnerableVersion
                 && isSafeVersion
-                && !isIgnoredByType;
+                && !isIgnoredByType
+                && !isIgnoredByPatchOnlyDefault;
         };
+    }
+
+    private static VersionBumpType GetVersionBumpType(NuGetVersion currentVersion, NuGetVersion candidateVersion)
+    {
+        if (candidateVersion.Major > currentVersion.Major)
+        {
+            return VersionBumpType.Major;
+        }
+
+        if (candidateVersion.Major == currentVersion.Major && candidateVersion.Minor > currentVersion.Minor)
+        {
+            return VersionBumpType.Minor;
+        }
+
+        if (candidateVersion.Major == currentVersion.Major &&
+            candidateVersion.Minor == currentVersion.Minor &&
+            candidateVersion.Patch > currentVersion.Patch)
+        {
+            return VersionBumpType.Patch;
+        }
+
+        return VersionBumpType.Other;
     }
 
     internal static Func<NuGetVersion, bool> CreateVersionFilter(NuGetVersion currentVersion)


### PR DESCRIPTION
### What are you trying to accomplish?

Microsoft.Build packages serve two different roles. Visual Studio and the .NET SDK are plugin hosts. MSBuild task packages are plugins loaded into those hosts.

Task authors usually reference Microsoft.Build packages only to compile their tasks. Their projects then exclude these packages from runtime assets. This design lets each host provide its own MSBuild assemblies when it loads a task in-process.

A Microsoft.Build package update can unintentionally increase a task's minimum supported Visual Studio or .NET SDK version. This happens even when the task does not need a newer MSBuild API. Task authors therefore intentionally use older, compatible Microsoft.Build package versions. This is especially painful because often the Task authors aren't aware of this lifted IDE compatibility constraint - their _users_ are the ones that run into issues.

This PR introduces a narrow prototype default for these packages:

- `Microsoft.Build.Framework`
- `Microsoft.Build.Utilities.Core`
- `Microsoft.Build.Tasks.Core`
- `Microsoft.Build`

Dependabot now proposes patch updates for these package IDs by default. It filters regular major and minor update candidates before selecting the highest remaining version.

### Anything you want to highlight for special attention from reviewers?

The policy is implemented in the NuGet candidate-filtering and final-selection paths. The implementation:

- matches the four package IDs case-insensitively
- classifies candidates as major, minor, patch, or other
- rejects only major and minor candidates for regular version updates
- checks every package ID affected by a shared version property, not only the dependency that initiated analysis
- applies the same restriction to direct package-name lookups used for collateral dependency resolution
- allows patch and unclassified transitions
- bypasses the prototype policy for vulnerable dependencies, so security updates remain unrestricted
- preserves existing version ranges, ignored versions, vulnerability checks, prerelease rules, and ignored update types

This is intentionally a built-in prototype rather than a new user-facing setting. The package list is deliberately small. A future iteration can add a feature flag or repository configuration if users need an override.

### How will you know you've accomplished your goal?

Focused tests cover patch, minor, major, mixed-candidate, shared-property, direct-lookup, case-insensitive, prerelease, non-target, explicit-ignore, and security-update behavior. The affected test selection passes 31 tests.

A broader `NuGetUpdater.Core.Test` run was attempted. It encountered unrelated SDK project discovery failures and timeouts outside this change.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.