### PR TITLE
Separate grouped security update diagnosis from reporting

### DIFF
--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -166,6 +166,13 @@ module Dependabot
       T.must(@handled_dependencies[@current_directory])
     end
 
+    # Handled dependencies across every directory, for job-scoped decisions that must not
+    # depend on whichever directory happens to be current.
+    sig { returns(T::Set[String]) }
+    def all_handled_dependencies
+      @handled_dependencies.values.reduce(Set.new) { |all, names| all.merge(names) }
+    end
+
     sig { params(dir: String).void }
     def current_directory=(dir)
       @current_directory = dir

--- a/updater/lib/dependabot/dependency_snapshot.rb
+++ b/updater/lib/dependabot/dependency_snapshot.rb
@@ -77,7 +77,7 @@ module Dependabot
     sig { returns(T::Array[Dependabot::Dependency]) }
     def allowed_dependencies
       if job.security_updates_only?
-        dependencies.select { |d| T.must(job.dependencies).include?(d.name) }
+        job_dependencies
       else
         dependencies.select { |d| job.allowed_update?(d) }
       end

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -818,11 +818,13 @@ module Dependabot
       def failed_security_update_dependencies(dependency_change)
         return [] unless job.security_updates_only?
 
-        updated_names = (dependency_change&.updated_dependencies || []).map(&:name)
+        # Names are compared case-insensitively: Gradle, Maven and NuGet names are
+        # case-insensitive, and advisories often disagree with the manifest on casing.
+        updated_names = (dependency_change&.updated_dependencies || []).map { |dep| dep.name.downcase }
 
         group.dependencies
-             .uniq(&:name)
-             .reject { |dependency| updated_names.include?(dependency.name) }
+             .uniq { |dependency| dependency.name.downcase }
+             .reject { |dependency| updated_names.include?(dependency.name.downcase) }
       end
 
       sig { params(dependency_change: T.nilable(Dependabot::DependencyChange)).void }

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -828,9 +828,16 @@ module Dependabot
         # Dependencies may have changed since the original PR was opened.
         return if job.updating_a_pull_request?
 
+        requested = Set.new(job.dependencies || []).to_a
+        return if requested.empty?
+
         known_names = dependency_snapshot.all_dependencies.map(&:name)
-        missing_dependencies = Set.new(job.dependencies || []).to_a - known_names
-        return if missing_dependencies.empty?
+        missing_dependencies = requested - known_names
+
+        # Only a job with nothing at all to work on is a failure. Reporting when some
+        # requested dependencies resolved would fail a job that still opens a valid PR,
+        # and matches how CreateSecurityUpdatePullRequest treats an empty target set.
+        return unless missing_dependencies.length == requested.length
 
         error_handler.handle_job_error(
           error: Dependabot::DependencyNotFound.new(

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -8,6 +8,7 @@ require "dependabot/updater/dependency_group_change_batch"
 require "dependabot/workspace"
 require "dependabot/updater/security_update_helpers"
 require "dependabot/notices"
+require "dependabot/update_checkers/base"
 require "dependabot/update_checkers/cooldown_calculation"
 
 # This module contains the methods required to build a DependencyChange for
@@ -30,6 +31,13 @@ module Dependabot
       include SecurityUpdateHelpers
 
       abstract!
+
+      # Why a dependency with a security advisory could not be updated, diagnosed while
+      # compiling a directory and reported once the whole job has been compiled.
+      class SecurityUpdateFailure < T::Struct
+        const :error_type, Symbol
+        const :checker, Dependabot::UpdateCheckers::Base
+      end
 
       sig do
         params(
@@ -57,6 +65,11 @@ module Dependabot
 
       sig { returns(Dependabot::DependencyGroup) }
       attr_reader :group
+
+      sig { returns(T::Hash[String, SecurityUpdateFailure]) }
+      def security_update_failures
+        @security_update_failures ||= T.let({}, T.nilable(T::Hash[String, SecurityUpdateFailure]))
+      end
 
       # Returns a Dependabot::DependencyChange object that encapsulates the
       # outcome of attempting to update every dependency iteratively which
@@ -321,7 +334,7 @@ module Dependabot
         )
 
         if all_versions_ignored?(dependency, checker)
-          record_security_update_ignored_if_applicable(dependency, checker, group)
+          note_security_update_ignored(dependency, checker, group)
           mark_handled_for_group_by_name(dependency, group, "all versions ignored")
           return []
         end
@@ -338,7 +351,7 @@ module Dependabot
           log_up_to_date(dependency)
 
           # Check if this up-to-date dependency has security advisories but no fix
-          record_security_update_not_found_if_applicable(dependency, checker, group)
+          note_security_update_not_found(dependency, checker, group)
           return []
         end
 
@@ -351,7 +364,7 @@ module Dependabot
           )
 
           # Check if this is a security update with vulnerability audit explanation
-          record_security_update_error_if_applicable(dependency, checker, group)
+          note_security_update_not_possible(dependency, checker, group)
           return []
         end
 
@@ -692,8 +705,9 @@ module Dependabot
         Dependabot::Dependency.new(**dependency_params)
       end
 
-      # Records appropriate security update errors when vulnerability auditor
-      # reports that fixes are unavailable in group updates
+      # Diagnoses why a dependency with a security advisory could not be updated in the
+      # directory currently being compiled. Nothing is reported here: see
+      # #report_security_update_failures.
       sig do
         params(
           dependency: Dependabot::Dependency,
@@ -701,40 +715,37 @@ module Dependabot
           group: Dependabot::DependencyGroup
         ).void
       end
-      def record_security_update_error_if_applicable(dependency, checker, group)
-        # Only record errors for dependencies with security advisories
-        security_advisories = job.security_advisories_for(dependency)
-        return unless security_advisories.any?
+      def note_security_update_not_possible(dependency, checker, group)
+        return unless job.security_advisories_for(dependency).any?
 
-        # Check if vulnerability audit was performed and has explanations
-        if checker.respond_to?(:conflicting_dependencies)
-          conflicting_deps = checker.conflicting_dependencies
-          vulnerability_conflicts = conflicting_deps.select do |conflict|
-            conflict.key?("explanation") && !conflict.key?("dependency_name")
-          end
-
-          if vulnerability_conflicts.any?
-            # This indicates vulnerability auditor found fix unavailable
-            first_conflict = vulnerability_conflicts.first
-            explanation = first_conflict["explanation"] if first_conflict
-            Dependabot.logger.info(
-              "Security update not possible for #{dependency.name} in group #{group.name}: #{explanation}"
-            )
-
-            # Use the SecurityUpdateHelpers method for consistency
-            record_security_update_not_possible_error(checker)
-            return
-          end
+        explanation = vulnerability_conflict_explanation(checker)
+        if explanation
+          Dependabot.logger.info(
+            "Security update not possible for #{dependency.name} in group #{group.name}: #{explanation}"
+          )
+        else
+          Dependabot.logger.info(
+            "Security update not possible for #{dependency.name} in group #{group.name}"
+          )
         end
 
-        # Fallback: record generic security update not possible error
-        Dependabot.logger.info(
-          "Security update not possible for #{dependency.name} in group #{group.name}"
-        )
-        record_security_update_not_possible_error(checker)
+        note_security_update_failure(dependency, checker, :security_update_not_possible)
       end
 
-      # Records security update not found error for up-to-date dependencies with advisories
+      # Returns the vulnerability auditor's explanation for why no fix is available, if it ran.
+      sig { params(checker: Dependabot::UpdateCheckers::Base).returns(T.nilable(String)) }
+      def vulnerability_conflict_explanation(checker)
+        return nil unless checker.respond_to?(:conflicting_dependencies)
+
+        conflict = checker.conflicting_dependencies.find do |candidate|
+          candidate.key?("explanation") && !candidate.key?("dependency_name")
+        end
+        return nil unless conflict
+
+        explanation = conflict["explanation"]
+        explanation.is_a?(String) ? explanation : nil
+      end
+
       sig do
         params(
           dependency: Dependabot::Dependency,
@@ -742,19 +753,16 @@ module Dependabot
           group: Dependabot::DependencyGroup
         ).void
       end
-      def record_security_update_not_found_if_applicable(dependency, checker, group)
-        # Only record errors for dependencies with security advisories
-        security_advisories = job.security_advisories_for(dependency)
-        return unless security_advisories.any?
+      def note_security_update_not_found(dependency, checker, group)
+        return unless job.security_advisories_for(dependency).any?
 
         Dependabot.logger.info(
           "Security update not found for #{dependency.name} in group #{group.name} - " \
           "dependency is up to date but still vulnerable"
         )
-        record_security_update_not_found(checker)
+        note_security_update_failure(dependency, checker, :security_update_not_found)
       end
 
-      # Records security update ignored error for dependencies with all versions ignored
       sig do
         params(
           dependency: Dependabot::Dependency,
@@ -762,15 +770,66 @@ module Dependabot
           group: Dependabot::DependencyGroup
         ).void
       end
-      def record_security_update_ignored_if_applicable(dependency, checker, group)
-        # Only record errors for dependencies with security advisories
-        security_advisories = job.security_advisories_for(dependency)
-        return unless security_advisories.any?
+      def note_security_update_ignored(dependency, checker, group)
+        return unless job.security_advisories_for(dependency).any?
 
         Dependabot.logger.info(
           "All versions ignored for #{dependency.name} in group #{group.name} but security advisories exist"
         )
-        record_security_update_ignored(checker)
+        note_security_update_failure(dependency, checker, :all_versions_ignored)
+      end
+
+      sig do
+        params(
+          dependency: Dependabot::Dependency,
+          checker: Dependabot::UpdateCheckers::Base,
+          error_type: Symbol
+        ).void
+      end
+      def note_security_update_failure(dependency, checker, error_type)
+        # The first directory to fail wins: a job reports one outcome per dependency.
+        security_update_failures[dependency.name.downcase] ||= SecurityUpdateFailure.new(
+          error_type: error_type,
+          checker: checker
+        )
+      end
+
+      # The single job-scoped report of why a security update failed. `record_update_job_error`
+      # marks the whole job as failed, so it must not be called while compiling an individual
+      # directory: a dependency that cannot be updated in one directory may still be updated in
+      # another, as happens routinely in multi-directory groups.
+      sig { params(dependency_name: String).void }
+      def report_security_update_failure(dependency_name)
+        failure = security_update_failures[dependency_name.downcase]
+        return unless failure
+
+        case failure.error_type
+        when :security_update_not_possible then record_security_update_not_possible_error(failure.checker)
+        when :security_update_not_found then record_security_update_not_found(failure.checker)
+        when :all_versions_ignored then record_security_update_ignored(failure.checker)
+        end
+      end
+
+      # Group dependencies that no directory managed to update.
+      sig do
+        params(dependency_change: T.nilable(Dependabot::DependencyChange))
+          .returns(T::Array[Dependabot::Dependency])
+      end
+      def failed_security_update_dependencies(dependency_change)
+        return [] unless job.security_updates_only?
+
+        updated_names = (dependency_change&.updated_dependencies || []).map(&:name)
+
+        group.dependencies
+             .uniq(&:name)
+             .reject { |dependency| updated_names.include?(dependency.name) }
+      end
+
+      sig { params(dependency_change: T.nilable(Dependabot::DependencyChange)).void }
+      def report_security_update_failures(dependency_change)
+        failed_security_update_dependencies(dependency_change).each do |dependency|
+          report_security_update_failure(dependency.name)
+        end
       end
     end
   end

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -88,23 +88,10 @@ module Dependabot
 
         # deduplicate the dependencies.
         original_dependencies = dependency_snapshot.dependencies
-        job_dependencies = Set.new(job.dependencies || []).to_a
 
         # log the original dependencies and job specified dependencies.
         Dependabot.logger.info("Dependency Snapshot: #{original_dependencies.map(&:name).join(', ')}")
-        Dependabot.logger.info("Job specified dependencies: #{job_dependencies.join(', ')}")
-
-        # If there are job dependencies not present in the dependency snapshot, record an error.
-        # Skip this check for pull request updates as dependencies may have changed since the original PR.
-        dependency_names = dependency_snapshot.all_dependencies.map(&:name)
-        missing_dependencies = job_dependencies - dependency_names
-        if missing_dependencies.any? && !job.updating_a_pull_request?
-          error_handler.handle_job_error(
-            error: Dependabot::DependencyNotFound.new(
-              "Job dependencies not found in the dependency snapshot: #{missing_dependencies.join(', ')}"
-            )
-          )
-        end
+        Dependabot.logger.info("Job specified dependencies: #{Set.new(job.dependencies || []).to_a.join(', ')}")
 
         # A list of notices that will be used in PR messages and/or sent to the dependabot github alerts.
         notices = dependency_snapshot.notices
@@ -832,6 +819,24 @@ module Dependabot
         failed_security_update_dependencies(dependency_change).each do |dependency|
           report_security_update_failure(dependency.name)
         end
+      end
+
+      # Both the requested dependencies and the snapshot span every directory, so this is a
+      # job-scoped check and must not run inside the per-directory compile.
+      sig { void }
+      def report_missing_job_dependencies
+        # Dependencies may have changed since the original PR was opened.
+        return if job.updating_a_pull_request?
+
+        known_names = dependency_snapshot.all_dependencies.map(&:name)
+        missing_dependencies = Set.new(job.dependencies || []).to_a - known_names
+        return if missing_dependencies.empty?
+
+        error_handler.handle_job_error(
+          error: Dependabot::DependencyNotFound.new(
+            "Job dependencies not found in the dependency snapshot: #{missing_dependencies.join(', ')}"
+          )
+        )
       end
     end
   end

--- a/updater/lib/dependabot/updater/group_update_creation.rb
+++ b/updater/lib/dependabot/updater/group_update_creation.rb
@@ -7,6 +7,7 @@ require "dependabot/dependency_change_builder"
 require "dependabot/updater/dependency_group_change_batch"
 require "dependabot/workspace"
 require "dependabot/updater/security_update_helpers"
+require "dependabot/service"
 require "dependabot/notices"
 require "dependabot/update_checkers/base"
 require "dependabot/update_checkers/cooldown_calculation"
@@ -31,13 +32,6 @@ module Dependabot
       include SecurityUpdateHelpers
 
       abstract!
-
-      # Why a dependency with a security advisory could not be updated, diagnosed while
-      # compiling a directory and reported once the whole job has been compiled.
-      class SecurityUpdateFailure < T::Struct
-        const :error_type, Symbol
-        const :checker, Dependabot::UpdateCheckers::Base
-      end
 
       sig do
         params(
@@ -66,9 +60,9 @@ module Dependabot
       sig { returns(Dependabot::DependencyGroup) }
       attr_reader :group
 
-      sig { returns(T::Hash[String, SecurityUpdateFailure]) }
+      sig { returns(T::Hash[String, Dependabot::Service::ErrorRecord]) }
       def security_update_failures
-        @security_update_failures ||= T.let({}, T.nilable(T::Hash[String, SecurityUpdateFailure]))
+        @security_update_failures ||= T.let({}, T.nilable(T::Hash[String, Dependabot::Service::ErrorRecord]))
       end
 
       # Returns a Dependabot::DependencyChange object that encapsulates the
@@ -705,7 +699,8 @@ module Dependabot
       def note_security_update_not_possible(dependency, checker, group)
         return unless job.security_advisories_for(dependency).any?
 
-        explanation = vulnerability_conflict_explanation(checker)
+        conflicting_dependencies = checker.conflicting_dependencies
+        explanation = vulnerability_conflict_explanation(conflicting_dependencies)
         if explanation
           Dependabot.logger.info(
             "Security update not possible for #{dependency.name} in group #{group.name}: #{explanation}"
@@ -716,15 +711,22 @@ module Dependabot
           )
         end
 
-        note_security_update_failure(dependency, checker, :security_update_not_possible)
+        note_security_update_failure(
+          dependency,
+          Dependabot::Service::ErrorRecord.new(
+            error_type: "security_update_not_possible",
+            error_details: security_update_not_possible_error_details(checker, conflicting_dependencies:),
+            dependency: nil
+          )
+        )
       end
 
       # Returns the vulnerability auditor's explanation for why no fix is available, if it ran.
-      sig { params(checker: Dependabot::UpdateCheckers::Base).returns(T.nilable(String)) }
-      def vulnerability_conflict_explanation(checker)
-        return nil unless checker.respond_to?(:conflicting_dependencies)
-
-        conflict = checker.conflicting_dependencies.find do |candidate|
+      sig do
+        params(conflicting_dependencies: T::Array[Dependabot::UpdateCheckers::Conflict]).returns(T.nilable(String))
+      end
+      def vulnerability_conflict_explanation(conflicting_dependencies)
+        conflict = conflicting_dependencies.find do |candidate|
           candidate.key?("explanation") && !candidate.key?("dependency_name")
         end
         return nil unless conflict
@@ -747,7 +749,17 @@ module Dependabot
           "Security update not found for #{dependency.name} in group #{group.name} - " \
           "dependency is up to date but still vulnerable"
         )
-        note_security_update_failure(dependency, checker, :security_update_not_found)
+        note_security_update_failure(
+          dependency,
+          Dependabot::Service::ErrorRecord.new(
+            error_type: "security_update_not_found",
+            error_details: {
+              "dependency-name": checker.dependency.name,
+              "dependency-version": checker.dependency.version
+            },
+            dependency: checker.dependency
+          )
+        )
       end
 
       sig do
@@ -763,22 +775,25 @@ module Dependabot
         Dependabot.logger.info(
           "All versions ignored for #{dependency.name} in group #{group.name} but security advisories exist"
         )
-        note_security_update_failure(dependency, checker, :all_versions_ignored)
+        note_security_update_failure(
+          dependency,
+          Dependabot::Service::ErrorRecord.new(
+            error_type: "all_versions_ignored",
+            error_details: { "dependency-name": checker.dependency.name },
+            dependency: nil
+          )
+        )
       end
 
       sig do
         params(
           dependency: Dependabot::Dependency,
-          checker: Dependabot::UpdateCheckers::Base,
-          error_type: Symbol
+          failure: Dependabot::Service::ErrorRecord
         ).void
       end
-      def note_security_update_failure(dependency, checker, error_type)
+      def note_security_update_failure(dependency, failure)
         # The first directory to fail wins: a job reports one outcome per dependency.
-        security_update_failures[dependency.name.downcase] ||= SecurityUpdateFailure.new(
-          error_type: error_type,
-          checker: checker
-        )
+        security_update_failures[dependency.name.downcase] ||= failure
       end
 
       # The single job-scoped report of why a security update failed. `record_update_job_error`
@@ -790,11 +805,11 @@ module Dependabot
         failure = security_update_failures[dependency_name.downcase]
         return unless failure
 
-        case failure.error_type
-        when :security_update_not_possible then record_security_update_not_possible_error(failure.checker)
-        when :security_update_not_found then record_security_update_not_found(failure.checker)
-        when :all_versions_ignored then record_security_update_ignored(failure.checker)
-        end
+        service.record_update_job_error(
+          error_type: failure.error_type,
+          error_details: failure.error_details,
+          dependency: failure.dependency
+        )
       end
 
       # Group dependencies that no directory managed to update.
@@ -828,11 +843,11 @@ module Dependabot
         # Dependencies may have changed since the original PR was opened.
         return if job.updating_a_pull_request?
 
-        requested = Set.new(job.dependencies || []).to_a
+        requested = (job.dependencies || []).uniq(&:downcase)
         return if requested.empty?
 
-        known_names = dependency_snapshot.all_dependencies.map(&:name)
-        missing_dependencies = requested - known_names
+        known_names = dependency_snapshot.all_dependencies.to_set { |dependency| dependency.name.downcase }
+        missing_dependencies = requested.reject { |name| known_names.include?(name.downcase) }
 
         # Only a job with nothing at all to work on is a failure. Reporting when some
         # requested dependencies resolved would fail a job that still opens a valid PR,

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -106,6 +106,8 @@ module Dependabot
         def dependency_change
           return @dependency_change if defined?(@dependency_change)
 
+          report_missing_job_dependencies
+
           if job.source.directories.nil?
             @dependency_change = compile_all_dependency_changes_for(group)
           else

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -152,8 +152,12 @@ module Dependabot
           # A diagnosed failure carries the conflicting dependencies and lowest non-vulnerable version.
           diagnosed.each { |dep| report_security_update_failure(dep.name) }
 
+          # Handled state has to span every directory: computing `dependency_change` leaves
+          # `current_directory` pointing at the last one.
+          handled = dependency_snapshot.all_handled_dependencies
+
           undiagnosed
-            .reject { |dep| dependency_snapshot.handled_dependencies.include?(dep.name) }
+            .reject { |dep| handled.include?(dep.name) }
             .each do |dep|
               error_handler.handle_dependency_error(
                 error: Dependabot::DependabotError.new(

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -141,32 +141,28 @@ module Dependabot
           @dependency_change
         end
 
+        # The single place a security update failure is reported for the job. A dependency is
+        # only a failure if no directory managed to update it, so this cannot run until every
+        # directory has been compiled.
         sig { void }
         def report_failed_dependency_updates_for_security_updates
-          # Only report failed updates if the group applies to security updates
-          return unless job.security_updates_only?
+          diagnosed, undiagnosed = failed_security_update_dependencies(dependency_change)
+                                   .partition { |dep| security_update_failures.key?(dep.name.downcase) }
 
-          original_dependencies = group.dependencies
-          updated_dependency_names = dependency_change&.updated_dependencies&.map(&:name) || []
+          # A diagnosed failure carries the conflicting dependencies and lowest non-vulnerable version.
+          diagnosed.each { |dep| report_security_update_failure(dep.name) }
 
-          failed_dependencies = original_dependencies.reject do |dep|
-            updated_dependency_names.include?(dep.name)
-          end
-
-          # Filter out dependencies that were already handled (i.e., had errors reported during processing)
-          unhandled_failed_dependencies = failed_dependencies.reject do |dep|
-            dependency_snapshot.handled_dependencies.include?(dep.name)
-          end
-
-          unhandled_failed_dependencies.each do |failed_dependency|
-            error_handler.handle_dependency_error(
-              error: Dependabot::DependabotError.new(
-                "Security update failed for #{failed_dependency.name} #{failed_dependency.version}"
-              ),
-              dependency: failed_dependency,
-              dependency_group: group
-            )
-          end
+          undiagnosed
+            .reject { |dep| dependency_snapshot.handled_dependencies.include?(dep.name) }
+            .each do |dep|
+              error_handler.handle_dependency_error(
+                error: Dependabot::DependabotError.new(
+                  "Security update failed for #{dep.name} #{dep.version}"
+                ),
+                dependency: dep,
+                dependency_group: group
+              )
+            end
         end
       end
     end

--- a/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/create_group_update_pull_request.rb
@@ -106,8 +106,6 @@ module Dependabot
         def dependency_change
           return @dependency_change if defined?(@dependency_change)
 
-          report_missing_job_dependencies
-
           if job.source.directories.nil?
             @dependency_change = compile_all_dependency_changes_for(group)
           else
@@ -156,10 +154,10 @@ module Dependabot
 
           # Handled state has to span every directory: computing `dependency_change` leaves
           # `current_directory` pointing at the last one.
-          handled = dependency_snapshot.all_handled_dependencies
+          handled = Set.new(dependency_snapshot.all_handled_dependencies.map(&:downcase))
 
           undiagnosed
-            .reject { |dep| handled.include?(dep.name) }
+            .reject { |dep| handled.include?(dep.name.downcase) }
             .each do |dep|
               error_handler.handle_dependency_error(
                 error: Dependabot::DependabotError.new(

--- a/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
+++ b/updater/lib/dependabot/updater/operations/group_update_all_versions.rb
@@ -59,6 +59,7 @@ module Dependabot
 
         sig { void }
         def perform
+          report_missing_job_dependencies
           run_grouped_dependency_updates if dependency_snapshot.groups.any?
           run_ungrouped_dependency_updates unless job.multi_ecosystem_update?
         end

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -161,6 +161,8 @@ module Dependabot
         def dependency_change
           return @dependency_change if defined?(@dependency_change)
 
+          report_missing_job_dependencies
+
           job_group = T.must(dependency_snapshot.job_group)
 
           if job.source.directories.nil?

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -161,8 +161,6 @@ module Dependabot
         def dependency_change
           return @dependency_change if defined?(@dependency_change)
 
-          report_missing_job_dependencies
-
           job_group = T.must(dependency_snapshot.job_group)
 
           if job.source.directories.nil?

--- a/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
+++ b/updater/lib/dependabot/updater/operations/refresh_group_update_pull_request.rb
@@ -147,9 +147,11 @@ module Dependabot
 
           if dependency_change.nil?
             Dependabot.logger.info("Nothing could update for Dependency Group: '#{job_group.name}'")
+            report_security_update_failures(nil)
             return
           end
 
+          report_security_update_failures(dependency_change)
           upsert_pull_request_with_error_handling(T.must(dependency_change), job_group)
         end
 

--- a/updater/lib/dependabot/updater/security_update_helpers.rb
+++ b/updater/lib/dependabot/updater/security_update_helpers.rb
@@ -69,12 +69,25 @@ module Dependabot
 
       sig { params(checker: Dependabot::UpdateCheckers::Base).void }
       def record_security_update_not_possible_error(checker)
+        service.record_update_job_error(
+          error_type: "security_update_not_possible",
+          error_details: security_update_not_possible_error_details(checker)
+        )
+      end
+
+      sig do
+        params(
+          checker: Dependabot::UpdateCheckers::Base,
+          conflicting_dependencies: T.nilable(T::Array[Dependabot::UpdateCheckers::Conflict])
+        ).returns(Dependabot::ErrorDetails::Detail)
+      end
+      def security_update_not_possible_error_details(checker, conflicting_dependencies: nil)
         latest_allowed_version =
           (checker.lowest_resolvable_security_fix_version ||
            checker.dependency.version)&.to_s
         lowest_non_vulnerable_version =
           checker.lowest_security_fix_version&.to_s
-        conflicting_dependencies = checker.conflicting_dependencies
+        conflicting_dependencies ||= checker.conflicting_dependencies
 
         Dependabot.logger.info(
           security_update_not_possible_message(checker, T.must(latest_allowed_version), conflicting_dependencies)
@@ -83,15 +96,12 @@ module Dependabot
           earliest_fixed_version_message(lowest_non_vulnerable_version)
         )
 
-        service.record_update_job_error(
-          error_type: "security_update_not_possible",
-          error_details: {
-            "dependency-name": checker.dependency.name,
-            "latest-resolvable-version": latest_allowed_version,
-            "lowest-non-vulnerable-version": lowest_non_vulnerable_version,
-            "conflicting-dependencies": conflicting_dependencies
-          }
-        )
+        {
+          "dependency-name": checker.dependency.name,
+          "latest-resolvable-version": latest_allowed_version,
+          "lowest-non-vulnerable-version": lowest_non_vulnerable_version,
+          "conflicting-dependencies": conflicting_dependencies
+        }
       end
 
       sig { params(checker: Dependabot::UpdateCheckers::Base).void }

--- a/updater/spec/dependabot/dependency_snapshot_spec.rb
+++ b/updater/spec/dependabot/dependency_snapshot_spec.rb
@@ -173,6 +173,16 @@ RSpec.describe Dependabot::DependencySnapshot do
         snapshot.current_directory = "/foo"
         expect(snapshot.handled_dependencies).to eq(Set.new(%w(a b)))
       end
+
+      it "exposes handled dependencies across every directory" do
+        snapshot = create_dependency_snapshot
+        snapshot.current_directory = "/foo"
+        snapshot.add_handled_dependencies(%w(a b))
+        snapshot.current_directory = "/bar"
+        snapshot.add_handled_dependencies(%w(c d))
+
+        expect(snapshot.all_handled_dependencies).to eq(Set.new(%w(a b c d)))
+      end
     end
   end
 

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -334,6 +334,15 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
       test_instance.report_security_update_failures(nil)
     end
+
+    it "does not report a dependency updated under different casing in another directory" do
+      updated = instance_double(Dependabot::Dependency, name: "DEP1")
+      dependency_change = instance_double(Dependabot::DependencyChange, updated_dependencies: [updated])
+
+      expect(test_instance).not_to receive(:record_security_update_not_possible_error)
+
+      test_instance.report_security_update_failures(dependency_change)
+    end
   end
 
   describe "compile_all_dependency_changes_for" do

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
     Dependabot::Experiments.reset!
   end
 
-  describe "#record_security_update_error_if_applicable" do
+  describe "#note_security_update_not_possible" do
     let(:dependency) { dependencies.first }
 
     context "when recording security update errors" do
@@ -152,7 +152,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           )
           expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker)
 
-          test_instance.record_security_update_error_if_applicable(dependency, checker, group)
+          test_instance.note_security_update_not_possible(dependency, checker, group)
+          test_instance.report_security_update_failure(dependency.name)
         end
 
         context "when checker has conflicting dependencies with vulnerability explanation" do
@@ -172,7 +173,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
             )
             expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker)
 
-            test_instance.record_security_update_error_if_applicable(dependency, checker, group)
+            test_instance.note_security_update_not_possible(dependency, checker, group)
+            test_instance.report_security_update_failure(dependency.name)
           end
         end
 
@@ -192,7 +194,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
             )
             expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker)
 
-            test_instance.record_security_update_error_if_applicable(dependency, checker, group)
+            test_instance.note_security_update_not_possible(dependency, checker, group)
+            test_instance.report_security_update_failure(dependency.name)
           end
         end
       end
@@ -208,13 +211,14 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           expect(Dependabot.logger).not_to receive(:info)
           expect(test_instance).not_to receive(:record_security_update_not_possible_error)
 
-          test_instance.record_security_update_error_if_applicable(dependency, checker, group)
+          test_instance.note_security_update_not_possible(dependency, checker, group)
+          test_instance.report_security_update_failure(dependency.name)
         end
       end
     end
   end
 
-  describe "#record_security_update_not_found_if_applicable" do
+  describe "#note_security_update_not_found" do
     let(:dependency) { dependencies.first }
 
     context "when recording missing security updates" do
@@ -232,7 +236,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           )
           expect(test_instance).to receive(:record_security_update_not_found).with(checker)
 
-          test_instance.record_security_update_not_found_if_applicable(dependency, checker, group)
+          test_instance.note_security_update_not_found(dependency, checker, group)
+          test_instance.report_security_update_failure(dependency.name)
         end
       end
 
@@ -247,13 +252,14 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           expect(Dependabot.logger).not_to receive(:info)
           expect(test_instance).not_to receive(:record_security_update_not_found)
 
-          test_instance.record_security_update_not_found_if_applicable(dependency, checker, group)
+          test_instance.note_security_update_not_found(dependency, checker, group)
+          test_instance.report_security_update_failure(dependency.name)
         end
       end
     end
   end
 
-  describe "#record_security_update_ignored_if_applicable" do
+  describe "#note_security_update_ignored" do
     let(:dependency) { dependencies.first }
 
     context "when recording ignored security updates" do
@@ -270,7 +276,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           )
           expect(test_instance).to receive(:record_security_update_ignored).with(checker)
 
-          test_instance.record_security_update_ignored_if_applicable(dependency, checker, group)
+          test_instance.note_security_update_ignored(dependency, checker, group)
+          test_instance.report_security_update_failure(dependency.name)
         end
       end
 
@@ -285,9 +292,47 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           expect(Dependabot.logger).not_to receive(:info)
           expect(test_instance).not_to receive(:record_security_update_ignored)
 
-          test_instance.record_security_update_ignored_if_applicable(dependency, checker, group)
+          test_instance.note_security_update_ignored(dependency, checker, group)
+          test_instance.report_security_update_failure(dependency.name)
         end
       end
+    end
+  end
+
+  describe "#report_security_update_failures" do
+    let(:dependency) { dependencies.first }
+
+    before do
+      allow(job).to receive_messages(security_updates_only?: true)
+      allow(job).to receive(:security_advisories_for).with(dependency).and_return([{ "id" => "advisory-1" }])
+      allow(Dependabot.logger).to receive(:info)
+      test_instance.note_security_update_not_possible(dependency, checker, group)
+    end
+
+    it "does not report a dependency that was updated in another directory" do
+      updated = instance_double(Dependabot::Dependency, name: "dep1")
+      dependency_change = instance_double(Dependabot::DependencyChange, updated_dependencies: [updated])
+
+      expect(test_instance).not_to receive(:record_security_update_not_possible_error)
+
+      test_instance.report_security_update_failures(dependency_change)
+    end
+
+    it "reports the failure once when several directories fail for the same dependency" do
+      test_instance.note_security_update_not_possible(dependency, checker, group)
+
+      expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker).once
+
+      test_instance.report_security_update_failures(nil)
+    end
+
+    it "keeps the first diagnosis when a later directory fails differently" do
+      test_instance.note_security_update_not_found(dependency, checker, group)
+
+      expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker)
+      expect(test_instance).not_to receive(:record_security_update_not_found)
+
+      test_instance.report_security_update_failures(nil)
     end
   end
 
@@ -380,7 +425,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           all_versions_ignored?: false,
           semver_rules_allow_grouping?: true,
           log_up_to_date: nil,
-          record_security_update_not_found_if_applicable: nil
+          note_security_update_not_found: nil
         )
         allow(test_instance).to receive(:dependency_file_parser).and_return(
           instance_double(Dependabot::FileParsers::Base, parse: [reparsed_dependency])
@@ -628,7 +673,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
       before do
         allow(test_instance).to receive(:all_versions_ignored?).and_return(true)
-        allow(test_instance).to receive(:record_security_update_ignored_if_applicable)
+        allow(test_instance).to receive(:note_security_update_ignored)
       end
 
       it "marks the dependency as handled" do
@@ -681,7 +726,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
       before do
         allow(test_instance).to receive(:all_versions_ignored?).and_return(true)
-        allow(test_instance).to receive(:record_security_update_ignored_if_applicable)
+        allow(test_instance).to receive(:note_security_update_ignored)
       end
 
       it "does NOT mark the dependency as handled" do
@@ -805,8 +850,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           allow(job).to receive(:security_advisories_for).with(dependency).and_return([{ "id" => "advisory-1" }])
         end
 
-        it "calls record_security_update_ignored_if_applicable" do
-          expect(test_instance).to receive(:record_security_update_ignored_if_applicable)
+        it "calls note_security_update_ignored" do
+          expect(test_instance).to receive(:note_security_update_ignored)
             .with(dependency, checker, group)
 
           test_instance.compile_updates_for(dependency, dependency_files, group)
@@ -819,8 +864,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           allow(job).to receive(:security_advisories_for).with(dependency).and_return([{ "id" => "advisory-1" }])
         end
 
-        it "calls record_security_update_not_found_if_applicable" do
-          expect(test_instance).to receive(:record_security_update_not_found_if_applicable)
+        it "calls note_security_update_not_found" do
+          expect(test_instance).to receive(:note_security_update_not_found)
             .with(dependency, checker, group)
 
           test_instance.compile_updates_for(dependency, dependency_files, group)

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -474,6 +474,12 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
             expect(error.message).to include("missing_dep")
           end
 
+          test_instance.report_missing_job_dependencies
+        end
+
+        it "is not reported while compiling an individual directory" do
+          expect(error_handler).not_to receive(:handle_job_error)
+
           test_instance.compile_all_dependency_changes_for(group)
         end
 
@@ -485,7 +491,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           it "does not record missing dependency error" do
             expect(error_handler).not_to receive(:handle_job_error)
 
-            test_instance.compile_all_dependency_changes_for(group)
+            test_instance.report_missing_job_dependencies
           end
         end
       end
@@ -496,7 +502,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
         it "does not record any missing dependency error" do
           expect(error_handler).not_to receive(:handle_job_error)
 
-          test_instance.compile_all_dependency_changes_for(group)
+          test_instance.report_missing_job_dependencies
         end
       end
 

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -465,8 +465,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
     end
 
     context "when checking job dependencies" do
-      context "when job dependencies are missing from dependency snapshot" do
-        let(:job_dependencies) { %w(dep1 missing_dep) }
+      context "when no job dependency is present in the dependency snapshot" do
+        let(:job_dependencies) { %w(missing_dep other_missing_dep) }
 
         it "records missing dependency error for non-PR updates" do
           expect(error_handler).to receive(:handle_job_error) do |error:|
@@ -493,6 +493,16 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
             test_instance.report_missing_job_dependencies
           end
+        end
+      end
+
+      context "when only some job dependencies are missing" do
+        let(:job_dependencies) { %w(dep1 missing_dep) }
+
+        it "does not fail the job, since it still has something to update" do
+          expect(error_handler).not_to receive(:handle_job_error)
+
+          test_instance.report_missing_job_dependencies
         end
       end
 

--- a/updater/spec/dependabot/updater/group_update_creation_spec.rb
+++ b/updater/spec/dependabot/updater/group_update_creation_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
     end
   end
 
-  let(:service) { instance_double(Dependabot::Service) }
+  let(:service) { instance_double(Dependabot::Service, record_update_job_error: nil) }
   let(:test_instance) { test_class.new(dependency_snapshot, error_handler, job, group, service) }
 
   let(:dependency_snapshot) do
@@ -106,6 +106,8 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
       Dependabot::UpdateCheckers::Base,
       dependency: dependencies.first,
       up_to_date?: false,
+      lowest_resolvable_security_fix_version: nil,
+      lowest_security_fix_version: "3.0.0",
       conflicting_dependencies: [],
       respond_to?: false
     )
@@ -122,10 +124,9 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
     )
     allow(test_instance).to receive_messages(
       dependency_file_parser: instance_double(Dependabot::FileParsers::Base, parse: dependencies),
-      service: instance_double(Dependabot::Service).tap do |service|
-        allow(service).to receive(:record_update_job_error)
-      end
+      service: service
     )
+    allow(Dependabot.logger).to receive(:info)
 
     # Reset experiments before each test
     Dependabot::Experiments.reset!
@@ -150,7 +151,11 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           expect(Dependabot.logger).to receive(:info).with(
             "Security update not possible for #{dependency.name} in group #{group.name}"
           )
-          expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker)
+          expect(service).to receive(:record_update_job_error).with(
+            error_type: "security_update_not_possible",
+            error_details: hash_including("dependency-name": dependency.name),
+            dependency: nil
+          )
 
           test_instance.note_security_update_not_possible(dependency, checker, group)
           test_instance.report_security_update_failure(dependency.name)
@@ -171,7 +176,11 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
               "Security update not possible for #{dependency.name} in group #{group.name}: " \
               "Vulnerability fix not available"
             )
-            expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker)
+            expect(service).to receive(:record_update_job_error).with(
+              error_type: "security_update_not_possible",
+              error_details: hash_including("conflicting-dependencies": conflicting_deps),
+              dependency: nil
+            )
 
             test_instance.note_security_update_not_possible(dependency, checker, group)
             test_instance.report_security_update_failure(dependency.name)
@@ -192,7 +201,11 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
             expect(Dependabot.logger).to receive(:info).with(
               "Security update not possible for #{dependency.name} in group #{group.name}"
             )
-            expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker)
+            expect(service).to receive(:record_update_job_error).with(
+              error_type: "security_update_not_possible",
+              error_details: hash_including("conflicting-dependencies": conflicting_deps),
+              dependency: nil
+            )
 
             test_instance.note_security_update_not_possible(dependency, checker, group)
             test_instance.report_security_update_failure(dependency.name)
@@ -209,7 +222,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
         it "does not log or record any error" do
           expect(Dependabot.logger).not_to receive(:info)
-          expect(test_instance).not_to receive(:record_security_update_not_possible_error)
+          expect(service).not_to receive(:record_update_job_error)
 
           test_instance.note_security_update_not_possible(dependency, checker, group)
           test_instance.report_security_update_failure(dependency.name)
@@ -234,7 +247,11 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
             "Security update not found for #{dependency.name} in group #{group.name} - " \
             "dependency is up to date but still vulnerable"
           )
-          expect(test_instance).to receive(:record_security_update_not_found).with(checker)
+          expect(service).to receive(:record_update_job_error).with(
+            error_type: "security_update_not_found",
+            error_details: { "dependency-name": dependency.name, "dependency-version": dependency.version },
+            dependency: dependency
+          )
 
           test_instance.note_security_update_not_found(dependency, checker, group)
           test_instance.report_security_update_failure(dependency.name)
@@ -250,7 +267,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
         it "does not log or record any error" do
           expect(Dependabot.logger).not_to receive(:info)
-          expect(test_instance).not_to receive(:record_security_update_not_found)
+          expect(service).not_to receive(:record_update_job_error)
 
           test_instance.note_security_update_not_found(dependency, checker, group)
           test_instance.report_security_update_failure(dependency.name)
@@ -274,7 +291,9 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
           expect(Dependabot.logger).to receive(:info).with(
             "All versions ignored for #{dependency.name} in group #{group.name} but security advisories exist"
           )
-          expect(test_instance).to receive(:record_security_update_ignored).with(checker)
+          expect(service).to receive(:record_update_job_error).with(
+            error_type: "all_versions_ignored", error_details: { "dependency-name": dependency.name }, dependency: nil
+          )
 
           test_instance.note_security_update_ignored(dependency, checker, group)
           test_instance.report_security_update_failure(dependency.name)
@@ -290,7 +309,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
 
         it "does not log or record any error" do
           expect(Dependabot.logger).not_to receive(:info)
-          expect(test_instance).not_to receive(:record_security_update_ignored)
+          expect(service).not_to receive(:record_update_job_error)
 
           test_instance.note_security_update_ignored(dependency, checker, group)
           test_instance.report_security_update_failure(dependency.name)
@@ -313,7 +332,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
       updated = instance_double(Dependabot::Dependency, name: "dep1")
       dependency_change = instance_double(Dependabot::DependencyChange, updated_dependencies: [updated])
 
-      expect(test_instance).not_to receive(:record_security_update_not_possible_error)
+      expect(service).not_to receive(:record_update_job_error)
 
       test_instance.report_security_update_failures(dependency_change)
     end
@@ -321,7 +340,11 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
     it "reports the failure once when several directories fail for the same dependency" do
       test_instance.note_security_update_not_possible(dependency, checker, group)
 
-      expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker).once
+      expect(service).to receive(:record_update_job_error).with(
+        error_type: "security_update_not_possible",
+        error_details: hash_including("dependency-name": dependency.name),
+        dependency: nil
+      ).once
 
       test_instance.report_security_update_failures(nil)
     end
@@ -329,8 +352,11 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
     it "keeps the first diagnosis when a later directory fails differently" do
       test_instance.note_security_update_not_found(dependency, checker, group)
 
-      expect(test_instance).to receive(:record_security_update_not_possible_error).with(checker)
-      expect(test_instance).not_to receive(:record_security_update_not_found)
+      expect(service).to receive(:record_update_job_error).with(
+        error_type: "security_update_not_possible",
+        error_details: hash_including("dependency-name": dependency.name),
+        dependency: nil
+      ).once
 
       test_instance.report_security_update_failures(nil)
     end
@@ -339,7 +365,7 @@ RSpec.describe Dependabot::Updater::GroupUpdateCreation do
       updated = instance_double(Dependabot::Dependency, name: "DEP1")
       dependency_change = instance_double(Dependabot::DependencyChange, updated_dependencies: [updated])
 
-      expect(test_instance).not_to receive(:record_security_update_not_possible_error)
+      expect(service).not_to receive(:record_update_job_error)
 
       test_instance.report_security_update_failures(dependency_change)
     end

--- a/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
@@ -203,6 +203,14 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
         allow(dependency_snapshot).to receive(:all_handled_dependencies).and_return(Set[dependency.name])
       end
 
+      it "does not report dependencies handled under different casing" do
+        allow(dependency_snapshot).to receive(:all_handled_dependencies)
+          .and_return(Set[dependency.name.upcase, failed_dependency.name.upcase])
+        expect(mock_error_handler).not_to receive(:handle_dependency_error)
+
+        perform
+      end
+
       it "reports unhandled dependencies that failed to update" do
         expect(mock_error_handler).to receive(:handle_dependency_error)
           .with(
@@ -213,6 +221,94 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
 
         perform
       end
+    end
+  end
+
+  describe "#perform with deferred security errors" do
+    let(:dependency) do
+      dependency_snapshot.all_dependencies.find { |candidate| candidate.name == "dummy-pkg-a" }
+    end
+    let(:dependency_group) do
+      Dependabot::DependencyGroup.new(name: "security", rules: { "patterns" => ["*"] }).tap do |group|
+        group.dependencies.push(dependency, successful_dependency)
+      end
+    end
+    let(:successful_dependency) do
+      dependency_snapshot.all_dependencies.find { |candidate| candidate.name == "dummy-git-dependency" }
+    end
+    let(:successful_update) do
+      Dependabot::Dependency.new(
+        name: successful_dependency.name,
+        version: "2.0.0",
+        previous_version: successful_dependency.version,
+        requirements: successful_dependency.requirements,
+        previous_requirements: successful_dependency.requirements,
+        package_manager: "bundler"
+      )
+    end
+    let(:stub_dependency_change) do
+      Dependabot::DependencyChange.new(
+        job: job,
+        updated_dependencies: [successful_update],
+        updated_dependency_files: dependency_files
+      )
+    end
+    let(:successful_checker) do
+      instance_double(
+        Dependabot::UpdateCheckers::Base,
+        dependency: successful_dependency,
+        lowest_security_fix_version: "2.0.0",
+        up_to_date?: false,
+        requirements_unlocked_or_can_be?: true,
+        can_update?: true,
+        updated_dependencies: [successful_update]
+      )
+    end
+
+    before do
+      allow(job).to receive_messages(
+        security_updates_only?: true,
+        updating_a_pull_request?: false,
+        dependencies: %w(dummy-pkg-a dummy-git-dependency),
+        allowed_update?: true,
+        security_advisories_for: [{}]
+      )
+      allow(stub_update_checker).to receive_messages(
+        can_update?: false,
+        lowest_resolvable_security_fix_version: nil
+      )
+      allow(stub_update_checker_class).to receive(:new) do |**arguments|
+        arguments.fetch(:dependency).name == dependency.name ? stub_update_checker : successful_checker
+      end
+    end
+
+    it "resolves the error details once and reports the captured payload" do
+      expect(stub_update_checker).to receive(:conflicting_dependencies).once.and_return([])
+      expect(mock_service).to receive(:record_update_job_error).with(
+        error_type: "security_update_not_possible",
+        error_details: {
+          "dependency-name": dependency.name,
+          "latest-resolvable-version": dependency.version,
+          "lowest-non-vulnerable-version": "2.0.0",
+          "conflicting-dependencies": []
+        },
+        dependency: nil
+      )
+      expect(mock_service).to receive(:create_pull_request)
+
+      perform
+    end
+
+    it "still creates a PR when resolving another dependency's error details fails" do
+      resolver_error = RuntimeError.new("resolver failed")
+      allow(stub_update_checker).to receive(:lowest_resolvable_security_fix_version).and_raise(resolver_error)
+      expect(mock_error_handler).to receive(:handle_dependency_error)
+        .with(error: resolver_error, dependency: dependency, dependency_group: dependency_group)
+      expect(mock_service).to receive(:create_pull_request) do |change, _base_commit|
+        expect(change.updated_dependencies.map(&:name)).to eq([successful_dependency.name])
+      end
+
+      expect { perform }.not_to raise_error
     end
   end
 

--- a/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_group_update_pull_request_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
       let(:updated_dependencies) { [] }
 
       before do
-        allow(dependency_snapshot).to receive(:handled_dependencies).and_return([dependency.name])
+        allow(dependency_snapshot).to receive(:all_handled_dependencies).and_return(Set[dependency.name])
       end
 
       it "reports unhandled dependencies that failed to update" do

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -222,6 +222,68 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
     end
   end
 
+  describe "#perform when all requested dependencies are missing" do
+    let(:requested_dependencies) { %w(missing-one missing-two) }
+
+    before do
+      allow(job).to receive_messages(
+        security_updates_only?: true,
+        updating_a_pull_request?: false,
+        dependencies: requested_dependencies,
+        dependency_groups: %w(first second).map do |name|
+          Dependabot::Job::DependencyGroupDefinition.from_hash(
+            "name" => name, "applies-to" => "security-updates", "rules" => { "patterns" => ["*"] }
+          )
+        end
+      )
+    end
+
+    it "reports one job error even when every group is empty" do
+      expect(mock_error_handler).to receive(:handle_job_error)
+        .with(error: kind_of(Dependabot::DependencyNotFound)).once
+
+      perform
+    end
+
+    context "with no configured groups" do
+      before do
+        allow(job).to receive(:dependency_groups).and_return([])
+      end
+
+      it "still reports the missing targets" do
+        expect(mock_error_handler).to receive(:handle_job_error)
+          .with(error: kind_of(Dependabot::DependencyNotFound)).once
+
+        perform
+      end
+    end
+
+    context "when a requested dependency is present" do
+      let(:requested_dependencies) { %w(dummy-pkg-a missing-one) }
+
+      before do
+        allow(Dependabot::Updater::Operations::CreateGroupUpdatePullRequest).to receive(:new)
+          .and_return(instance_double(Dependabot::Updater::Operations::CreateGroupUpdatePullRequest, perform: nil))
+      end
+
+      it "does not report a missing-dependency error for a partial match" do
+        expect(mock_error_handler).not_to receive(:handle_job_error)
+
+        perform
+      end
+
+      context "with different casing" do
+        let(:requested_dependencies) { %w(DUMMY-PKG-A missing-one) }
+
+        it "recognizes the manifest dependency" do
+          expect(mock_error_handler).not_to receive(:handle_job_error)
+
+          perform
+        end
+      end
+    end
+  end
+
   describe "#perform" do
     let(:mock_create_group_update) do
       instance_double(Dependabot::Updater::Operations::CreateGroupUpdatePullRequest)

--- a/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
+++ b/updater/spec/dependabot/updater/operations/group_update_all_versions_spec.rb
@@ -275,10 +275,22 @@ RSpec.describe Dependabot::Updater::Operations::GroupUpdateAllVersions do
       context "with different casing" do
         let(:requested_dependencies) { %w(DUMMY-PKG-A missing-one) }
 
-        it "recognizes the manifest dependency" do
+        let(:checker) do
+          instance_double(Dependabot::UpdateCheckers::Base, lowest_security_fix_version: nil, up_to_date?: true)
+        end
+
+        before do
+          allow(Dependabot::Updater::Operations::CreateGroupUpdatePullRequest).to receive(:new).and_call_original
+          allow(Dependabot::Bundler::UpdateChecker).to receive(:new).and_return(checker)
+        end
+
+        it "checks the manifest dependency through the real grouped operation" do
           expect(mock_error_handler).not_to receive(:handle_job_error)
 
           perform
+
+          expect(Dependabot::Bundler::UpdateChecker).to have_received(:new)
+            .with(hash_including(dependency: have_attributes(name: "dummy-pkg-a"))).once
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Separate per-directory security diagnostics from aggregate grouped-update reporting. Capture diagnostics during dependency processing, then report only dependencies that were not updated in any directory.

### Anything you want to highlight for special attention from reviewers?

- Store diagnostic payloads instead of live checkers, keeping resolution inside dependency-level error handling.
- Check missing targets once before group iteration, reporting only when all requested dependencies are absent.
- Compare dependency names case-insensitively.

### How will you know you've accomplished your goal?

963 updater specs pass, including regression coverage. Bundler and Cargo multi-directory smoke outputs match unchanged fixtures. RuboCop on changed files and Sorbet pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

Validation covered the full updater suite, not every ecosystem suite.