### PR TITLE
Fix Pipenv graphing for local path dependencies

### DIFF
--- a/python/lib/dependabot/python/dependency_grapher.rb
+++ b/python/lib/dependabot/python/dependency_grapher.rb
@@ -393,7 +393,8 @@ module Dependabot
             dependency: nil,
             lockfile: pipfile_lock,
             language_version_manager: language_version_manager,
-            dependency_files: dependency_files
+            dependency_files: dependency_files,
+            repo_contents_path: file_parser.repo_contents_path
           ),
           T.nilable(PipenvRunner)
         )

--- a/python/lib/dependabot/python/pipenv_runner.rb
+++ b/python/lib/dependabot/python/pipenv_runner.rb
@@ -16,15 +16,17 @@ module Dependabot
           dependency: T.nilable(Dependabot::Dependency),
           lockfile: T.nilable(Dependabot::DependencyFile),
           language_version_manager: LanguageVersionManager,
-          dependency_files: T.nilable(T::Array[Dependabot::DependencyFile])
+          dependency_files: T.nilable(T::Array[Dependabot::DependencyFile]),
+          repo_contents_path: T.nilable(String)
         )
           .void
       end
-      def initialize(dependency:, lockfile:, language_version_manager:, dependency_files: nil)
+      def initialize(dependency:, lockfile:, language_version_manager:, dependency_files: nil, repo_contents_path: nil)
         @dependency = dependency
         @lockfile = lockfile
         @language_version_manager = language_version_manager
         @dependency_files = dependency_files
+        @repo_contents_path = repo_contents_path
       end
 
       sig { params(constraint: T.nilable(String)).returns(String) }
@@ -53,7 +55,8 @@ module Dependabot
       # Called by Python::DependencyGrapher.
       sig { returns(String) }
       def run_pipenv_graph
-        SharedHelpers.in_a_temporary_directory do
+        SharedHelpers.in_a_temporary_repo_directory(base_directory, repo_contents_path) do
+          File.write(".python-version", language_version_manager.python_major_minor)
           write_temporary_dependency_files
           language_version_manager.install_required_python
           run_command("pyenv exec pipenv sync --dev", fingerprint: "pyenv exec pipenv sync --dev")
@@ -85,6 +88,9 @@ module Dependabot
       sig { returns(T.nilable(T::Array[Dependabot::DependencyFile])) }
       attr_reader :dependency_files
 
+      sig { returns(T.nilable(String)) }
+      attr_reader :repo_contents_path
+
       sig { returns(Dependabot::Dependency) }
       def current_dependency
         T.must(dependency)
@@ -99,6 +105,11 @@ module Dependabot
           FileUtils.mkdir_p(Pathname.new(path).dirname)
           File.write(path, file.content)
         end
+      end
+
+      sig { returns(String) }
+      def base_directory
+        dependency_files&.first&.directory || "/"
       end
 
       sig { returns(String) }

--- a/python/spec/dependabot/python/pipenv_runner_spec.rb
+++ b/python/spec/dependabot/python/pipenv_runner_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Dependabot::Python::PipenvRunner do
     described_class.new(
       dependency: dependency,
       lockfile: lockfile,
-      language_version_manager: language_version_manager
+      language_version_manager: language_version_manager,
+      dependency_files: dependency_files,
+      repo_contents_path: repo_contents_path
     )
   end
 
@@ -59,6 +61,9 @@ RSpec.describe Dependabot::Python::PipenvRunner do
       }
     )
   end
+
+  let(:dependency_files) { nil }
+  let(:repo_contents_path) { nil }
 
   describe "#run_upgrade_and_fetch_version" do
     before do
@@ -190,6 +195,59 @@ RSpec.describe Dependabot::Python::PipenvRunner do
 
       it "returns nil" do
         expect(runner.run_upgrade_and_fetch_version(">=2.19.0")).to be_nil
+      end
+    end
+  end
+
+  describe "#run_pipenv_graph" do
+    context "when the repository contains a local path dependency" do
+      let(:repo_contents_path) { Dir.mktmpdir }
+      let(:commands) { [] }
+      let(:python_version) { "3.10" }
+      let(:dependency_files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "Pipfile",
+            content: "[packages]\nlocal-package = {path = \"./local-package\"}\n",
+            directory: "/project"
+          ),
+          Dependabot::DependencyFile.new(
+            name: "Pipfile.lock",
+            content: "{}",
+            directory: "/project"
+          ),
+          Dependabot::DependencyFile.new(
+            name: ".python-version",
+            content: "3.9\n",
+            directory: "/project"
+          )
+        ]
+      end
+
+      before do
+        FileUtils.mkdir_p(File.join(repo_contents_path, "project", "local-package"))
+        File.write(File.join(repo_contents_path, "project", "local-package", "setup.py"), "")
+        File.write(File.join(repo_contents_path, "project", ".python-version"), "3.9\n")
+        allow(language_version_manager).to receive(:python_major_minor).and_return(python_version)
+        allow(Dependabot::SharedHelpers).to receive(:run_shell_command) do |command, **_options|
+          commands << [command, Dir.pwd]
+          next "" if command.start_with?("git ")
+
+          command.include?("pipenv graph") ? "[]" : ""
+        end
+      end
+
+      after do
+        FileUtils.rm_rf(repo_contents_path)
+      end
+
+      it "runs Pipenv from the checked out repository" do
+        expect(runner.run_pipenv_graph).to eq("[]")
+        pipenv_commands = commands.reject { |command, _directory| command.start_with?("git ") }
+
+        expect(pipenv_commands.map(&:last)).to all(eq(File.join(repo_contents_path, "project")))
+        expect(File).to exist(File.join(repo_contents_path, "project", "local-package", "setup.py"))
+        expect(File.read(File.join(repo_contents_path, "project", ".python-version"))).to eq(python_version)
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes #15447.

Pipenv graph generation previously copied only `Pipfile` and `Pipfile.lock` into a temporary directory. Relative local path dependencies were therefore resolved from a directory where their packages did not exist, causing incorrect PyPI fallback or degraded dependency graphs.

This change passes the repository checkout path into `PipenvRunner` and runs graph commands from the manifest directory inside the checkout. The existing temporary-directory fallback remains in place when no repository checkout is available.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
