### PR TITLE
Use typed requirements helper results in Python and UV

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 652
+# Offense count: 640
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"

--- a/python/lib/dependabot/python/file_parser.rb
+++ b/python/lib/dependabot/python/file_parser.rb
@@ -295,16 +295,16 @@ module Dependabot
           # probably blocked. Ignore it.
           next if blocking_marker?(dep)
 
-          name = dep["name"]
-          file = dep["file"]
-          version = dep["version"]
+          name = dep.name
+          file = dep.file
+          version = dep.version
           original_file = get_original_file(file)
 
           requirements =
             if original_file && pip_compile_file_matcher.lockfile_for_pip_compile_file?(original_file) then []
             else
               [{
-                requirement: dep["requirement"],
+                requirement: dep.requirement,
                 file: Pathname.new(file).cleanpath.to_path,
                 source: nil,
                 groups: group_from_filename(file)
@@ -320,7 +320,7 @@ module Dependabot
               version: version&.include?("*") ? nil : version,
               requirements: requirements,
               package_manager: "pip",
-              metadata: extras_metadata(dep["extras"])
+              metadata: extras_metadata(dep.extras)
             )
         end
         dependencies
@@ -342,36 +342,33 @@ module Dependabot
         end
       end
 
-      sig { params(dep: T.untyped).returns(T::Boolean) }
+      sig { params(dep: PepDependency).returns(T::Boolean) }
       def blocking_marker?(dep)
-        return false if dep["markers"] == "None"
+        marker = dep.markers
+        return false if marker.nil? || marker == "None"
 
-        marker = dep["markers"]
         version = python_raw_version
 
         if marker.include?("python_version")
           !marker_satisfied?(marker, version)
         else
-          return true if dep["markers"].include?("<")
-          return false if dep["markers"].include?(">")
-          return false if dep["requirement"].nil?
+          return true if marker.include?("<")
+          return false if marker.include?(">")
 
-          dep["requirement"].include?("<")
+          dep.requirement&.include?("<") || false
         end
       end
 
-      sig do
-        params(marker: T.untyped, python_version: T.any(String, Integer, Gem::Version)).returns(T::Boolean)
-      end
+      sig { params(marker: String, python_version: T.any(String, Integer, Gem::Version)).returns(T::Boolean) }
       def marker_satisfied?(marker, python_version)
         conditions = marker.split(/\s+(and|or)\s+/)
 
         # Explicitly define the type of result as T::Boolean
-        result = T.let(evaluate_condition(conditions.shift, python_version), T::Boolean)
+        result = T.let(evaluate_condition(T.must(conditions.shift), python_version), T::Boolean)
 
         until conditions.empty?
           operator = conditions.shift
-          next_condition = conditions.shift
+          next_condition = T.must(conditions.shift)
           next_result = evaluate_condition(next_condition, python_version)
 
           result = if operator == "and"
@@ -386,12 +383,13 @@ module Dependabot
 
       sig do
         params(
-          condition: T.untyped,
+          condition: String,
           python_version: T.any(String, Integer, Gem::Version)
         ).returns(T::Boolean)
       end
       def evaluate_condition(condition, python_version)
         operator, version = condition.match(/([<>=!]=?)\s*"?([\d.]+)"?/)&.captures
+        return false unless version
 
         case operator
         when "<"
@@ -418,17 +416,18 @@ module Dependabot
         )
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Array[PepDependency]) }
       def parsed_requirement_files
         SharedHelpers.in_a_temporary_directory do
           write_temporary_dependency_files
 
-          requirements = SharedHelpers.run_helper_subprocess(
+          result = SharedHelpers.run_helper_subprocess(
             command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
             function: "parse_requirements",
             args: [Dir.pwd]
           )
 
+          requirements = PepDependency.from_requirements_helper_result(result)
           check_requirements(requirements)
           requirements
         end
@@ -439,12 +438,13 @@ module Dependabot
         raise Dependabot::DependencyFileNotEvaluatable, e.message
       end
 
-      sig { params(requirements: T.untyped).returns(T.untyped) }
+      sig { params(requirements: T::Array[PepDependency]).void }
       def check_requirements(requirements)
         requirements.each do |dep|
-          next unless dep["requirement"]
+          requirement = dep.requirement
+          next unless requirement
 
-          Python::Requirement.new(dep["requirement"].split(","))
+          Python::Requirement.new(requirement.split(","))
         rescue Gem::Requirement::BadRequirementError => e
           raise Dependabot::DependencyFileNotEvaluatable, e.message
         end

--- a/python/lib/dependabot/python/file_parser/pep_dependency.rb
+++ b/python/lib/dependabot/python/file_parser/pep_dependency.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 
+require "dependabot/errors"
 require "dependabot/python/file_parser"
 
 module Dependabot
@@ -25,6 +26,17 @@ module Dependabot
           PyprojectValueParser.array(result, "PEP dependency result").map do |value|
             from_object(value)
           end
+        end
+
+        sig { params(result: Object).returns(T::Array[PepDependency]) }
+        def self.from_requirements_helper_result(result)
+          PyprojectValueParser.array(result, "parse_requirements result").each_with_index.map do |value, index|
+            from_object(value)
+          rescue TypeError => e
+            raise Dependabot::DependencyFileNotEvaluatable, "parse_requirements result[#{index}]: #{e.message}"
+          end
+        rescue TypeError => e
+          raise Dependabot::DependencyFileNotEvaluatable, e.message
         end
 
         sig { params(value: Object).returns(PepDependency) }

--- a/python/spec/dependabot/python/file_parser/pep_dependency_spec.rb
+++ b/python/spec/dependabot/python/file_parser/pep_dependency_spec.rb
@@ -77,4 +77,149 @@ RSpec.describe Dependabot::Python::FileParser::PepDependency do
       end
     end
   end
+
+  describe ".from_requirements_helper_result" do
+    subject(:dependencies) { described_class.from_requirements_helper_result(result) }
+
+    let(:record) do
+      {
+        "name" => "requests",
+        "version" => "2.31.0",
+        "markers" => "None",
+        "file" => "requirements.txt",
+        "requirement" => "==2.31.0",
+        "extras" => ["security"],
+        "unknown" => true
+      }
+    end
+    let(:result) { [record] }
+
+    it "returns typed records without changing the helper fields" do
+      expect(dependencies.first).to be_a(described_class)
+      expect(dependencies.first).to have_attributes(
+        name: "requests",
+        version: "2.31.0",
+        markers: "None",
+        file: "requirements.txt",
+        requirement: "==2.31.0",
+        extras: ["security"],
+        source_requirement: nil,
+        requirement_type: nil
+      )
+    end
+
+    context "with an empty result" do
+      let(:result) { [] }
+
+      it "returns no records" do
+        expect(dependencies).to be_empty
+      end
+    end
+
+    context "with multiple records" do
+      let(:result) { [record, record.merge("name" => "urllib3"), record] }
+
+      it "preserves order and duplicate records" do
+        expect(dependencies.map(&:name)).to eq(%w(requests urllib3 requests))
+      end
+    end
+
+    context "without optional fields" do
+      let(:record) { super().except("version", "markers", "requirement").merge("extras" => []) }
+
+      it "uses nil for the missing fields" do
+        expect(dependencies.first).to have_attributes(version: nil, markers: nil, requirement: nil, extras: [])
+      end
+    end
+
+    context "with null optional fields" do
+      let(:record) { super().merge("version" => nil, "markers" => nil, "requirement" => nil) }
+
+      it "preserves null fields" do
+        expect(dependencies.first).to have_attributes(version: nil, markers: nil, requirement: nil)
+      end
+    end
+
+    context "with empty strings" do
+      let(:record) { super().merge("version" => "", "markers" => "", "requirement" => "") }
+
+      it "does not coerce them to nil" do
+        expect(dependencies.first).to have_attributes(version: "", markers: "", requirement: "")
+      end
+    end
+
+    [nil, {}, "invalid", 1].each do |value|
+      context "with #{value.inspect} as the result" do
+        let(:result) { value }
+
+        it "reports a malformed requirements result" do
+          expect { dependencies }.to raise_error(
+            Dependabot::DependencyFileNotEvaluatable,
+            "parse_requirements result must be an array"
+          )
+        end
+      end
+    end
+
+    [nil, [], "invalid", 1].each do |value|
+      context "with #{value.inspect} as a record" do
+        let(:result) { [record, value] }
+
+        it "identifies the malformed record" do
+          expect { dependencies }.to raise_error(
+            Dependabot::DependencyFileNotEvaluatable,
+            /parse_requirements result\[1\].*must be an object/
+          )
+        end
+      end
+    end
+
+    %w(name file extras).each do |field|
+      context "without #{field}" do
+        let(:record) { super().except(field) }
+
+        it "identifies the missing field" do
+          expect { dependencies }.to raise_error(
+            Dependabot::DependencyFileNotEvaluatable,
+            /parse_requirements result\[0\].*#{field}/
+          )
+        end
+      end
+    end
+
+    [
+      ["name", 1],
+      ["file", false],
+      ["version", []],
+      ["markers", 1],
+      ["requirement", false],
+      ["extras", nil],
+      %w(extras not-an-extra-list),
+      ["extras", [1]]
+    ].each do |field, value|
+      context "with #{field} set to #{value.inspect}" do
+        let(:record) { super().merge(field => value) }
+
+        it "identifies the field without echoing the helper response" do
+          expect { dependencies }.to raise_error(
+            Dependabot::DependencyFileNotEvaluatable,
+            /parse_requirements result\[0\].*#{field}/
+          ) do |error|
+            expect(error.message).not_to include("not-an-extra-list")
+          end
+        end
+      end
+    end
+
+    context "with a non-string key" do
+      let(:record) { super().merge(1 => "unknown") }
+
+      it "identifies the record's key type" do
+        expect { dependencies }.to raise_error(
+          Dependabot::DependencyFileNotEvaluatable,
+          /parse_requirements result\[0\].*keys must be strings/
+        )
+      end
+    end
+  end
 end

--- a/python/spec/dependabot/python/file_parser_spec.rb
+++ b/python/spec/dependabot/python/file_parser_spec.rb
@@ -40,6 +40,133 @@ RSpec.describe Dependabot::Python::FileParser do
 
     its(:length) { is_expected.to eq(5) }
 
+    context "with requirements helper results" do
+      let(:requirements_body) { "requests[security]==2.31.0\n" }
+      let(:helper_record) do
+        {
+          "name" => "requests",
+          "version" => "2.31.0",
+          "markers" => "None",
+          "file" => "requirements.txt",
+          "requirement" => "==2.31.0",
+          "extras" => ["security"]
+        }
+      end
+      let(:helper_result) { [helper_record] }
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess).and_call_original
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+          .with(hash_including(function: "parse_requirements")).and_return(helper_result)
+        allow(parser).to receive(:python_raw_version).and_return("3.13.1")
+      end
+
+      it "preserves Python's dependency name and extras metadata" do
+        expect(dependencies.first).to have_attributes(name: "requests", version: "2.31.0", package_manager: "pip")
+        expect(dependencies.first.metadata).to include(extras: "security")
+        expect(dependencies.first.requirements).to eq(
+          [{
+            requirement: "==2.31.0",
+            file: "requirements.txt",
+            groups: ["dependencies"],
+            source: nil
+          }]
+        )
+      end
+
+      [nil, "None"].each do |marker|
+        context "with #{marker.inspect} as the marker" do
+          let(:helper_record) { super().merge("markers" => marker, "version" => nil, "requirement" => "<3") }
+
+          it "does not filter an unmarked requirement" do
+            expect(dependencies.map(&:name)).to eq(["requests"])
+          end
+        end
+      end
+
+      context "without a marker field" do
+        let(:helper_record) { super().except("markers") }
+
+        it "treats the requirement as unmarked" do
+          expect(dependencies.map(&:name)).to eq(["requests"])
+        end
+      end
+
+      context "with an empty marker and an upper-bound requirement" do
+        let(:helper_record) { super().merge("markers" => "", "requirement" => "<3") }
+
+        it "preserves the existing upper-bound filtering" do
+          expect(dependencies).to be_empty
+        end
+      end
+
+      context "with a missing helper result" do
+        let(:helper_result) { nil }
+
+        it "reports a malformed requirements result" do
+          expect { dependencies }.to raise_error(
+            Dependabot::DependencyFileNotEvaluatable,
+            "parse_requirements result must be an array"
+          )
+        end
+      end
+
+      context "with a malformed record excluded by its marker" do
+        let(:helper_result) do
+          [
+            helper_record,
+            helper_record.merge("name" => "ignored", "markers" => "python_version < \"3.0\"", "extras" => [1])
+          ]
+        end
+
+        it "rejects the complete result before filtering records" do
+          expect { dependencies }.to raise_error(
+            Dependabot::DependencyFileNotEvaluatable,
+            /parse_requirements result\[1\].*extras/
+          )
+        end
+      end
+
+      context "with invalid requirement syntax" do
+        let(:helper_record) { super().merge("requirement" => "not a requirement") }
+
+        it "preserves the requirement evaluation error" do
+          expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
+        end
+      end
+
+      [
+        ["InstallationError: invalid input", Dependabot::DependencyFileNotEvaluatable],
+        ["Unexpected helper failure", Dependabot::SharedHelpers::HelperSubprocessFailed]
+      ].each do |message, error_class|
+        context "when the helper reports #{message}" do
+          let(:helper_error) do
+            Dependabot::SharedHelpers::HelperSubprocessFailed.new(message: message, error_context: {})
+          end
+
+          before do
+            allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+              .with(hash_including(function: "parse_requirements")).and_raise(helper_error)
+          end
+
+          it "preserves the existing helper error mapping" do
+            expect { dependencies }.to raise_error(error_class, message)
+          end
+        end
+      end
+
+      context "when the helper call itself raises a type error" do
+        before do
+          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+            .with(hash_including(function: "parse_requirements")).and_raise(TypeError, "unexpected helper type error")
+        end
+
+        it "does not treat it as a malformed result" do
+          expect { dependencies }.to raise_error(TypeError, "unexpected helper type error")
+        end
+      end
+    end
+
     context "with a version specified" do
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }

--- a/uv/lib/dependabot/uv/file_parser.rb
+++ b/uv/lib/dependabot/uv/file_parser.rb
@@ -16,6 +16,7 @@ require "dependabot/uv/name_normaliser"
 require "dependabot/uv/requirements_file_matcher"
 require "dependabot/uv/language_version_manager"
 require "dependabot/uv/package_manager"
+require "dependabot/python/file_parser/pep_dependency"
 require "toml-rb"
 
 module Dependabot
@@ -235,16 +236,16 @@ module Dependabot
         parsed_requirement_files.each do |dep|
           next if blocking_marker?(dep)
 
-          name = dep["name"]
-          file = dep["file"]
-          version = dep["version"]
+          name = dep.name
+          file = dep.file
+          version = dep.version
           original_file = get_original_file(file)
 
           requirements =
             if original_file && requirements_in_file_matcher.compiled_file?(original_file) then []
             else
               [{
-                requirement: dep["requirement"],
+                requirement: dep.requirement,
                 file: Pathname.new(file).cleanpath.to_path,
                 source: nil,
                 groups: group_from_filename(file)
@@ -256,7 +257,7 @@ module Dependabot
 
           dependencies <<
             Dependency.new(
-              name: normalised_name(name, dep["extras"]),
+              name: normalised_name(name, dep.extras),
               version: version&.include?("*") ? nil : version,
               requirements: requirements,
               package_manager: "uv"
@@ -281,35 +282,32 @@ module Dependabot
         end
       end
 
-      sig { params(dep: T.untyped).returns(T::Boolean) }
+      sig { params(dep: Dependabot::Python::FileParser::PepDependency).returns(T::Boolean) }
       def blocking_marker?(dep)
-        return false if dep["markers"] == "None"
+        marker = dep.markers
+        return false if marker.nil? || marker == "None"
 
-        marker = dep["markers"]
         version = python_raw_version
 
         if marker.include?("python_version")
           !marker_satisfied?(marker, version)
         else
-          return true if dep["markers"].include?("<")
-          return false if dep["markers"].include?(">")
-          return false if dep["requirement"].nil?
+          return true if marker.include?("<")
+          return false if marker.include?(">")
 
-          dep["requirement"].include?("<")
+          dep.requirement&.include?("<") || false
         end
       end
 
-      sig do
-        params(marker: T.untyped, python_version: T.any(String, Integer, Gem::Version)).returns(T::Boolean)
-      end
+      sig { params(marker: String, python_version: T.any(String, Integer, Gem::Version)).returns(T::Boolean) }
       def marker_satisfied?(marker, python_version)
         conditions = marker.split(/\s+(and|or)\s+/)
 
-        result = T.let(evaluate_condition?(conditions.shift, python_version), T::Boolean)
+        result = T.let(evaluate_condition?(T.must(conditions.shift), python_version), T::Boolean)
 
         until conditions.empty?
           operator = conditions.shift
-          next_condition = conditions.shift
+          next_condition = T.must(conditions.shift)
           next_result = evaluate_condition?(next_condition, python_version)
 
           result = if operator == "and"
@@ -324,12 +322,13 @@ module Dependabot
 
       sig do
         params(
-          condition: T.untyped,
+          condition: String,
           python_version: T.any(String, Integer, Gem::Version)
         ).returns(T::Boolean)
       end
       def evaluate_condition?(condition, python_version)
         operator, version = condition.match(/([<>=!]=?)\s*"?([\d.]+)"?/)&.captures
+        return false unless version
 
         case operator
         when "<"
@@ -347,17 +346,18 @@ module Dependabot
         end
       end
 
-      sig { returns(T.untyped) }
+      sig { returns(T::Array[Dependabot::Python::FileParser::PepDependency]) }
       def parsed_requirement_files
         SharedHelpers.in_a_temporary_directory do
           write_temporary_dependency_files
 
-          requirements = SharedHelpers.run_helper_subprocess(
+          result = SharedHelpers.run_helper_subprocess(
             command: "pyenv exec python3 #{NativeHelpers.python_helper_path}",
             function: "parse_requirements",
             args: [Dir.pwd]
           )
 
+          requirements = Dependabot::Python::FileParser::PepDependency.from_requirements_helper_result(result)
           check_requirements(requirements)
           requirements
         end
@@ -368,12 +368,13 @@ module Dependabot
         raise DependencyFileNotEvaluatable, e.message
       end
 
-      sig { params(requirements: T.untyped).returns(T.untyped) }
+      sig { params(requirements: T::Array[Dependabot::Python::FileParser::PepDependency]).void }
       def check_requirements(requirements)
         requirements.each do |dep|
-          next unless dep["requirement"]
+          requirement = dep.requirement
+          next unless requirement
 
-          Requirement.new(dep["requirement"].split(","))
+          Requirement.new(requirement.split(","))
         rescue Gem::Requirement::BadRequirementError => e
           raise DependencyFileNotEvaluatable, e.message
         end

--- a/uv/spec/dependabot/uv/file_parser_spec.rb
+++ b/uv/spec/dependabot/uv/file_parser_spec.rb
@@ -40,6 +40,136 @@ RSpec.describe Dependabot::Uv::FileParser do
 
     its(:length) { is_expected.to eq(5) }
 
+    context "with requirements helper results" do
+      let(:requirements_body) { "requests[security]==2.31.0\n" }
+      let(:helper_record) do
+        {
+          "name" => "requests",
+          "version" => "2.31.0",
+          "markers" => "None",
+          "file" => "requirements.txt",
+          "requirement" => "==2.31.0",
+          "extras" => ["security"]
+        }
+      end
+      let(:helper_result) { [helper_record] }
+
+      before do
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess).and_call_original
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+          .with(hash_including(function: "parse_requirements")).and_return(helper_result)
+        allow(parser).to receive(:python_raw_version).and_return("3.13.1")
+      end
+
+      it "preserves UV's extras in the dependency name" do
+        expect(dependencies.first).to have_attributes(
+          name: "requests[security]",
+          version: "2.31.0",
+          package_manager: "uv"
+        )
+        expect(dependencies.first.requirements).to eq(
+          [{
+            requirement: "==2.31.0",
+            file: "requirements.txt",
+            groups: ["dependencies"],
+            source: nil
+          }]
+        )
+      end
+
+      [nil, "None"].each do |marker|
+        context "with #{marker.inspect} as the marker" do
+          let(:helper_record) { super().merge("markers" => marker, "version" => nil, "requirement" => "<3") }
+
+          it "does not filter an unmarked requirement" do
+            expect(dependencies.map(&:name)).to eq(["requests[security]"])
+          end
+        end
+      end
+
+      context "without a marker field" do
+        let(:helper_record) { super().except("markers") }
+
+        it "treats the requirement as unmarked" do
+          expect(dependencies.map(&:name)).to eq(["requests[security]"])
+        end
+      end
+
+      context "with an empty marker and an upper-bound requirement" do
+        let(:helper_record) { super().merge("markers" => "", "requirement" => "<3") }
+
+        it "preserves the existing upper-bound filtering" do
+          expect(dependencies).to be_empty
+        end
+      end
+
+      context "with a missing helper result" do
+        let(:helper_result) { nil }
+
+        it "reports a malformed requirements result" do
+          expect { dependencies }.to raise_error(
+            Dependabot::DependencyFileNotEvaluatable,
+            "parse_requirements result must be an array"
+          )
+        end
+      end
+
+      context "with a malformed record excluded by its marker" do
+        let(:helper_result) do
+          [
+            helper_record,
+            helper_record.merge("name" => "ignored", "markers" => "python_version < \"3.0\"", "extras" => [1])
+          ]
+        end
+
+        it "rejects the complete result before filtering records" do
+          expect { dependencies }.to raise_error(
+            Dependabot::DependencyFileNotEvaluatable,
+            /parse_requirements result\[1\].*extras/
+          )
+        end
+      end
+
+      context "with invalid requirement syntax" do
+        let(:helper_record) { super().merge("requirement" => "not a requirement") }
+
+        it "preserves the requirement evaluation error" do
+          expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable)
+        end
+      end
+
+      [
+        ["InstallationError: invalid input", Dependabot::DependencyFileNotEvaluatable],
+        ["Unexpected helper failure", Dependabot::SharedHelpers::HelperSubprocessFailed]
+      ].each do |message, error_class|
+        context "when the helper reports #{message}" do
+          let(:helper_error) do
+            Dependabot::SharedHelpers::HelperSubprocessFailed.new(message: message, error_context: {})
+          end
+
+          before do
+            allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+              .with(hash_including(function: "parse_requirements")).and_raise(helper_error)
+          end
+
+          it "preserves the existing helper error mapping" do
+            expect { dependencies }.to raise_error(error_class, message)
+          end
+        end
+      end
+
+      context "when the helper call itself raises a type error" do
+        before do
+          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+            .with(hash_including(function: "parse_requirements")).and_raise(TypeError, "unexpected helper type error")
+        end
+
+        it "does not treat it as a malformed result" do
+          expect { dependencies }.to raise_error(TypeError, "unexpected helper type error")
+        end
+      end
+    end
+
     context "with a version specified" do
       describe "the first dependency" do
         subject(:dependency) { dependencies.first }


### PR DESCRIPTION
### What are you trying to accomplish?

Python and UV now parse requirements-helper responses into `PepDependency` records. This keeps field types through dependency parsing and removes 12 `T.untyped` annotations.

### Anything you want to highlight for special attention from reviewers?

Malformed records raise `DependencyFileNotEvaluatable` before marker filtering, even for excluded dependencies. Missing/null markers mean no marker, while the helper protocol and PEP error contract stay unchanged.

### How will you know you've accomplished your goal?

Targeted parser suites pass: 271 Python examples and 124 UV examples, plus the final focused reruns. Sorbet, RuboCop, and the existing strictness checks pass.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
