### PR TITLE
julia: process [extras] with existing compat entries

### DIFF
--- a/julia/README.md
+++ b/julia/README.md
@@ -25,6 +25,8 @@ There are some notable differences:
 - **Workspace Support**: Dependabot handles Julia workspaces where multiple packages share a common manifest file in a parent directory.
 - **Conflict Notifications**: When manifest updates fail due to dependency conflicts (common in workspaces), Dependabot adds warning notices to pull requests explaining the issue.
 
+`[extras]` dependencies are included when they already have a `[compat]` entry, matching CompatHelper.jl's default `IfExistingCompatExtras()` policy.
+
 Also, a goal of this is to integrate into github's CVE database and alerting systems for vulnerabilities in Julia packages.
 
 ## Julia Documentation References

--- a/julia/helpers/DependabotHelper.jl/src/project_parsing.jl
+++ b/julia/helpers/DependabotHelper.jl/src/project_parsing.jl
@@ -87,9 +87,6 @@ function parse_project(project_path::String, manifest_path::Union{String,Nothing
                 push!(dependencies, dep_info)
             end
 
-            # Note: We don't process [extras] to match CompatHelper.jl behavior
-            # CompatHelper only processes [deps] and [weakdeps]
-
             # Get weak dependencies (weakdeps) - available in Julia 1.9+
             # Read directly from TOML since Pkg may not populate project_info.weakdeps
             weak_dependencies = []
@@ -121,6 +118,32 @@ function parse_project(project_path::String, manifest_path::Union{String,Nothing
                 end
             end
 
+            # Process [extras] that already have a [compat] entry, matching
+            # CompatHelper.jl's default `IfExistingCompatExtras()` policy.
+            # Extras without a compat bound are ignored to avoid opening PRs for
+            # every undeclared test-only dependency.
+            extra_dependencies = []
+            if haskey(project_toml, "extras")
+                extras_section = project_toml["extras"]
+                for (dep_name, dep_uuid_str) in extras_section
+                    haskey(sources, dep_name) && continue
+                    haskey(project_info.compat, dep_name) || continue
+
+                    compat_spec = project_info.compat[dep_name]
+                    constraint_str = if isa(compat_spec, Pkg.Types.Compat)
+                        compat_spec.str
+                    else
+                        string(compat_spec)
+                    end
+
+                    push!(extra_dependencies, Dict{String,Any}(
+                        "name" => dep_name,
+                        "uuid" => dep_uuid_str,
+                        "requirement" => constraint_str
+                    ))
+                end
+            end
+
             # Get Julia version requirement
             julia_version = ""
             if haskey(project_info.compat, "julia")
@@ -139,6 +162,7 @@ function parse_project(project_path::String, manifest_path::Union{String,Nothing
                 "julia_version" => julia_version,
                 "dependencies" => dependencies,
                 "weak_dependencies" => weak_dependencies,
+                "extra_dependencies" => extra_dependencies,
                 "project_path" => ctx.env.project_file
             )
         end

--- a/julia/lib/dependabot/julia/file_parser.rb
+++ b/julia/lib/dependabot/julia/file_parser.rb
@@ -133,6 +133,14 @@ module Dependabot
             dependencies_map,
             workspace_package_uuids
           )
+
+          merge_dependencies_from_list(
+            result.extra_dependencies,
+            ["extras"],
+            proj_file.name,
+            dependencies_map,
+            workspace_package_uuids
+          )
         end
 
         apply_manifest_versions(dependencies_map)

--- a/julia/lib/dependabot/julia/registry_client/result.rb
+++ b/julia/lib/dependabot/julia/registry_client/result.rb
@@ -188,6 +188,7 @@ module Dependabot
           const :julia_version, String
           const :dependencies, T::Array[ProjectDependency]
           const :weak_dependencies, T::Array[ProjectDependency]
+          const :extra_dependencies, T::Array[ProjectDependency]
           const :project_path, String
 
           sig { params(value: Object).returns(T.any(Project, Failure)) }
@@ -204,6 +205,7 @@ module Dependabot
               julia_version: ValueParser.string(hash, "julia_version", context),
               dependencies: parse_dependencies(hash, "dependencies", context),
               weak_dependencies: parse_dependencies(hash, "weak_dependencies", context),
+              extra_dependencies: parse_dependencies(hash, "extra_dependencies", context),
               project_path: ValueParser.string(hash, "project_path", context)
             )
           end

--- a/julia/spec/dependabot/julia/file_parser_spec.rb
+++ b/julia/spec/dependabot/julia/file_parser_spec.rb
@@ -85,9 +85,12 @@ RSpec.describe Dependabot::Julia::FileParser do
         )
       end
 
-      it "parses runtime and weak dependencies (matching CompatHelper.jl)" do
-        # CompatHelper.jl only processes [deps] and [weakdeps], not [extras]
-        expect(dependencies.length).to eq(2) # Example (deps), JSON (weakdeps)
+      it "parses deps, weakdeps, and extras that already have compat entries" do
+        # Matches CompatHelper.jl's default IfExistingCompatExtras(): extras
+        # without a [compat] entry are ignored.
+        expect(dependencies.map(&:name)).to contain_exactly(
+          "Example", "JSON", "FilePathsBase", "Test"
+        )
 
         # deps dependency
         example_dep = dependencies.find { |d| d.name == "Example" }
@@ -104,6 +107,15 @@ RSpec.describe Dependabot::Julia::FileParser do
         expect(json_dep.version).to eq("0.21.4") # Weakdeps also get manifest versions
         expect(json_dep.requirements.first[:groups]).to eq(["weakdeps"])
         expect(json_dep.requirements.first[:requirement]).to eq("0.21")
+
+        # Extras with existing compat entries
+        filepaths_dep = dependencies.find { |d| d.name == "FilePathsBase" }
+        expect(filepaths_dep.requirements.first[:groups]).to eq(["extras"])
+        expect(filepaths_dep.requirements.first[:requirement]).to eq("0.6, 0.7, 0.8")
+
+        test_dep = dependencies.find { |d| d.name == "Test" }
+        expect(test_dep.requirements.first[:groups]).to eq(["extras"])
+        expect(test_dep.requirements.first[:requirement]).to eq("1")
       end
     end
 

--- a/julia/spec/dependabot/julia/registry_client_spec.rb
+++ b/julia/spec/dependabot/julia/registry_client_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe Dependabot::Julia::RegistryClient do
               }
             ],
             "weak_dependencies" => [],
+            "extra_dependencies" => [],
             "project_path" => project_path,
             "ignored" => "value"
           }
@@ -199,6 +200,7 @@ RSpec.describe Dependabot::Julia::RegistryClient do
             "julia_version" => "",
             "dependencies" => [{ "name" => 123, "uuid" => "uuid" }],
             "weak_dependencies" => [],
+            "extra_dependencies" => [],
             "project_path" => project_path
           }
         )


### PR DESCRIPTION
## Summary
- Parse `[extras]` dependencies that already have a `[compat]` entry in `DependabotHelper.parse_project`, matching CompatHelper.jl's default `IfExistingCompatExtras()` policy.
- Surface them to the Ruby file parser as the `extras` group so Dependabot can open compat bumps for test-only packages.
- Update specs/README accordingly.

Motivation: SciML/QuasiMonteCarlo.jl needed HypothesisTests 0.12 for a 32-bit overflow fix, but Dependabot never opened a PR because HypothesisTests lives only in `[extras]`.

## Test plan
- [ ] `parse_project` on `spec/fixtures/projects/with_extras` returns FilePathsBase and Test in `extra_dependencies` (verified locally with Julia)
- [ ] `file_parser_spec` extras example expects deps + weakdeps + extras-with-compat
- [ ] CI Julia specs green

Made with [Cursor](https://cursor.com)