### PR TITLE
Cover unavailable cooldown dates in Dotnet SDK, vcpkg, and Nix

### DIFF
--- a/dotnet_sdk/spec/dependabot/dotnet_sdk/update_checker/latest_version_finder_spec.rb
+++ b/dotnet_sdk/spec/dependabot/dotnet_sdk/update_checker/latest_version_finder_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
@@ -12,7 +12,8 @@ RSpec.describe Dependabot::DotnetSdk::UpdateChecker::LatestVersionFinder do
       credentials: credentials,
       ignored_versions: ignored_versions,
       security_advisories: security_advisories,
-      raise_on_ignored: raise_on_ignored
+      raise_on_ignored: raise_on_ignored,
+      cooldown_options: cooldown_options
     )
   end
 
@@ -31,6 +32,7 @@ RSpec.describe Dependabot::DotnetSdk::UpdateChecker::LatestVersionFinder do
   let(:ignored_versions) { [] }
   let(:security_advisories) { [] }
   let(:raise_on_ignored) { false }
+  let(:cooldown_options) { nil }
   let(:metadata) { {} }
 
   let(:mock_package_details_fetcher) { instance_double(Dependabot::DotnetSdk::Package::PackageDetailsFetcher) }
@@ -139,6 +141,21 @@ RSpec.describe Dependabot::DotnetSdk::UpdateChecker::LatestVersionFinder do
     context "with language_version parameter" do
       it "accepts the parameter and returns the latest version" do
         expect(finder.latest_version(language_version: "8.0")).to eq(Dependabot::DotnetSdk::Version.new("8.0.400"))
+      end
+    end
+
+    context "when cooldown is configured and the release date is unavailable" do
+      let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+      let(:available_releases) do
+        [Dependabot::Package::PackageRelease.new(
+          version: Dependabot::DotnetSdk::Version.new("8.0.300"),
+          released_at: nil
+        )]
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(finder.latest_version).to eq(Dependabot::DotnetSdk::Version.new("8.0.300"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
     end
   end

--- a/nix/spec/dependabot/nix/update_checker/latest_version_finder_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker/latest_version_finder_spec.rb
@@ -1,0 +1,52 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/nix/update_checker/latest_version_finder"
+
+RSpec.describe Dependabot::Nix::UpdateChecker::LatestVersionFinder do
+  subject(:latest_version) { finder.latest_version }
+
+  let(:finder) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: [],
+      credentials: [],
+      ignored_versions: [],
+      security_advisories: [],
+      raise_on_ignored: false,
+      cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+    )
+  end
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "nixpkgs",
+      version: "0.0.0-0.1",
+      requirements: [],
+      package_manager: "nix"
+    )
+  end
+  let(:release) do
+    Dependabot::Package::PackageRelease.new(
+      version: Dependabot::Nix::Version.new("0.0.0-0.2"),
+      released_at: nil,
+      tag: "new-revision"
+    )
+  end
+  let(:package_details_fetcher) do
+    instance_double(
+      Dependabot::Nix::Package::PackageDetailsFetcher,
+      available_versions: [release]
+    )
+  end
+
+  before do
+    allow(Dependabot::Nix::Package::PackageDetailsFetcher)
+      .to receive(:new).and_return(package_details_fetcher)
+  end
+
+  it "allows the release and marks the dependency when its date is unavailable" do
+    expect(latest_version).to eq(Dependabot::Nix::Version.new("0.0.0-0.2"))
+    expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+  end
+end

--- a/vcpkg/spec/dependabot/vcpkg/update_checker/latest_version_finder_spec.rb
+++ b/vcpkg/spec/dependabot/vcpkg/update_checker/latest_version_finder_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
@@ -185,6 +185,25 @@ RSpec.describe Dependabot::Vcpkg::UpdateChecker::LatestVersionFinder do
 
       it "returns the latest non-ignored version" do
         expect(latest_version).to eq(Dependabot::Vcpkg::Version.new("2025.04.09"))
+      end
+    end
+
+    context "when cooldown is configured and the release date is unavailable" do
+      let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+      let(:mock_package_details) do
+        Dependabot::Package::PackageDetails.new(
+          dependency: dependency,
+          releases: [Dependabot::Package::PackageRelease.new(
+            version: Dependabot::Vcpkg::Version.new("2025.06.13"),
+            tag: "abc123",
+            released_at: nil
+          )]
+        )
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(latest_version).to eq(Dependabot::Vcpkg::Version.new("2025.06.13"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Stacked on #16266 (Bazel/Pub). This is the final PR at the top of native stack #16267.

Combine the Dotnet SDK, vcpkg, and Nix regression coverage for unavailable publication dates into one reviewable, test-only PR. Each example verifies that a release remains eligible under the existing fail-open policy and marks the dependency when a positive cooldown cannot be evaluated.

This PR supersedes the separate vcpkg (#16245) and Nix (#16246) companion PRs. Shared production behavior remains in #16211. NuGet has no changes in this stack.

### Anything you want to highlight for special attention from reviewers?

Dotnet SDK and vcpkg are grouped for Microsoft ecosystem review; Nix is included in the same review group by request, not because it is Microsoft-owned. Existing CODEOWNERS routing is unchanged.

Stack, bottom to top: #16211 -> #16261 -> #16262 -> #16263 -> #16264 -> #16265 -> #16266 -> #16244. Julia and OpenTofu remain separate PRs.

### How will you know you have accomplished your goal?

Validated on the combined branch in Docker:

- Dotnet SDK finder: 28 examples, 0 failures.
- vcpkg finder: 12 examples, 0 failures.
- Nix finder: 1 example, 0 failures.
- RuboCop for all three changed specs: no offenses.
- Repository Sorbet check: no errors.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have tested the changed specs and checked lint and types.
- [x] I have written a clear commit message and described the scope and stack dependencies.