### PR TITLE
Cover unavailable cooldown dates in Nix

### DIFF
--- a/bun/spec/dependabot/bun/update_checker/package_latest_version_finder_spec.rb
+++ b/bun/spec/dependabot/bun/update_checker/package_latest_version_finder_spec.rb
@@ -165,6 +165,20 @@ RSpec.describe Dependabot::Bun::UpdateChecker::PackageLatestVersionFinder do
       it { is_expected.to eq(Gem::Version.new("1.5.1")) }
     end
 
+    context "when cooldown is configured and the release date is unavailable" do
+      let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+      let(:registry_response) do
+        response = JSON.parse(super())
+        response.fetch("time").delete("1.7.0")
+        JSON.dump(response)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(latest_version_from_registry).to eq(Dependabot::Bun::Version.new("1.7.0"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
+
     context "when the latest version is a prerelease" do
       before do
         body = fixture("npm_responses", "prerelease.json")

--- a/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker/latest_version_finder_spec.rb
@@ -308,6 +308,31 @@ RSpec.describe Dependabot::Bundler::UpdateChecker::LatestVersionFinder do
           expect(result).to eq(Dependabot::Bundler::Version.new("1.4.0"))
         end
       end
+
+      context "when the release date is unavailable" do
+        let(:release) do
+          Dependabot::Package::PackageRelease.new(
+            version: Dependabot::Bundler::Version.new("1.5.0"),
+            released_at: nil
+          )
+        end
+        let(:package_details) do
+          Dependabot::Package::PackageDetails.new(dependency: dependency, releases: [release])
+        end
+        let(:package_details_fetcher) do
+          instance_double(Dependabot::Bundler::Package::PackageDetailsFetcher, fetch: package_details)
+        end
+
+        before do
+          allow(Dependabot::Bundler::Package::PackageDetailsFetcher)
+            .to receive(:new).and_return(package_details_fetcher)
+        end
+
+        it "allows the release and marks the dependency" do
+          expect(finder.latest_version).to eq(Dependabot::Bundler::Version.new("1.5.0"))
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        end
+      end
     end
 
     context "with cooldown enabled with private registry" do

--- a/cargo/spec/dependabot/cargo/update_checker/latest_version_finder_spec.rb
+++ b/cargo/spec/dependabot/cargo/update_checker/latest_version_finder_spec.rb
@@ -538,6 +538,34 @@ RSpec.describe Dependabot::Cargo::UpdateChecker::LatestVersionFinder do
 
           it { is_expected.to eq(Gem::Version.new("2.0.0")) }
         end
+
+        context "when the release date is unavailable" do
+          let(:sparse_registry_response) do
+            <<~BODY
+              {"name":"hello-world","vers":"1.0.0","created_at":"2024-12-02T20:07:38.990663Z","deps":[],"cksum":"abc123","features":{},"yanked":false,"links":null}
+              {"name":"hello-world","vers":"2.0.0","created_at":null,"deps":[],"cksum":"def456","features":{},"yanked":false,"links":null}
+            BODY
+          end
+          let(:requirements) do
+            [{
+              file: "Cargo.toml",
+              requirement: "~2.0.0",
+              groups: ["dependencies"],
+              source: {
+                type: "registry",
+                name: "honeyankit-test",
+                index: "sparse+https://cargo.cloudsmith.io/honeyankit/test/",
+                dl: "https://dl.cloudsmith.io/basic/honeyankit/test/cargo/{crate}-{version}.crate",
+                api: "https://cargo.cloudsmith.io/honeyankit/test"
+              }
+            }]
+          end
+
+          it "allows the release and marks the dependency" do
+            expect(latest_version).to eq(Gem::Version.new("2.0.0"))
+            expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+          end
+        end
       end
     end
   end

--- a/common/lib/dependabot/package/cooldown_date_tracker.rb
+++ b/common/lib/dependabot/package/cooldown_date_tracker.rb
@@ -16,11 +16,14 @@ module Dependabot
       def initialize(dependency:, ignored_versions:)
         @dependency = dependency
         @ignored_versions = ignored_versions
-        @defer = T.let(false, T::Boolean)
+        @active = T.let(false, T::Boolean)
         @language_version = T.let(nil, T.nilable(T.any(String, Dependabot::Version)))
         @enforce_requirements = T.let(false, T::Boolean)
         @releases = T.let({}, T::Hash[Dependabot::Package::PackageRelease, Integer])
       end
+
+      sig { returns(T::Boolean) }
+      attr_reader :active
 
       sig do
         params(
@@ -30,7 +33,7 @@ module Dependabot
         ).returns(T::Array[Dependabot::Package::PackageRelease])
       end
       def filter(language_version:, requirements:, &block)
-        @defer = true
+        @active = true
         @language_version = language_version
         @enforce_requirements = requirements
 
@@ -38,7 +41,7 @@ module Dependabot
         mark_for_selected_release(filtered)
         filtered
       ensure
-        @defer = false
+        @active = false
         @language_version = nil
         @enforce_requirements = false
         @releases.clear
@@ -52,11 +55,10 @@ module Dependabot
         ).void
       end
       def record(release:, current_version:, days:)
-        if @defer
-          @releases[release] = days if relevant?(release, current_version)
-        elsif current_version.nil? || release.version > current_version
-          mark(days)
-        end
+        return unless active
+        return unless relevant?(release, current_version)
+
+        @releases[release] = days
       end
 
       private
@@ -74,6 +76,7 @@ module Dependabot
         ).returns(T::Boolean)
       end
       def relevant?(release, current_version)
+        return false if release.yanked?
         return false if current_version && release.version <= current_version
         return false if unwanted_prerelease?(release)
         return false if ignored?(release)
@@ -129,15 +132,14 @@ module Dependabot
 
       sig { params(filtered: T::Array[Dependabot::Package::PackageRelease]).void }
       def mark_for_selected_release(filtered)
-        selected = (filtered + @releases.keys).max_by(&:version)
+        current_version = T.cast(dependency.numeric_version, T.nilable(Dependabot::Version))
+        eligible = filtered.select { |release| relevant?(release, current_version) }
+        selected = (eligible + @releases.keys).max_by(&:version)
         return unless selected
 
         days = @releases[selected]
-        mark(days) if days
-      end
+        return unless days
 
-      sig { params(days: Integer).void }
-      def mark(days)
         Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
           dependency,
           cooldown_days: days

--- a/common/lib/dependabot/package/cooldown_date_tracker.rb
+++ b/common/lib/dependabot/package/cooldown_date_tracker.rb
@@ -19,6 +19,7 @@ module Dependabot
         @active = T.let(false, T::Boolean)
         @language_version = T.let(nil, T.nilable(T.any(String, Dependabot::Version)))
         @enforce_requirements = T.let(false, T::Boolean)
+        @prefiltered = T.let(false, T::Boolean)
         @releases = T.let({}, T::Hash[Dependabot::Package::PackageRelease, Integer])
       end
 
@@ -48,6 +49,17 @@ module Dependabot
       end
 
       sig do
+        params(block: T.proc.returns(T::Array[Dependabot::Package::PackageRelease]))
+          .returns(T::Array[Dependabot::Package::PackageRelease])
+      end
+      def filter_prefiltered(&block)
+        @prefiltered = true
+        filter(language_version: nil, requirements: false, &block)
+      ensure
+        @prefiltered = false
+      end
+
+      sig do
         params(
           release: Dependabot::Package::PackageRelease,
           current_version: T.nilable(Dependabot::Version),
@@ -56,7 +68,7 @@ module Dependabot
       end
       def record(release:, current_version:, days:)
         return unless active
-        return unless relevant?(release, current_version)
+        return unless @prefiltered || relevant?(release, current_version)
 
         @releases[release] = days
       end
@@ -133,7 +145,11 @@ module Dependabot
       sig { params(filtered: T::Array[Dependabot::Package::PackageRelease]).void }
       def mark_for_selected_release(filtered)
         current_version = T.cast(dependency.numeric_version, T.nilable(Dependabot::Version))
-        eligible = filtered.select { |release| relevant?(release, current_version) }
+        eligible = if @prefiltered
+                     filtered
+                   else
+                     filtered.select { |release| relevant?(release, current_version) }
+                   end
         selected = (eligible + @releases.keys).max_by(&:version)
         return unless selected
 

--- a/common/lib/dependabot/package/cooldown_date_unavailable_tracker.rb
+++ b/common/lib/dependabot/package/cooldown_date_unavailable_tracker.rb
@@ -1,0 +1,148 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+
+require "dependabot/dependency"
+require "dependabot/package/package_release"
+require "dependabot/update_checkers/cooldown_calculation"
+
+module Dependabot
+  module Package
+    class CooldownDateTracker
+      extend T::Sig
+
+      sig { params(dependency: Dependabot::Dependency, ignored_versions: T::Array[String]).void }
+      def initialize(dependency:, ignored_versions:)
+        @dependency = dependency
+        @ignored_versions = ignored_versions
+        @defer = T.let(false, T::Boolean)
+        @language_version = T.let(nil, T.nilable(T.any(String, Dependabot::Version)))
+        @enforce_requirements = T.let(false, T::Boolean)
+        @releases = T.let({}, T::Hash[Dependabot::Package::PackageRelease, Integer])
+      end
+
+      sig do
+        params(
+          language_version: T.nilable(T.any(String, Dependabot::Version)),
+          requirements: T::Boolean,
+          block: T.proc.returns(T::Array[Dependabot::Package::PackageRelease])
+        ).returns(T::Array[Dependabot::Package::PackageRelease])
+      end
+      def filter(language_version:, requirements:, &block)
+        @defer = true
+        @language_version = language_version
+        @enforce_requirements = requirements
+
+        filtered = yield
+        mark_for_selected_release(filtered)
+        filtered
+      ensure
+        @defer = false
+        @language_version = nil
+        @enforce_requirements = false
+        @releases.clear
+      end
+
+      sig do
+        params(
+          release: Dependabot::Package::PackageRelease,
+          current_version: T.nilable(Dependabot::Version),
+          days: Integer
+        ).void
+      end
+      def record(release:, current_version:, days:)
+        if @defer
+          @releases[release] = days if relevant?(release, current_version)
+        elsif current_version.nil? || release.version > current_version
+          mark(days)
+        end
+      end
+
+      private
+
+      sig { returns(Dependabot::Dependency) }
+      attr_reader :dependency
+
+      sig { returns(T::Array[String]) }
+      attr_reader :ignored_versions
+
+      sig do
+        params(
+          release: Dependabot::Package::PackageRelease,
+          current_version: T.nilable(Dependabot::Version)
+        ).returns(T::Boolean)
+      end
+      def relevant?(release, current_version)
+        return false if current_version && release.version <= current_version
+        return false if unwanted_prerelease?(release)
+        return false if ignored?(release)
+        return false unless language_supported?(release)
+
+        requirements_allow?(release)
+      end
+
+      sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
+      def unwanted_prerelease?(release)
+        release.version.prerelease? && !wants_prerelease?
+      end
+
+      sig { returns(T::Boolean) }
+      def wants_prerelease?
+        return true if dependency.numeric_version&.prerelease?
+
+        dependency.requirements.any? do |requirement|
+          requirement_string = requirement.requirement_string || ""
+          requirement_string.split(",").map(&:strip).any? do |part|
+            version_string = part.gsub(/^\s*[!<>=~^]+\s*/, "").strip
+            next false unless dependency.version_class.correct?(version_string)
+
+            dependency.version_class.new(version_string).prerelease?
+          end
+        end
+      end
+
+      sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
+      def ignored?(release)
+        requirements = ignored_versions.flat_map do |requirement|
+          dependency.requirement_class.requirements_array(requirement)
+        end
+        requirements.any? { |requirement| requirement.satisfied_by?(release.version) }
+      end
+
+      sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
+      def language_supported?(release)
+        requirement = release.language&.requirement
+        !@language_version || !requirement || requirement.satisfied_by?(@language_version)
+      end
+
+      sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
+      def requirements_allow?(release)
+        return true unless @enforce_requirements
+
+        dependency.requirements.filter_map(&:requirement_string).all? do |requirement_string|
+          dependency.requirement_class.requirements_array(requirement_string).any? do |requirement|
+            requirement.satisfied_by?(release.version)
+          end
+        end
+      end
+
+      sig { params(filtered: T::Array[Dependabot::Package::PackageRelease]).void }
+      def mark_for_selected_release(filtered)
+        selected = (filtered + @releases.keys).max_by(&:version)
+        return unless selected
+
+        days = @releases[selected]
+        mark(days) if days
+      end
+
+      sig { params(days: Integer).void }
+      def mark(days)
+        Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+          dependency,
+          cooldown_days: days
+        )
+      end
+    end
+  end
+end

--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -198,20 +198,20 @@ module Dependabot
 
       sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
       def in_cooldown_period?(release)
-        return false unless release.released_at
-
-        cooldown = @cooldown_options
-        return false if Dependabot::UpdateCheckers::CooldownCalculation.skip_cooldown?(
-          cooldown, dependency.name, cooldown_enabled: cooldown_enabled?
-        )
-
         current_version = version_class.correct?(dependency.version) ? version_class.new(dependency.version) : nil
-        days = Dependabot::UpdateCheckers::CooldownCalculation.cooldown_days_for(
-          T.must(cooldown), current_version, release.version
-        )
-        Dependabot::UpdateCheckers::CooldownCalculation.within_cooldown_window?(
-          T.must(release.released_at), days
-        )
+        days = cooldown_days_for(current_version, release.version)
+        return false unless days.positive?
+
+        released_at = released_at_for(release)
+        unless released_at
+          Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+            dependency,
+            cooldown_days: days
+          )
+          return missing_release_date_blocks_update?(release)
+        end
+
+        Dependabot::UpdateCheckers::CooldownCalculation.within_cooldown_window?(released_at, days)
       end
 
       sig do
@@ -359,6 +359,17 @@ module Dependabot
       sig { returns(T::Boolean) }
       def cooldown_enabled?
         true
+      end
+
+      # Registries that only expose a publication date through a second request resolve it here.
+      sig { overridable.params(release: Dependabot::Package::PackageRelease).returns(T.nilable(Time)) }
+      def released_at_for(release)
+        release.released_at
+      end
+
+      sig { overridable.params(_release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
+      def missing_release_date_blocks_update?(_release)
+        false
       end
 
       sig do

--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -131,6 +131,9 @@ module Dependabot
 
       protected
 
+      sig { returns(CooldownDateTracker) }
+      attr_reader :cooldown_tracker
+
       sig do
         params(language_version: T.nilable(T.any(String, Dependabot::Version)))
           .returns(T.nilable(Dependabot::Version))
@@ -366,9 +369,7 @@ module Dependabot
       end
 
       sig { overridable.returns(Dependabot::Package::PackageRelease) }
-      def current_dependency_release
-        Dependabot::Package::PackageRelease.new(version: version_class.new(T.must(dependency.version)))
-      end
+      def current_dependency_release = PackageRelease.new(version: version_class.new(T.must(dependency.version)))
 
       sig do
         params(language_version: T.nilable(T.any(String, Dependabot::Version)))

--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -12,6 +12,7 @@ require "dependabot/update_checkers/cooldown_calculation"
 require "dependabot/registry_client"
 require "dependabot/package/package_details"
 require "dependabot/package/release_cooldown_options"
+require "dependabot/package/cooldown_date_unavailable_tracker"
 
 module Dependabot
   module Package
@@ -79,6 +80,8 @@ module Dependabot
         @latest_version_with_no_unlock = T.let(nil, T.nilable(Dependabot::Version))
         @lowest_security_fix_version = T.let(nil, T.nilable(Dependabot::Version))
         @package_details = T.let(nil, T.nilable(Dependabot::Package::PackageDetails))
+        cooldown_tracker = CooldownDateTracker.new(dependency: dependency, ignored_versions: ignored_versions)
+        @cooldown_tracker = T.let(cooldown_tracker, CooldownDateTracker)
       end
 
       sig do
@@ -139,7 +142,7 @@ module Dependabot
         return unless releases
 
         releases = filter_yanked_versions(releases)
-        releases = filter_by_cooldown(releases)
+        releases = @cooldown_tracker.filter(language_version:, requirements: true) { filter_by_cooldown(releases) }
         releases = filter_unsupported_versions(releases, language_version)
         releases = filter_prerelease_versions(releases)
         releases = filter_ignored_versions(releases)
@@ -204,10 +207,7 @@ module Dependabot
 
         released_at = released_at_for(release)
         unless released_at
-          Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
-            dependency,
-            cooldown_days: days
-          )
+          @cooldown_tracker.record(release: release, current_version: current_version, days: days)
           return missing_release_date_blocks_update?(release)
         end
 
@@ -389,7 +389,7 @@ module Dependabot
         return unless releases
 
         releases = filter_yanked_versions(releases)
-        releases = filter_by_cooldown(releases)
+        releases = @cooldown_tracker.filter(language_version:, requirements: false) { filter_by_cooldown(releases) }
         releases = filter_unsupported_versions(releases, language_version)
         releases = filter_prerelease_versions(releases)
         releases = filter_ignored_versions(releases)

--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -12,7 +12,7 @@ require "dependabot/update_checkers/cooldown_calculation"
 require "dependabot/registry_client"
 require "dependabot/package/package_details"
 require "dependabot/package/release_cooldown_options"
-require "dependabot/package/cooldown_date_unavailable_tracker"
+require "dependabot/package/cooldown_date_tracker"
 
 module Dependabot
   module Package
@@ -124,9 +124,7 @@ module Dependabot
         @lowest_security_fix_version ||= fetch_lowest_security_fix_version(language_version: language_version)
       end
 
-      sig do
-        returns(T.nilable(T::Array[Dependabot::Package::PackageRelease]))
-      end
+      sig { returns(T.nilable(T::Array[Dependabot::Package::PackageRelease])) }
       def available_versions
         package_details&.releases
       end
@@ -142,12 +140,13 @@ module Dependabot
         return unless releases
 
         releases = filter_yanked_versions(releases)
-        releases = @cooldown_tracker.filter(language_version:, requirements: true) { filter_by_cooldown(releases) }
-        releases = filter_unsupported_versions(releases, language_version)
-        releases = filter_prerelease_versions(releases)
-        releases = filter_ignored_versions(releases)
-        releases = filter_out_of_range_versions(releases)
-        releases = apply_post_fetch_latest_versions_filter(releases)
+        releases = @cooldown_tracker.filter(language_version:, requirements: true) do
+          filtered = filter_by_cooldown(releases)
+          filtered = filter_prerelease_versions(filter_unsupported_versions(filtered, language_version))
+          filtered = filter_ignored_versions(filtered)
+          filtered = filter_out_of_range_versions(filtered)
+          apply_post_fetch_latest_versions_filter(filtered)
+        end
         releases.max_by(&:version)&.version
       end
 
@@ -157,9 +156,8 @@ module Dependabot
       end
       def filter_yanked_versions(releases)
         filtered = releases.reject(&:yanked?)
-        if releases.count > filtered.count
-          Dependabot.logger.info("Filtered out #{releases.count - filtered.count} yanked versions")
-        end
+        removed_count = releases.count - filtered.count
+        Dependabot.logger.info("Filtered out #{removed_count} yanked versions") if removed_count.positive?
         filtered
       end
 
@@ -168,8 +166,13 @@ module Dependabot
           .returns(T::Array[Dependabot::Package::PackageRelease])
       end
       def filter_by_cooldown(releases)
-        return releases unless cooldown_enabled?
-        return releases unless cooldown_options
+        unless @cooldown_tracker.active
+          return @cooldown_tracker.filter(language_version: nil, requirements: false) do
+            filter_by_cooldown(releases)
+          end
+        end
+
+        return releases unless cooldown_enabled? && cooldown_options
 
         filtered = releases.reject { |release| in_cooldown_period?(release) }
 
@@ -179,21 +182,11 @@ module Dependabot
 
         # If all releases were filtered out due to cooldown and we have a current version, use it as fallback
         if filtered.empty? && !releases.empty? && dependency.version
-          current_version_str = dependency.version
-
           Dependabot.logger.info(
             "All versions filtered by cooldown for #{dependency.name}, " \
-            "falling back to current version #{current_version_str}"
+            "falling back to current version #{dependency.version}"
           )
-
-          # Create a PackageRelease for the current version
-          current_version = version_class.new(current_version_str)
-          current_release = Dependabot::Package::PackageRelease.new(
-            version: current_version,
-            released_at: nil,
-            tag: nil
-          )
-          return [current_release]
+          return [current_dependency_release]
         end
 
         filtered
@@ -372,6 +365,11 @@ module Dependabot
         false
       end
 
+      sig { overridable.returns(Dependabot::Package::PackageRelease) }
+      def current_dependency_release
+        Dependabot::Package::PackageRelease.new(version: version_class.new(T.must(dependency.version)))
+      end
+
       sig do
         params(language_version: T.nilable(T.any(String, Dependabot::Version)))
           .returns(T.nilable(Dependabot::Version))
@@ -389,11 +387,12 @@ module Dependabot
         return unless releases
 
         releases = filter_yanked_versions(releases)
-        releases = @cooldown_tracker.filter(language_version:, requirements: false) { filter_by_cooldown(releases) }
-        releases = filter_unsupported_versions(releases, language_version)
-        releases = filter_prerelease_versions(releases)
-        releases = filter_ignored_versions(releases)
-        releases = apply_post_fetch_latest_versions_filter(releases)
+        releases = @cooldown_tracker.filter(language_version:, requirements: false) do
+          filtered = filter_by_cooldown(releases)
+          filtered = filter_prerelease_versions(filter_unsupported_versions(filtered, language_version))
+          filtered = filter_ignored_versions(filtered)
+          apply_post_fetch_latest_versions_filter(filtered)
+        end
         releases.max_by(&:version)
       end
 

--- a/common/spec/dependabot/package/package_latest_version_finder_spec.rb
+++ b/common/spec/dependabot/package/package_latest_version_finder_spec.rb
@@ -730,6 +730,32 @@ RSpec.describe Dependabot::Package::PackageLatestVersionFinder do
       end
     end
 
+    context "when a release date is unavailable" do
+      let(:available_releases) do
+        [{ version: "6.0.1", released_at: nil, yanked: false }]
+      end
+
+      it "allows the version and marks the dependency" do
+        expect(finder.latest_version).to eq(TestVersion.new("6.0.1"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+
+      context "when the dependency is excluded from cooldown" do
+        let(:cooldown_options) do
+          Dependabot::Package::ReleaseCooldownOptions.new(
+            default_days: 7,
+            exclude: [dependency_name]
+          )
+        end
+
+        it "does not mark the dependency" do
+          finder.latest_version
+
+          expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+        end
+      end
+    end
+
     context "when dependency has no current version" do
       let(:dependency_version) { nil }
 

--- a/common/spec/dependabot/package/package_latest_version_finder_spec.rb
+++ b/common/spec/dependabot/package/package_latest_version_finder_spec.rb
@@ -754,6 +754,46 @@ RSpec.describe Dependabot::Package::PackageLatestVersionFinder do
           expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
         end
       end
+
+      context "when the undated release is ignored" do
+        let(:available_releases) do
+          [
+            { version: "6.0.2", released_at: "2023-01-01", yanked: false },
+            { version: "6.0.1", released_at: nil, yanked: false }
+          ]
+        end
+        let(:ignored_versions) { ["6.0.1"] }
+
+        it "does not mark the dependency" do
+          expect(finder.latest_version).to eq(TestVersion.new("6.0.2"))
+          expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+        end
+      end
+
+      context "when a newer selected release has a usable date" do
+        let(:available_releases) do
+          [
+            { version: "6.0.2", released_at: "2023-01-01", yanked: false },
+            { version: "6.0.1", released_at: nil, yanked: false }
+          ]
+        end
+
+        it "does not mark the dependency" do
+          expect(finder.latest_version).to eq(TestVersion.new("6.0.2"))
+          expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+        end
+      end
+
+      context "when the effective cooldown is zero days" do
+        let(:cooldown_options) do
+          Dependabot::Package::ReleaseCooldownOptions.new(default_days: 0)
+        end
+
+        it "does not mark the dependency" do
+          expect(finder.latest_version).to eq(TestVersion.new("6.0.1"))
+          expect(dependency.metadata).not_to include(:cooldown_date_unavailable)
+        end
+      end
     end
 
     context "when dependency has no current version" do

--- a/common/spec/dependabot/package/package_latest_version_finder_spec.rb
+++ b/common/spec/dependabot/package/package_latest_version_finder_spec.rb
@@ -784,6 +784,20 @@ RSpec.describe Dependabot::Package::PackageLatestVersionFinder do
         end
       end
 
+      context "when a higher dated prerelease is filtered out" do
+        let(:available_releases) do
+          [
+            { version: "7.0.0.beta1", released_at: "2023-01-01", yanked: false },
+            { version: "6.0.1", released_at: nil, yanked: false }
+          ]
+        end
+
+        it "marks the selected undated release" do
+          expect(finder.latest_version).to eq(TestVersion.new("6.0.1"))
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        end
+      end
+
       context "when the effective cooldown is zero days" do
         let(:cooldown_options) do
           Dependabot::Package::ReleaseCooldownOptions.new(default_days: 0)

--- a/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
+++ b/composer/spec/dependabot/composer/update_checker/latest_version_finder_spec.rb
@@ -411,6 +411,34 @@ RSpec.describe Dependabot::Composer::UpdateChecker::LatestVersionFinder do
         end
       end
     end
+
+    context "when the release date is unavailable" do
+      let(:release) do
+        Dependabot::Package::PackageRelease.new(
+          version: Dependabot::Composer::Version.new("3.2.0"),
+          released_at: nil
+        )
+      end
+      let(:package_details) do
+        Dependabot::Package::PackageDetails.new(dependency: dependency, releases: [release])
+      end
+      let(:package_details_fetcher) do
+        instance_double(
+          Dependabot::Composer::Package::PackageDetailsFetcher,
+          fetch_releases: [release]
+        )
+      end
+
+      before do
+        allow(Dependabot::Composer::Package::PackageDetailsFetcher)
+          .to receive(:new).and_return(package_details_fetcher)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(finder.latest_version).to eq(Dependabot::Composer::Version.new("3.2.0"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
   end
 
   describe "#lowest_security_fix_version" do

--- a/conda/spec/dependabot/conda/update_checker/latest_version_finder_spec.rb
+++ b/conda/spec/dependabot/conda/update_checker/latest_version_finder_spec.rb
@@ -132,6 +132,17 @@ RSpec.describe Dependabot::Conda::UpdateChecker::LatestVersionFinder do
         end
       end
 
+      context "with cooldown configured" do
+        let(:cooldown_options) do
+          Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+        end
+
+        it "allows the release and marks the dependency when its date is unavailable" do
+          expect(finder.latest_version.to_s).to eq("1.23.0")
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        end
+      end
+
       context "when package does not exist in Conda API" do
         before do
           # Stub all channels that will be tried during fallback

--- a/deno/spec/dependabot/deno/update_checker/latest_version_finder_spec.rb
+++ b/deno/spec/dependabot/deno/update_checker/latest_version_finder_spec.rb
@@ -1,0 +1,51 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/deno/update_checker/latest_version_finder"
+
+RSpec.describe Dependabot::Deno::UpdateChecker::LatestVersionFinder do
+  subject(:latest_version) { finder.latest_version }
+
+  let(:finder) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: [],
+      credentials: [],
+      ignored_versions: [],
+      security_advisories: [],
+      raise_on_ignored: false,
+      cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+    )
+  end
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "@std/path",
+      version: "1.0.0",
+      requirements: [],
+      package_manager: "deno"
+    )
+  end
+  let(:release) do
+    Dependabot::Package::PackageRelease.new(
+      version: Dependabot::Deno::Version.new("1.1.0"),
+      released_at: nil
+    )
+  end
+  let(:package_details_fetcher) do
+    instance_double(
+      Dependabot::Deno::Package::PackageDetailsFetcher,
+      available_versions: [release]
+    )
+  end
+
+  before do
+    allow(Dependabot::Deno::Package::PackageDetailsFetcher)
+      .to receive(:new).with(dependency: dependency).and_return(package_details_fetcher)
+  end
+
+  it "allows the release and marks the dependency when its date is unavailable" do
+    expect(latest_version).to eq(Dependabot::Deno::Version.new("1.1.0"))
+    expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+  end
+end

--- a/deno/spec/dependabot/deno/update_checker/latest_version_finder_spec.rb
+++ b/deno/spec/dependabot/deno/update_checker/latest_version_finder_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"

--- a/elm/spec/dependabot/elm/update_checker/latest_version_finder_spec.rb
+++ b/elm/spec/dependabot/elm/update_checker/latest_version_finder_spec.rb
@@ -126,5 +126,30 @@ RSpec.describe namespace::LatestVersionFinder do
         end
       end
     end
+
+    context "when the release date is unavailable" do
+      let(:release) do
+        Dependabot::Package::PackageRelease.new(
+          version: Dependabot::Elm::Version.new("1.2.0"),
+          released_at: nil
+        )
+      end
+      let(:package_details_fetcher) do
+        instance_double(
+          Dependabot::Elm::Package::PackageDetailsFetcher,
+          fetch_package_releases: [release]
+        )
+      end
+
+      before do
+        allow(Dependabot::Elm::Package::PackageDetailsFetcher)
+          .to receive(:new).with(dependency: dependency).and_return(package_details_fetcher)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(latest_version).to eq(Dependabot::Elm::Version.new("1.2.0"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
   end
 end

--- a/git_submodules/lib/dependabot/git_submodules/update_checker/latest_version_finder.rb
+++ b/git_submodules/lib/dependabot/git_submodules/update_checker/latest_version_finder.rb
@@ -45,40 +45,15 @@ module Dependabot
             )
         end
 
-        protected
-
-        sig do
-          override.params(releases: T::Array[Dependabot::Package::PackageRelease])
-                  .returns(T::Array[Dependabot::Package::PackageRelease])
-        end
-        def filter_by_cooldown(releases)
-          return releases unless cooldown_enabled?
-          return releases unless cooldown_options
-
-          filtered = releases.reject { |release| in_cooldown_period?(release) }
-
-          if releases.count > filtered.count
-            Dependabot.logger.info("Filtered out #{releases.count - filtered.count} versions due to cooldown")
-          end
-
-          if filtered.empty? && !releases.empty? && dependency.version
-            Dependabot.logger.info(
-              "All versions filtered by cooldown for #{dependency.name}, " \
-              "falling back to current version #{dependency.version}"
-            )
-
-            return [
-              Dependabot::Package::PackageRelease.new(
-                version: GitSubmodules::Version.new("0.0.0-0.0"),
-                tag: dependency.version
-              )
-            ]
-          end
-
-          filtered
-        end
-
         private
+
+        sig { override.returns(Dependabot::Package::PackageRelease) }
+        def current_dependency_release
+          Dependabot::Package::PackageRelease.new(
+            version: GitSubmodules::Version.new("0.0.0-0.0"),
+            tag: dependency.version
+          )
+        end
 
         sig do
           params(releases: T::Array[Dependabot::Package::PackageRelease])

--- a/git_submodules/spec/dependabot/git_submodules/update_checker/latest_version_finder_spec.rb
+++ b/git_submodules/spec/dependabot/git_submodules/update_checker/latest_version_finder_spec.rb
@@ -159,6 +159,28 @@ RSpec.describe Dependabot::GitSubmodules::UpdateChecker::LatestVersionFinder do
     it { is_expected.to eq(dependency.version) }
   end
 
+  describe "#latest_tag when a release date is unavailable" do
+    subject(:latest_tag) { checker.latest_tag }
+
+    let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+    let(:releases) do
+      [Dependabot::Package::PackageRelease.new(
+        version: Dependabot::GitSubmodules::Version.new("1.0.0"),
+        released_at: nil,
+        tag: "abc123"
+      )]
+    end
+
+    before do
+      allow(checker).to receive(:version_list).and_return(releases)
+    end
+
+    it "allows the tag and marks the dependency" do
+      expect(latest_tag).to eq("abc123")
+      expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+    end
+  end
+
   describe "#latest_tag with ignored_versions" do
     subject { checker.latest_tag }
 

--- a/hex/spec/dependabot/hex/update_checker/latest_version_finder_spec.rb
+++ b/hex/spec/dependabot/hex/update_checker/latest_version_finder_spec.rb
@@ -82,5 +82,31 @@ RSpec.describe namespace::LatestVersionFinder do
         it { is_expected.to eq(Gem::Version.new("1.7.1")) }
       end
     end
+
+    context "when cooldown is configured and the release date is unavailable" do
+      let(:update_cooldown) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+      let(:release) do
+        Dependabot::Package::PackageRelease.new(
+          version: Dependabot::Hex::Version.new("1.8.0"),
+          released_at: nil
+        )
+      end
+      let(:package_details_fetcher) do
+        instance_double(
+          Dependabot::Hex::Package::PackageDetailsFetcher,
+          fetch_package_releases: [release]
+        )
+      end
+
+      before do
+        allow(Dependabot::Hex::Package::PackageDetailsFetcher)
+          .to receive(:new).with(dependency: dependency).and_return(package_details_fetcher)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(latest_version).to eq(Dependabot::Hex::Version.new("1.8.0"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
   end
 end

--- a/nix/spec/dependabot/nix/update_checker/latest_version_finder_spec.rb
+++ b/nix/spec/dependabot/nix/update_checker/latest_version_finder_spec.rb
@@ -1,0 +1,52 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/nix/update_checker/latest_version_finder"
+
+RSpec.describe Dependabot::Nix::UpdateChecker::LatestVersionFinder do
+  subject(:latest_version) { finder.latest_version }
+
+  let(:finder) do
+    described_class.new(
+      dependency: dependency,
+      dependency_files: [],
+      credentials: [],
+      ignored_versions: [],
+      security_advisories: [],
+      raise_on_ignored: false,
+      cooldown_options: Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+    )
+  end
+  let(:dependency) do
+    Dependabot::Dependency.new(
+      name: "nixpkgs",
+      version: "0.0.0-0.1",
+      requirements: [],
+      package_manager: "nix"
+    )
+  end
+  let(:release) do
+    Dependabot::Package::PackageRelease.new(
+      version: Dependabot::Nix::Version.new("0.0.0-0.2"),
+      released_at: nil,
+      tag: "new-revision"
+    )
+  end
+  let(:package_details_fetcher) do
+    instance_double(
+      Dependabot::Nix::Package::PackageDetailsFetcher,
+      available_versions: [release]
+    )
+  end
+
+  before do
+    allow(Dependabot::Nix::Package::PackageDetailsFetcher)
+      .to receive(:new).and_return(package_details_fetcher)
+  end
+
+  it "allows the release and marks the dependency when its date is unavailable" do
+    expect(latest_version).to eq(Dependabot::Nix::Version.new("0.0.0-0.2"))
+    expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+  end
+end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/package_latest_version_finder_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/update_checker/package_latest_version_finder_spec.rb
@@ -165,6 +165,20 @@ RSpec.describe Dependabot::NpmAndYarn::UpdateChecker::PackageLatestVersionFinder
       it { is_expected.to eq(Gem::Version.new("1.5.1")) }
     end
 
+    context "when cooldown is configured and the release date is unavailable" do
+      let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+      let(:registry_response) do
+        response = JSON.parse(super())
+        response.fetch("time").delete("1.7.0")
+        JSON.dump(response)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(latest_version_from_registry).to eq(Dependabot::NpmAndYarn::Version.new("1.7.0"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
+
     context "when the latest version is a prerelease" do
       before do
         body = fixture("npm_responses", "prerelease.json")

--- a/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
+++ b/python/spec/dependabot/python/update_checker/latest_version_finder_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
       credentials: credentials,
       ignored_versions: ignored_versions,
       raise_on_ignored: raise_on_ignored,
-      security_advisories: security_advisories
+      security_advisories: security_advisories,
+      cooldown_options: cooldown_options
     )
   end
   let(:credentials) do
@@ -49,6 +50,7 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
   let(:ignored_versions) { [] }
   let(:raise_on_ignored) { false }
   let(:security_advisories) { [] }
+  let(:cooldown_options) { nil }
   let(:dependency_files) { [requirements_file] }
   let(:pipfile) do
     Dependabot::DependencyFile.new(
@@ -128,6 +130,32 @@ RSpec.describe Dependabot::Python::UpdateChecker::LatestVersionFinder do
       let(:pypi_response) { fixture("pypi", "pypi_simple_response_zip.html") }
 
       it { is_expected.to eq(Gem::Version.new("2.6.0")) }
+    end
+
+    context "when cooldown is configured and the release date is unavailable" do
+      let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+      let(:release) do
+        Dependabot::Package::PackageRelease.new(
+          version: Dependabot::Python::Version.new("2.6.0"),
+          released_at: nil
+        )
+      end
+      let(:package_details) do
+        Dependabot::Package::PackageDetails.new(dependency: dependency, releases: [release])
+      end
+      let(:package_details_fetcher) do
+        instance_double(Dependabot::Python::Package::PackageDetailsFetcher, fetch: package_details)
+      end
+
+      before do
+        allow(Dependabot::Python::Package::PackageDetailsFetcher)
+          .to receive(:new).and_return(package_details_fetcher)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(latest_version).to eq(Dependabot::Python::Version.new("2.6.0"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
     end
 
     context "when the pypi link responds with devpi-style" do

--- a/rust_toolchain/spec/dependabot/rust_toolchain/update_checker/latest_version_finder_spec.rb
+++ b/rust_toolchain/spec/dependabot/rust_toolchain/update_checker/latest_version_finder_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe Dependabot::RustToolchain::UpdateChecker::LatestVersionFinder do
     end
   end
 
+  describe "#latest_version with cooldown" do
+    let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+    let(:mock_versions) { [Dependabot::RustToolchain::Version.new("1.73")] }
+
+    it "allows the release and marks the dependency when its date is unavailable" do
+      expect(version_finder.latest_version).to eq(Dependabot::RustToolchain::Version.new("1.73"))
+      expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+    end
+  end
+
   describe "#apply_post_fetch_latest_versions_filter" do
     let(:mock_versions) do
       [

--- a/sbt/spec/dependabot/sbt/update_checker/version_finder_spec.rb
+++ b/sbt/spec/dependabot/sbt/update_checker/version_finder_spec.rb
@@ -196,6 +196,36 @@ RSpec.describe Dependabot::Sbt::UpdateChecker::VersionFinder do
       its([:version]) { is_expected.to eq(version_class.new("33.2.0-jre")) }
     end
 
+    context "when cooldown is configured and the release date is unavailable" do
+      let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+      let(:release) do
+        Dependabot::Package::PackageRelease.new(
+          version: version_class.new("33.4.0-jre"),
+          released_at: nil
+        )
+      end
+      let(:package_details) do
+        Dependabot::Package::PackageDetails.new(dependency: dependency, releases: [release])
+      end
+      let(:package_details_fetcher) do
+        instance_double(
+          Dependabot::Sbt::Package::PackageDetailsFetcher,
+          fetch: package_details,
+          released?: true
+        )
+      end
+
+      before do
+        allow(Dependabot::Sbt::Package::PackageDetailsFetcher)
+          .to receive(:new).and_return(package_details_fetcher)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(latest_version_details[:version]).to eq(version_class.new("33.4.0-jre"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
+
     context "with custom repositories" do
       let(:build_sbt) do
         Dependabot::DependencyFile.new(

--- a/uv/spec/dependabot/uv/update_checker_spec.rb
+++ b/uv/spec/dependabot/uv/update_checker_spec.rb
@@ -189,6 +189,32 @@ RSpec.describe Dependabot::Uv::UpdateChecker do
         ).and_call_original
       expect(checker.latest_version).to eq(Gem::Version.new("2.6.0"))
     end
+
+    context "when cooldown is configured and the release date is unavailable" do
+      let(:cooldown_options) { Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7) }
+      let(:release) do
+        Dependabot::Package::PackageRelease.new(
+          version: Dependabot::Uv::Version.new("2.6.0"),
+          released_at: nil
+        )
+      end
+      let(:package_details) do
+        Dependabot::Package::PackageDetails.new(dependency: dependency, releases: [release])
+      end
+      let(:package_details_fetcher) do
+        instance_double(Dependabot::Python::Package::PackageDetailsFetcher, fetch: package_details)
+      end
+
+      before do
+        allow(Dependabot::Python::Package::PackageDetailsFetcher)
+          .to receive(:new).and_return(package_details_fetcher)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(checker.latest_version).to eq(Dependabot::Uv::Version.new("2.6.0"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
   end
 
   describe "#lowest_security_fix_version" do


### PR DESCRIPTION
### What are you trying to accomplish?

Companion to #16211.

Add Nix regression coverage for the shared `PackageLatestVersionFinder` behavior when a positive cooldown is configured but no publication date is available. The release remains eligible under the existing fail-open policy, and the dependency is marked so the shared warning delivery can notify the user.

### Anything you want to highlight for special attention from reviewers?

This test-only PR is isolated for the requested ecosystem review. The shared production behavior remains in #16211.

### How will you know you've accomplished your goal?

- `bin/test nix spec/dependabot/nix/update_checker/latest_version_finder_spec.rb`: 1 example, 0 failures.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.