### PR TITLE
updater: deduplicate multi-directory update files by path

### DIFF
--- a/updater/lib/dependabot/dependency_change.rb
+++ b/updater/lib/dependabot/dependency_change.rb
@@ -156,6 +156,7 @@ module Dependabot
       end
       updated_dependencies.compact!
       updated_dependency_files.compact!
+      deduplicate_updated_dependency_files!
       notices.compact!
     end
 
@@ -196,6 +197,25 @@ module Dependabot
     end
 
     private
+
+    sig { void }
+    def deduplicate_updated_dependency_files!
+      files_by_path = T.let({}, T::Hash[String, Dependabot::DependencyFile])
+
+      updated_dependency_files.each do |file|
+        existing_file = files_by_path[file.path]
+        next if existing_file && parent_directory_references(existing_file) <= parent_directory_references(file)
+
+        files_by_path[file.path] = file
+      end
+
+      updated_dependency_files.replace(files_by_path.values)
+    end
+
+    sig { params(file: Dependabot::DependencyFile).returns(Integer) }
+    def parent_directory_references(file)
+      file.name.split("/").count("..")
+    end
 
     # Older PRs will not have a directory key, in that case do not consider directory in the comparison. This will
     # allow rebases to continue working for those, but for multi-directory configs we do compare with the directory.

--- a/updater/spec/dependabot/updater/operations/create_group_update_pull_request_multi_dir_spec.rb
+++ b/updater/spec/dependabot/updater/operations/create_group_update_pull_request_multi_dir_spec.rb
@@ -218,6 +218,41 @@ RSpec.describe Dependabot::Updater::Operations::CreateGroupUpdatePullRequest do
       expect(dependency_change.updated_dependencies.length).to eq(9)
     end
 
+    context "when directories update different representations of the same file" do
+      let(:directories) { ["/", "/dir1"] }
+      let(:dependency_files) do
+        [
+          Dependabot::DependencyFile.new(name: "main.tf", content: "# original", directory: "/"),
+          Dependabot::DependencyFile.new(name: "../main.tf", content: "# original", directory: "/dir1")
+        ]
+      end
+
+      before do
+        Dependabot::FileUpdaters.register(
+          "terraform",
+          Class.new(Dependabot::FileUpdaters::Base) do
+            define_method(:updated_dependency_files) do
+              dependency_files.map do |file|
+                content = file.name == "main.tf" ? "# updated" : "# stale"
+                Dependabot::DependencyFile.new(name: file.name, content: content, directory: file.directory)
+              end
+            end
+            define_method(:check_required_files) { nil }
+          end
+        )
+      end
+
+      it "sends the direct representation with its updated content once" do
+        dependency_change = nil
+        allow(mock_service).to receive(:create_pull_request) { |change| dependency_change = change }
+
+        create_operation.perform
+
+        matching_files = dependency_change.updated_dependency_files.select { |file| file.path == "/main.tf" }
+        expect(matching_files.map(&:content)).to eq(["# updated"])
+      end
+    end
+
     context "when no directory produces a change" do
       before do
         # Re-register an update checker whose updates are missing a previous version and


### PR DESCRIPTION
### What are you trying to accomplish?

Ensure multi-directory grouped updates apply all dependencies reported in the PR summary.

A shared file can be returned under multiple relative paths, such as `pom.xml` and `../pom.xml`. These representations normalize to the same repository path but may contain conflicting content. A stale indirect representation could overwrite the updated direct representation, causing the PR summary to report an update that was absent from the PR diff.

This change deduplicates merged files by their normalized repository path and prefers the most direct representation.

### Anything you want to highlight for special attention from reviewers?

The fix is applied at the shared multi-directory merge boundary, so it covers both PR creation and refresh workflows across ecosystems.

When duplicate representations resolve to the same path, the one with fewer parent-directory references is retained. This avoids ecosystem-specific handling and prevents stale support-file snapshots from overriding direct updates.

### How will you know you've accomplished your goal?

A regression test reproduces the conflict using direct and parent-relative representations of the same file and verifies that only the direct, updated content reaches the PR operation.

The focused dependency-change, grouped creation, and grouped refresh suites pass with 25 examples and no failures. RuboCop also passes with no offenses.

### Checklist

<!-- Before requesting review, please ensure that your pull request fulfills the following requirements: -->

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
