### PR TITLE
julia: support Pkg 1.13's `registry_info` and pin the image to Julia 1.13

### DIFF
--- a/julia/CHANGELOG.md
+++ b/julia/CHANGELOG.md
@@ -10,11 +10,13 @@
 
 ### Changed
 
+- Pinned the updater image to the Julia 1.13 release channel instead of juliaup's default `release` channel
 - Simplified file updater architecture to work directly in temporary repo directory instead of nested temporary directories
 - Improved manifest update error handling with detailed user notifications
 
 ### Fixed
 
+- Fixed registry lookups on Julia 1.13, where Pkg changed `registry_info` to also take the registry instance
 - Fixed Julia version requirement parsing to correctly handle caret (^) and tilde (~) semantics according to Julia's official specification
 - Fixed handling julia style compat version spec lists
 - Corrected test expectations for 0.0.x version semantics to match Julia Pkg behavior (0.0.5 satisfies only itself, not 0.0.6+)

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -10,8 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 USER dependabot
 
-# Install Julia
-RUN curl -fsSL https://install.julialang.org | sh -s -- -y \
+# Install Julia, pinned to the 1.13 release channel rather than juliaup's default
+# `release` channel so a new minor Julia release cannot change the image under us.
+RUN curl -fsSL https://install.julialang.org | sh -s -- -y --default-channel 1.13 \
     && . ~/.bashrc
 
 ENV PATH="/home/dependabot/.juliaup/bin:$PATH"

--- a/julia/helpers/DependabotHelper.jl/src/package_discovery.jl
+++ b/julia/helpers/DependabotHelper.jl/src/package_discovery.jl
@@ -19,7 +19,7 @@ function get_latest_version(package_name::String, package_uuid::String)
 
                 if name_matches && uuid_matches
                     # Get versions from the registry, excluding yanked ones
-                    versions = Pkg.Registry.registry_info(entry).version_info
+                    versions = registry_info(reg, entry).version_info
                     if !isempty(versions)
                         # Filter out yanked versions
                         non_yanked_versions = [ver for (ver, info) in versions if !info.yanked]
@@ -72,7 +72,7 @@ function get_package_metadata(package_name::String, package_uuid::String)
         for reg in Pkg.Registry.reachable_registries()
             for (uuid, entry) in reg.pkgs
                 if entry.name == package_name && string(uuid) == package_uuid
-                    reg_info = Pkg.Registry.registry_info(entry)
+                    reg_info = registry_info(reg, entry)
 
                     # Get available versions, excluding yanked ones
                     non_yanked = [v for (v, info) in reg_info.version_info if !info.yanked]
@@ -126,7 +126,7 @@ function fetch_package_versions(package_name::String, package_uuid::String)
                 uuid_matches = string(uuid) == package_uuid
 
                 if name_matches && uuid_matches
-                    version_info = Pkg.Registry.registry_info(entry).version_info
+                    version_info = registry_info(reg, entry).version_info
                     versions = [string(v) for (v, info) in version_info if !info.yanked]
                     break
                 end
@@ -189,7 +189,7 @@ function fetch_package_info(package_name::String, package_uuid::String)
                 uuid_matches = string(uuid) == package_uuid
 
                 if name_matches && uuid_matches
-                    reg_info = Pkg.Registry.registry_info(entry)
+                    reg_info = registry_info(reg, entry)
 
                     # Get all versions, excluding yanked ones
                     non_yanked = [v for (v, info) in reg_info.version_info if !info.yanked]
@@ -285,7 +285,7 @@ function source_url_from_registry(package_name::String, package_uuid::String)
                         continue  # Skip this entry if UUID doesn't match
                     end
 
-                    reg_info = Pkg.Registry.registry_info(entry)
+                    reg_info = registry_info(reg, entry)
 
                     # Get repository URL from PkgInfo.repo field
                     if reg_info.repo !== nothing && !isempty(reg_info.repo)
@@ -388,7 +388,7 @@ function get_available_versions(package_name::String, package_uuid::String)
                 uuid_matches = string(uuid) == package_uuid
 
                 if name_matches && uuid_matches
-                    version_info = Pkg.Registry.registry_info(entry).version_info
+                    version_info = registry_info(reg, entry).version_info
                     # Filter out yanked versions so callers (e.g. latest version finder)
                     # never consider retracted releases.
                     versions = [string(ver) for (ver, info) in version_info if !info.yanked]

--- a/julia/helpers/DependabotHelper.jl/src/utilities.jl
+++ b/julia/helpers/DependabotHelper.jl/src/utilities.jl
@@ -1,5 +1,13 @@
 # Core utility functions for DependabotHelper.jl
 
+# Pkg 1.13 changed `registry_info` to take the `RegistryInstance` alongside the
+# `PkgEntry`; earlier versions only accept the entry. Dispatch on what this Pkg has.
+if hasmethod(Pkg.Registry.registry_info, Tuple{Pkg.Registry.RegistryInstance, Pkg.Registry.PkgEntry})
+    registry_info(reg::Pkg.Registry.RegistryInstance, entry::Pkg.Registry.PkgEntry) = Pkg.Registry.registry_info(reg, entry)
+else
+    registry_info(::Pkg.Registry.RegistryInstance, entry::Pkg.Registry.PkgEntry) = Pkg.Registry.registry_info(entry)
+end
+
 """
     with_autoprecompilation_disabled(f::Function)
 

--- a/julia/helpers/Manifest.toml
+++ b/julia/helpers/Manifest.toml
@@ -1,7 +1,7 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.1"
-manifest_format = "2.0"
+julia_version = "1.13.0"
+manifest_format = "2.1"
 project_hash = "52a9d0e606a4f2ddd668a272242a08bce4a5b323"
 
 [[deps.ArgTools]]
@@ -15,6 +15,11 @@ version = "1.11.0"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.5.5+2"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -30,7 +35,7 @@ version = "0.1.0"
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -39,6 +44,7 @@ version = "1.11.0"
 [[deps.JSON]]
 deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
 git-tree-sha1 = "06ea418d0c95878c8f3031023951edcf25b9e0ef"
+registries = "General"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "1.2.0"
 
@@ -56,12 +62,12 @@ version = "1.12.0"
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.4"
+version = "1.0.0"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "Zstd_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.11.1+1"
+version = "8.18.0+1"
 
 [[deps.LibGit2]]
 deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
@@ -69,14 +75,14 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.9.0+0"
+version = "1.9.1+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl", "OpenSSL_jll", "Zlib_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.3+1"
+version = "1.11.103+0"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -93,7 +99,7 @@ version = "1.11.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.5.20"
+version = "2026.8.13"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -102,18 +108,24 @@ version = "1.3.0"
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.1+0"
+version = "3.5.6+0"
+
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.46.0+0"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
 git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
+registries = "General"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.8.3"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "Zstd_jll", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.12.0"
+version = "1.13.0"
 
     [deps.Pkg.extensions]
     REPLExt = "REPL"
@@ -124,12 +136,14 @@ version = "1.12.0"
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
 git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
+registries = "General"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 version = "1.3.3"
 
 [[deps.Preferences]]
 deps = ["TOML"]
 git-tree-sha1 = "0f27480397253da18fe2c12a4ba4eb9eb208bf3d"
+registries = "General"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 version = "1.5.0"
 
@@ -145,11 +159,12 @@ version = "1.11.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-version = "0.7.0"
+version = "1.0.0"
 
 [[deps.StructUtils]]
 deps = ["Dates", "UUIDs"]
 git-tree-sha1 = "cd47aa083c9c7bdeb7b92de26deb46d6a33163c9"
+registries = "General"
 uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
 version = "2.5.1"
 
@@ -189,12 +204,21 @@ deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.3.1+2"
 
+[[deps.Zstd_jll]]
+deps = ["CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.5.7+1"
+
 [[deps.nghttp2_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.64.0+1"
+version = "1.67.1+0"
 
 [[deps.p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.5.0+2"
+version = "17.8.2+0"
+
+[registries.General]
+url = "https://github.com/JuliaRegistries/General.git"
+uuid = "23338594-aafe-5451-b93e-139f81909106"


### PR DESCRIPTION
Claude:

---

Julia 1.13.0 was released today and the updater image installs Julia through juliaup's default `release` channel, so the image moved to 1.13 on its own. Pkg 1.13 changed `Pkg.Registry.registry_info` to take the `RegistryInstance` alongside the `PkgEntry` and dropped the one-argument method, so every registry lookup in the helper raised a MethodError. That is what broke the four Julia specs on main that call the real helper (see the failing run at https://github.com/dependabot/dependabot-core/actions/runs/34420256901/job/102905083886).

This adds a small `registry_info(reg, entry)` wrapper in the helper that dispatches on which method the running Pkg provides, and passes the registry at the six call sites, which already had it in scope. The helper keeps working on Julia 1.12.

It also pins the juliaup install to the 1.13 channel so a future minor Julia release cannot change the image unannounced, and re-resolves the helpers manifest under 1.13.0 to match. The other `PkgInfo` fields the helper reads (`version_info`, `repo`) are unchanged in Pkg 1.13.

Verified locally: the helper's own test suite passes on Julia 1.13.0 and 1.12.7, and the full Julia rspec suite (276 examples) passes with `julia` resolving to 1.13.0.
