### PR TITLE
docker: fix repeated image update and regex metacharacter matching

### DIFF
--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -174,7 +174,7 @@ module Dependabot
         replacement = new_yaml_image(file)
 
         old_images.each do |old_image|
-          old_image_regex = /^\s*(?:-\s)?image:\s+#{Regexp.escape(old_image)}(?=\s|$)/
+          old_image_regex = /^\s*(?:-\s)?image:\s+(?:docker\.io\/)?#{Regexp.escape(old_image)}(?=\s|$)/
           modified_content = modified_content&.gsub(old_image_regex) do |old_img|
             old_img.gsub(old_image.to_s, replacement.to_s)
           end

--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -174,7 +174,7 @@ module Dependabot
         replacement = new_yaml_image(file)
 
         old_images.each do |old_image|
-          old_image_regex = /^\s*(?:-\s)?image:\s+(?:docker\.io\/)?#{Regexp.escape(old_image)}(?=\s|$)/
+          old_image_regex = %r{^\s*(?:-\s)?image:\s+(?:docker\.io/)?#{Regexp.escape(old_image)}(?=\s|$)}
           modified_content = modified_content&.gsub(old_image_regex) do |old_img|
             old_img.gsub(old_image.to_s, replacement.to_s)
           end

--- a/docker/lib/dependabot/shared/shared_file_updater.rb
+++ b/docker/lib/dependabot/shared/shared_file_updater.rb
@@ -154,11 +154,12 @@ module Dependabot
         return if old_tags.empty?
 
         modified_content = content
+        replacement = new_helm_tag(file)
 
         old_tags.each do |old_tag|
-          old_tag_regex = /^\s*(?:-\s)?(?:tag|version):\s+["']?#{old_tag}["']?(?=\s|$)/
+          old_tag_regex = /^\s*(?:-\s)?(?:tag|version):\s+["']?#{Regexp.escape(old_tag)}["']?(?=\s|$)/
           modified_content = modified_content&.gsub(old_tag_regex) do |old_img_tag|
-            old_img_tag.gsub(old_tag.to_s, new_helm_tag(file).to_s)
+            old_img_tag.gsub(old_tag.to_s, replacement.to_s)
           end
         end
         modified_content
@@ -170,11 +171,12 @@ module Dependabot
         return if old_images.empty?
 
         modified_content = content
+        replacement = new_yaml_image(file)
 
         old_images.each do |old_image|
-          old_image_regex = /^\s*(?:-\s)?image:\s+#{old_image}(?=\s|$)/
+          old_image_regex = /^\s*(?:-\s)?image:\s+#{Regexp.escape(old_image)}(?=\s|$)/
           modified_content = modified_content&.gsub(old_image_regex) do |old_img|
-            old_img.gsub(old_image.to_s, new_yaml_image(file).to_s)
+            old_img.gsub(old_image.to_s, replacement.to_s)
           end
         end
         modified_content
@@ -182,7 +184,7 @@ module Dependabot
 
       sig { params(file: Dependabot::DependencyFile).returns(String) }
       def new_yaml_image(file)
-        element = T.must(dependency).requirements.find { |r| r.file == file.name }
+        element = requirement_for_file(file)
         source = image_source(element)
         prefix = source[:registry] ? "#{source[:registry]}/" : ""
         digest = source[:digest] ? "@sha256:#{source[:digest]}" : ""
@@ -198,7 +200,7 @@ module Dependabot
           digest = source[:digest] ? "@sha256:#{source[:digest]}" : ""
           tag = source[:tag] ? ":#{source[:tag]}" : ""
           "#{prefix}#{T.must(dependency).name}#{tag}#{digest}"
-        end
+        end.uniq
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(T::Array[String]) }
@@ -208,16 +210,21 @@ module Dependabot
           tag = source[:tag] || ""
           digest = source[:digest] ? "@sha256:#{source[:digest]}" : ""
           "#{tag}#{digest}"
-        end
+        end.uniq
       end
 
       sig { params(file: Dependabot::DependencyFile).returns(String) }
       def new_helm_tag(file)
-        element = T.must(dependency).requirements.find { |r| r.file == file.name }
+        element = requirement_for_file(file)
         source = image_source(element)
         tag = source[:tag] || ""
         digest = source[:digest] ? "@sha256:#{source[:digest]}" : ""
         "#{tag}#{digest}"
+      end
+
+      sig { params(file: Dependabot::DependencyFile).returns(T.nilable(Dependabot::DependencyRequirement)) }
+      def requirement_for_file(file)
+        requirements(file).first
       end
 
       protected

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -1299,13 +1299,15 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             requirement: nil,
             groups: [],
             file: "calico.yaml",
-            source: { registry: "docker.io", tag: "v3.32.2" }
+            # Docker::FileParser normalizes the "docker.io" registry to nil,
+            # even though the manifest keeps the explicit prefix in its text.
+            source: { tag: "v3.32.2" }
           }],
           previous_requirements: [{
             requirement: nil,
             groups: [],
             file: "calico.yaml",
-            source: { registry: "docker.io", tag: "v3.26.1" }
+            source: { tag: "v3.26.1" }
           }],
           package_manager: "docker"
         )
@@ -1357,13 +1359,13 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             requirement: nil,
             groups: [],
             file: "calico.yaml",
-            source: { registry: "docker.io", tag: "v3.32.2" }
+            source: { tag: "v3.32.2" }
           }],
           previous_requirements: [{
             requirement: nil,
             groups: [],
             file: "calico.yaml",
-            source: { registry: "docker.io", tag: "v3.26.1" }
+            source: { tag: "v3.26.1" }
           }],
           package_manager: "docker"
         )
@@ -1408,20 +1410,20 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             requirement: nil,
             groups: [],
             file: "calico.yaml",
-            source: { registry: "docker.io", tag: "v3.32.2" }
+            source: { tag: "v3.32.2" }
           }],
           previous_requirements: [
             {
               requirement: nil,
               groups: [],
               file: "calico.yaml",
-              source: { registry: "docker.io", tag: "v3.25.0" }
+              source: { tag: "v3.25.0" }
             },
             {
               requirement: nil,
               groups: [],
               file: "calico.yaml",
-              source: { registry: "docker.io", tag: "v3.26.1" }
+              source: { tag: "v3.26.1" }
             }
           ],
           package_manager: "docker"
@@ -1441,7 +1443,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       end
     end
 
-    context "when an old tag contains regex metacharacters (build-metadata style tag)" do
+    context "when an old tag contains a regex metacharacter that must not fuzzy-match a similar tag" do
       let(:podfile) do
         Dependabot::DependencyFile.new(
           content: <<~YAML,
@@ -1452,7 +1454,9 @@ RSpec.describe Dependabot::Docker::FileUpdater do
             spec:
               containers:
                 - name: app
-                  image: docker.io/example/app:1.2.3+build.4
+                  image: example/app:1.2.3
+                - name: unrelated
+                  image: example/app:1x2y3
           YAML
           name: "app.yaml"
         )
@@ -1460,19 +1464,19 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       let(:yaml_dependency) do
         Dependabot::Dependency.new(
           name: "example/app",
-          version: "1.3.0+build.1",
-          previous_version: "1.2.3+build.4",
+          version: "1.4.0",
+          previous_version: "1.2.3",
           requirements: [{
             requirement: nil,
             groups: [],
             file: "app.yaml",
-            source: { registry: "docker.io", tag: "1.3.0+build.1" }
+            source: { tag: "1.4.0" }
           }],
           previous_requirements: [{
             requirement: nil,
             groups: [],
             file: "app.yaml",
-            source: { registry: "docker.io", tag: "1.2.3+build.4" }
+            source: { tag: "1.2.3" }
           }],
           package_manager: "docker"
         )
@@ -1483,9 +1487,9 @@ RSpec.describe Dependabot::Docker::FileUpdater do
           updated_files.find { |f| f.name == "app.yaml" }
         end
 
-        it "matches and updates a tag containing a '+' without treating it as a regex quantifier" do
-          expect(updated_podfile.content).to include("image: docker.io/example/app:1.3.0+build.1")
-          expect(updated_podfile.content).not_to include("1.2.3+build.4")
+        it "updates only the exact tag match, leaving the similarly-shaped unrelated tag untouched" do
+          expect(updated_podfile.content).to include("image: example/app:1.4.0")
+          expect(updated_podfile.content).to include("image: example/app:1x2y3")
         end
       end
     end
@@ -1798,13 +1802,16 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       end
     end
 
-    context "when the helm tag contains regex metacharacters (build-metadata style tag)" do
+    context "when the helm tag contains a regex metacharacter that must not fuzzy-match a similar tag" do
       let(:helmfile) do
         Dependabot::DependencyFile.new(
           content: <<~YAML,
             image:
               repository: 'example/app'
-              tag: 1.2.3+build.4
+              tag: 1.2.3
+            sidecar:
+              repository: 'example/other'
+              tag: 1x2y3
           YAML
           name: "values.yaml"
         )
@@ -1812,19 +1819,19 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       let(:helm_dependency) do
         Dependabot::Dependency.new(
           name: "example/app",
-          version: "1.3.0+build.1",
-          previous_version: "1.2.3+build.4",
+          version: "1.4.0",
+          previous_version: "1.2.3",
           requirements: [{
             requirement: nil,
             groups: [],
             file: "values.yaml",
-            source: { tag: "1.3.0+build.1" }
+            source: { tag: "1.4.0" }
           }],
           previous_requirements: [{
             requirement: nil,
             groups: [],
             file: "values.yaml",
-            source: { tag: "1.2.3+build.4" }
+            source: { tag: "1.2.3" }
           }],
           package_manager: "docker"
         )
@@ -1835,9 +1842,9 @@ RSpec.describe Dependabot::Docker::FileUpdater do
           updated_files.find { |f| f.name == "values.yaml" }
         end
 
-        it "matches and updates a tag containing a '+' without treating it as a regex quantifier" do
-          expect(updated_helmfile.content).to include("tag: 1.3.0+build.1")
-          expect(updated_helmfile.content).not_to include("1.2.3+build.4")
+        it "updates only the exact tag match, leaving the similarly-shaped unrelated tag untouched" do
+          expect(updated_helmfile.content).to include("tag: 1.4.0")
+          expect(updated_helmfile.content).to include("tag: 1x2y3")
         end
       end
     end

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -1443,57 +1443,6 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       end
     end
 
-    context "when an old tag contains a regex metacharacter that must not fuzzy-match a similar tag" do
-      let(:podfile) do
-        Dependabot::DependencyFile.new(
-          content: <<~YAML,
-            apiVersion: v1
-            kind: Pod
-            metadata:
-              name: test
-            spec:
-              containers:
-                - name: app
-                  image: example/app:1.2.3
-                - name: unrelated
-                  image: example/app:1x2y3
-          YAML
-          name: "app.yaml"
-        )
-      end
-      let(:yaml_dependency) do
-        Dependabot::Dependency.new(
-          name: "example/app",
-          version: "1.4.0",
-          previous_version: "1.2.3",
-          requirements: [{
-            requirement: nil,
-            groups: [],
-            file: "app.yaml",
-            source: { tag: "1.4.0" }
-          }],
-          previous_requirements: [{
-            requirement: nil,
-            groups: [],
-            file: "app.yaml",
-            source: { tag: "1.2.3" }
-          }],
-          package_manager: "docker"
-        )
-      end
-
-      describe "the updated podfile" do
-        subject(:updated_podfile) do
-          updated_files.find { |f| f.name == "app.yaml" }
-        end
-
-        it "updates only the exact tag match, leaving the similarly-shaped unrelated tag untouched" do
-          expect(updated_podfile.content).to include("image: example/app:1.4.0")
-          expect(updated_podfile.content).to include("image: example/app:1x2y3")
-        end
-      end
-    end
-
     context "when multiple yaml to be updated" do
       let(:yaml_files) { [podfile, podfile2] }
       let(:podfile2) do
@@ -1799,53 +1748,6 @@ RSpec.describe Dependabot::Docker::FileUpdater do
 
         its(:content) { is_expected.to include "  image: nginx:1.14.3\n" }
         its(:content) { is_expected.to include "  image:\n    repository: 'canonical/ubuntu'\n    tag: 18.04" }
-      end
-    end
-
-    context "when the helm tag contains a regex metacharacter that must not fuzzy-match a similar tag" do
-      let(:helmfile) do
-        Dependabot::DependencyFile.new(
-          content: <<~YAML,
-            image:
-              repository: 'example/app'
-              tag: 1.2.3
-            sidecar:
-              repository: 'example/other'
-              tag: 1x2y3
-          YAML
-          name: "values.yaml"
-        )
-      end
-      let(:helm_dependency) do
-        Dependabot::Dependency.new(
-          name: "example/app",
-          version: "1.4.0",
-          previous_version: "1.2.3",
-          requirements: [{
-            requirement: nil,
-            groups: [],
-            file: "values.yaml",
-            source: { tag: "1.4.0" }
-          }],
-          previous_requirements: [{
-            requirement: nil,
-            groups: [],
-            file: "values.yaml",
-            source: { tag: "1.2.3" }
-          }],
-          package_manager: "docker"
-        )
-      end
-
-      describe "the updated helmfile" do
-        subject(:updated_helmfile) do
-          updated_files.find { |f| f.name == "values.yaml" }
-        end
-
-        it "updates only the exact tag match, leaving the similarly-shaped unrelated tag untouched" do
-          expect(updated_helmfile.content).to include("tag: 1.4.0")
-          expect(updated_helmfile.content).to include("tag: 1x2y3")
-        end
       end
     end
 

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -1272,6 +1272,224 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       end
     end
 
+    context "when the same image is referenced multiple times in one manifest" do
+      let(:podfile) do
+        Dependabot::DependencyFile.new(
+          content: <<~YAML,
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: test
+            spec:
+              initContainers:
+                - name: upgrade-ipam
+                  image: docker.io/calico/cni:v3.26.1
+                - name: install-cni
+                  image: docker.io/calico/cni:v3.26.1
+          YAML
+          name: "calico.yaml"
+        )
+      end
+      let(:yaml_dependency) do
+        Dependabot::Dependency.new(
+          name: "calico/cni",
+          version: "v3.32.2",
+          previous_version: "v3.26.1",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "calico.yaml",
+            source: { registry: "docker.io", tag: "v3.32.2" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "calico.yaml",
+            source: { registry: "docker.io", tag: "v3.26.1" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      describe "the updated podfile" do
+        subject(:updated_podfile) do
+          updated_files.find { |f| f.name == "calico.yaml" }
+        end
+
+        its(:content) { is_expected.to include "image: docker.io/calico/cni:v3.32.2" }
+        its(:content) { is_expected.to include "- name: upgrade-ipam" }
+        its(:content) { is_expected.to include "- name: install-cni" }
+
+        it "updates every occurrence and leaves none on the old version" do
+          expect(updated_podfile.content.scan("docker.io/calico/cni:v3.32.2").length).to eq(2)
+          expect(updated_podfile.content).not_to include("v3.26.1")
+        end
+      end
+    end
+
+    context "when the same image is referenced three times in one manifest" do
+      let(:podfile) do
+        Dependabot::DependencyFile.new(
+          content: <<~YAML,
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: test
+            spec:
+              initContainers:
+                - name: upgrade-ipam
+                  image: docker.io/calico/cni:v3.26.1
+                - name: install-cni
+                  image: docker.io/calico/cni:v3.26.1
+              containers:
+                - name: calico-node
+                  image: docker.io/calico/cni:v3.26.1
+          YAML
+          name: "calico.yaml"
+        )
+      end
+      let(:yaml_dependency) do
+        Dependabot::Dependency.new(
+          name: "calico/cni",
+          version: "v3.32.2",
+          previous_version: "v3.26.1",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "calico.yaml",
+            source: { registry: "docker.io", tag: "v3.32.2" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "calico.yaml",
+            source: { registry: "docker.io", tag: "v3.26.1" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      describe "the updated podfile" do
+        subject(:updated_podfile) do
+          updated_files.find { |f| f.name == "calico.yaml" }
+        end
+
+        it "updates all three occurrences" do
+          expect(updated_podfile.content.scan("docker.io/calico/cni:v3.32.2").length).to eq(3)
+          expect(updated_podfile.content).not_to include("v3.26.1")
+        end
+      end
+    end
+
+    context "when the same image name has different old tags in one manifest" do
+      let(:podfile) do
+        Dependabot::DependencyFile.new(
+          content: <<~YAML,
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: test
+            spec:
+              initContainers:
+                - name: upgrade-ipam
+                  image: docker.io/calico/cni:v3.25.0
+                - name: install-cni
+                  image: docker.io/calico/cni:v3.26.1
+          YAML
+          name: "calico.yaml"
+        )
+      end
+      let(:yaml_dependency) do
+        Dependabot::Dependency.new(
+          name: "calico/cni",
+          version: "v3.32.2",
+          previous_version: "v3.26.1",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "calico.yaml",
+            source: { registry: "docker.io", tag: "v3.32.2" }
+          }],
+          previous_requirements: [
+            {
+              requirement: nil,
+              groups: [],
+              file: "calico.yaml",
+              source: { registry: "docker.io", tag: "v3.25.0" }
+            },
+            {
+              requirement: nil,
+              groups: [],
+              file: "calico.yaml",
+              source: { registry: "docker.io", tag: "v3.26.1" }
+            }
+          ],
+          package_manager: "docker"
+        )
+      end
+
+      describe "the updated podfile" do
+        subject(:updated_podfile) do
+          updated_files.find { |f| f.name == "calico.yaml" }
+        end
+
+        it "updates both differently-tagged occurrences to the new tag" do
+          expect(updated_podfile.content.scan("docker.io/calico/cni:v3.32.2").length).to eq(2)
+          expect(updated_podfile.content).not_to include("v3.25.0")
+          expect(updated_podfile.content).not_to include("v3.26.1")
+        end
+      end
+    end
+
+    context "when an old tag contains regex metacharacters (build-metadata style tag)" do
+      let(:podfile) do
+        Dependabot::DependencyFile.new(
+          content: <<~YAML,
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: test
+            spec:
+              containers:
+                - name: app
+                  image: docker.io/example/app:1.2.3+build.4
+          YAML
+          name: "app.yaml"
+        )
+      end
+      let(:yaml_dependency) do
+        Dependabot::Dependency.new(
+          name: "example/app",
+          version: "1.3.0+build.1",
+          previous_version: "1.2.3+build.4",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "app.yaml",
+            source: { registry: "docker.io", tag: "1.3.0+build.1" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "app.yaml",
+            source: { registry: "docker.io", tag: "1.2.3+build.4" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      describe "the updated podfile" do
+        subject(:updated_podfile) do
+          updated_files.find { |f| f.name == "app.yaml" }
+        end
+
+        it "matches and updates a tag containing a '+' without treating it as a regex quantifier" do
+          expect(updated_podfile.content).to include("image: docker.io/example/app:1.3.0+build.1")
+          expect(updated_podfile.content).not_to include("1.2.3+build.4")
+        end
+      end
+    end
+
     context "when multiple yaml to be updated" do
       let(:yaml_files) { [podfile, podfile2] }
       let(:podfile2) do
@@ -1577,6 +1795,50 @@ RSpec.describe Dependabot::Docker::FileUpdater do
 
         its(:content) { is_expected.to include "  image: nginx:1.14.3\n" }
         its(:content) { is_expected.to include "  image:\n    repository: 'canonical/ubuntu'\n    tag: 18.04" }
+      end
+    end
+
+    context "when the helm tag contains regex metacharacters (build-metadata style tag)" do
+      let(:helmfile) do
+        Dependabot::DependencyFile.new(
+          content: <<~YAML,
+            image:
+              repository: 'example/app'
+              tag: 1.2.3+build.4
+          YAML
+          name: "values.yaml"
+        )
+      end
+      let(:helm_dependency) do
+        Dependabot::Dependency.new(
+          name: "example/app",
+          version: "1.3.0+build.1",
+          previous_version: "1.2.3+build.4",
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "1.3.0+build.1" }
+          }],
+          previous_requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "values.yaml",
+            source: { tag: "1.2.3+build.4" }
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      describe "the updated helmfile" do
+        subject(:updated_helmfile) do
+          updated_files.find { |f| f.name == "values.yaml" }
+        end
+
+        it "matches and updates a tag containing a '+' without treating it as a regex quantifier" do
+          expect(updated_helmfile.content).to include("tag: 1.3.0+build.1")
+          expect(updated_helmfile.content).not_to include("1.2.3+build.4")
+        end
       end
     end
 


### PR DESCRIPTION

Fixes #16234

- old_yaml_images/old_helm_tags now dedupe so the same image/tag referenced multiple times in one manifest no longer triggers a false 'Expected content to change!' no-op.
- update_image now optionally matches a leading `docker.io/` prefix, since `Docker::FileParser` normalizes the `docker.io` registry to nil while the raw manifest text can still contain the explicit prefix. This was the actual root cause of the reported no-op failure.
- update_image/update_helm build their match regexes with `Regexp.escape`, consistent with the existing Dockerfile matcher, for exact-match correctness (the only realistic parser-emitted tag character this affects is `.`; `+`-containing build-metadata tags can't reach this updater at all, since `Docker::FileParser::TAG_NO_PREFIX` truncates them before the `+`).
- Consolidated duplicated requirement lookup into requirement_for_file.


### What are you trying to accomplish?

Fix the Docker/Kubernetes YAML updater so it correctly updates `image:` lines when the same Docker Hub image is referenced multiple times in one manifest with an explicit `docker.io/` prefix (the actual root cause), and dedupe repeated old-image/tag values so duplicate references don't spuriously trigger a "no changes" error.

### Anything you want to highlight for special attention from reviewers?

`Regexp.escape` in `update_image`/`update_helm` is a defensive correctness improvement, not a fix for a demonstrated production bug — `Docker::FileParser` cannot currently emit a tag containing regex-metacharacters other than `.`, so build-metadata-style tags (e.g. `1.2.3+build.4`) never reach this code path. Extending tag parsing to support that syntax is out of scope for this fix.

### How will you know you've accomplished your goal?

`bin/test docker spec/dependabot/docker/file_updater_spec.rb` and the full `docker` ecosystem suite both pass; a regression test reproduces the original repeated-`docker.io/`-image manifest from #16234.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
