### PR TITLE
Use typed npm lockfile lookup results

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 640
+# Offense count: 629
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -307,7 +307,6 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher/path_dependency_builder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/pnpm_lock.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/berry_lockfile_handler.rb"

--- a/common/lib/dependabot/package/npm_lockfile_details.rb
+++ b/common/lib/dependabot/package/npm_lockfile_details.rb
@@ -1,0 +1,37 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/errors"
+
+module Dependabot
+  module Package
+    class NpmLockfileDetails < T::ImmutableStruct
+      extend T::Sig
+
+      const :version, T.nilable(String), default: nil
+      const :resolved, T.nilable(String), default: nil
+      const :resolution, T.nilable(String), default: nil
+
+      sig { params(value: Object, path: String, context: String).returns(NpmLockfileDetails) }
+      def self.from_object(value, path:, context:)
+        raise DependencyFileNotParseable.new(path, "#{context} must be an object") unless value.is_a?(Hash)
+
+        new(
+          version: optional_string(T.cast(value["version"], Object), path, "#{context}.version"),
+          resolved: optional_string(T.cast(value["resolved"], Object), path, "#{context}.resolved"),
+          resolution: optional_string(T.cast(value["resolution"], Object), path, "#{context}.resolution")
+        )
+      end
+
+      sig { params(value: Object, path: String, field: String).returns(T.nilable(String)) }
+      def self.optional_string(value, path, field)
+        return if value.nil?
+        return value if value.is_a?(String)
+
+        raise DependencyFileNotParseable.new(path, "#{field} must be a string or nil")
+      end
+      private_class_method :optional_string
+    end
+  end
+end

--- a/common/spec/dependabot/package/npm_lockfile_details_spec.rb
+++ b/common/spec/dependabot/package/npm_lockfile_details_spec.rb
@@ -1,0 +1,83 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/package/npm_lockfile_details"
+
+RSpec.describe Dependabot::Package::NpmLockfileDetails do
+  describe ".from_object" do
+    subject(:details) { described_class.from_object(value, path: path, context: "chalk") }
+
+    let(:path) { "nested/package-lock.json" }
+    let(:value) do
+      {
+        "version" => "1.0.0",
+        "resolved" => "https://registry.example/chalk.tgz",
+        "resolution" => "chalk@npm:1.0.0",
+        "dependencies" => ["unconsumed"]
+      }
+    end
+
+    it "exposes only the typed lookup fields" do
+      expect(details).to have_attributes(
+        version: "1.0.0",
+        resolved: "https://registry.example/chalk.tgz",
+        resolution: "chalk@npm:1.0.0"
+      )
+    end
+
+    context "with an empty entry" do
+      let(:value) { {} }
+
+      it "retains the presence of an unresolved entry" do
+        expect(details).to be_a(described_class)
+        expect(details).to have_attributes(version: nil, resolved: nil, resolution: nil)
+      end
+    end
+
+    context "with null fields" do
+      let(:value) { { "version" => nil, "resolved" => nil, "resolution" => nil } }
+
+      it "preserves them" do
+        expect(details).to have_attributes(version: nil, resolved: nil, resolution: nil)
+      end
+    end
+
+    context "with empty and non-semver strings" do
+      let(:value) { { "version" => "git+https://example/repo#ref", "resolved" => "", "resolution" => "" } }
+
+      it "does not normalize their contents" do
+        expect(details).to have_attributes(version: "git+https://example/repo#ref", resolved: "", resolution: "")
+      end
+    end
+
+    [nil, [], "invalid", false].each do |invalid_value|
+      context "with #{invalid_value.inspect} instead of an entry" do
+        let(:value) { invalid_value }
+
+        it "identifies the file and entry" do
+          expect { details }
+            .to raise_error(Dependabot::DependencyFileNotParseable, "chalk must be an object") do |error|
+              expect(error.file_path).to eq(path)
+            end
+        end
+      end
+    end
+
+    [["version", 1], ["resolved", false], ["resolution", {}]].each do |field, invalid_value|
+      context "with malformed #{field}" do
+        let(:value) { { field => invalid_value } }
+
+        it "identifies the consumed field" do
+          expect { details }
+            .to raise_error(
+              Dependabot::DependencyFileNotParseable,
+              "chalk.#{field} must be a string or nil"
+            ) do |error|
+              expect(error.file_path).to eq(path)
+            end
+        end
+      end
+    end
+  end
+end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb
@@ -5,6 +5,7 @@
 
 require "cgi/escape"
 require "dependabot/dependency"
+require "dependabot/package/npm_lockfile_details"
 require "dependabot/package/npm_package_json"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
@@ -460,7 +461,7 @@ module Dependabot
       end
 
       sig do
-        params(requirement: String, lockfile_details: T.nilable(T::Hash[String, T.untyped]))
+        params(requirement: String, lockfile_details: T.nilable(Dependabot::Package::NpmLockfileDetails))
           .returns(T.nilable(T.any(String, Integer, Gem::Version)))
       end
       def version_for(requirement, lockfile_details)
@@ -482,10 +483,10 @@ module Dependabot
         end
       end
 
-      sig { params(lockfile_details: T.nilable(T::Hash[String, T.untyped])).returns(T.nilable(String)) }
+      sig { params(lockfile_details: T.nilable(Dependabot::Package::NpmLockfileDetails)).returns(T.nilable(String)) }
       def git_revision_for(lockfile_details)
-        version = T.cast(lockfile_details&.fetch("version", nil), T.nilable(String))
-        resolved = T.cast(lockfile_details&.fetch("resolved", nil), T.nilable(String))
+        version = lockfile_details&.version
+        resolved = lockfile_details&.resolved
         [
           version&.split("#")&.last,
           resolved&.split("#")&.last,
@@ -525,11 +526,11 @@ module Dependabot
       end
 
       sig do
-        params(lockfile_details: T.nilable(T::Hash[String, T.untyped]))
+        params(lockfile_details: T.nilable(Dependabot::Package::NpmLockfileDetails))
           .returns(T.nilable(T.any(String, Integer, Gem::Version)))
       end
       def lockfile_version_for(lockfile_details)
-        semver_version_for(lockfile_details&.fetch("version", ""))
+        semver_version_for(lockfile_details&.version)
       end
 
       sig { params(version: T.nilable(String)).returns(T.nilable(T.any(String, Integer, Gem::Version))) }
@@ -548,18 +549,18 @@ module Dependabot
       end
 
       sig do
-        params(name: String, requirement: String, lockfile_details: T.nilable(T::Hash[String, T.untyped]))
+        params(name: String, requirement: String, lockfile_details: T.nilable(Dependabot::Package::NpmLockfileDetails))
           .returns(T.nilable(T::Hash[Symbol, T.untyped]))
       end
       def source_for(name, requirement, lockfile_details)
         return git_source_for(requirement) if git_url?(requirement)
         return jsr_registry_source if requirement.start_with?("jsr:")
 
-        resolved_url = lockfile_details&.fetch("resolved", nil)
+        resolved_url = lockfile_details&.resolved
 
-        resolution = lockfile_details&.fetch("resolution", nil)
-        package_match = resolution&.match(/__archiveUrl=(?<package_url>.+)/)
-        resolved_url = CGI.unescape(package_match.named_captures.fetch("package_url", "")) if package_match
+        resolution = lockfile_details&.resolution
+        package_url = resolution&.[](/__archiveUrl=(.+)/, 1)
+        resolved_url = CGI.unescape(package_url) if package_url
 
         return unless resolved_url
         return unless resolved_url.start_with?("http")

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
@@ -4,6 +4,7 @@
 require "json"
 require "dependabot/errors"
 require "dependabot/npm_and_yarn/helpers"
+require "dependabot/package/npm_lockfile_details"
 require "sorbet-runtime"
 
 module Dependabot
@@ -32,8 +33,8 @@ module Dependabot
         end
 
         sig do
-          params(dependency_name: String, _requirement: T.untyped, manifest_name: String)
-            .returns(T.nilable(T::Hash[String, T.untyped]))
+          params(dependency_name: String, _requirement: T.nilable(String), manifest_name: String)
+            .returns(T.nilable(Dependabot::Package::NpmLockfileDetails))
         end
         def details(dependency_name, _requirement, manifest_name)
           if Helpers.parse_npm8?(@dependency_file)
@@ -41,10 +42,17 @@ module Dependabot
             # workspace folder so we need to fallback to checking top-level
             nested_details = parsed.dig("packages", node_modules_path(manifest_name, dependency_name))
             details = nested_details || parsed.dig("packages", "node_modules/#{dependency_name}")
-            details&.slice("version", "resolved", "integrity", "dev")
+            details = details.slice("version", "resolved") if details.is_a?(Hash)
           else
-            parsed.dig("dependencies", dependency_name)
+            details = parsed.dig("dependencies", dependency_name)
           end
+          return if details.nil?
+
+          Dependabot::Package::NpmLockfileDetails.from_object(
+            details,
+            path: @dependency_file.path,
+            context: dependency_name
+          )
         end
 
         private

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/lockfile_parser.rb
@@ -4,6 +4,7 @@
 require "dependabot/dependency_file"
 require "dependabot/npm_and_yarn/file_parser"
 require "dependabot/npm_and_yarn/helpers"
+require "dependabot/package/npm_lockfile_details"
 require "sorbet-runtime"
 
 module Dependabot
@@ -48,10 +49,10 @@ module Dependabot
 
         sig do
           params(dependency_name: String, requirement: T.nilable(String), manifest_name: String)
-            .returns(T.nilable(T::Hash[String, T.untyped]))
+            .returns(T.nilable(Dependabot::Package::NpmLockfileDetails))
         end
         def lockfile_details(dependency_name:, requirement:, manifest_name:)
-          details = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
+          details = T.let(nil, T.nilable(Dependabot::Package::NpmLockfileDetails))
           potential_lockfiles_for_manifest(manifest_name).each do |lockfile|
             details = lockfile_for(lockfile).details(dependency_name, requirement, manifest_name)
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/pnpm_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/pnpm_lock.rb
@@ -7,6 +7,7 @@ require "dependabot/errors"
 require "dependabot/dependency"
 require "dependabot/file_parsers/base"
 require "dependabot/npm_and_yarn/native_helpers"
+require "dependabot/package/npm_lockfile_details"
 require "dependabot/shared_helpers"
 
 module Dependabot
@@ -115,18 +116,25 @@ module Dependabot
             requirement: T.nilable(String),
             _manifest_name: T.nilable(String)
           )
-            .returns(T.nilable(T::Hash[String, T.untyped]))
+            .returns(T.nilable(Dependabot::Package::NpmLockfileDetails))
         end
         def details(dependency_name, requirement, _manifest_name)
           details_candidates = parsed.select { |info| info["name"] == dependency_name }
 
           # If there's only one entry for this dependency, use it, even if
           # the requirement in the lockfile doesn't match
-          if details_candidates.one?
-            details_candidates.first
-          else
-            details_candidates.find { |info| info["specifiers"]&.include?(requirement) }
-          end
+          details = if details_candidates.one?
+                      details_candidates.first
+                    else
+                      details_candidates.find { |info| info["specifiers"]&.include?(requirement) }
+                    end
+          return if details.nil?
+
+          Dependabot::Package::NpmLockfileDetails.from_object(
+            details,
+            path: @dependency_file.path,
+            context: dependency_name
+          )
         end
 
         private

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
@@ -4,6 +4,7 @@
 require "dependabot/shared_helpers"
 require "dependabot/errors"
 require "dependabot/npm_and_yarn/native_helpers"
+require "dependabot/package/npm_lockfile_details"
 require "sorbet-runtime"
 
 module Dependabot
@@ -88,9 +89,9 @@ module Dependabot
           params(
             dependency_name: String,
             requirement: T.nilable(String),
-            _manifest_name: T.untyped
+            _manifest_name: String
           )
-            .returns(T.nilable(T::Hash[String, T.untyped]))
+            .returns(T.nilable(Dependabot::Package::NpmLockfileDetails))
         end
         def details(dependency_name, requirement, _manifest_name)
           details_candidates =
@@ -99,13 +100,20 @@ module Dependabot
 
           # If there's only one entry for this dependency, use it, even if
           # the requirement in the lockfile doesn't match
-          if details_candidates.one?
-            T.must(details_candidates.first).last
-          else
-            details_candidates.find do |k, _|
-              k.scan(/(?<=\w)\@(?:npm:)?([^\s,]+)/).flatten.include?(requirement)
-            end&.last
-          end
+          details = if details_candidates.one?
+                      T.must(details_candidates.first).last
+                    else
+                      details_candidates.find do |k, _|
+                        k.scan(/(?<=\w)\@(?:npm:)?([^\s,]+)/).flatten.include?(requirement)
+                      end&.last
+                    end
+          return if details.nil?
+
+          Dependabot::Package::NpmLockfileDetails.from_object(
+            details,
+            path: @dependency_file.path,
+            context: dependency_name
+          )
         end
 
         private

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/lockfile_parser_spec.rb
@@ -376,13 +376,53 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
     let(:requirement) { nil }
     let(:manifest_name) { "package.json" }
 
+    context "with an unresolved entry in the manifest's lockfile" do
+      let(:manifest_name) { "nested/package.json" }
+      let(:dependency_files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "package-lock.json",
+            content: { "lockfileVersion" => 1, "dependencies" => { "etag" => { "version" => "1.0.0" } } }.to_json
+          ),
+          Dependabot::DependencyFile.new(
+            name: "nested/package-lock.json",
+            content: { "lockfileVersion" => 1, "dependencies" => { "etag" => {} } }.to_json
+          )
+        ]
+      end
+
+      it "does not fall back to the root lockfile" do
+        expect(lockfile_details).to have_attributes(version: nil, resolved: nil, resolution: nil)
+      end
+    end
+
+    context "with unconsumed fields in a modern npm entry" do
+      let(:dependency_files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "package-lock.json",
+            content: {
+              "lockfileVersion" => 3,
+              "packages" => {
+                "node_modules/etag" => { "version" => "1.0.0", "resolution" => { "unconsumed" => true } }
+              }
+            }.to_json
+          )
+        ]
+      end
+
+      it "keeps npm lookup projection separate from Yarn resolution fields" do
+        expect(lockfile_details).to have_attributes(version: "1.0.0", resolved: nil, resolution: nil)
+      end
+    end
+
     context "when dealing with yarn lockfiles" do
       let(:dependency_files) { project_dependency_files("yarn/only_dev_dependencies") }
 
       it "finds the dependency" do
-        expect(lockfile_details).to eq(
-          "resolved" => "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051",
-          "version" => "1.8.0"
+        expect(lockfile_details).to have_attributes(
+          resolved: "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051",
+          version: "1.8.0"
         )
       end
 
@@ -392,11 +432,11 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:requirement) { "^2.2.1" }
 
         it "finds the one matching the requirement" do
-          expect(lockfile_details).to eq(
-            "version" => "2.2.1",
-            "resolved" => "https://registry.yarnpkg.com/ansi-styles/-/" \
-                          "ansi-styles-2.2.1.tgz#" \
-                          "b432dd3358b634cf75e1e4664368240533c1ddbe"
+          expect(lockfile_details).to have_attributes(
+            version: "2.2.1",
+            resolved: "https://registry.yarnpkg.com/ansi-styles/-/" \
+                      "ansi-styles-2.2.1.tgz#" \
+                      "b432dd3358b634cf75e1e4664368240533c1ddbe"
           )
         end
 
@@ -413,14 +453,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:requirement) { "^8.4.17" }
 
         it "finds the one matching the requirement" do
-          expect(lockfile_details).to eq(
-            "version" => "8.4.17",
-            "resolution" => "postcss@npm:8.4.17",
-            "dependencies" => { "nanoid" => "^3.3.4", "picocolors" => "^1.0.0", "source-map-js" => "^1.0.2" },
-            "checksum" => "a6d9096dd711e17f7b1d18ff5dcb4fdedf3941d5a3dc8b0e4ea" \
-                          "873b8f31972d57f73d6da9a8aed7ff389eb52190ed34f6a94f299a7f5ddc68b08a24a48f77eb9",
-            "languageName" => "node",
-            "linkType" => "hard"
+          expect(lockfile_details).to have_attributes(
+            version: "8.4.17",
+            resolution: "postcss@npm:8.4.17"
           )
         end
       end
@@ -430,12 +465,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
       let(:dependency_files) { project_dependency_files("pnpm/only_dev_dependencies") }
 
       it "finds the dependency" do
-        expect(lockfile_details).to eq(
-          "aliased" => false,
-          "dev" => true,
-          "name" => "etag",
-          "specifiers" => ["^1.0.0"],
-          "version" => "1.8.0"
+        expect(lockfile_details).to have_attributes(
+          version: "1.8.0",
+          resolved: nil
         )
       end
 
@@ -445,12 +477,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:requirement) { "^6.24.1" }
 
         it "finds the one matching the requirement" do
-          expect(lockfile_details).to eq(
-            "aliased" => false,
-            "dev" => true,
-            "name" => "babel-register",
-            "specifiers" => ["^6.24.1"],
-            "version" => "6.24.1"
+          expect(lockfile_details).to have_attributes(
+            version: "6.24.1",
+            resolved: nil
           )
         end
 
@@ -467,12 +496,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:requirement) { "^5.0.0" }
 
         it "finds the one matching the requirement" do
-          expect(lockfile_details).to eq(
-            "aliased" => false,
-            "dev" => true,
-            "name" => "@typescript-eslint/parser",
-            "specifiers" => ["^5.0.0"],
-            "version" => "5.59.0"
+          expect(lockfile_details).to have_attributes(
+            version: "5.59.0",
+            resolved: nil
           )
         end
       end
@@ -483,12 +509,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:requirement) { "^5.0.0" }
 
         it "finds the one matching the requirement" do
-          expect(lockfile_details).to eq(
-            "aliased" => false,
-            "dev" => true,
-            "name" => "@typescript-eslint/parser",
-            "specifiers" => ["^5.0.0"],
-            "version" => "5.59.0"
+          expect(lockfile_details).to have_attributes(
+            version: "5.59.0",
+            resolved: nil
           )
         end
       end
@@ -499,13 +522,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:requirement) { "^6.26.0" }
 
         it "includes the URL in the details" do
-          expect(lockfile_details).to eq(
-            "aliased" => false,
-            "dev" => true,
-            "name" => "babel-core",
-            "resolved" => "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-            "specifiers" => ["^6.26.0"],
-            "version" => "6.26.3"
+          expect(lockfile_details).to have_attributes(
+            resolved: "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+            version: "6.26.3"
           )
         end
       end
@@ -515,11 +534,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
       let(:dependency_files) { project_dependency_files("npm6/only_dev_dependencies") }
 
       it "finds the dependency" do
-        expect(lockfile_details).to eq(
-          "version" => "1.8.1",
-          "resolved" => "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-          "integrity" => "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev" => true
+        expect(lockfile_details).to have_attributes(
+          version: "1.8.1",
+          resolved: "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
         )
       end
 
@@ -527,11 +544,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:dependency_files) { project_dependency_files("npm6/irrelevant_nested_lockfile") }
 
         it "finds the correct dependency" do
-          expect(lockfile_details).to eq(
-            "version" => "1.8.1",
-            "resolved" => "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity" => "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-            "dev" => true
+          expect(lockfile_details).to have_attributes(
+            version: "1.8.1",
+            resolved: "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
           )
         end
 
@@ -539,10 +554,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
           let(:manifest_name) { "nested/package.json" }
 
           it "finds the correct dependency" do
-            expect(lockfile_details).to eq(
-              "version" => "1.8.0",
-              "resolved" => "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-              "integrity" => "sha1-Qa4u62XvpiJorr/qg6x9eSm111c="
+            expect(lockfile_details).to have_attributes(
+              version: "1.8.0",
+              resolved: "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
             )
           end
         end
@@ -553,11 +567,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
       let(:dependency_files) { project_dependency_files("npm6/shrinkwrap_only_dev_dependencies") }
 
       it "finds the dependency" do
-        expect(lockfile_details).to eq(
-          "version" => "1.8.1",
-          "resolved" => "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-          "integrity" => "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev" => true
+        expect(lockfile_details).to have_attributes(
+          version: "1.8.1",
+          resolved: "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
         )
       end
     end
@@ -569,11 +581,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:manifest_name) { "packages/build/package.json" }
 
         it "finds the correct dependency" do
-          expect(lockfile_details).to eq(
-            "version" => "16.2.0",
-            "resolved" => "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-            "integrity" =>
-              "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="
+          expect(lockfile_details).to have_attributes(
+            version: "16.2.0",
+            resolved: "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
           )
         end
       end
@@ -586,11 +596,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:manifest_name) { "api/package.json" }
 
         it "finds the correct dependency" do
-          expect(lockfile_details).to eq(
-            "version" => "8.3.2",
-            "resolved" => "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity" =>
-              "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+          expect(lockfile_details).to have_attributes(
+            version: "8.3.2",
+            resolved: "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
           )
         end
       end
@@ -602,10 +610,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
       let(:manifest_name) { "package.json" }
 
       it "finds the dependency" do
-        expect(lockfile_details).to eq(
-          "version" => "0.0.1",
-          "resolved" => "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz",
-          "integrity" => "sha1-4AdgWb2zHjFHx1s7jAQTO6jH4HE="
+        expect(lockfile_details).to have_attributes(
+          version: "0.0.1",
+          resolved: "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz"
         )
       end
     end
@@ -618,11 +625,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
           let(:manifest_name) { "packages/build/package.json" }
 
           it "finds the correct dependency" do
-            expect(lockfile_details).to eq(
-              "version" => "16.2.0",
-              "resolved" => "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-              "integrity" =>
-              "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="
+            expect(lockfile_details).to have_attributes(
+              version: "16.2.0",
+              resolved: "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
             )
           end
         end
@@ -635,11 +640,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
           let(:manifest_name) { "api/package.json" }
 
           it "finds the correct dependency" do
-            expect(lockfile_details).to eq(
-              "version" => "8.3.2",
-              "resolved" => "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-              "integrity" =>
-              "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            expect(lockfile_details).to have_attributes(
+              version: "8.3.2",
+              resolved: "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
             )
           end
         end
@@ -651,10 +654,9 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::LockfileParser do
         let(:manifest_name) { "package.json" }
 
         it "finds the dependency" do
-          expect(lockfile_details).to eq(
-            "version" => "0.0.1",
-            "resolved" => "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz",
-            "integrity" => "sha1-4AdgWb2zHjFHx1s7jAQTO6jH4HE="
+          expect(lockfile_details).to have_attributes(
+            version: "0.0.1",
+            resolved: "https://registry.npmjs.org/fetch-factory/-/fetch-factory-0.0.1.tgz"
           )
         end
       end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser_spec.rb
@@ -39,6 +39,43 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser do
 
   it_behaves_like "a dependency file parser"
 
+  describe "lockfile lookup presence" do
+    let(:locked_entries) { { "chalk" => {} } }
+    let(:files) do
+      [
+        Dependabot::DependencyFile.new(
+          name: "package.json",
+          content: { "dependencies" => { "chalk" => "1.0.0" } }.to_json
+        ),
+        Dependabot::DependencyFile.new(
+          name: "package-lock.json",
+          content: { "lockfileVersion" => 1, "dependencies" => locked_entries }.to_json
+        )
+      ]
+    end
+
+    it "does not use the manifest version for an unresolved locked entry" do
+      expect(parser.parse).to be_empty
+    end
+
+    context "without a matching locked entry" do
+      let(:locked_entries) { {} }
+
+      it "uses the exact manifest version" do
+        expect(parser.parse.first).to have_attributes(name: "chalk", version: "1.0.0")
+      end
+    end
+
+    context "with malformed lookup data" do
+      let(:locked_entries) { { "chalk" => { "version" => "1.0.0", "resolved" => false } } }
+
+      it "reports the lockfile field" do
+        expect { parser.parse }
+          .to raise_error(Dependabot::DependencyFileNotParseable, /chalk\.resolved must be a string or nil/)
+      end
+    end
+  end
+
   describe ".each_dependency compatibility" do
     it "keeps raw values and section order for updater callers" do
       json = {


### PR DESCRIPTION
### What are you trying to accomplish?

Introduce `NpmLockfileDetails` for npm, Yarn, and pnpm lookups. Consumers now use typed version and source fields instead of hashes.

### Anything you want to highlight for special attention from reviewers?

A found-but-unresolvable entry remains distinct from no entry. Malformed lookup fields raise `DependencyFileNotParseable`, while raw reader APIs remain unchanged for later stack layers.

### How will you know you've accomplished your goal?

Shared model specs (11), npm/Yarn parser suites (314), and final lookup cases (22) pass. Sorbet, RuboCop, the promotion check, and the parent-based burndown check pass.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
