### PR TITLE
Use typed npm JSON lockfile records

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 624
+# Offense count: 619
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -306,7 +306,6 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher/path_dependency_builder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/berry_lockfile_handler.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb
@@ -179,17 +179,9 @@ module Dependabot
         end
 
         known_registries = []
-        FileParser::JsonLock.new(T.must(package_lock)).parsed.fetch(
-          "dependencies",
-          {}
-        ).each do |dependency_name, details|
-          resolved = details.fetch("resolved", DEFAULT_NPM_REGISTRY)
-
-          begin
-            uri = URI.parse(resolved)
-          rescue URI::InvalidURIError
-            next
-          end
+        FileParser::JsonLock.new(T.must(package_lock)).legacy_dependencies.each do |dependency_name, details|
+          uri = details.registry_uri(DEFAULT_NPM_REGISTRY)
+          next unless uri
 
           next unless uri.scheme && uri.host
 

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock.rb
@@ -1,8 +1,9 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "json"
 require "dependabot/errors"
+require "dependabot/npm_and_yarn/file_parser"
 require "dependabot/npm_and_yarn/helpers"
 require "dependabot/package/npm_lockfile_details"
 require "sorbet-runtime"
@@ -13,16 +14,24 @@ module Dependabot
       class JsonLock
         extend T::Sig
 
+        require_relative "json_lock/record"
+
         sig { params(dependency_file: DependencyFile, dealias_packages: T::Boolean).void }
         def initialize(dependency_file, dealias_packages: false)
           @dependency_file = dependency_file
           @dealias_packages = dealias_packages
         end
 
-        sig { returns(T::Hash[String, T.untyped]) }
+        sig { returns(Record) }
         def parsed
-          json_obj = JSON.parse(T.must(@dependency_file.content))
-          @parsed ||= T.let(json_obj, T.nilable(T::Hash[String, T.untyped]))
+          @parsed ||= T.let(
+            Record.new(
+              T.cast(JSON.parse(T.must(@dependency_file.content)), Object),
+              path: @dependency_file.path,
+              context: "lockfile"
+            ),
+            T.nilable(Record)
+          )
         rescue JSON::ParserError
           raise Dependabot::DependencyFileNotParseable, @dependency_file.path
         end
@@ -32,97 +41,91 @@ module Dependabot
           recursively_fetch_dependencies(parsed)
         end
 
+        sig { returns(T::Hash[String, Record]) }
+        def legacy_dependencies
+          parsed.legacy_entries
+        end
+
         sig do
           params(dependency_name: String, _requirement: T.nilable(String), manifest_name: String)
             .returns(T.nilable(Dependabot::Package::NpmLockfileDetails))
         end
         def details(dependency_name, _requirement, manifest_name)
-          if Helpers.parse_npm8?(@dependency_file)
-            # NOTE: npm 8 sometimes doesn't install workspace dependencies in the
-            # workspace folder so we need to fallback to checking top-level
-            nested_details = parsed.dig("packages", node_modules_path(manifest_name, dependency_name))
-            details = nested_details || parsed.dig("packages", "node_modules/#{dependency_name}")
-            details = details.slice("version", "resolved") if details.is_a?(Hash)
-          else
-            details = parsed.dig("dependencies", dependency_name)
-          end
+          modern = Helpers.parse_npm8?(@dependency_file)
+          details = if modern
+                      # NOTE: npm 8 sometimes doesn't install workspace dependencies in the
+                      # workspace folder so we need to fallback to checking top-level
+                      parsed.package_entry(
+                        node_modules_path(manifest_name, dependency_name),
+                        "node_modules/#{dependency_name}"
+                      )
+                    else
+                      parsed.legacy_entry(dependency_name)
+                    end
           return if details.nil?
 
-          Dependabot::Package::NpmLockfileDetails.from_object(
-            details,
-            path: @dependency_file.path,
-            context: dependency_name
+          Dependabot::Package::NpmLockfileDetails.new(
+            version: details.version,
+            resolved: details.resolved,
+            resolution: modern ? nil : details.resolution
           )
         end
 
         private
 
         sig do
-          params(object_with_dependencies: T::Hash[String, T.untyped])
+          params(object_with_dependencies: Record)
             .returns(Dependabot::FileParsers::Base::DependencySet)
         end
         def recursively_fetch_dependencies(object_with_dependencies)
           dependency_set = Dependabot::FileParsers::Base::DependencySet.new
 
-          dependencies = object_with_dependencies["dependencies"]
-          dependencies ||= object_with_dependencies.fetch("packages", {})
-
-          dependencies.each do |name, details|
+          object_with_dependencies.dependency_entries.each do |name, details|
             next if name.empty? # v3 lockfiles include an empty key holding info of the current package
 
-            version = Version.semver_for(details["version"])
+            version = Version.semver_for(details.version)
             next unless version
 
             package_name = package_name_for(name, details)
             version = version.to_s
 
-            dependency_args = {
+            metadata = aliased_package?(name, details) ? { alias: name.split("node_modules/").last } : nil
+            subdependency_metadata = T.let(nil, T.nilable(T::Array[T::Hash[Symbol, Object]]))
+            subdependency_metadata = [{ npm_bundled: true }] if details.bundled?
+            subdependency_metadata = [{ production: false }] if details.dev?
+
+            dependency_set << Dependency.new(
               name: package_name,
               version: version,
               package_manager: "npm_and_yarn",
-              requirements: []
-            }
-
-            if aliased_package?(name, details)
-              alias_name = name.split("node_modules/").last
-              dependency_args[:metadata] = { alias: alias_name }
-            end
-
-            if details["bundled"]
-              dependency_args[:subdependency_metadata] =
-                [{ npm_bundled: details["bundled"] }]
-            end
-
-            if details["dev"]
-              dependency_args[:subdependency_metadata] =
-                [{ production: !details["dev"] }]
-            end
-
-            dependency_set << Dependency.new(**dependency_args)
+              requirements: [],
+              metadata: metadata,
+              subdependency_metadata: subdependency_metadata
+            )
             dependency_set += recursively_fetch_dependencies(details)
           end
 
           dependency_set
         end
 
-        sig { params(package_path: String, details: T::Hash[String, T.untyped]).returns(String) }
+        sig { params(package_path: String, details: Record).returns(String) }
         def package_name_for(package_path, details)
           package_name = T.must(package_path.split("node_modules/").last)
           return package_name unless dealias_packages?
 
-          real_package_name = details["name"]
-          return package_name unless real_package_name.is_a?(String)
+          real_package_name = details.name
+          return package_name if real_package_name.nil?
           return package_name if real_package_name == package_name
 
           real_package_name
         end
 
-        sig { params(package_path: String, details: T::Hash[String, T.untyped]).returns(T::Boolean) }
+        sig { params(package_path: String, details: Record).returns(T::Boolean) }
         def aliased_package?(package_path, details)
           return false unless dealias_packages?
 
-          real_package_name = details["name"]
-          return false unless real_package_name.is_a?(String)
+          real_package_name = details.name
+          return false if real_package_name.nil?
 
           package_name = T.must(package_path.split("node_modules/").last)
           real_package_name != package_name

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock/record.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/json_lock/record.rb
@@ -1,0 +1,155 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "uri"
+require "sorbet-runtime"
+require "dependabot/npm_and_yarn/file_parser/json_lock"
+
+module Dependabot
+  module NpmAndYarn
+    class FileParser < Dependabot::FileParsers::Base
+      class JsonLock
+        class Record
+          extend T::Sig
+
+          ObjectHash = T.type_alias { T::Hash[String, Object] }
+
+          sig { params(data: Object, path: String, context: String).void }
+          def initialize(data, path:, context:)
+            @data = data
+            @path = path
+            @context = context
+            @object = T.let(nil, T.nilable(ObjectHash))
+          end
+
+          sig { returns(T.nilable(String)) }
+          def version
+            optional_string("version")
+          end
+
+          sig { returns(T.nilable(String)) }
+          def name
+            optional_string("name")
+          end
+
+          sig { returns(T.nilable(String)) }
+          def resolved
+            optional_string("resolved")
+          end
+
+          sig { returns(T.nilable(String)) }
+          def resolution
+            optional_string("resolution")
+          end
+
+          sig { returns(T::Boolean) }
+          def dev?
+            boolean("dev")
+          end
+
+          sig { returns(T::Boolean) }
+          def bundled?
+            boolean("bundled")
+          end
+
+          sig { returns(T::Hash[String, Record]) }
+          def dependency_entries
+            field = object["dependencies"] ? "dependencies" : "packages"
+            context = "#{@context}.#{field}"
+            mapping = object_value(object.fetch(field, {}), context)
+
+            # Modern package records contain requirement strings rather than nested lock entries.
+            mapping.reject { |_, value| value.is_a?(String) }.to_h do |key, data|
+              [key, self.class.new(data, path: @path, context: "#{context}.#{key}")]
+            end
+          end
+
+          sig { returns(T::Hash[String, Record]) }
+          def legacy_entries
+            entries(object.fetch("dependencies", {}), "#{@context}.dependencies")
+          end
+
+          sig { params(name: String).returns(T.nilable(Record)) }
+          def legacy_entry(name)
+            dependencies = object["dependencies"]
+            return if dependencies.nil?
+
+            data = object_value(dependencies, "#{@context}.dependencies")[name]
+            self.class.new(data, path: @path, context: "dependencies.#{name}") unless data.nil?
+          end
+
+          sig { params(primary: String, fallback: String).returns(T.nilable(Record)) }
+          def package_entry(primary, fallback)
+            packages = object["packages"]
+            return if packages.nil?
+
+            mapping = object_value(packages, "#{@context}.packages")
+            key = mapping[primary] ? primary : fallback
+            data = mapping[key]
+            self.class.new(data, path: @path, context: "packages.#{key}") unless data.nil?
+          end
+
+          sig { params(default_registry: String).returns(T.nilable(URI::Generic)) }
+          def registry_uri(default_registry)
+            value = object.fetch("resolved", default_registry)
+            # Registry inference filters invalid URIs, including non-string values.
+            return unless value.is_a?(String)
+
+            URI.parse(value)
+          rescue URI::InvalidURIError
+            nil
+          end
+
+          private
+
+          sig { returns(ObjectHash) }
+          def object
+            @object ||= object_value(@data, @context)
+          end
+
+          sig { params(value: Object, context: String).returns(ObjectHash) }
+          def object_value(value, context)
+            invalid!("#{context} must be an object") unless value.is_a?(Hash)
+
+            value.to_h do |raw_key, raw_value|
+              key = T.cast(raw_key, Object)
+              invalid!("#{context} keys must be strings") unless key.is_a?(String)
+
+              [key, T.cast(raw_value, Object)]
+            end
+          end
+
+          sig { params(value: Object, context: String).returns(T::Hash[String, Record]) }
+          def entries(value, context)
+            object_value(value, context).to_h do |key, data|
+              [key, self.class.new(data, path: @path, context: "#{context}.#{key}")]
+            end
+          end
+
+          sig { params(key: String).returns(T.nilable(String)) }
+          def optional_string(key)
+            value = object[key]
+            return if value.nil?
+            return value if value.is_a?(String)
+
+            invalid!("#{@context}.#{key} must be a string or nil")
+          end
+
+          sig { params(key: String).returns(T::Boolean) }
+          def boolean(key)
+            value = object[key]
+            return false if value.nil? || value == false
+            return true if value == true
+
+            invalid!("#{@context}.#{key} must be a boolean or nil")
+          end
+
+          sig { params(message: String).returns(T.noreturn) }
+          def invalid!(message)
+            raise DependencyFileNotParseable.new(@path, message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/json_lock_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/json_lock_spec.rb
@@ -1,0 +1,198 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/npm_and_yarn/file_parser/json_lock"
+
+RSpec.describe Dependabot::NpmAndYarn::FileParser::JsonLock do
+  subject(:reader) { described_class.new(file, dealias_packages: dealias_packages) }
+
+  let(:dealias_packages) { false }
+  let(:file) { Dependabot::DependencyFile.new(name: "package-lock.json", content: content) }
+  let(:content) { data.to_json }
+  let(:entry) { { "version" => "1.0.0" } }
+  let(:data) { { "lockfileVersion" => 3, "packages" => { "node_modules/example" => entry } } }
+
+  describe "#dependencies" do
+    subject(:dependencies) { reader.dependencies.dependencies }
+
+    it "reads package records" do
+      expect(dependencies.first).to have_attributes(name: "example", version: "1.0.0")
+    end
+
+    context "with an empty legacy map" do
+      let(:data) { super().merge("dependencies" => {}) }
+
+      it "does not merge the packages table" do
+        expect(dependencies).to be_empty
+      end
+    end
+
+    [nil, false].each do |legacy|
+      context "with dependencies set to #{legacy.inspect}" do
+        let(:data) { super().merge("dependencies" => legacy) }
+
+        it "falls back to packages" do
+          expect(dependencies.map(&:name)).to eq(["example"])
+        end
+      end
+    end
+
+    context "with an ignored root and a versionless link" do
+      let(:data) do
+        {
+          "lockfileVersion" => 3,
+          "packages" => {
+            "" => false,
+            "node_modules/local" => { "link" => true, "dependencies" => "unconsumed" },
+            "node_modules/example" => entry
+          }
+        }
+      end
+
+      it "does not read fields below skipped entries" do
+        expect(dependencies.map(&:name)).to eq(["example"])
+      end
+    end
+
+    context "with an invalid version string" do
+      let(:entry) { { "version" => "not-semver", "dependencies" => "unconsumed", "dev" => "unconsumed" } }
+
+      it "skips the entry before reading metadata or children" do
+        expect(dependencies).to be_empty
+      end
+    end
+
+    context "with a nested legacy dependency" do
+      let(:data) do
+        {
+          "lockfileVersion" => 1,
+          "dependencies" => {
+            "example" => { "version" => "1.0.0", "dependencies" => { "child" => { "version" => "2.0.0" } } }
+          }
+        }
+      end
+
+      it "preserves recursion" do
+        expect(dependencies.map(&:name)).to eq(%w(example child))
+      end
+    end
+
+    context "with modern dependency requirement strings" do
+      let(:data) do
+        {
+          "lockfileVersion" => 3,
+          "packages" => {
+            "node_modules/example" => { "version" => "1.0.0", "dependencies" => { "child" => "^2.0.0" } },
+            "node_modules/child" => { "version" => "2.0.0" }
+          }
+        }
+      end
+
+      it "reads versions from package records rather than dependency specifiers" do
+        expect(dependencies.map(&:name)).to eq(%w(example child))
+      end
+    end
+
+    context "with both bundled and dev metadata" do
+      let(:entry) { super().merge("bundled" => true, "dev" => true) }
+
+      it "preserves the dev metadata override" do
+        expect(dependencies.first.subdependency_metadata).to eq([{ production: false }])
+      end
+    end
+
+    context "with bundled metadata only" do
+      let(:entry) { super().merge("bundled" => true, "dev" => false) }
+
+      it "retains the bundled flag" do
+        expect(dependencies.first.subdependency_metadata).to eq([{ npm_bundled: true }])
+      end
+    end
+
+    context "with an unconsumed malformed alias hint" do
+      let(:entry) { super().merge("name" => 1) }
+
+      it "uses the package key without dealiasing" do
+        expect(dependencies.first.name).to eq("example")
+      end
+
+      context "with dealiasing enabled" do
+        let(:dealias_packages) { true }
+
+        it "reports the consumed name field" do
+          expect { dependencies }.to raise_error(Dependabot::DependencyFileNotParseable, /name must be a string or nil/)
+        end
+      end
+    end
+
+    context "with an alias followed by a regular package" do
+      let(:dealias_packages) { true }
+      let(:data) do
+        {
+          "lockfileVersion" => 3,
+          "packages" => {
+            "node_modules/alias" => { "name" => "real", "version" => "1.0.0" },
+            "node_modules/ordinary" => { "version" => "2.0.0" }
+          }
+        }
+      end
+
+      it "does not carry alias metadata into later entries" do
+        expect(dependencies.first.metadata).to eq(alias: "alias")
+        expect(dependencies.last.metadata).to be_empty
+      end
+    end
+
+    [["version", 1], %w(dev true), ["bundled", []], ["dependencies", []]].each do |field, value|
+      context "with malformed #{field}" do
+        let(:entry) { super().merge(field => value) }
+
+        it "reports the consumed field and file" do
+          expect { dependencies }.to raise_error(Dependabot::DependencyFileNotParseable, /#{field}/) do |error|
+            expect(error.file_name).to eq("package-lock.json")
+          end
+        end
+      end
+    end
+  end
+
+  describe "#legacy_dependencies" do
+    let(:data) { { "dependencies" => { "example" => entry }, "packages" => { "ignored" => {} } } }
+
+    it "exposes typed legacy entries without including packages" do
+      expect(reader.legacy_dependencies.keys).to eq(["example"])
+      expect(reader.legacy_dependencies.fetch("example").version).to eq("1.0.0")
+    end
+
+    it "uses the registry default only for an absent resolved key" do
+      uri = reader.legacy_dependencies.fetch("example").registry_uri("https://registry.example")
+      expect(uri.to_s).to eq("https://registry.example")
+    end
+
+    [nil, false, 1, "not a URI"].each do |value|
+      context "with resolved set to #{value.inspect}" do
+        let(:entry) { super().merge("resolved" => value) }
+
+        it "preserves URI filtering without applying the missing-key default" do
+          expect(reader.legacy_dependencies.fetch("example").registry_uri("https://registry.example")).to be_nil
+        end
+      end
+    end
+  end
+
+  describe "#details" do
+    it "does not inspect unused metadata" do
+      entry["dev"] = "unconsumed"
+      entry["resolution"] = {}
+      expect(reader.details("example", nil, "package.json")).to have_attributes(version: "1.0.0", resolution: nil)
+    end
+
+    it "leaves the input file unchanged" do
+      original = file.content.dup
+      reader.dependencies
+      reader.details("example", nil, "package.json")
+      expect(file.content).to eq(original)
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Use selective typed records for npm package-lock and shrinkwrap reads, including registry inference. The JSON reader is now `strong`, with five fewer `T.untyped` annotations.

### Anything you want to highlight for special attention from reviewers?

The reader keeps legacy/packages precedence, nested dependency handling, and metadata overrides. Registry inference still uses only legacy entries and filters invalid URLs without applying the missing-key default to null values.

### How will you know you've accomplished your goal?

The final JSON reader, parser, registry, and graph cases pass (67 examples). Sorbet, RuboCop, the promotion check, and the parent-based burndown check pass.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
