### PR TITLE
Use typed Yarn lockfile records and relationships

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 619
+# Offense count: 614
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -302,11 +302,9 @@ Sorbet/ForbidTUntyped:
     - "npm_and_yarn/lib/dependabot/npm_and_yarn.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/npm_relationship_resolver.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/yarn_relationship_resolver.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_fetcher/path_dependency_builder.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser.rb"
-    - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/berry_lockfile_handler.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npm_lockfile_updater.rb"
     - "npm_and_yarn/lib/dependabot/npm_and_yarn/file_updater/npmrc_builder.rb"

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/yarn_relationship_resolver.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/dependency_grapher/yarn_relationship_resolver.rb
@@ -20,13 +20,11 @@ module Dependabot
           parsed = FileParser::YarnLock.new(@lockfile).parsed
 
           parsed.each_with_object({}) do |(req, details), rels|
-            next unless details.is_a?(Hash)
-
-            version = details["version"]
+            version = details.version
             parent_name = T.must(req.split(/(?<=\w)\@/).first)
-            children = details.fetch("dependencies", {})
+            children = details.dependencies
 
-            next if children.nil? || children.empty?
+            next if children.empty?
 
             key = "#{parent_name}@#{version}"
             resolved_children = resolve_children(children, parsed)
@@ -38,7 +36,10 @@ module Dependabot
 
         private
 
-        sig { params(children: T::Hash[String, String], parsed: T::Hash[String, T.untyped]).returns(T::Array[String]) }
+        sig do
+          params(children: T::Hash[String, String], parsed: T::Hash[String, FileParser::YarnLock::Record])
+            .returns(T::Array[String])
+        end
         def resolve_children(children, parsed)
           children.filter_map do |child_name, child_req|
             version = resolve_child_version(child_name, child_req, parsed)
@@ -46,21 +47,25 @@ module Dependabot
           end
         end
 
-        sig { params(child_name: String, child_req: String, parsed: T::Hash[String, T.untyped]).returns(T.nilable(String)) }
+        sig do
+          params(child_name: String, child_req: String, parsed: T::Hash[String, FileParser::YarnLock::Record])
+            .returns(T.nilable(String))
+        end
         def resolve_child_version(child_name, child_req, parsed)
           # Try exact key first
           child_entry = parsed["#{child_name}@#{child_req}"]
-          return child_entry["version"] if child_entry && child_entry["version"]
+          return child_entry.version if child_entry&.version
 
           # Yarn groups multiple requirements into single keys like "foo@^1.0.0, foo@^1.2.0"
           target_req = "#{child_name}@#{child_req}"
           grouped_match = parsed.find { |k, _| k.split(", ").include?(target_req) }
-          return grouped_match.last["version"] if grouped_match && grouped_match.last["version"]
+          grouped_version = grouped_match&.last&.version
+          return grouped_version if grouped_version
 
           # Fallback: find by name only if there's exactly one candidate
           candidates = parsed.select { |k, _| k.split(/(?<=\w)\@/).first == child_name }
           candidate = candidates.first
-          candidate.last["version"] if candidates.size == 1 && candidate
+          candidate.last.version if candidates.size == 1 && candidate
         end
       end
     end

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock.rb
@@ -3,6 +3,7 @@
 
 require "dependabot/shared_helpers"
 require "dependabot/errors"
+require "dependabot/npm_and_yarn/file_parser"
 require "dependabot/npm_and_yarn/native_helpers"
 require "dependabot/package/npm_lockfile_details"
 require "sorbet-runtime"
@@ -13,35 +14,36 @@ module Dependabot
       class YarnLock
         extend T::Sig
 
+        require_relative "yarn_lock/record"
+
         sig { params(dependency_file: Dependabot::DependencyFile, dealias_packages: T::Boolean).void }
         def initialize(dependency_file, dealias_packages: false)
           @dependency_file = dependency_file
           @dealias_packages = dealias_packages
+          @parsed = T.let(nil, T.nilable(T::Hash[String, Record]))
         end
 
-        sig { returns(T::Hash[String, T::Hash[String, T.untyped]]) }
+        sig { returns(T::Hash[String, Record]) }
         def parsed
-          @parsed ||= T.let(
-            T.cast(
-              SharedHelpers.in_a_temporary_directory do
-                File.write("yarn.lock", @dependency_file.content)
+          return @parsed if @parsed
 
-                SharedHelpers.run_helper_subprocess(
-                  command: NativeHelpers.helper_path,
-                  function: "yarn:parseLockfile",
-                  args: [Dir.pwd]
-                )
-              rescue SharedHelpers::HelperSubprocessFailed => e
-                raise Dependabot::OutOfDisk, e.message if e.message.end_with?("No space left on device")
-                raise Dependabot::OutOfDisk, e.message if e.message.end_with?("Out of diskspace")
-                raise Dependabot::OutOfMemory, e.message if e.message.end_with?("MemoryError")
+          result = SharedHelpers.in_a_temporary_directory do
+            File.write("yarn.lock", @dependency_file.content)
 
-                raise Dependabot::DependencyFileNotParseable, @dependency_file.path
-              end,
-              T::Hash[String, T::Hash[String, T.untyped]]
-            ),
-            T.nilable(T::Hash[String, T::Hash[String, T.untyped]])
-          )
+            SharedHelpers.run_helper_subprocess(
+              command: NativeHelpers.helper_path,
+              function: "yarn:parseLockfile",
+              args: [Dir.pwd]
+            )
+          rescue SharedHelpers::HelperSubprocessFailed => e
+            raise Dependabot::OutOfDisk, e.message if e.message.end_with?("No space left on device")
+            raise Dependabot::OutOfDisk, e.message if e.message.end_with?("Out of diskspace")
+            raise Dependabot::OutOfMemory, e.message if e.message.end_with?("MemoryError")
+
+            raise Dependabot::DependencyFileNotParseable, @dependency_file.path
+          end
+
+          @parsed = parse_records(result)
         end
 
         sig { returns(Dependabot::FileParsers::Base::DependencySet) }
@@ -50,10 +52,11 @@ module Dependabot
 
           parsed.each do |reqs, details|
             reqs.split(", ").each do |req|
-              version = Version.semver_for(details["version"])
-              next unless version
               next if workspace_package?(req)
               next if req == "__metadata"
+
+              version = Version.semver_for(details.version)
+              next unless version
 
               if alias_package?(req)
                 # Skip unless we are dealiasing packages
@@ -109,14 +112,33 @@ module Dependabot
                     end
           return if details.nil?
 
-          Dependabot::Package::NpmLockfileDetails.from_object(
-            details,
-            path: @dependency_file.path,
-            context: dependency_name
-          )
+          details.lookup_details
         end
 
         private
+
+        sig { params(value: Object).returns(T::Hash[String, Record]) }
+        def parse_records(value)
+          unless value.is_a?(Hash)
+            raise DependencyFileNotParseable.new(@dependency_file.path, "yarn helper result must be an object")
+          end
+
+          records = T.let({}, T::Hash[String, Record])
+          value.each_with_index do |(raw_key, data), index|
+            key = T.cast(raw_key, Object)
+            unless key.is_a?(String)
+              raise DependencyFileNotParseable.new(@dependency_file.path, "yarn helper descriptors must be strings")
+            end
+            next if key == "__metadata"
+
+            records[key] = Record.new(
+              T.cast(data, Object),
+              path: @dependency_file.path,
+              context: "yarn helper result[#{index}]"
+            )
+          end
+          records
+        end
 
         sig { returns(T::Boolean) }
         def dealias_packages?

--- a/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock/record.rb
+++ b/npm_and_yarn/lib/dependabot/npm_and_yarn/file_parser/yarn_lock/record.rb
@@ -1,0 +1,79 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/npm_and_yarn/file_parser/yarn_lock"
+
+module Dependabot
+  module NpmAndYarn
+    class FileParser < Dependabot::FileParsers::Base
+      class YarnLock
+        class Record
+          extend T::Sig
+
+          ObjectHash = T.type_alias { T::Hash[String, Object] }
+
+          sig { params(data: Object, path: String, context: String).void }
+          def initialize(data, path:, context:)
+            @data = data
+            @path = path
+            @context = context
+            @object = T.let(nil, T.nilable(ObjectHash))
+          end
+
+          sig { returns(T.nilable(String)) }
+          def version
+            value = object["version"]
+            return if value.nil?
+            return value if value.is_a?(String)
+
+            invalid!("#{@context}.version must be a string or nil")
+          end
+
+          sig { returns(Dependabot::Package::NpmLockfileDetails) }
+          def lookup_details
+            Dependabot::Package::NpmLockfileDetails.from_object(object, path: @path, context: @context)
+          end
+
+          sig { returns(T::Hash[String, String]) }
+          def dependencies
+            value = object["dependencies"]
+            return {} if value.nil?
+
+            invalid!("#{@context}.dependencies must be an object") unless value.is_a?(Hash)
+            value.to_h do |raw_name, raw_requirement|
+              name = T.cast(raw_name, Object)
+              requirement = T.cast(raw_requirement, Object)
+              invalid!("#{@context}.dependencies keys must be strings") unless name.is_a?(String)
+              invalid!("#{@context}.dependencies.#{name} must be a string") unless requirement.is_a?(String)
+
+              [name, requirement]
+            end
+          end
+
+          private
+
+          sig { returns(ObjectHash) }
+          def object
+            return @object if @object
+
+            data = @data
+            invalid!("#{@context} must be an object") unless data.is_a?(Hash)
+
+            @object = data.to_h do |raw_key, raw_value|
+              key = T.cast(raw_key, Object)
+              invalid!("#{@context} keys must be strings") unless key.is_a?(String)
+
+              [key, T.cast(raw_value, Object)]
+            end
+          end
+
+          sig { params(message: String).returns(T.noreturn) }
+          def invalid!(message)
+            raise DependencyFileNotParseable.new(@path, message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher/yarn_relationship_resolver_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/dependency_grapher/yarn_relationship_resolver_spec.rb
@@ -1,0 +1,66 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/npm_and_yarn/dependency_grapher"
+require "dependabot/npm_and_yarn/dependency_grapher/yarn_relationship_resolver"
+
+RSpec.describe Dependabot::NpmAndYarn::DependencyGrapher::YarnRelationshipResolver do
+  subject(:relationships) { described_class.new(lockfile).relationships }
+
+  let(:lockfile) { Dependabot::DependencyFile.new(name: "yarn.lock", content: "unused helper input") }
+  let(:result) do
+    {
+      "__metadata" => { "version" => 8 },
+      "parent@^1" => {
+        "version" => "1.0.0",
+        "dependencies" => { "exact" => "^1", "grouped" => "^2", "sole" => "^9", "ambiguous" => "^9" }
+      },
+      "exact@^1" => { "version" => "1.1.0" },
+      "exact@^2" => { "version" => "2.0.0" },
+      "grouped@^1, grouped@^2" => { "version" => "2.1.0" },
+      "sole@^1" => { "version" => "1.2.0" },
+      "ambiguous@^1" => { "version" => "1.0.0" },
+      "ambiguous@^2" => { "version" => "2.0.0" }
+    }
+  end
+
+  before do
+    allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+      .with(hash_including(function: "yarn:parseLockfile")).and_return(result)
+  end
+
+  it "preserves exact, grouped, and sole-name resolution order" do
+    expect(relationships).to eq("parent@1.0.0" => %w(exact@1.1.0 grouped@2.1.0 sole@1.2.0))
+  end
+
+  context "with workspace parents" do
+    let(:result) do
+      super().merge("local@workspace:." => { "version" => "0.0.0-use.local", "dependencies" => { "exact" => "^1" } })
+    end
+
+    it "retains workspace relationship data" do
+      expect(relationships.fetch("local@0.0.0-use.local")).to eq(["exact@1.1.0"])
+    end
+  end
+
+  context "with duplicate parents" do
+    let(:result) do
+      super().merge(
+        "parent@~1.0.0" => { "version" => "1.0.0", "dependencies" => { "exact" => "^1", "grouped" => "^1" } }
+      )
+    end
+
+    it "merges and deduplicates their resolved children" do
+      expect(relationships.fetch("parent@1.0.0")).to eq(%w(exact@1.1.0 grouped@2.1.0 sole@1.2.0))
+    end
+  end
+
+  context "with null child data" do
+    let(:result) { { "parent@^1" => { "version" => "1.0.0", "dependencies" => nil } } }
+
+    it "preserves the empty-child skip" do
+      expect(relationships).to be_empty
+    end
+  end
+end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/yarn_lock_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/yarn_lock_spec.rb
@@ -84,23 +84,23 @@ RSpec.describe Dependabot::NpmAndYarn::FileParser::YarnLock do
           .to raise_error(Dependabot::DependencyFileNotParseable, /yarn helper result must be an object/)
       end
     end
+  end
 
-    [
-      ["No space left on device", Dependabot::OutOfDisk],
-      ["Out of diskspace", Dependabot::OutOfDisk],
-      ["MemoryError", Dependabot::OutOfMemory],
-      ["invalid lockfile", Dependabot::DependencyFileNotParseable]
-    ].each do |message, error_class|
-      context "when the helper reports #{message}" do
-        before do
-          error = Dependabot::SharedHelpers::HelperSubprocessFailed.new(message: message, error_context: {})
-          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
-            .with(hash_including(function: "yarn:parseLockfile")).and_raise(error)
-        end
+  [
+    ["No space left on device", Dependabot::OutOfDisk],
+    ["Out of diskspace", Dependabot::OutOfDisk],
+    ["MemoryError", Dependabot::OutOfMemory],
+    ["invalid lockfile", Dependabot::DependencyFileNotParseable]
+  ].each do |message, error_class|
+    context "when the helper reports #{message}" do
+      before do
+        error = Dependabot::SharedHelpers::HelperSubprocessFailed.new(message: message, error_context: {})
+        allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+          .with(hash_including(function: "yarn:parseLockfile")).and_raise(error)
+      end
 
-        it "retains the existing error category" do
-          expect { reader.parsed }.to raise_error(error_class)
-        end
+      it "retains the existing error category" do
+        expect { reader.parsed }.to raise_error(error_class)
       end
     end
   end

--- a/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/yarn_lock_spec.rb
+++ b/npm_and_yarn/spec/dependabot/npm_and_yarn/file_parser/yarn_lock_spec.rb
@@ -1,0 +1,107 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/npm_and_yarn/file_parser/yarn_lock"
+
+RSpec.describe Dependabot::NpmAndYarn::FileParser::YarnLock do
+  subject(:reader) { described_class.new(file) }
+
+  let(:file) { Dependabot::DependencyFile.new(name: "yarn.lock", content: "unused helper input") }
+  let(:entry) { { "version" => "1.2.0", "resolution" => "example@npm:1.2.0" } }
+  let(:result) { { "__metadata" => { "version" => 8 }, "example@^1.0.0, example@~1.2.0" => entry } }
+
+  before do
+    allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+      .with(hash_including(function: "yarn:parseLockfile")).and_return(result)
+  end
+
+  it "returns descriptor-keyed records without decoding control metadata" do
+    expect(reader.parsed.keys).to eq(["example@^1.0.0, example@~1.2.0"])
+    expect(reader.parsed.values.first.version).to eq("1.2.0")
+  end
+
+  it "preserves the sole-candidate lookup fallback" do
+    expect(reader.details("example", "^9.0.0", "package.json"))
+      .to have_attributes(version: "1.2.0", resolution: "example@npm:1.2.0")
+  end
+
+  context "with unconsumed malformed dependency data" do
+    let(:entry) { super().merge("dependencies" => []) }
+
+    it "does not read child requirements during dependency enumeration or lookup" do
+      expect(reader.dependencies.dependencies.map(&:name)).to eq(["example"])
+      expect(reader.details("example", nil, "package.json").version).to eq("1.2.0")
+    end
+
+    it "reports the field when relationship data is requested" do
+      expect { reader.parsed.values.first.dependencies }
+        .to raise_error(Dependabot::DependencyFileNotParseable, /dependencies must be an object/)
+    end
+  end
+
+  context "with workspace descriptors" do
+    let(:result) { super().merge("local@workspace:." => { "version" => "0.0.0-use.local", "dependencies" => {} }) }
+
+    it "keeps workspace records available to graph readers" do
+      expect(reader.parsed.keys).to include("local@workspace:.")
+      expect(reader.dependencies.dependencies.map(&:name)).to eq(["example"])
+    end
+  end
+
+  context "with malformed unused workspace fields" do
+    let(:result) { { "local@workspace:." => { "version" => [], "dependencies" => false } } }
+
+    it "skips workspace entries before consuming their fields" do
+      expect(reader.dependencies.dependencies).to be_empty
+    end
+  end
+
+  context "with a malformed version" do
+    let(:entry) { super().merge("version" => 1) }
+
+    it "reports the consumed field" do
+      expect { reader.dependencies }
+        .to raise_error(Dependabot::DependencyFileNotParseable, /version must be a string or nil/)
+    end
+  end
+
+  context "with malformed child requirements" do
+    let(:entry) { super().merge("dependencies" => { "child" => 1 }) }
+
+    it "reports the child requirement type" do
+      expect { reader.parsed.values.first.dependencies }
+        .to raise_error(Dependabot::DependencyFileNotParseable, /dependencies.*child.*must be a string/)
+    end
+  end
+
+  [nil, [], "invalid"].each do |value|
+    context "with #{value.inspect} as the helper result" do
+      let(:result) { value }
+
+      it "reports the malformed root" do
+        expect { reader.parsed }
+          .to raise_error(Dependabot::DependencyFileNotParseable, /yarn helper result must be an object/)
+      end
+    end
+
+    [
+      ["No space left on device", Dependabot::OutOfDisk],
+      ["Out of diskspace", Dependabot::OutOfDisk],
+      ["MemoryError", Dependabot::OutOfMemory],
+      ["invalid lockfile", Dependabot::DependencyFileNotParseable]
+    ].each do |message, error_class|
+      context "when the helper reports #{message}" do
+        before do
+          error = Dependabot::SharedHelpers::HelperSubprocessFailed.new(message: message, error_context: {})
+          allow(Dependabot::SharedHelpers).to receive(:run_helper_subprocess)
+            .with(hash_including(function: "yarn:parseLockfile")).and_raise(error)
+        end
+
+        it "retains the existing error category" do
+          expect { reader.parsed }.to raise_error(error_class)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Use typed Yarn records for dependency lookup and relationship resolution. This removes five `T.untyped` annotations without changing the helper protocol.

### Anything you want to highlight for special attention from reviewers?

Control metadata is excluded, while workspace records remain available to graph readers. Grouped descriptors, child-resolution order, aliases, and disk/memory error categories stay unchanged.

### How will you know you've accomplished your goal?

The combined Yarn cases pass (138 examples), followed by 19 reader and resolver cases after the final changes. Sorbet, RuboCop, the promotion check, and the parent-based burndown check pass.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
