### PR TITLE
Use typed Bun lockfile records and graph reads

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,15 +239,13 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 614
+# Offense count: 602
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
     - "bun/lib/dependabot/bun/file_fetcher.rb"
     - "bun/lib/dependabot/bun/file_fetcher/path_dependency_builder.rb"
     - "bun/lib/dependabot/bun/file_parser.rb"
-    - "bun/lib/dependabot/bun/file_parser/bun_lock.rb"
-    - "bun/lib/dependabot/bun/file_parser/lockfile_parser.rb"
     - "bun/lib/dependabot/bun/metadata_finder.rb"
     - "bun/lib/dependabot/bun/package/registry_finder.rb"
     - "bun/lib/dependabot/bun/registry_helper.rb"

--- a/bun/lib/dependabot/bun/dependency_grapher.rb
+++ b/bun/lib/dependabot/bun/dependency_grapher.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "sorbet-runtime"
@@ -110,17 +110,15 @@ module Dependabot
       def fetch_package_relationships
         return {} unless lockfile
 
-        parsed_lockfile = FileParser::BunLock.new(T.must(lockfile)).parsed
-        packages = parsed_lockfile.fetch("packages", nil)
-        return {} unless packages.is_a?(Hash)
+        packages = FileParser::BunLock.new(T.must(lockfile)).records
+        return {} unless packages
 
-        # bun.lock entries are arrays: ["{name}@{version}", registry, {details}, integrity]
-        packages.each_with_object({}) do |(_key, entry), rels|
-          next unless entry.is_a?(Array) && entry.first.is_a?(String)
+        packages.each_with_object({}) do |(_key, record), rels|
+          next unless record.graph_compatible?
 
-          parent_name = T.must(T.cast(entry.first, String).split(/(?<=\w)\@/).first)
-          children = entry.dig(2, "dependencies")&.keys
-          next unless children&.any?
+          parent_name = record.name
+          children = record.dependency_names
+          next if children.empty?
 
           rels[parent_name] = children
         end

--- a/bun/lib/dependabot/bun/file_parser.rb
+++ b/bun/lib/dependabot/bun/file_parser.rb
@@ -5,6 +5,7 @@
 
 require "cgi/escape"
 require "dependabot/dependency"
+require "dependabot/package/npm_lockfile_details"
 require "dependabot/package/npm_package_json"
 require "dependabot/file_parsers"
 require "dependabot/file_parsers/base"
@@ -309,7 +310,7 @@ module Dependabot
       end
 
       sig do
-        params(requirement: String, lockfile_details: T.nilable(T::Hash[String, T.untyped]))
+        params(requirement: String, lockfile_details: T.nilable(Dependabot::Package::NpmLockfileDetails))
           .returns(T.nilable(T.any(String, Integer, Gem::Version)))
       end
       def version_for(requirement, lockfile_details)
@@ -331,10 +332,10 @@ module Dependabot
         end
       end
 
-      sig { params(lockfile_details: T.nilable(T::Hash[String, T.untyped])).returns(T.nilable(String)) }
+      sig { params(lockfile_details: T.nilable(Dependabot::Package::NpmLockfileDetails)).returns(T.nilable(String)) }
       def git_revision_for(lockfile_details)
-        version = T.cast(lockfile_details&.fetch("version", nil), T.nilable(String))
-        resolved = T.cast(lockfile_details&.fetch("resolved", nil), T.nilable(String))
+        version = lockfile_details&.version
+        resolved = lockfile_details&.resolved
         [
           version&.split("#")&.last,
           resolved&.split("#")&.last,
@@ -374,11 +375,11 @@ module Dependabot
       end
 
       sig do
-        params(lockfile_details: T.nilable(T::Hash[String, T.untyped]))
+        params(lockfile_details: T.nilable(Dependabot::Package::NpmLockfileDetails))
           .returns(T.nilable(T.any(String, Integer, Gem::Version)))
       end
       def lockfile_version_for(lockfile_details)
-        semver_version_for(lockfile_details&.fetch("version", ""))
+        semver_version_for(lockfile_details&.version)
       end
 
       sig { params(version: T.nilable(String)).returns(T.nilable(T.any(String, Integer, Gem::Version))) }
@@ -397,17 +398,17 @@ module Dependabot
       end
 
       sig do
-        params(name: String, requirement: String, lockfile_details: T.nilable(T::Hash[String, T.untyped]))
+        params(name: String, requirement: String, lockfile_details: T.nilable(Dependabot::Package::NpmLockfileDetails))
           .returns(T.nilable(T::Hash[Symbol, T.untyped]))
       end
       def source_for(name, requirement, lockfile_details)
         return git_source_for(requirement) if git_url?(requirement)
 
-        resolved_url = lockfile_details&.fetch("resolved", nil)
+        resolved_url = lockfile_details&.resolved
 
-        resolution = lockfile_details&.fetch("resolution", nil)
-        package_match = resolution&.match(/__archiveUrl=(?<package_url>.+)/)
-        resolved_url = CGI.unescape(package_match.named_captures.fetch("package_url", "")) if package_match
+        resolution = lockfile_details&.resolution
+        package_url = resolution&.[](/__archiveUrl=(.+)/, 1)
+        resolved_url = CGI.unescape(package_url) if package_url
 
         return unless resolved_url
         return unless resolved_url.start_with?("http")

--- a/bun/lib/dependabot/bun/file_parser/bun_lock.rb
+++ b/bun/lib/dependabot/bun/file_parser/bun_lock.rb
@@ -1,8 +1,9 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 require "yaml"
 require "dependabot/errors"
+require "dependabot/bun/file_parser"
 require "dependabot/bun/bun_package_manager"
 require "dependabot/bun/helpers"
 require "sorbet-runtime"
@@ -13,22 +14,19 @@ module Dependabot
       class BunLock
         extend T::Sig
 
+        require_relative "bun_lock/record"
+
         sig { params(dependency_file: DependencyFile).void }
         def initialize(dependency_file)
           @dependency_file = dependency_file
+          @parsed = T.let(nil, T.nilable(T::Hash[Object, Object]))
+          @records = T.let(nil, T.nilable(T::Hash[String, Record]))
         end
 
-        sig { returns(T::Hash[String, T.untyped]) }
+        sig { returns(T::Hash[Object, Object]) }
         def parsed
           @parsed ||= begin
-            content = begin
-              # Since bun.lock is a JSONC file, which is a subset of YAML, we can use YAML to parse it
-              YAML.load(T.must(@dependency_file.content))
-            rescue Psych::SyntaxError => e
-              raise_invalid!("malformed JSONC at line #{e.line}, column #{e.column}")
-            end
-            raise_invalid!("expected to be an object") unless content.is_a?(Hash)
-
+            content = parse_document
             version = content["lockfileVersion"]
             raise_invalid!("expected 'lockfileVersion' to be an integer") unless version.is_a?(Integer)
             raise_invalid!("expected 'lockfileVersion' to be >= 0") unless version >= 0
@@ -45,7 +43,23 @@ module Dependabot
               end
             end
 
-            T.let(content, T.untyped)
+            content
+          end
+        end
+        private :parsed
+
+        sig { returns(T.nilable(T::Hash[String, Record])) }
+        def records
+          return @records if @records
+
+          packages = parsed["packages"]
+          return unless packages.is_a?(Hash)
+
+          @records = packages.to_h do |raw_key, value|
+            key = T.cast(raw_key, Object)
+            raise_invalid!("expected package keys to be strings") unless key.is_a?(String)
+
+            [key, Record.new(T.cast(value, Object), path: @dependency_file.path, context: "packages.#{key}")]
           end
         end
 
@@ -56,24 +70,19 @@ module Dependabot
           # bun.lock v0 format:
           # https://github.com/oven-sh/bun/blob/c130df6c589fdf28f9f3c7f23ed9901140bc9349/src/install/bun.lock.zig#L595-L605
 
-          packages = parsed["packages"]
-          raise_invalid!("expected 'packages' to be an object") unless packages.is_a?(Hash)
+          packages = records
+          raise_invalid!("expected 'packages' to be an object") unless packages
 
-          packages.each do |key, details|
-            raise_invalid!("expected 'packages.#{key}' to be an array") unless details.is_a?(Array)
-
-            resolution = details.first
-            raise_invalid!("expected 'packages.#{key}[0]' to be a string") unless resolution.is_a?(String)
-
-            name, version = resolution.split(/(?<=\w)\@/)
+          packages.each_value do |record|
+            name = record.name
             next if name.empty?
 
-            semver = Version.semver_for(version)
+            semver = record.version
             next unless semver
 
             dependency_set << Dependency.new(
               name: name,
-              version: semver.to_s,
+              version: semver,
               package_manager: "bun",
               requirements: []
             )
@@ -83,33 +92,27 @@ module Dependabot
         end
 
         sig do
-          params(dependency_name: String, requirement: T.untyped, _manifest_name: String)
-            .returns(T.nilable(T::Hash[String, T.untyped]))
+          params(dependency_name: String, _requirement: T.nilable(String), _manifest_name: String)
+            .returns(T.nilable(Dependabot::Package::NpmLockfileDetails))
         end
-        def details(dependency_name, requirement, _manifest_name)
-          packages = parsed["packages"]
-          return unless packages.is_a?(Hash)
-
-          candidates =
-            packages
-            .select { |name, _| name == dependency_name }
-            .values
-
-          # If there's only one entry for this dependency, use it, even if
-          # the requirement in the lockfile doesn't match
-          if candidates.one?
-            parse_details(candidates.first)
-          else
-            candidate = candidates.find do |label, _|
-              label.scan(/(?<=\w)\@(?:npm:)?([^\s,]+)/).flatten.include?(requirement)
-            end&.last
-            parse_details(candidate)
-          end
+        def details(dependency_name, _requirement, _manifest_name)
+          records&.[](dependency_name)&.lookup_details
         end
 
         private
 
-        sig { params(message: String).void }
+        sig { returns(T::Hash[Object, Object]) }
+        def parse_document
+          # Since bun.lock is a JSONC file, which is a subset of YAML, we can use YAML to parse it
+          content = T.cast(YAML.load(T.must(@dependency_file.content)), Object)
+          raise_invalid!("expected to be an object") unless content.is_a?(Hash)
+
+          content.to_h { |key, value| [T.cast(key, Object), T.cast(value, Object)] }
+        rescue Psych::SyntaxError => e
+          raise_invalid!("malformed JSONC at line #{e.line}, column #{e.column}")
+        end
+
+        sig { params(message: String).returns(T.noreturn) }
         def raise_invalid!(message)
           raise Dependabot::DependencyFileNotParseable.new(@dependency_file.path, "Invalid bun.lock file: #{message}")
         end
@@ -123,40 +126,6 @@ module Dependabot
                 "Unsupported bun.lock 'lockfileVersion' #{version} in #{@dependency_file.path}. " \
                 "The bun version Dependabot runs supports up to " \
                 "#{BunPackageManager::MAX_SUPPORTED_LOCKFILE_VERSION}."
-        end
-
-        sig do
-          params(entry: T.nilable(T::Array[T.untyped])).returns(T.nilable(T::Hash[String, T.untyped]))
-        end
-        def parse_details(entry)
-          return unless entry.is_a?(Array)
-
-          # Either:
-          # - "{name}@{version}", registry, details, integrity
-          # - "{name}@{resolution}", details
-          resolution = entry.first
-          return unless resolution.is_a?(String)
-
-          name, version = resolution.split(/(?<=\w)\@/)
-          semver = Version.semver_for(version)
-
-          if semver
-            registry, details, integrity = entry[1..3]
-            {
-              "name" => name,
-              "version" => semver.to_s,
-              "registry" => registry,
-              "details" => details,
-              "integrity" => integrity
-            }
-          else
-            details = entry[1]
-            {
-              "name" => name,
-              "resolution" => version,
-              "details" => details
-            }
-          end
         end
       end
     end

--- a/bun/lib/dependabot/bun/file_parser/bun_lock/record.rb
+++ b/bun/lib/dependabot/bun/file_parser/bun_lock/record.rb
@@ -1,0 +1,101 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/bun/file_parser/bun_lock"
+require "dependabot/package/npm_lockfile_details"
+
+module Dependabot
+  module Bun
+    class FileParser < Dependabot::FileParsers::Base
+      class BunLock
+        class Record
+          extend T::Sig
+
+          sig { params(data: Object, path: String, context: String).void }
+          def initialize(data, path:, context:)
+            @data = data
+            @path = path
+            @context = context
+            @entry = T.let(nil, T.nilable(T::Array[Object]))
+          end
+
+          sig { returns(T::Boolean) }
+          def graph_compatible?
+            data = @data
+            data.is_a?(Array) && T.cast(data.first, Object).is_a?(String)
+          end
+
+          sig { returns(String) }
+          def name
+            name = resolution_label.split(/(?<=\w)\@/).first
+            invalid!("#{@context}[0] must contain a package name") unless name
+
+            name
+          end
+
+          sig { returns(T.nilable(String)) }
+          def version
+            Version.semver_for(package_resolution)&.to_s
+          end
+
+          sig { returns(Dependabot::Package::NpmLockfileDetails) }
+          def lookup_details
+            semver = version
+            Dependabot::Package::NpmLockfileDetails.new(
+              version: semver,
+              resolution: semver ? nil : package_resolution
+            )
+          end
+
+          sig { returns(T::Array[String]) }
+          def dependency_names
+            details = entry[2]
+            return [] if details.nil?
+
+            invalid!("#{@context} details must be an object") unless details.is_a?(Hash)
+            dependencies = T.cast(details["dependencies"], Object)
+            return [] if dependencies.nil?
+
+            invalid!("#{@context}.dependencies must be an object") unless dependencies.is_a?(Hash)
+            dependencies.keys.map do |raw_name|
+              child = T.cast(raw_name, Object)
+              invalid!("#{@context}.dependencies keys must be strings") unless child.is_a?(String)
+
+              child
+            end
+          end
+
+          private
+
+          sig { returns(T::Array[Object]) }
+          def entry
+            return @entry if @entry
+
+            data = @data
+            invalid!("#{@context} must be an array") unless data.is_a?(Array)
+            @entry = data.map { |value| T.cast(value, Object) }
+          end
+
+          sig { returns(String) }
+          def resolution_label
+            label = entry.first
+            invalid!("#{@context}[0] must be a string") unless label.is_a?(String)
+
+            label
+          end
+
+          sig { returns(T.nilable(String)) }
+          def package_resolution
+            resolution_label.split(/(?<=\w)\@/)[1]
+          end
+
+          sig { params(message: String).returns(T.noreturn) }
+          def invalid!(message)
+            raise DependencyFileNotParseable.new(@path, "Invalid bun.lock file: #{message}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/bun/lib/dependabot/bun/file_parser/lockfile_parser.rb
+++ b/bun/lib/dependabot/bun/file_parser/lockfile_parser.rb
@@ -4,6 +4,7 @@
 require "dependabot/dependency_file"
 require "dependabot/bun/file_parser"
 require "dependabot/bun/helpers"
+require "dependabot/package/npm_lockfile_details"
 require "sorbet-runtime"
 
 module Dependabot
@@ -45,10 +46,10 @@ module Dependabot
 
         sig do
           params(dependency_name: String, requirement: T.nilable(String), manifest_name: String)
-            .returns(T.nilable(T::Hash[String, T.untyped]))
+            .returns(T.nilable(Dependabot::Package::NpmLockfileDetails))
         end
         def lockfile_details(dependency_name:, requirement:, manifest_name:)
-          details = T.let(nil, T.nilable(T::Hash[String, T.untyped]))
+          details = T.let(nil, T.nilable(Dependabot::Package::NpmLockfileDetails))
           potential_lockfiles_for_manifest(manifest_name).each do |lockfile|
             details = lockfile_for(lockfile).details(dependency_name, requirement, manifest_name)
 

--- a/bun/spec/dependabot/bun/file_parser/bun_lock_spec.rb
+++ b/bun/spec/dependabot/bun/file_parser/bun_lock_spec.rb
@@ -1,0 +1,107 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/bun/file_parser/bun_lock"
+
+RSpec.describe Dependabot::Bun::FileParser::BunLock do
+  subject(:reader) { described_class.new(file) }
+
+  let(:file) { Dependabot::DependencyFile.new(name: "bun.lock", content: data.to_json) }
+  let(:entry) { ["example@1.2.0", "https://registry.example", { "dependencies" => { "child" => "^1" } }, "integrity"] }
+  let(:data) { { "lockfileVersion" => 0, "packages" => { "example" => entry } } }
+
+  it "exposes typed package records" do
+    record = reader.records.fetch("example")
+    expect(record).to have_attributes(name: "example", version: "1.2.0", dependency_names: ["child"])
+  end
+
+  it "does not reinterpret the registry field as a resolved URL" do
+    expect(reader.details("example", "^9", "package.json"))
+      .to have_attributes(version: "1.2.0", resolved: nil, resolution: nil)
+  end
+
+  it "returns no details for a missing package key" do
+    expect(reader.details("missing", nil, "package.json")).to be_nil
+  end
+
+  context "with a nested package key" do
+    let(:data) { { "lockfileVersion" => 1, "packages" => { "parent/example" => entry } } }
+
+    it "keeps lookup keys separate from names" do
+      expect(reader.details("example", nil, "package.json")).to be_nil
+      expect(reader.details("parent/example", nil, "package.json").version).to eq("1.2.0")
+      expect(reader.dependencies.dependencies.first.name).to eq("example")
+    end
+  end
+
+  context "with a non-registry tuple" do
+    let(:entry) { ["example@file:../local", { "dependencies" => { "hidden" => "1" } }] }
+
+    it "preserves the resolution without inventing a version or URL" do
+      expect(reader.details("example", nil, "package.json"))
+        .to have_attributes(version: nil, resolved: nil, resolution: "file:../local")
+    end
+
+    it "does not add graph edges from slot-one details" do
+      expect(reader.records.fetch("example").dependency_names).to be_empty
+      expect(reader.dependencies.dependencies).to be_empty
+    end
+  end
+
+  context "with unused tuple fields" do
+    let(:entry) { ["example@1.2.0", [], "unconsumed", false] }
+
+    it "does not decode them for dependency or version lookup" do
+      expect(reader.dependencies.dependencies.first.version).to eq("1.2.0")
+      expect(reader.details("example", nil, "package.json").version).to eq("1.2.0")
+    end
+
+    it "reports malformed details only when graph data is requested" do
+      expect { reader.records.fetch("example").dependency_names }
+        .to raise_error(Dependabot::DependencyFileNotParseable, /packages.*example.*details must be an object/)
+    end
+  end
+
+  context "with unconsumed dependency requirement values" do
+    let(:entry) { ["example@1.2.0", "", { "dependencies" => { "child" => [], "second" => nil } }] }
+
+    it "preserves child names without parsing unused ranges" do
+      expect(reader.records.fetch("example").dependency_names).to eq(%w(child second))
+    end
+  end
+
+  [nil, "invalid", [1], []].each do |value|
+    context "with #{value.inspect} as a package tuple" do
+      let(:entry) { value }
+
+      it "reports malformed data for dependency parsing" do
+        expect { reader.dependencies }.to raise_error(Dependabot::DependencyFileNotParseable)
+      end
+
+      it "preserves the graph's structural filter" do
+        expect(reader.records.fetch("example").graph_compatible?).to be(false)
+      end
+    end
+  end
+
+  context "with no packages map" do
+    let(:data) { { "lockfileVersion" => 0 } }
+
+    it "preserves the optional graph and lookup view" do
+      expect(reader.records).to be_nil
+      expect(reader.details("example", nil, "package.json")).to be_nil
+    end
+
+    it "still rejects the missing map for dependency enumeration" do
+      expect { reader.dependencies }.to raise_error(Dependabot::DependencyFileNotParseable, /packages/)
+    end
+  end
+
+  it "leaves file content unchanged" do
+    original = file.content.dup
+    reader.dependencies
+    reader.details("example", nil, "package.json")
+    expect(file.content).to eq(original)
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

Use typed Bun package records for dependency lookup and graph reads. This removes 12 `T.untyped` annotations and makes the lockfile reader and grapher `strong`.

### Anything you want to highlight for special attention from reviewers?

The graph still reads dependency names from tuple slot 2 without adding edges from non-registry slot-1 data. Lockfile-version checks, configVersion handling, and registry/non-registry lookup behavior stay unchanged.

### How will you know you've accomplished your goal?

The Bun reader, parser, and graph suites pass (72 examples), along with 11 filterer and 12 updater compatibility cases. Sorbet, RuboCop, the promotion check, and the parent-based burndown check pass.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
