### PR TITLE
Share cooldown handling across metadata-backed finders

### DIFF
--- a/common/lib/dependabot/package/cooldown_date_tracker.rb
+++ b/common/lib/dependabot/package/cooldown_date_tracker.rb
@@ -73,6 +73,11 @@ module Dependabot
         @releases[release] = days
       end
 
+      sig { params(release: Dependabot::Package::PackageRelease).void }
+      def discard(release)
+        @releases.delete(release)
+      end
+
       private
 
       sig { returns(Dependabot::Dependency) }

--- a/common/spec/dependabot/package/cooldown_date_tracker_spec.rb
+++ b/common/spec/dependabot/package/cooldown_date_tracker_spec.rb
@@ -31,4 +31,39 @@ RSpec.describe Dependabot::Package::CooldownDateTracker do
       end
     end
   end
+
+  describe "#discard" do
+    let(:rejected_release) do
+      Dependabot::Package::PackageRelease.new(version: TestVersion.new("3.0.0"), released_at: nil)
+    end
+
+    it "does not mark a discarded undated release" do
+      filtered = tracker.filter_prefiltered do
+        tracker.record(release: rejected_release, current_version: dependency.numeric_version, days: 7)
+        tracker.discard(rejected_release)
+        releases
+      end
+
+      expect(filtered).to equal(releases)
+      expect(dependency.metadata[:cooldown_date_unavailable]).to be_nil
+    end
+
+    context "when the selected release is also undated" do
+      let(:release) do
+        Dependabot::Package::PackageRelease.new(version: TestVersion.new("2.0.0"), released_at: nil)
+      end
+
+      it "still marks the selected release" do
+        filtered = tracker.filter_prefiltered do
+          tracker.record(release: rejected_release, current_version: dependency.numeric_version, days: 7)
+          tracker.record(release: release, current_version: dependency.numeric_version, days: 7)
+          tracker.discard(rejected_release)
+          releases
+        end
+
+        expect(filtered).to equal(releases)
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
+  end
 end

--- a/devcontainers/lib/dependabot/devcontainers/update_checker/latest_version_finder.rb
+++ b/devcontainers/lib/dependabot/devcontainers/update_checker/latest_version_finder.rb
@@ -137,55 +137,31 @@ module Dependabot
           filtered_versions = []
           cooldown_filtered_versions = 0
 
-          sorted_releases.each do |release|
-            if in_cooldown_period?(release)
-              Dependabot.logger.info("Filtered out (cooldown) : #{release}")
-              cooldown_filtered_versions += 1
-              next
-            end
+          cooldown_tracker.filter_prefiltered do
+            sorted_releases.each do |release|
+              if in_cooldown_period?(release)
+                Dependabot.logger.info("Filtered out (cooldown) : #{release}")
+                cooldown_filtered_versions += 1
+                next
+              end
 
-            filtered_versions << release
-            break
+              filtered_versions << release
+              break
+            end
+            filtered_versions
           end
           Dependabot.logger.info("Filtered out #{cooldown_filtered_versions} version(s) due to cooldown")
 
           filtered_versions
         end
 
-        # rubocop:disable Metrics/AbcSize
-        sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
-        def in_cooldown_period?(release)
-          release = T.let(
-            Dependabot::Devcontainers::Package::PackageDetailsFetcher
-                      .new(dependency: dependency)
-                      .fetch_release_metadata(release: release),
-            T.nilable(Dependabot::Package::PackageRelease)
-          )
-
-          unless T.must(release).released_at
-            Dependabot.logger.info(
-              "Release date unavailable for #{T.must(release).version}. Cooldown filtering not possible"
-            )
-            return false
-          end
-
-          current_version = version_class.correct?(dependency.version) ? version_class.new(dependency.version) : nil
-
-          days = cooldown_days_for(current_version, T.must(release).version)
-          in_cooldown = Dependabot::UpdateCheckers::CooldownCalculation
-                        .within_cooldown_window?(T.must(T.must(release).released_at), days)
-
-          if in_cooldown
-            passed_days = (Time.now.to_i - T.must(release).released_at.to_i) / (24 * 60 * 60)
-            Dependabot.logger.info(
-              "Version #{T.must(release).version}, Release date: #{T.must(release).released_at}." \
-              " Days since release: #{passed_days} (cooldown days: #{days})"
-            )
-          end
-
-          in_cooldown
+        sig { override.params(release: Dependabot::Package::PackageRelease).returns(T.nilable(Time)) }
+        def released_at_for(release)
+          Dependabot::Devcontainers::Package::PackageDetailsFetcher
+            .new(dependency: dependency)
+            .fetch_release_metadata(release: release)
+            .released_at
         end
-        # rubocop:enable Metrics/AbcSize
       end
     end
   end

--- a/devcontainers/spec/dependabot/devcontainers/update_checker/latest_version_finder_spec.rb
+++ b/devcontainers/spec/dependabot/devcontainers/update_checker/latest_version_finder_spec.rb
@@ -36,9 +36,11 @@ RSpec.describe namespace::LatestVersionFinder do
       credentials: github_credentials,
       security_advisories: security_advisories,
       ignored_versions: ignored_versions,
-      raise_on_ignored: raise_on_ignored
+      raise_on_ignored: raise_on_ignored,
+      cooldown_options: cooldown_options
     )
   end
+  let(:cooldown_options) { nil }
 
   describe "#release_versions" do
     subject(:release_versions) do
@@ -73,6 +75,35 @@ RSpec.describe namespace::LatestVersionFinder do
 
         expect(release).to be_a(Dependabot::Devcontainers::Version)
         expect(release.version).to eq("1.2.0")
+      end
+    end
+
+    context "when cooldown is configured and the release date is unavailable" do
+      let(:cooldown_options) do
+        Dependabot::Package::ReleaseCooldownOptions.new(default_days: 7)
+      end
+      let(:release) do
+        Dependabot::Package::PackageRelease.new(
+          version: Dependabot::Devcontainers::Version.new("2.0.0"),
+          released_at: nil
+        )
+      end
+      let(:package_details_fetcher) do
+        instance_double(
+          Dependabot::Devcontainers::Package::PackageDetailsFetcher,
+          fetch_package_releases: [release],
+          fetch_release_metadata: release
+        )
+      end
+
+      before do
+        allow(Dependabot::Devcontainers::Package::PackageDetailsFetcher)
+          .to receive(:new).with(dependency: dependency).and_return(package_details_fetcher)
+      end
+
+      it "allows the release and marks the dependency" do
+        expect(release_versions.map(&:to_s)).to eq(["2.0.0"])
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
     end
   end

--- a/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
+++ b/go_modules/lib/dependabot/go_modules/update_checker/latest_version_finder.rb
@@ -179,16 +179,18 @@ module Dependabot
           filtered_versions = []
           cooldown_filtered_versions = 0
 
-          # Iterate through the sorted versions lazily, filtering out cooldown versions
-          sorted_releases.each do |release|
-            if in_cooldown_period?(release)
-              Dependabot.logger.info("Filtered out (cooldown) : #{release}")
-              cooldown_filtered_versions += 1
-              next
-            end
+          cooldown_tracker.filter_prefiltered do
+            sorted_releases.each do |release|
+              if in_cooldown_period?(release)
+                Dependabot.logger.info("Filtered out (cooldown) : #{release}")
+                cooldown_filtered_versions += 1
+                next
+              end
 
-            filtered_versions << release
-            break
+              filtered_versions << release
+              break
+            end
+            filtered_versions
           end
 
           Dependabot.logger.info("Filtered out #{cooldown_filtered_versions} version(s) due to cooldown")
@@ -196,42 +198,19 @@ module Dependabot
           filtered_versions
         end
 
-        # rubocop:disable Metrics/AbcSize
-        sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
-        def in_cooldown_period?(release)
-          begin
-            dependency_name = AzureDevopsPathNormalizer.normalize(dependency.name)
-            release_info = SharedHelpers.run_shell_command(
-              "go list -m -json #{dependency_name}@#{release.details.[]('version_string')}",
-              fingerprint: "go list -m -json <dependency_name>"
-            )
-          rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
-            Dependabot.logger.info("Error while fetching release date info: #{e.message}")
-            return false
-          end
-
-          release.instance_variable_set(
-            :@released_at, JSON.parse(release_info)["Time"] ? Time.parse(JSON.parse(release_info)["Time"]) : nil
+        sig { override.params(release: Dependabot::Package::PackageRelease).returns(T.nilable(Time)) }
+        def released_at_for(release)
+          dependency_name = AzureDevopsPathNormalizer.normalize(dependency.name)
+          release_info = SharedHelpers.run_shell_command(
+            "go list -m -json #{dependency_name}@#{release.details.[]('version_string')}",
+            fingerprint: "go list -m -json <dependency_name>"
           )
-
-          return false unless release.released_at
-
-          current_version = version_class.correct?(dependency.version) ? version_class.new(dependency.version) : nil
-          days = cooldown_days_for(current_version, release.version)
-          in_cooldown = Dependabot::UpdateCheckers::CooldownCalculation
-                        .within_cooldown_window?(T.must(release.released_at), days)
-
-          if in_cooldown
-            passed_days = (Time.now.to_i - release.released_at.to_i) / (24 * 60 * 60)
-            Dependabot.logger.info(
-              "Version #{release.version}, Release date: #{release.released_at}." \
-              " Days since release: #{passed_days} (cooldown days: #{days})"
-            )
-          end
-
-          in_cooldown
+          published_at = JSON.parse(release_info)["Time"]
+          published_at ? Time.parse(published_at) : nil
+        rescue Dependabot::SharedHelpers::HelperSubprocessFailed => e
+          Dependabot.logger.info("Error while fetching release date info: #{e.message}")
+          nil
         end
-        # rubocop:enable Metrics/AbcSize
 
         sig do
           override.returns(T.nilable(Dependabot::Package::PackageDetails))

--- a/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
+++ b/go_modules/spec/dependabot/go_modules/update_checker/latest_version_finder_spec.rb
@@ -465,6 +465,7 @@ RSpec.describe Dependabot::GoModules::UpdateChecker::LatestVersionFinder do
 
       it "returns the latest resolvable version" do
         expect(finder.latest_version).to eq(Dependabot::GoModules::Version.new("0.0.0"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
       end
     end
   end

--- a/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
+++ b/gradle/lib/dependabot/gradle/update_checker/version_finder.rb
@@ -219,63 +219,34 @@ module Dependabot
           filtered_versions = []
           cooldown_filtered_versions = 0
 
-          # Iterate through the sorted versions lazily, filtering out cooldown versions
-          sorted_releases.each do |release|
-            if in_cooldown_period?(release)
-              Dependabot.logger.info("Filtered out (cooldown) : #{release}")
-              cooldown_filtered_versions += 1
+          cooldown_tracker.filter_prefiltered do
+            sorted_releases.each do |release|
+              if in_cooldown_period?(release)
+                Dependabot.logger.info("Filtered out (cooldown) : #{release}")
+                cooldown_filtered_versions += 1
 
-              next
+                next
+              end
+
+              filtered_versions << release
+              break
             end
-
-            filtered_versions << release
-            break
+            filtered_versions
           end
 
           Dependabot.logger.info("Filtered out #{cooldown_filtered_versions} version(s) due to cooldown")
           filtered_versions
         end
 
-        sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
-        def in_cooldown_period?(release)
-          current_version = version_class.correct?(dependency.version) ? version_class.new(dependency.version) : nil
-          days = cooldown_days_for(current_version, release.version)
-          return false if days <= 0
-
-          release = package_details_fetcher.fetch_release_metadata(release: release)
-          return missing_release_date_in_cooldown?(release) unless release.released_at
-
-          cooldown_window?(release: release, days: days)
+        sig { override.params(release: Dependabot::Package::PackageRelease).returns(T.nilable(Time)) }
+        def released_at_for(release)
+          package_details_fetcher.fetch_release_metadata(release: release).released_at
         end
 
-        sig { params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
-        def missing_release_date_in_cooldown?(release)
-          if cooldown_options
-            Dependabot.logger.info("Release date not available for version #{release.version} - filtering out")
-            true
-          else
-            Dependabot.logger.info("Release date not available for version #{release.version}")
-            false
-          end
-        end
-
-        sig do
-          params(
-            release: Dependabot::Package::PackageRelease,
-            days: Integer
-          ).returns(T::Boolean)
-        end
-        def cooldown_window?(release:, days:)
-          in_cooldown = Dependabot::UpdateCheckers::CooldownCalculation
-                        .within_cooldown_window?(T.must(release.released_at), days)
-          if in_cooldown
-            passed_days = (Time.now.to_i - release.released_at.to_i) / (24 * 60 * 60)
-            Dependabot.logger.info(
-              "Version #{release.version}, Release date: #{release.released_at}." \
-              " Days since release: #{passed_days} (cooldown days: #{days})"
-            )
-          end
-          in_cooldown
+        sig { override.params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
+        def missing_release_date_blocks_update?(release)
+          Dependabot.logger.info("Release date not available for version #{release.version} - filtering out")
+          true
         end
 
         sig { override.returns(T.nilable(Dependabot::Package::PackageDetails)) }

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -675,6 +675,11 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
           expect(in_cooldown).to be true
         end
 
+        it "marks the dependency through cooldown filtering" do
+          expect(finder.send(:filter_cooldown_versions, [release])).to be_empty
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        end
+
         it "logs that release date is not available and filtering out" do
           expect(Dependabot.logger).to receive(:info)
             .with("Release date not available for version 1.0.0 - filtering out")

--- a/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
+++ b/gradle/spec/dependabot/gradle/update_checker/version_finder_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "spec_helper"
@@ -581,6 +581,50 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
     its([:source_url]) do
       is_expected.to eq("https://repo.maven.apache.org/maven2")
     end
+
+    context "when the newest release has no publication date" do
+      let(:maven_central_releases) do
+        <<~XML
+          <metadata>
+            <versioning>
+              <versions>
+                <version>23.3-jre</version>
+                <version>23.5-jre</version>
+                <version>23.6-jre</version>
+              </versions>
+            </versioning>
+          </metadata>
+        XML
+      end
+      let(:release_listing) do
+        <<~HTML
+          <pre>
+          <a href="23.3-jre/">23.3-jre/</a> 2017-11-09 10:00
+          <a href="23.5-jre/">23.5-jre/</a> 2017-11-22 10:00
+          <a href="23.6-jre/">23.6-jre/</a>
+          </pre>
+        HTML
+      end
+
+      before do
+        stub_request(:get, "https://repo.maven.apache.org/maven2/com/google/guava/guava/")
+          .to_return(status: 200, body: release_listing)
+      end
+
+      it "selects the older dated release and marks the dependency" do
+        expect(latest_version_details[:version]).to eq(version_class.new("23.5-jre"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+
+      context "when no release has a publication date" do
+        let(:release_listing) { "<pre></pre>" }
+
+        it "returns no release and marks the dependency" do
+          expect(latest_version_details).to be_nil
+          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+        end
+      end
+    end
   end
 
   describe "#in_cooldown_period?" do
@@ -673,11 +717,6 @@ RSpec.describe Dependabot::Gradle::UpdateChecker::VersionFinder do
 
         it "filters out the version" do
           expect(in_cooldown).to be true
-        end
-
-        it "marks the dependency through cooldown filtering" do
-          expect(finder.send(:filter_cooldown_versions, [release])).to be_empty
-          expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
         end
 
         it "logs that release date is not available and filtering out" do

--- a/maven/lib/dependabot/maven/shared/base_version_finder.rb
+++ b/maven/lib/dependabot/maven/shared/base_version_finder.rb
@@ -88,7 +88,9 @@ module Dependabot
                 next false
               end
 
-              released?(release.version)
+              published = released?(release.version)
+              cooldown_tracker.discard(release) unless published
+              published
             end
             latest_release ? [latest_release] : []
           end

--- a/maven/lib/dependabot/maven/update_checker/version_finder.rb
+++ b/maven/lib/dependabot/maven/update_checker/version_finder.rb
@@ -60,16 +60,9 @@ module Dependabot
 
         protected
 
-        sig { override.params(release: Dependabot::Package::PackageRelease).returns(T::Boolean) }
-        def in_cooldown_period?(release)
-          return super if release.released_at
-          return false if Dependabot::UpdateCheckers::CooldownCalculation.skip_cooldown?(
-            cooldown_options,
-            dependency.name,
-            cooldown_enabled: cooldown_enabled?
-          )
-
-          super(package_details_fetcher.fetch_release_metadata(release: release))
+        sig { override.params(release: Dependabot::Package::PackageRelease).returns(T.nilable(Time)) }
+        def released_at_for(release)
+          release.released_at || package_details_fetcher.fetch_release_metadata(release: release).released_at
         end
 
         private

--- a/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/version_finder_spec.rb
@@ -873,6 +873,18 @@ RSpec.describe Dependabot::Maven::UpdateChecker::VersionFinder do
         end
       end
 
+      context "when an undated release is not actually published" do
+        before do
+          stub_request(:head, version_1_2_pom_url).to_return(status: 404)
+          stub_request(:head, version_1_2_jar_url).to_return(status: 404)
+        end
+
+        it "selects the dated release without marking the dependency" do
+          expect(latest_version_details[:version]).to eq(version_class.new("1.1.0"))
+          expect(dependency.metadata[:cooldown_date_unavailable]).not_to be(true)
+        end
+      end
+
       context "when the newest eligible release is not actually published" do
         before do
           stub_request(:head, version_1_1_pom_url).to_return(status: 404)


### PR DESCRIPTION
### What are you trying to accomplish?

Replaces #16212. GitHub automatically marked the original PR merged into an intermediate branch during a stack reorder, not into `main`. Original review discussions remain at #16212; this replacement restores the same code change for review.

Stacked on #16211.

Use the common `PackageLatestVersionFinder` cooldown path for Devcontainers, Go Modules, Gradle, and Maven, whose publication dates require ecosystem-specific metadata lookups. Each ecosystem now supplies only its date-resolution hook; Gradle retains its existing fail-closed policy while the others remain fail-open.

### Anything you want to highlight for special attention from reviewers?

The refactor removes duplicated cooldown algorithms without changing whether an unavailable date allows or blocks an update. The warning marker comes from the shared finder introduced in the parent PR.

### How will you know you've accomplished your goal?

Recovery verification: preserved commit `e1e950bf4353cbb0b6c8dd3e552de8d28011729c`, one commit and 8 changed files relative to the preceding branch. The complete stack file tree matches the pre-reorder snapshot. Tests were not rerun for this branch/PR-only recovery. The results below are historical validation from #16212; new CI is pending.

- Devcontainers finder: 3 examples, 0 failures.
- Go Modules finder: 39 examples, 0 failures.
- Earlier full-tree runs: Gradle 72/0 and Maven 67/0. Their split-branch rerun stalled while preparing the Docker image before RSpec started; CI should confirm them.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.