### PR TITLE
Share cooldown handling across tag resolvers

### DIFF
--- a/common/lib/dependabot/update_checkers/tag_cooldown_filter.rb
+++ b/common/lib/dependabot/update_checkers/tag_cooldown_filter.rb
@@ -1,0 +1,53 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "time"
+require "sorbet-runtime"
+require "dependabot/package/release_cooldown_options"
+require "dependabot/update_checkers/cooldown_calculation"
+
+module Dependabot
+  module UpdateCheckers
+    # Cooldown filtering for resolvers whose publication dates come from git tags as strings.
+    module TagCooldownFilter
+      extend T::Sig
+      extend T::Helpers
+
+      abstract!
+
+      sig { abstract.returns(Dependabot::Dependency) }
+      def dependency; end
+
+      sig { abstract.returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
+      def cooldown_options; end
+
+      sig { params(release_date: T.nilable(String)).returns(T::Boolean) }
+      def check_if_version_in_cooldown_period?(release_date)
+        cooldown = cooldown_options
+        return false if CooldownCalculation.skip_cooldown?(cooldown, dependency.name)
+
+        cooldown_days = T.must(cooldown).default_days
+        return false unless cooldown_days.positive?
+
+        released_at = release_date_to_seconds(release_date)
+        unless released_at
+          CooldownCalculation.mark_cooldown_date_unavailable(dependency, cooldown_days: cooldown_days)
+          return false
+        end
+
+        (Time.now.to_i - released_at) < cooldown_days * CooldownCalculation::DAY_IN_SECONDS
+      end
+
+      # Nil when the registry gave no usable date, so the caller can flag the dependency.
+      sig { params(release_date: T.nilable(String)).returns(T.nilable(Integer)) }
+      def release_date_to_seconds(release_date)
+        return nil if release_date.nil? || release_date.empty?
+
+        Time.parse(release_date).to_i
+      rescue ArgumentError => e
+        Dependabot.logger.error("Invalid release date format: #{release_date} and error: #{e.message}")
+        nil
+      end
+    end
+  end
+end

--- a/helm/lib/dependabot/helm/update_checker/latest_version_resolver.rb
+++ b/helm/lib/dependabot/helm/update_checker/latest_version_resolver.rb
@@ -5,13 +5,13 @@ require "dependabot/helm/package/package_details_fetcher"
 require "sorbet-runtime"
 require "dependabot/git_commit_checker"
 require "dependabot/helm/version"
+require "dependabot/update_checkers/tag_cooldown_filter"
 
 module Dependabot
   module Helm
     class LatestVersionResolver
       extend T::Sig
-
-      DAY_IN_SECONDS = T.let(24 * 60 * 60, Integer)
+      include Dependabot::UpdateCheckers::TagCooldownFilter
 
       sig do
         params(
@@ -26,8 +26,11 @@ module Dependabot
         @cooldown_options = cooldown_options
       end
 
-      sig { returns(Dependabot::Dependency) }
+      sig { override.returns(Dependabot::Dependency) }
       attr_reader :dependency
+
+      sig { override.returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
+      attr_reader :cooldown_options
 
       # To filter versions in cooldown period based on version tags from registry call
       sig do
@@ -79,7 +82,7 @@ module Dependabot
 
         begin
           package_details_fetcher.fetch_tag_and_release_date_from_chart(repo_name).each do |git_tag_with_detail|
-            if check_if_version_in_cooldown_period?(T.must(git_tag_with_detail.release_date))
+            if check_if_version_in_cooldown_period?(git_tag_with_detail.release_date)
               version_tags_in_cooldown_from_chart << git_tag_with_detail.tag
             end
           end
@@ -117,7 +120,7 @@ module Dependabot
 
         begin
           package_details_fetcher.fetch_tag_and_release_date_helm_chart_index(index_url, chart_name).each do |git_tag|
-            if check_if_version_in_cooldown_period?(T.must(git_tag.release_date))
+            if check_if_version_in_cooldown_period?(git_tag.release_date)
               fetch_tag_and_release_date_helm_chart_index << git_tag.tag
             end
           end
@@ -128,36 +131,13 @@ module Dependabot
         end
       end
 
-      sig { params(release_date: String).returns(T::Boolean) }
-      def check_if_version_in_cooldown_period?(release_date)
-        return false unless release_date.length.positive?
-
-        cooldown = @cooldown_options
-        return false unless cooldown
-
-        return false if cooldown.nil?
-
-        # Calculate the number of seconds passed since the release
-        passed_seconds = Time.now.to_i - release_date_to_seconds(release_date)
-        # Check if the release is within the cooldown period
-        passed_seconds < cooldown.default_days * DAY_IN_SECONDS
-      end
-
-      sig { params(release_date: String).returns(Integer) }
-      def release_date_to_seconds(release_date)
-        Time.parse(release_date).to_i
-      rescue ArgumentError => e
-        Dependabot.logger.error("Invalid release date format: #{release_date} and error: #{e.message}")
-        0 # Default to 360 days in seconds if parsing fails, so that it will not be in cooldown
-      end
-
       sig { params(tags_with_release_date: T::Array[GitTagWithDetail]).returns(T.nilable(T::Array[String])) }
       def select_tags_which_in_cooldown_using_oci(tags_with_release_date)
         fetch_tag_and_release_date_helm_using_oci = T.let([], T::Array[String])
 
         begin
           tags_with_release_date.each do |git_tag_with_detail|
-            if check_if_version_in_cooldown_period?(T.must(git_tag_with_detail.release_date))
+            if check_if_version_in_cooldown_period?(git_tag_with_detail.release_date)
               fetch_tag_and_release_date_helm_using_oci << git_tag_with_detail.tag
             end
           end
@@ -177,11 +157,6 @@ module Dependabot
           ),
           T.nilable(Package::PackageDetailsFetcher)
         )
-      end
-
-      sig { returns(T::Boolean) }
-      def cooldown_enabled?
-        true
       end
 
       sig { returns(T::Array[Dependabot::Credential]) }

--- a/helm/spec/dependabot/helm/update_checker/latest_version_resolver_spec.rb
+++ b/helm/spec/dependabot/helm/update_checker/latest_version_resolver_spec.rb
@@ -95,6 +95,19 @@ RSpec.describe Dependabot::Helm::LatestVersionResolver do
       end
     end
 
+    context "when a release date is unavailable" do
+      let(:tags_with_release_date) do
+        [Dependabot::GitTagWithDetail.new(tag: "2.0.0", release_date: nil)]
+      end
+
+      it "keeps the tag and marks the dependency" do
+        result = resolver.filter_versions_in_cooldown_period_using_oci(tags.dup, tags_with_release_date)
+
+        expect(result).to eq(tags)
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
+
     context "when select_tags_which_in_cooldown_using_oci returns nil" do
       before do
         allow(resolver).to receive(:select_tags_which_in_cooldown_using_oci)
@@ -183,10 +196,17 @@ RSpec.describe Dependabot::Helm::LatestVersionResolver do
       expect(resolver.release_date_to_seconds(release_date)).to eq(Time.parse(release_date).to_i)
     end
 
-    it "returns 0 for an invalid release date" do
+    it "returns nil for an invalid release date" do
       invalid_release_date = "invalid-date"
       expect(Dependabot.logger).to receive(:error).with(/Invalid release date format/)
-      expect(resolver.release_date_to_seconds(invalid_release_date)).to eq(0)
+      expect(resolver.release_date_to_seconds(invalid_release_date)).to be_nil
+    end
+
+    it "marks the dependency when the release date cannot be parsed" do
+      allow(Dependabot.logger).to receive(:error)
+
+      expect(resolver.check_if_version_in_cooldown_period?("invalid-date")).to be false
+      expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
     end
   end
 end

--- a/terraform/lib/dependabot/terraform/update_checker/latest_version_resolver.rb
+++ b/terraform/lib/dependabot/terraform/update_checker/latest_version_resolver.rb
@@ -5,14 +5,14 @@ require "dependabot/update_checkers/base"
 require "dependabot/terraform/package/package_details_fetcher"
 require "sorbet-runtime"
 require "dependabot/git_commit_checker"
+require "dependabot/update_checkers/tag_cooldown_filter"
 
 module Dependabot
   module Terraform
     class UpdateChecker < Dependabot::UpdateCheckers::Base
       class LatestVersionResolver
         extend T::Sig
-
-        DAY_IN_SECONDS = T.let(24 * 60 * 60, Integer)
+        include Dependabot::UpdateCheckers::TagCooldownFilter
 
         sig do
           params(
@@ -29,8 +29,11 @@ module Dependabot
           @git_commit_checker = git_commit_checker
         end
 
-        sig { returns(Dependabot::Dependency) }
+        sig { override.returns(Dependabot::Dependency) }
         attr_reader :dependency
+
+        sig { override.returns(T.nilable(Dependabot::Package::ReleaseCooldownOptions)) }
+        attr_reader :cooldown_options
 
         # To filter versions in cooldown period based on version tags from registry call
         sig do
@@ -84,35 +87,12 @@ module Dependabot
           versions
         end
 
-        sig { params(release_date: String).returns(T::Boolean) }
-        def check_if_version_in_cooldown_period?(release_date)
-          return false unless release_date.length.positive?
-
-          cooldown = @cooldown_options
-          return false unless cooldown
-
-          return false if cooldown.nil?
-
-          # Calculate the number of seconds passed since the release
-          passed_seconds = Time.now.to_i - release_date_to_seconds(release_date)
-          # Check if the release is within the cooldown period
-          passed_seconds < cooldown.default_days * DAY_IN_SECONDS
-        end
-
-        sig { params(release_date: String).returns(Integer) }
-        def release_date_to_seconds(release_date)
-          Time.parse(release_date).to_i
-        rescue ArgumentError => e
-          Dependabot.logger.error("Invalid release date format: #{release_date} and error: #{e.message}")
-          0 # Default to 360 days in seconds if parsing fails, so that it will not be in cooldown
-        end
-
         sig { returns(T.nilable(T::Array[String])) }
         def select_tags_which_in_cooldown_from_provider
           version_tags_in_cooldown_from_provider = T.let([], T::Array[String])
 
           package_details_fetcher.fetch_tag_and_release_date_from_provider.each do |git_tag_with_detail|
-            if check_if_version_in_cooldown_period?(T.must(git_tag_with_detail.release_date))
+            if check_if_version_in_cooldown_period?(git_tag_with_detail.release_date)
               version_tags_in_cooldown_from_provider << git_tag_with_detail.tag
             end
           end
@@ -127,7 +107,7 @@ module Dependabot
           version_tags_in_cooldown_from_module = T.let([], T::Array[String])
 
           package_details_fetcher.fetch_tag_and_release_date_from_module.each do |git_tag_with_detail|
-            if check_if_version_in_cooldown_period?(T.must(git_tag_with_detail.release_date))
+            if check_if_version_in_cooldown_period?(git_tag_with_detail.release_date)
               version_tags_in_cooldown_from_module << git_tag_with_detail.tag
             end
           end

--- a/terraform/spec/dependabot/terraform/update_checker/latest_version_resolver_spec.rb
+++ b/terraform/spec/dependabot/terraform/update_checker/latest_version_resolver_spec.rb
@@ -106,5 +106,10 @@ RSpec.describe Dependabot::Terraform::UpdateChecker::LatestVersionResolver do
       release_date = (Time.now - (100 * 24 * 60 * 60)).iso8601 # 100 days ago
       expect(resolver.check_if_version_in_cooldown_period?(release_date)).to be false
     end
+
+    it "marks the dependency when the release date is unavailable" do
+      expect(resolver.check_if_version_in_cooldown_period?(nil)).to be false
+      expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Replaces #16213. GitHub automatically marked the original PR merged into an intermediate branch during a stack reorder, not into `main`. Original review discussions remain at #16213; this replacement restores the same code change for review.

Stacked on #16261.

Extract the common cooldown algorithm used by tag-backed registry resolvers into `TagCooldownFilter`, then adopt it in Helm and Terraform. Missing and unparseable publication dates fail open as before, but now mark the dependency so the warning can be surfaced.

### Anything you want to highlight for special attention from reviewers?

OpenTofu is intentionally excluded and follows in its own PR. This slice establishes the shared module it will consume.

The extracted parser returns `nil` for unusable dates instead of using the Unix epoch, allowing callers to distinguish an unavailable date from an old release.

### How will you know you've accomplished your goal?

Recovery verification: preserved commit `82e549e71a0ed4aa28fea676158442318f7b4f79`, one commit and 5 changed files relative to the preceding branch. The complete stack file tree matches the pre-reorder snapshot. Tests were not rerun for this branch/PR-only recovery. The results below are historical validation from #16213; new CI is pending.

- Helm resolver: 14 examples, 0 failures.
- Terraform retains its existing fail-open filtering behavior and gains local marker coverage.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.