### PR TITLE
Surface unavailable cooldown dates for Julia

### DIFF
--- a/julia/lib/dependabot/julia/update_checker/latest_version_finder.rb
+++ b/julia/lib/dependabot/julia/update_checker/latest_version_finder.rb
@@ -4,6 +4,7 @@
 require "time"
 require "dependabot/julia/package/package_details_fetcher"
 require "dependabot/julia/version"
+require "dependabot/update_checkers/cooldown_calculation"
 require "dependabot/update_checkers/version_filters"
 
 module Dependabot
@@ -187,7 +188,14 @@ module Dependabot
       def cooldown_active_for_release?(release)
         cooldown_days = determine_cooldown_days(release.version)
         return false unless cooldown_days&.positive?
-        return false unless release.released_at
+
+        unless release.released_at
+          Dependabot::UpdateCheckers::CooldownCalculation.mark_cooldown_date_unavailable(
+            dependency,
+            cooldown_days: cooldown_days
+          )
+          return false
+        end
 
         # Check if enough time has passed since release
         seconds_since_release = T.cast(Time.now - release.released_at, Float)

--- a/julia/spec/dependabot/julia/latest_version_finder_spec.rb
+++ b/julia/spec/dependabot/julia/latest_version_finder_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe Dependabot::Julia::LatestVersionFinder do
       end
     end
 
+    context "when the release date is unavailable" do
+      let(:release_dates) { { "1.5.0" => nil } }
+
+      it "allows the release and marks the dependency" do
+        expect(finder.latest_version).to eq(Dependabot::Julia::Version.new("1.5.0"))
+        expect(dependency.metadata[:cooldown_date_unavailable]).to be(true)
+      end
+    end
+
     context "when the dependency is excluded by exact name" do
       let(:exclude_patterns) { ["Example"] }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Replaces #16216. GitHub automatically marked the original PR merged into an intermediate branch during a stack reorder, not into `main`. Original review discussions remain at #16216; this replacement restores the same code change for review.

Stacked on #16264.

Mark Julia dependencies when a release has a positive effective cooldown but no publication date is available, allowing the stack's shared delivery code to surface the warning.

### Anything you want to highlight for special attention from reviewers?

Julia is deliberately isolated in this PR. Its existing cooldown configuration format, include/exclude matching, SemVer-specific day selection, and fail-open behavior remain unchanged.

### How will you know you've accomplished your goal?

Recovery verification: preserved commit `384935f16a5de066a3a95889c36ec2571f5bb83e`, one commit and 2 changed files relative to the preceding branch. The complete stack file tree matches the pre-reorder snapshot. Tests were not rerun for this branch/PR-only recovery. The results below are historical validation from #16216; new CI is pending.

- Julia latest-version finder: 10 examples, 0 failures.
- The new regression verifies that the release remains eligible and the dependency is marked.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.