### PR TITLE
Log filtered package versions

### DIFF
--- a/common/lib/dependabot/package/package_latest_version_finder.rb
+++ b/common/lib/dependabot/package/package_latest_version_finder.rb
@@ -16,7 +16,7 @@ require "dependabot/package/cooldown_date_tracker"
 
 module Dependabot
   module Package
-    class PackageLatestVersionFinder
+    class PackageLatestVersionFinder # rubocop:disable Metrics/ClassLength
       extend T::Sig
       extend T::Helpers
 
@@ -219,10 +219,20 @@ module Dependabot
       end
       def filter_unsupported_versions(releases, language_version)
         filtered = releases.filter_map do |release|
-          language_requirement = release.language&.requirement
-          next release unless language_version
+          language = release.language
+          next release unless language_version && language
+
+          language_requirement = language.requirement
           next release unless language_requirement
-          next unless language_requirement.satisfied_by?(language_version)
+
+          unless language_requirement.satisfied_by?(language_version)
+            Dependabot.logger.info(
+              "Filtered out #{dependency.name} #{release.version} because " \
+              "#{language.name} requirement #{language_requirement} is not satisfied by " \
+              "#{language.name} #{language_version}"
+            )
+            next
+          end
 
           release
         end

--- a/common/spec/dependabot/package/package_latest_version_finder_spec.rb
+++ b/common/spec/dependabot/package/package_latest_version_finder_spec.rb
@@ -281,6 +281,22 @@ RSpec.describe Dependabot::Package::PackageLatestVersionFinder do
 
     it { is_expected.to eq(TestVersion.new("7.0.0")) }
 
+    context "when a release requires an unsupported language version" do
+      subject(:latest_version) { finder.latest_version(language_version: TestVersion.new("2.6.0")) }
+
+      let(:available_releases) { [available_release_7_0_0, available_release_6_1_4] }
+      let(:cooldown_options) { nil }
+
+      it "logs why the release was filtered out" do
+        expect(Dependabot.logger).to receive(:info).with(
+          /Filtered out rails 7\.0\.0 because dummy requirement >= 2\.7\.0 is not satisfied by dummy 2\.6\.0/
+        )
+        expect(Dependabot.logger).to receive(:info).with(/Filtered out 1 unsupported Language 2\.6\.0 versions/)
+
+        expect(latest_version).to eq(TestVersion.new("6.1.4"))
+      end
+    end
+
     context "when all supported versions are ignored" do
       let(:ignored_versions) { ["7.0.0", "6.1.4", "6.0.2", "6.0.0"] }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Improve Dependabot diagnostics for releases filtered out because they are incompatible with the selected language runtime. This addresses [dependabot/dependabot-core#15978](https://github.com/dependabot/dependabot-core/issues/15978), where NumPy 2.5.2 was not proposed because PyPI declares `Requires-Python: >=3.12` while the project supports Python 3.11.

**Important**: We are adding filtered event log to provide more info why a package was filtered out. The filter mechanism will remain same.

### Anything you want to highlight for special attention from reviewers?

The filtering policy is unchanged. Releases are still filtered only when an explicit language requirement is not satisfied by the selected language version. Releases without language metadata or without a language requirement remain eligible as before.

When a release is filtered, the shared package finder now logs an `info` message containing the package version, language, requirement, and selected runtime. For example:

```text
Filtered out numpy 2.5.2 because Python requirement >=3.12 is not satisfied by Python 3.11
```

### How will you know you have accomplished your goal?

The shared finder regression test verifies that an incompatible release is excluded, the compatible release remains selected, and both the detailed reason and aggregate count are logged.

Validation completed:

- `bin/test common spec/dependabot/package/package_latest_version_finder_spec.rb` - 45 examples, 0 failures
- Docker RuboCop for the changed common implementation and spec - no offenses
- Editor diagnostics - no errors

### Checklist

- [x] I have run the focused test suite for the change.
- [x] I have thoroughly tested the code changes, including adding regression coverage.
- [x] I have written a clear and descriptive commit message.
- [x] I have provided a detailed description of the problem and fix.
- [x] I have ensured that the changed code is documented by its behavior and tests.
