### PR TITLE
Bump Python 3.14 to 3.14.7

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,7 +3,7 @@
 # python/lib/dependabot/python/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # python/spec/dependabot/python/file_fetcher_spec.rb: exposes the expected ecosystem_versions metric spec
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.5
+ARG PY_3_14=3.14.7
 ARG PY_3_13=3.13.13
 ARG PY_3_12=3.12.13
 ARG PY_3_11=3.11.15

--- a/python/lib/dependabot/python/language.rb
+++ b/python/lib/dependabot/python/language.rb
@@ -16,7 +16,7 @@ module Dependabot
       # e.g. ARG PY_3_13=3.13.x
       # Note: uv ecosystem aliases this class, so updates here apply to both ecosystems.
       PRE_INSTALLED_PYTHON_VERSIONS_RAW = %w(
-        3.14.5
+        3.14.7
         3.13.13
         3.12.13
         3.11.15

--- a/uv/Dockerfile
+++ b/uv/Dockerfile
@@ -3,7 +3,7 @@
 # python/lib/dependabot/python/language.rb: PRE_INSTALLED_PYTHON_VERSIONS_RAW
 # (`uv/lib/dependabot/uv/language.rb` aliases `Dependabot::Python::Language`).
 # Python versions are pinned to the release of each minor/patch version.
-ARG PY_3_14=3.14.5
+ARG PY_3_14=3.14.7
 ARG PY_3_13=3.13.13
 ARG PY_3_12=3.12.13
 ARG PY_3_11=3.11.15


### PR DESCRIPTION
### What are you trying to accomplish?

Bumps the pre-installed Python 3.14 from 3.14.5 to 3.14.7.  Mirrors #13744.

### Anything you want to highlight for special attention from reviewers?

Only 3.14 is bumped, the other versions are behind but not included in this PR.

### How will you know you've accomplished your goal?

If the existing tests pass.

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
