### PR TITLE
Type Bundler resolvability results and caches

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 602
+# Offense count: 596
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"

--- a/bundler/lib/dependabot/bundler/update_checker.rb
+++ b/bundler/lib/dependabot/bundler/update_checker.rb
@@ -216,10 +216,10 @@ module Dependabot
         git_commit_checker.git_dependency?
       end
 
-      sig { params(version: Dependabot::Bundler::Version).returns(T.untyped) }
+      sig { params(version: Dependabot::Bundler::Version).returns(T::Boolean) }
       def resolvable?(version)
-        @resolvable ||= T.let({}, T.nilable(T::Hash[T.untyped, T.untyped]))
-        return @resolvable[version] if @resolvable.key?(version)
+        @resolvable ||= T.let({}, T.nilable(T::Hash[Dependabot::Bundler::Version, T::Boolean]))
+        return @resolvable.fetch(version) if @resolvable.key?(version)
 
         @resolvable[version] =
           begin
@@ -239,10 +239,10 @@ module Dependabot
           end
       end
 
-      sig { params(tag: T.nilable(String)).returns(T.untyped) }
+      sig { params(tag: T.nilable(String)).returns(T::Boolean) }
       def git_tag_resolvable?(tag)
-        @git_tag_resolvable ||= T.let({}, T.nilable(T::Hash[T.untyped, T.untyped]))
-        return @git_tag_resolvable[tag] if @git_tag_resolvable.key?(tag)
+        @git_tag_resolvable ||= T.let({}, T.nilable(T::Hash[T.nilable(String), T::Boolean]))
+        return @git_tag_resolvable.fetch(tag) if @git_tag_resolvable.key?(tag)
 
         @git_tag_resolvable[tag] =
           begin

--- a/bundler/spec/dependabot/bundler/update_checker_spec.rb
+++ b/bundler/spec/dependabot/bundler/update_checker_spec.rb
@@ -613,6 +613,159 @@ RSpec.describe Dependabot::Bundler::UpdateChecker do
     end
   end
 
+  describe "#lowest_resolvable_security_fix_version cached probes" do
+    let(:target_version) { Dependabot::Bundler::Version.new("1.5.0") }
+    let(:latest_finder) do
+      instance_double(
+        Dependabot::Bundler::UpdateChecker::LatestVersionFinder,
+        lowest_security_fix_version: target_version
+      )
+    end
+    let(:force_updater) { instance_double(Dependabot::Bundler::UpdateChecker::ForceUpdater, updated_dependencies: []) }
+    let(:security_advisories) do
+      [
+        Dependabot::SecurityAdvisory.new(
+          dependency_name: dependency_name,
+          package_manager: "bundler",
+          vulnerable_versions: ["<= 1.4.0"]
+        )
+      ]
+    end
+
+    before do
+      allow(Dependabot::Bundler::UpdateChecker::LatestVersionFinder).to receive(:new).and_return(latest_finder)
+      allow(Dependabot::Bundler::UpdateChecker::ForceUpdater).to receive(:new).and_return(force_updater)
+    end
+
+    it "reuses a successful probe" do
+      2.times { expect(checker.lowest_resolvable_security_fix_version).to eq(target_version) }
+
+      expect(force_updater).to have_received(:updated_dependencies).once
+    end
+
+    it "uses version equality for cache keys" do
+      allow(latest_finder).to receive(:lowest_security_fix_version)
+        .and_return(target_version, Dependabot::Bundler::Version.new("1.5.0"))
+
+      2.times { expect(checker.lowest_resolvable_security_fix_version).to eq(target_version) }
+
+      expect(force_updater).to have_received(:updated_dependencies).once
+    end
+
+    it "caches distinct versions independently" do
+      other_version = Dependabot::Bundler::Version.new("1.6.0")
+      allow(latest_finder).to receive(:lowest_security_fix_version).and_return(
+        target_version,
+        other_version,
+        target_version
+      )
+
+      expect(checker.lowest_resolvable_security_fix_version).to eq(target_version)
+      expect(checker.lowest_resolvable_security_fix_version).to eq(other_version)
+      expect(checker.lowest_resolvable_security_fix_version).to eq(target_version)
+      expect(force_updater).to have_received(:updated_dependencies).twice
+    end
+
+    context "when the version is not resolvable" do
+      before do
+        allow(force_updater).to receive(:updated_dependencies)
+          .and_raise(Dependabot::DependencyFileNotResolvable, "conflicting requirement")
+      end
+
+      it "reuses the failed probe rather than retrying it" do
+        2.times { expect(checker.lowest_resolvable_security_fix_version).to be_nil }
+
+        expect(force_updater).to have_received(:updated_dependencies).once
+      end
+    end
+
+    it "propagates unrelated errors without caching a result" do
+      allow(force_updater).to receive(:updated_dependencies).and_raise(RuntimeError, "unexpected failure")
+      expect { checker.lowest_resolvable_security_fix_version }.to raise_error(RuntimeError, "unexpected failure")
+
+      allow(force_updater).to receive(:updated_dependencies).and_return([])
+      2.times { expect(checker.lowest_resolvable_security_fix_version).to eq(target_version) }
+
+      expect(force_updater).to have_received(:updated_dependencies).twice
+    end
+  end
+
+  describe "#latest_resolvable_version cached tag probes" do
+    let(:current_version) { "a" * 40 }
+    let(:tag) { Dependabot::GitTagDetails.new(tag: "v1.5.0", tag_sha: "b" * 40) }
+    let(:resolution_result) { { version: Dependabot::Bundler::Version.new("1.5.0") } }
+    let(:resolver) do
+      instance_double(
+        Dependabot::Bundler::UpdateChecker::VersionResolver,
+        latest_resolvable_version_details: resolution_result
+      )
+    end
+    let(:git_checker) do
+      instance_double(
+        Dependabot::GitCommitChecker,
+        git_dependency?: true,
+        pinned?: true,
+        local_tag_for_pinned_version_ref: tag
+      )
+    end
+
+    before do
+      allow(checker).to receive(:latest_version).and_return(current_version)
+      allow(Dependabot::GitCommitChecker).to receive(:new).and_return(git_checker)
+      allow(Dependabot::Bundler::UpdateChecker::VersionResolver).to receive(:new).and_return(resolver)
+    end
+
+    it "reuses a successful tag probe" do
+      2.times { expect(checker.latest_resolvable_version).to eq(tag.tag_sha) }
+
+      expect(resolver).to have_received(:latest_resolvable_version_details).once
+    end
+
+    context "when the resolver returns nil without raising" do
+      let(:resolution_result) { nil }
+
+      it "still caches the probe as successful" do
+        2.times { expect(checker.latest_resolvable_version).to eq(tag.tag_sha) }
+
+        expect(resolver).to have_received(:latest_resolvable_version_details).once
+      end
+    end
+
+    it "caches distinct tags independently" do
+      expect(checker.latest_resolvable_version).to eq(tag.tag_sha)
+      other_tag = Dependabot::GitTagDetails.new(tag: "v1.6.0", tag_sha: "c" * 40)
+      allow(git_checker).to receive(:local_tag_for_pinned_version_ref).and_return(other_tag)
+      expect(checker.latest_resolvable_version).to eq(other_tag.tag_sha)
+
+      allow(git_checker).to receive(:local_tag_for_pinned_version_ref).and_return(tag)
+      expect(checker.latest_resolvable_version).to eq(tag.tag_sha)
+      expect(resolver).to have_received(:latest_resolvable_version_details).twice
+    end
+
+    context "when the tag is not resolvable" do
+      before do
+        allow(resolver).to receive(:latest_resolvable_version_details)
+          .and_raise(Dependabot::DependencyFileNotResolvable, "conflicting requirement")
+      end
+
+      it "reuses the failed probe and leaves the current version unchanged" do
+        2.times { expect(checker.latest_resolvable_version).to eq(current_version) }
+
+        expect(resolver).to have_received(:latest_resolvable_version_details).once
+      end
+    end
+
+    it "propagates unrelated errors without caching a result" do
+      allow(resolver).to receive(:latest_resolvable_version_details).and_raise(RuntimeError, "unexpected failure")
+      expect { checker.latest_resolvable_version }.to raise_error(RuntimeError, "unexpected failure")
+
+      allow(resolver).to receive(:latest_resolvable_version_details).and_return(resolution_result)
+      2.times { expect(checker.latest_resolvable_version).to eq(tag.tag_sha) }
+
+      expect(resolver).to have_received(:latest_resolvable_version_details).twice
+    end
+  end
+
   describe "#latest_version_resolvable_with_full_unlock?" do
     subject { checker.send(:latest_version_resolvable_with_full_unlock?) }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Give Bundler's resolvability probes boolean return types and typed cache keys. This removes six `T.untyped` annotations.

### Anything you want to highlight for special attention from reviewers?

Failed probes remain cached. A nil return without an exception still means success, while unrelated exceptions propagate without a cache entry.

### How will you know you've accomplished your goal?

The selected public resolver paths pass: 59 examples, no failures, and one existing pending example. Sorbet, RuboCop, and the existing strictness checks pass.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
