### PR TITLE
Use typed Gemfile and gemspec helper results

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -239,7 +239,7 @@ Style/HashSlice:
 Style/SafeNavigationChainLength:
   Enabled: false
 
-# Offense count: 596
+# Offense count: 593
 Sorbet/ForbidTUntyped:
   Exclude:
     - "bun/lib/dependabot/bun.rb"
@@ -254,7 +254,6 @@ Sorbet/ForbidTUntyped:
     - "bun/lib/dependabot/bun/update_checker/latest_version_finder.rb"
     - "bun/lib/dependabot/bun/update_checker/library_detector.rb"
     - "bun/lib/dependabot/bun/update_checker/version_resolver.rb"
-    - "bundler/lib/dependabot/bundler/file_parser.rb"
     - "bundler/lib/dependabot/bundler/file_updater/lockfile_updater.rb"
     - "bundler/lib/dependabot/bundler/file_updater/requirement_replacer.rb"
     - "bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb"

--- a/bundler/helpers/v2/spec/functions/file_parser_spec.rb
+++ b/bundler/helpers/v2/spec/functions/file_parser_spec.rb
@@ -3,6 +3,7 @@
 
 require "native_spec_helper"
 require "shared_contexts"
+require "json"
 
 RSpec.describe Functions::FileParser do
   include_context "when in a temporary bundler directory"
@@ -23,87 +24,87 @@ RSpec.describe Functions::FileParser do
     let(:project_name) { "gemfile" }
 
     it "parses gemfile" do
-      parsed_gemfile = [
+      expected = [
         {
-          groups: [:default],
-          name: "business",
-          requirement: Gem::Requirement.new("~> 1.4.0"),
-          source: nil,
-          type: :runtime
+          "groups" => ["default"],
+          "name" => "business",
+          "requirement" => "~> 1.4.0",
+          "source" => nil,
+          "type" => "runtime"
         },
         {
-          groups: [:default],
-          name: "statesman",
-          requirement: Gem::Requirement.new("~> 1.2.0"),
-          source: nil,
-          type: :runtime
+          "groups" => ["default"],
+          "name" => "statesman",
+          "requirement" => "~> 1.2.0",
+          "source" => nil,
+          "type" => "runtime"
         }
       ]
-      expect(parsed_gemfile).not_to be_nil # to get past IdenticalEqualityAssertion and NamedSubject
+      expect(JSON.parse(JSON.dump(parsed_gemfile))).to eq(expected)
     end
 
     context "with a git source" do
       let(:project_name) { "git_source" }
 
       it "parses gemfile" do
-        parsed_gemfile = [
+        expected = [
           {
-            groups: [:default],
-            name: "business",
-            requirement: Gem::Requirement.new("~> 1.6.0"),
-            source: {
-              branch: nil,
-              ref: "a1b78a9",
-              type: "git",
-              url: "git@github.com:dependabot-fixtures/business"
+            "groups" => ["default"],
+            "name" => "business",
+            "requirement" => "~> 1.6.0",
+            "source" => {
+              "branch" => nil,
+              "ref" => "a1b78a9",
+              "type" => "git",
+              "url" => "git@github.com:dependabot-fixtures/business"
             },
-            type: :runtime
+            "type" => "runtime"
           },
           {
-            groups: [:default],
-            name: "statesman",
-            requirement: Gem::Requirement.new("~> 1.2.0"),
-            source: nil,
-            type: :runtime
+            "groups" => ["default"],
+            "name" => "statesman",
+            "requirement" => "~> 1.2.0",
+            "source" => nil,
+            "type" => "runtime"
           },
           {
-            groups: [:default],
-            name: "prius",
-            requirement: Gem::Requirement.new(">= 0"),
-            source: {
-              branch: nil,
-              ref: nil,
-              type: "git",
-              url: "https://github.com/dependabot-fixtures/prius"
+            "groups" => ["default"],
+            "name" => "prius",
+            "requirement" => ">= 0",
+            "source" => {
+              "branch" => nil,
+              "ref" => nil,
+              "type" => "git",
+              "url" => "https://github.com/dependabot-fixtures/prius"
             },
-            type: :runtime
+            "type" => "runtime"
           },
           {
-            groups: [:default],
-            name: "que",
-            requirement: Gem::Requirement.new(">= 0"),
-            source: {
-              branch: nil,
-              ref: "v0.11.6",
-              type: "git",
-              url: "git@github.com:dependabot-fixtures/que"
+            "groups" => ["default"],
+            "name" => "que",
+            "requirement" => ">= 0",
+            "source" => {
+              "branch" => nil,
+              "ref" => "v0.11.6",
+              "type" => "git",
+              "url" => "git@github.com:dependabot-fixtures/que"
             },
-            type: :runtime
+            "type" => "runtime"
           },
           {
-            groups: [:default],
-            name: "uk_phone_numbers",
-            requirement: Gem::Requirement.new(">= 0"),
-            source: {
-              branch: nil,
-              ref: nil,
-              type: "git",
-              url: "https://github.com/dependabot-fixtures/uk_phone_numbers"
+            "groups" => ["default"],
+            "name" => "uk_phone_numbers",
+            "requirement" => ">= 0",
+            "source" => {
+              "branch" => nil,
+              "ref" => nil,
+              "type" => "git",
+              "url" => "https://github.com/dependabot-fixtures/uk_phone_numbers"
             },
-            type: :runtime
+            "type" => "runtime"
           }
         ]
-        expect(parsed_gemfile).not_to be_nil # to get past IdenticalEqualityAssertion and NamedSubject
+        expect(JSON.parse(JSON.dump(parsed_gemfile))).to eq(expected)
       end
     end
   end
@@ -118,23 +119,23 @@ RSpec.describe Functions::FileParser do
     let(:project_name) { "gemfile_exact" }
 
     it "parses gemspec" do
-      parsed_gemspec = [
+      expected = [
         {
-          groups: nil,
-          name: "business",
-          requirement: Gem::Requirement.new("= 1.0.0"),
-          source: nil,
-          type: :runtime
+          "groups" => nil,
+          "name" => "business",
+          "requirement" => "= 1.0.0",
+          "source" => nil,
+          "type" => "runtime"
         },
         {
-          groups: nil,
-          name: "statesman",
-          requirement: Gem::Requirement.new("= 1.0.0"),
-          source: nil,
-          type: :runtime
+          "groups" => nil,
+          "name" => "statesman",
+          "requirement" => "= 1.0.0",
+          "source" => nil,
+          "type" => "runtime"
         }
       ]
-      expect(parsed_gemspec).not_to be_nil # to get past IdenticalEqualityAssertion and NamedSubject
+      expect(JSON.parse(JSON.dump(parsed_gemspec))).to eq(expected)
     end
   end
 end

--- a/bundler/helpers/v4/spec/functions/file_parser_spec.rb
+++ b/bundler/helpers/v4/spec/functions/file_parser_spec.rb
@@ -3,6 +3,7 @@
 
 require "native_spec_helper"
 require "shared_contexts"
+require "json"
 
 RSpec.describe Functions::FileParser do
   include_context "when in a temporary bundler directory"
@@ -23,87 +24,87 @@ RSpec.describe Functions::FileParser do
     let(:project_name) { "gemfile" }
 
     it "parses gemfile" do
-      parsed_gemfile = [
+      expected = [
         {
-          groups: [:default],
-          name: "business",
-          requirement: Gem::Requirement.new("~> 1.4.0"),
-          source: nil,
-          type: :runtime
+          "groups" => ["default"],
+          "name" => "business",
+          "requirement" => "~> 1.4.0",
+          "source" => nil,
+          "type" => "runtime"
         },
         {
-          groups: [:default],
-          name: "statesman",
-          requirement: Gem::Requirement.new("~> 1.2.0"),
-          source: nil,
-          type: :runtime
+          "groups" => ["default"],
+          "name" => "statesman",
+          "requirement" => "~> 1.2.0",
+          "source" => nil,
+          "type" => "runtime"
         }
       ]
-      expect(parsed_gemfile).not_to be_nil # to get past IdenticalEqualityAssertion and NamedSubject
+      expect(JSON.parse(JSON.dump(parsed_gemfile))).to eq(expected)
     end
 
     context "with a git source" do
       let(:project_name) { "git_source" }
 
       it "parses gemfile" do
-        parsed_gemfile = [
+        expected = [
           {
-            groups: [:default],
-            name: "business",
-            requirement: Gem::Requirement.new("~> 1.6.0"),
-            source: {
-              branch: nil,
-              ref: "a1b78a9",
-              type: "git",
-              url: "git@github.com:dependabot-fixtures/business"
+            "groups" => ["default"],
+            "name" => "business",
+            "requirement" => "~> 1.6.0",
+            "source" => {
+              "branch" => nil,
+              "ref" => "a1b78a9",
+              "type" => "git",
+              "url" => "git@github.com:dependabot-fixtures/business"
             },
-            type: :runtime
+            "type" => "runtime"
           },
           {
-            groups: [:default],
-            name: "statesman",
-            requirement: Gem::Requirement.new("~> 1.2.0"),
-            source: nil,
-            type: :runtime
+            "groups" => ["default"],
+            "name" => "statesman",
+            "requirement" => "~> 1.2.0",
+            "source" => nil,
+            "type" => "runtime"
           },
           {
-            groups: [:default],
-            name: "prius",
-            requirement: Gem::Requirement.new(">= 0"),
-            source: {
-              branch: nil,
-              ref: nil,
-              type: "git",
-              url: "https://github.com/dependabot-fixtures/prius"
+            "groups" => ["default"],
+            "name" => "prius",
+            "requirement" => ">= 0",
+            "source" => {
+              "branch" => nil,
+              "ref" => nil,
+              "type" => "git",
+              "url" => "https://github.com/dependabot-fixtures/prius"
             },
-            type: :runtime
+            "type" => "runtime"
           },
           {
-            groups: [:default],
-            name: "que",
-            requirement: Gem::Requirement.new(">= 0"),
-            source: {
-              branch: nil,
-              ref: "v0.11.6",
-              type: "git",
-              url: "git@github.com:dependabot-fixtures/que"
+            "groups" => ["default"],
+            "name" => "que",
+            "requirement" => ">= 0",
+            "source" => {
+              "branch" => nil,
+              "ref" => "v0.11.6",
+              "type" => "git",
+              "url" => "git@github.com:dependabot-fixtures/que"
             },
-            type: :runtime
+            "type" => "runtime"
           },
           {
-            groups: [:default],
-            name: "uk_phone_numbers",
-            requirement: Gem::Requirement.new(">= 0"),
-            source: {
-              branch: nil,
-              ref: nil,
-              type: "git",
-              url: "https://github.com/dependabot-fixtures/uk_phone_numbers"
+            "groups" => ["default"],
+            "name" => "uk_phone_numbers",
+            "requirement" => ">= 0",
+            "source" => {
+              "branch" => nil,
+              "ref" => nil,
+              "type" => "git",
+              "url" => "https://github.com/dependabot-fixtures/uk_phone_numbers"
             },
-            type: :runtime
+            "type" => "runtime"
           }
         ]
-        expect(parsed_gemfile).not_to be_nil # to get past IdenticalEqualityAssertion and NamedSubject
+        expect(JSON.parse(JSON.dump(parsed_gemfile))).to eq(expected)
       end
     end
   end
@@ -118,23 +119,23 @@ RSpec.describe Functions::FileParser do
     let(:project_name) { "gemfile_exact" }
 
     it "parses gemspec" do
-      parsed_gemspec = [
+      expected = [
         {
-          groups: nil,
-          name: "business",
-          requirement: Gem::Requirement.new("= 1.0.0"),
-          source: nil,
-          type: :runtime
+          "groups" => nil,
+          "name" => "business",
+          "requirement" => "= 1.0.0",
+          "source" => nil,
+          "type" => "runtime"
         },
         {
-          groups: nil,
-          name: "statesman",
-          requirement: Gem::Requirement.new("= 1.0.0"),
-          source: nil,
-          type: :runtime
+          "groups" => nil,
+          "name" => "statesman",
+          "requirement" => "= 1.0.0",
+          "source" => nil,
+          "type" => "runtime"
         }
       ]
-      expect(parsed_gemspec).not_to be_nil # to get past IdenticalEqualityAssertion and NamedSubject
+      expect(JSON.parse(JSON.dump(parsed_gemspec))).to eq(expected)
     end
   end
 end

--- a/bundler/lib/dependabot/bundler/file_parser.rb
+++ b/bundler/lib/dependabot/bundler/file_parser.rb
@@ -22,6 +22,7 @@ module Dependabot
       extend T::Sig
 
       require "dependabot/file_parsers/base/dependency_set"
+      require "dependabot/bundler/file_parser/helper_dependencies"
       require "dependabot/bundler/file_parser/file_preparer"
       require "dependabot/bundler/file_parser/gemfile_declaration_finder"
       require "dependabot/bundler/file_parser/gemspec_declaration_finder"
@@ -121,15 +122,15 @@ module Dependabot
           gemfile_declaration_finder = GemfileDeclarationFinder.new(gemfile: file)
 
           parsed_gemfile.each do |dep|
-            next unless gemfile_declaration_finder.gemfile_includes_dependency?(dep)
+            next unless gemfile_declaration_finder.gemfile_includes_dependency?(dep.name)
 
             dependencies << Dependency.new(
-              name: dep.fetch("name"),
-              version: dependency_version(dep.fetch("name"))&.to_s,
+              name: dep.name,
+              version: dependency_version(dep.name)&.to_s,
               requirements: [{
-                requirement: gemfile_declaration_finder.enhanced_req_string(dep),
-                groups: dep.fetch("groups").map(&:to_sym),
-                source: dep.fetch("source")&.transform_keys(&:to_sym),
+                requirement: gemfile_declaration_finder.enhanced_req_string(dep.name, dep.requirement),
+                groups: dep.groups.map(&:to_sym),
+                source: dep.source&.dup,
                 file: file.name
               }],
               package_manager: "bundler"
@@ -141,7 +142,7 @@ module Dependabot
       end
 
       sig { returns(DependencySet) }
-      def gemspec_dependencies # rubocop:disable Metrics/PerceivedComplexity
+      def gemspec_dependencies
         @gemspec_dependencies = T.let(@gemspec_dependencies, T.nilable(DependencySet))
         return @gemspec_dependencies if @gemspec_dependencies
 
@@ -154,19 +155,19 @@ module Dependabot
             gemspec_declaration_finder = GemspecDeclarationFinder.new(gemspec: gemspec)
 
             parsed_gemspec(gemspec).each do |dependency|
-              next unless gemspec_declaration_finder.gemspec_includes_dependency?(dependency)
+              next unless gemspec_declaration_finder.gemspec_includes_dependency?(dependency.name)
 
               queue << Dependency.new(
-                name: dependency.fetch("name"),
-                version: dependency_version(dependency.fetch("name"))&.to_s,
+                name: dependency.name,
+                version: dependency_version(dependency.name)&.to_s,
                 requirements: [{
-                  requirement: dependency.fetch("requirement").to_s,
-                  groups: if dependency.fetch("type") == "runtime"
+                  requirement: dependency.requirement,
+                  groups: if dependency.type == "runtime"
                             ["runtime"]
                           else
                             ["development"]
                           end,
-                  source: dependency.fetch("source")&.transform_keys(&:to_sym),
+                  source: dependency.source&.dup,
                   file: gemspec.name
                 }],
                 package_manager: "bundler"
@@ -206,7 +207,7 @@ module Dependabot
         dependencies
       end
 
-      sig { returns(T::Array[T::Hash[String, T.untyped]]) }
+      sig { returns(T::Array[HelperDependencies::GemfileDependency]) }
       def parsed_gemfile
         @parsed_gemfile ||= T.let(
           SharedHelpers.in_a_temporary_repo_directory(
@@ -215,7 +216,7 @@ module Dependabot
           ) do
             write_temporary_dependency_files
 
-            NativeHelpers.run_bundler_subprocess(
+            result = NativeHelpers.run_bundler_subprocess(
               bundler_version: bundler_version,
               function: "parsed_gemfile",
               options: options,
@@ -225,8 +226,9 @@ module Dependabot
                 dir: Dir.pwd
               }
             )
+            HelperDependencies.from_gemfile_result(result, file: T.must(gemfile))
           end,
-          T.nilable(T::Array[T::Hash[String, T.untyped]])
+          T.nilable(T::Array[HelperDependencies::GemfileDependency])
         )
       rescue SharedHelpers::HelperSubprocessFailed => e
         handle_eval_error(e) if e.error_class == "JSON::ParserError"
@@ -242,9 +244,9 @@ module Dependabot
         raise Dependabot::DependencyFileNotEvaluatable, msg
       end
 
-      sig { params(file: Dependabot::DependencyFile).returns(T::Array[T::Hash[String, T.untyped]]) }
+      sig { params(file: Dependabot::DependencyFile).returns(T::Array[HelperDependencies::GemspecDependency]) }
       def parsed_gemspec(file)
-        NativeHelpers.run_bundler_subprocess(
+        result = NativeHelpers.run_bundler_subprocess(
           bundler_version: bundler_version,
           function: "parsed_gemspec",
           options: options,
@@ -254,6 +256,7 @@ module Dependabot
             dir: Dir.pwd
           }
         )
+        HelperDependencies.from_gemspec_result(result, file: file)
       rescue SharedHelpers::HelperSubprocessFailed => e
         msg = e.error_class + " with message: " + e.message
         raise Dependabot::DependencyFileNotEvaluatable, msg

--- a/bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/gemfile_declaration_finder.rb
@@ -4,7 +4,7 @@
 require "prism"
 require "sorbet-runtime"
 
-require "dependabot/file_parsers/base"
+require "dependabot/bundler/file_parser"
 
 module Dependabot
   module Bundler
@@ -16,21 +16,20 @@ module Dependabot
         sig { params(gemfile: Dependabot::DependencyFile).void }
         def initialize(gemfile:)
           @gemfile = gemfile
-          @declaration_nodes = T.let({}, T::Hash[T::Hash[String, String], T.nilable(Prism::Node)])
+          @declaration_nodes = T.let({}, T::Hash[String, T.nilable(Prism::Node)])
         end
 
-        sig { params(dependency: T::Hash[String, String]).returns(T::Boolean) }
-        def gemfile_includes_dependency?(dependency)
-          !declaration_node(dependency).nil?
+        sig { params(dependency_name: String).returns(T::Boolean) }
+        def gemfile_includes_dependency?(dependency_name)
+          !declaration_node(dependency_name).nil?
         end
 
         # rubocop:disable Metrics/PerceivedComplexity
-        sig { params(dependency: T::Hash[String, String]).returns(T.nilable(String)) }
-        def enhanced_req_string(dependency)
-          return unless gemfile_includes_dependency?(dependency)
+        sig { params(dependency_name: String, fallback_string: String).returns(T.nilable(String)) }
+        def enhanced_req_string(dependency_name, fallback_string)
+          return unless gemfile_includes_dependency?(dependency_name)
 
-          fallback_string = dependency.fetch("requirement")
-          call_node = declaration_node(dependency)
+          call_node = declaration_node(dependency_name)
           return fallback_string unless call_node.is_a?(Prism::CallNode)
 
           req_nodes = call_node.arguments&.arguments&.[](1..-1) || []
@@ -63,32 +62,32 @@ module Dependabot
           )
         end
 
-        sig { params(dependency: T::Hash[String, String]).returns(T.nilable(Prism::Node)) }
-        def declaration_node(dependency)
-          return @declaration_nodes[dependency] if @declaration_nodes.key?(dependency)
+        sig { params(dependency_name: String).returns(T.nilable(Prism::Node)) }
+        def declaration_node(dependency_name)
+          return @declaration_nodes[dependency_name] if @declaration_nodes.key?(dependency_name)
           return unless parsed_gemfile
 
-          @declaration_nodes[dependency] = nil
+          @declaration_nodes[dependency_name] = nil
           T.must(parsed_gemfile).child_nodes.any? do |node|
-            @declaration_nodes[dependency] = deep_search_for_gem(node, dependency)
+            @declaration_nodes[dependency_name] = deep_search_for_gem(node, dependency_name)
           end
-          @declaration_nodes[dependency]
+          @declaration_nodes[dependency_name]
         end
 
         sig do
           params(
             node: T.nilable(Prism::Node),
-            dependency: T::Hash[String, String]
+            dependency_name: String
           )
             .returns(T.nilable(Prism::Node))
         end
-        def deep_search_for_gem(node, dependency)
+        def deep_search_for_gem(node, dependency_name)
           return unless node.is_a?(Prism::Node)
-          return node if declares_targeted_gem?(node, dependency)
+          return node if declares_targeted_gem?(node, dependency_name)
 
           declaration_node = T.let(nil, T.nilable(Prism::Node))
           node.child_nodes.find do |child_node|
-            declaration_node = deep_search_for_gem(child_node, dependency)
+            declaration_node = deep_search_for_gem(child_node, dependency_name)
           end
           declaration_node
         end
@@ -96,18 +95,18 @@ module Dependabot
         sig do
           params(
             node: T.nilable(Prism::Node),
-            dependency: T::Hash[String, String]
+            dependency_name: String
           )
             .returns(T::Boolean)
         end
-        def declares_targeted_gem?(node, dependency)
+        def declares_targeted_gem?(node, dependency_name)
           return false unless node.is_a?(Prism::CallNode)
           return false unless node.name == :gem
 
           gem_name_node = node.arguments&.arguments&.first
           return false unless gem_name_node.is_a?(Prism::StringNode)
 
-          gem_name_node.unescaped == dependency.fetch("name")
+          gem_name_node.unescaped == dependency_name
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/file_parser/gemspec_declaration_finder.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/gemspec_declaration_finder.rb
@@ -4,7 +4,7 @@
 require "prism"
 require "sorbet-runtime"
 
-require "dependabot/file_parsers/base"
+require "dependabot/bundler/file_parser"
 
 module Dependabot
   module Bundler
@@ -16,12 +16,12 @@ module Dependabot
         sig { params(gemspec: Dependabot::DependencyFile).void }
         def initialize(gemspec:)
           @gemspec = gemspec
-          @declaration_nodes = T.let({}, T::Hash[T::Hash[String, String], T.nilable(Prism::Node)])
+          @declaration_nodes = T.let({}, T::Hash[String, T.nilable(Prism::Node)])
         end
 
-        sig { params(dependency: T::Hash[String, String]).returns(T::Boolean) }
-        def gemspec_includes_dependency?(dependency)
-          !declaration_node(dependency).nil?
+        sig { params(dependency_name: String).returns(T::Boolean) }
+        def gemspec_includes_dependency?(dependency_name)
+          !declaration_node(dependency_name).nil?
         end
 
         private
@@ -34,32 +34,32 @@ module Dependabot
           @parsed_gemspec ||= T.let(Prism.parse(gemspec.content).value, T.nilable(Prism::Node))
         end
 
-        sig { params(dependency: T::Hash[String, String]).returns(T.nilable(Prism::Node)) }
-        def declaration_node(dependency)
-          return @declaration_nodes[dependency] if @declaration_nodes.key?(dependency)
+        sig { params(dependency_name: String).returns(T.nilable(Prism::Node)) }
+        def declaration_node(dependency_name)
+          return @declaration_nodes[dependency_name] if @declaration_nodes.key?(dependency_name)
           return unless parsed_gemspec
 
-          @declaration_nodes[dependency] = nil
+          @declaration_nodes[dependency_name] = nil
           T.must(parsed_gemspec).child_nodes.any? do |node|
-            @declaration_nodes[dependency] = deep_search_for_gem(node, dependency)
+            @declaration_nodes[dependency_name] = deep_search_for_gem(node, dependency_name)
           end
-          @declaration_nodes[dependency]
+          @declaration_nodes[dependency_name]
         end
 
-        sig { params(node: T.nilable(Prism::Node), dependency: T::Hash[String, String]).returns(T.nilable(Prism::Node)) }
-        def deep_search_for_gem(node, dependency)
+        sig { params(node: T.nilable(Prism::Node), dependency_name: String).returns(T.nilable(Prism::Node)) }
+        def deep_search_for_gem(node, dependency_name)
           return unless node.is_a?(Prism::Node)
-          return T.cast(node, Prism::CallNode) if declares_targeted_gem?(node, dependency)
+          return T.cast(node, Prism::CallNode) if declares_targeted_gem?(node, dependency_name)
 
           declaration_node = T.let(nil, T.nilable(Prism::Node))
           node.child_nodes.find do |child_node|
-            declaration_node = deep_search_for_gem(child_node, dependency)
+            declaration_node = deep_search_for_gem(child_node, dependency_name)
           end
           declaration_node
         end
 
-        sig { params(node: T.nilable(Prism::Node), dependency: T::Hash[String, String]).returns(T::Boolean) }
-        def declares_targeted_gem?(node, dependency)
+        sig { params(node: T.nilable(Prism::Node), dependency_name: String).returns(T::Boolean) }
+        def declares_targeted_gem?(node, dependency_name)
           return false unless node.is_a?(Prism::CallNode)
 
           second_child = node.name
@@ -69,7 +69,7 @@ module Dependabot
           gem_name_node = node.arguments&.child_nodes&.first
           return false unless gem_name_node.is_a?(Prism::StringNode)
 
-          gem_name_node.unescaped == dependency.fetch("name")
+          gem_name_node.unescaped == dependency_name
         end
       end
     end

--- a/bundler/lib/dependabot/bundler/file_parser/helper_dependencies.rb
+++ b/bundler/lib/dependabot/bundler/file_parser/helper_dependencies.rb
@@ -1,0 +1,116 @@
+# typed: strong
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "dependabot/errors"
+require "dependabot/bundler/file_parser"
+
+module Dependabot
+  module Bundler
+    class FileParser < Dependabot::FileParsers::Base
+      module HelperDependencies
+        extend T::Sig
+
+        Source = T.type_alias { T::Hash[Symbol, T.nilable(String)] }
+        ObjectHash = T.type_alias { T::Hash[String, Object] }
+
+        class GemfileDependency < T::ImmutableStruct
+          const :name, String
+          const :requirement, String
+          const :groups, T::Array[String]
+          const :source, T.nilable(Source)
+        end
+
+        class GemspecDependency < T::ImmutableStruct
+          const :name, String
+          const :requirement, String
+          const :type, String
+          const :source, T.nilable(Source)
+        end
+
+        # Both helper versions serialize these fields in Functions::FileParser#serialize_bundler_dependency.
+        sig { params(result: Object, file: Dependabot::DependencyFile).returns(T::Array[GemfileDependency]) }
+        def self.from_gemfile_result(result, file:)
+          context = "parsed_gemfile result for #{file.path}"
+          array(result, context).each_with_index.map do |value, index|
+            entry_context = "#{context}[#{index}]"
+            entry = object(value, entry_context)
+
+            GemfileDependency.new(
+              name: string(entry["name"], "#{entry_context}.name"),
+              requirement: string(entry["requirement"], "#{entry_context}.requirement"),
+              groups: strings(entry["groups"], "#{entry_context}.groups"),
+              source: source(entry, entry_context)
+            )
+          end
+        end
+
+        sig { params(result: Object, file: Dependabot::DependencyFile).returns(T::Array[GemspecDependency]) }
+        def self.from_gemspec_result(result, file:)
+          context = "parsed_gemspec result for #{file.path}"
+          array(result, context).each_with_index.map do |value, index|
+            entry_context = "#{context}[#{index}]"
+            entry = object(value, entry_context)
+
+            GemspecDependency.new(
+              name: string(entry["name"], "#{entry_context}.name"),
+              requirement: string(entry["requirement"], "#{entry_context}.requirement"),
+              type: string(entry["type"], "#{entry_context}.type"),
+              source: source(entry, entry_context)
+            )
+          end
+        end
+
+        sig { params(entry: ObjectHash, context: String).returns(T.nilable(Source)) }
+        def self.source(entry, context)
+          raise DependencyFileNotEvaluatable, "#{context}.source must be present" unless entry.key?("source")
+
+          value = entry["source"]
+          return if value.nil?
+
+          fields = object(value, "#{context}.source")
+          string(fields["type"], "#{context}.source.type")
+          fields.to_h do |key, field|
+            [key.to_sym, field.nil? ? nil : string(field, "#{context}.source.#{key}")]
+          end
+        end
+        private_class_method :source
+
+        sig { params(value: Object, context: String).returns(ObjectHash) }
+        def self.object(value, context)
+          raise DependencyFileNotEvaluatable, "#{context} must be an object" unless value.is_a?(Hash)
+
+          value.to_h do |raw_key, raw_value|
+            key = T.cast(raw_key, Object)
+            raise DependencyFileNotEvaluatable, "#{context} keys must be strings" unless key.is_a?(String)
+
+            [key, T.cast(raw_value, Object)]
+          end
+        end
+        private_class_method :object
+
+        sig { params(value: Object, context: String).returns(T::Array[Object]) }
+        def self.array(value, context)
+          raise DependencyFileNotEvaluatable, "#{context} must be an array" unless value.is_a?(Array)
+
+          value.map { |entry| T.cast(entry, Object) }
+        end
+        private_class_method :array
+
+        sig { params(value: Object, context: String).returns(String) }
+        def self.string(value, context)
+          return value if value.is_a?(String)
+
+          raise DependencyFileNotEvaluatable, "#{context} must be a string"
+        end
+        private_class_method :string
+
+        sig { params(value: Object, context: String).returns(T::Array[String]) }
+        def self.strings(value, context)
+          array(value, context).each_with_index.map { |entry, index| string(entry, "#{context}[#{index}]") }
+        end
+        private_class_method :strings
+      end
+    end
+  end
+end

--- a/bundler/spec/dependabot/bundler/file_parser/gemfile_declaration_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser/gemfile_declaration_finder_spec.rb
@@ -11,16 +11,7 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
     described_class.new(gemfile: gemfile)
   end
 
-  let(:dependency) do
-    dep = ::Bundler::Dependency.new(
-      dependency_name,
-      dependency_requirement_sting
-    )
-    {
-      "name" => dep.name,
-      "requirement" => dep.requirement.to_s
-    }
-  end
+  let(:fallback_requirement) { Gem::Requirement.new(dependency_requirement_sting).to_s }
   let(:dependency_name) { "business" }
   let(:dependency_requirement_sting) { "~> 1" }
 
@@ -28,7 +19,7 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
 
   describe "#gemfile_includes_dependency?" do
     subject(:gemfile_includes_dependency) do
-      checker.gemfile_includes_dependency?(dependency)
+      checker.gemfile_includes_dependency?(dependency_name)
     end
 
     context "when the file does not include the dependency" do
@@ -67,7 +58,13 @@ RSpec.describe Dependabot::Bundler::FileParser::GemfileDeclarationFinder do
   end
 
   describe "#enhanced_req_string" do
-    subject(:enhanced_req_string) { checker.enhanced_req_string(dependency) }
+    subject(:enhanced_req_string) { checker.enhanced_req_string(dependency_name, fallback_requirement) }
+
+    it "does not cache the fallback requirement by name" do
+      expect(checker.enhanced_req_string(dependency_name, "~> 1.4.0")).to eq("~> 1.4.0")
+      expect(checker.enhanced_req_string(dependency_name, "~> 2.0")).to eq("~> 2.0")
+      expect(checker.enhanced_req_string(dependency_name, "~> 1.4.0")).to eq("~> 1.4.0")
+    end
 
     context "when the file does not include the dependency" do
       let(:dependency_name) { "dependabot-core" }

--- a/bundler/spec/dependabot/bundler/file_parser/gemspec_declaration_finder_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser/gemspec_declaration_finder_spec.rb
@@ -11,24 +11,13 @@ RSpec.describe Dependabot::Bundler::FileParser::GemspecDeclarationFinder do
     described_class.new(gemspec: gemspec)
   end
 
-  let(:dependency) do
-    dep = ::Bundler::Dependency.new(
-      dependency_name,
-      dependency_requirement_sting
-    )
-    {
-      "name" => dep.name,
-      "requirement" => dep.requirement.to_s
-    }
-  end
   let(:dependency_name) { "business" }
-  let(:dependency_requirement_sting) { "~> 1" }
 
   let(:gemspec) { bundler_project_dependency_file("gemspec_loads_another", filename: "example.gemspec") }
 
   describe "#gemspec_includes_dependency?" do
     subject(:gemspec_includes_dependency) do
-      checker.gemspec_includes_dependency?(dependency)
+      checker.gemspec_includes_dependency?(dependency_name)
     end
 
     context "when the file does not include the dependency" do

--- a/bundler/spec/dependabot/bundler/file_parser/helper_dependencies_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser/helper_dependencies_spec.rb
@@ -1,0 +1,216 @@
+# typed: false
+# frozen_string_literal: true
+
+require "spec_helper"
+require "dependabot/bundler/file_parser/helper_dependencies"
+
+RSpec.describe Dependabot::Bundler::FileParser::HelperDependencies do
+  gemfile_record = Dependabot::Bundler::FileParser::HelperDependencies::GemfileDependency
+  gemspec_record = Dependabot::Bundler::FileParser::HelperDependencies::GemspecDependency
+  invalid_results = [nil, {}, "invalid"]
+  invalid_entries = [nil, [], "invalid"]
+  required_fields = %w(name requirement source)
+  invalid_fields = [["name", 1], ["requirement", false], ["source", []]]
+
+  [
+    [:from_gemfile_result, "parsed_gemfile", "Gemfile", gemfile_record],
+    [:from_gemspec_result, "parsed_gemspec", "example.gemspec", gemspec_record]
+  ].each do |factory, operation, filename, record_class|
+    describe ".#{factory}" do
+      subject(:dependencies) { described_class.public_send(factory, result, file: file) }
+
+      let(:file) { Dependabot::DependencyFile.new(name: filename, content: "") }
+      let(:record) do
+        {
+          "name" => "business",
+          "requirement" => "~> 1.4.0",
+          "groups" => ["default"],
+          "source" => nil,
+          "type" => "runtime",
+          "unconsumed" => { "arbitrary" => true }
+        }
+      end
+      let(:result) { [record] }
+
+      it "returns operation-specific records" do
+        expect(dependencies.first).to be_a(record_class)
+        expect(dependencies.first).to have_attributes(name: "business", requirement: "~> 1.4.0", source: nil)
+      end
+
+      context "with an empty result" do
+        let(:result) { [] }
+
+        it "returns no dependencies" do
+          expect(dependencies).to be_empty
+        end
+      end
+
+      context "with repeated entries" do
+        let(:result) { [record, record.merge("name" => "statesman"), record] }
+
+        it "preserves order and duplicates" do
+          expect(dependencies.map(&:name)).to eq(%w(business statesman business))
+        end
+      end
+
+      context "with an empty requirement" do
+        let(:record) { super().merge("requirement" => "") }
+
+        it "does not normalize the requirement" do
+          expect(dependencies.first.requirement).to eq("")
+        end
+      end
+
+      context "with a Git source" do
+        let(:record) do
+          super().merge("source" => { "type" => "git", "url" => "git@example.com:repo", "branch" => nil, "ref" => "" })
+        end
+
+        it "preserves source keys and null values while symbolizing keys" do
+          expect(dependencies.first.source).to eq(type: "git", url: "git@example.com:repo", branch: nil, ref: "")
+        end
+      end
+
+      context "with a registry source" do
+        let(:record) { super().merge("source" => { "type" => "rubygems", "url" => "https://gems.example/" }) }
+
+        it "does not add absent Git fields" do
+          expect(dependencies.first.source).to eq(type: "rubygems", url: "https://gems.example/")
+        end
+      end
+
+      context "with another string source type" do
+        let(:record) { super().merge("source" => { "type" => "metadata" }) }
+
+        it "does not impose a new source-type enum" do
+          expect(dependencies.first.source).to eq(type: "metadata")
+        end
+      end
+
+      invalid_results.each do |value|
+        context "with #{value.inspect} as the result" do
+          let(:result) { value }
+
+          it "identifies the operation and file" do
+            expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
+              expect(error.message).to include(operation, file.path, "must be an array")
+            end
+          end
+        end
+      end
+
+      invalid_entries.each do |value|
+        context "with #{value.inspect} as an entry" do
+          let(:result) { [record, value] }
+
+          it "rejects the complete result with entry context" do
+            expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
+              expect(error.message).to include(operation, file.path, "[1]", "must be an object")
+            end
+          end
+        end
+      end
+
+      required_fields.each do |field|
+        context "without #{field}" do
+          let(:record) { super().except(field) }
+
+          it "reports the missing consumed field" do
+            expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable, /#{field}/)
+          end
+        end
+      end
+
+      invalid_fields.each do |field, value|
+        context "with malformed #{field}" do
+          let(:record) { super().merge(field => value) }
+
+          it "does not coerce the value" do
+            expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable, /#{field}/)
+          end
+        end
+      end
+
+      context "with a missing source type" do
+        let(:record) { super().merge("source" => { "url" => "https://gems.example/" }) }
+
+        it "reports the source type" do
+          expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable, /source.type/)
+        end
+      end
+
+      context "with a malformed source field" do
+        let(:record) { super().merge("source" => { "type" => "git", "url" => ["do-not-echo-this"] }) }
+
+        it "identifies the field without echoing its contents" do
+          expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
+            expect(error.message).to include("source.url")
+            expect(error.message).not_to include("do-not-echo-this")
+          end
+        end
+      end
+
+      context "with non-string source keys" do
+        let(:record) { super().merge("source" => { "type" => "git", 1 => "invalid" }) }
+
+        it "reports the key shape" do
+          expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable, /keys must be strings/)
+        end
+      end
+    end
+  end
+
+  describe ".from_gemfile_result groups" do
+    subject(:dependencies) { described_class.from_gemfile_result(result, file: file) }
+
+    let(:file) { Dependabot::DependencyFile.new(name: "Gemfile", content: "") }
+    let(:groups) { %w(development test development) }
+    let(:result) { [{ "name" => "business", "requirement" => ">= 0", "groups" => groups, "source" => nil }] }
+
+    it "preserves group ordering without requiring the unused type field" do
+      expect(dependencies.first.groups).to eq(groups)
+    end
+
+    [nil, "default", [1]].each do |value|
+      context "with groups set to #{value.inspect}" do
+        let(:groups) { value }
+
+        it "rejects the malformed groups" do
+          expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable, /groups/)
+        end
+      end
+    end
+  end
+
+  describe ".from_gemspec_result type" do
+    subject(:dependencies) { described_class.from_gemspec_result(result, file: file) }
+
+    let(:file) { Dependabot::DependencyFile.new(name: "example.gemspec", content: "") }
+    let(:type) { "runtime" }
+    let(:result) do
+      [{ "name" => "business", "requirement" => ">= 0", "groups" => nil, "source" => nil, "type" => type }]
+    end
+
+    it "accepts null groups without carrying them into the typed result" do
+      expect(dependencies.first.type).to eq("runtime")
+    end
+
+    context "with a different string type" do
+      let(:type) { "other" }
+
+      it "does not impose a new dependency-type enum" do
+        expect(dependencies.first.type).to eq("other")
+      end
+    end
+
+    [nil, 1].each do |value|
+      context "with type set to #{value.inspect}" do
+        let(:type) { value }
+
+        it "rejects the malformed type" do
+          expect { dependencies }.to raise_error(Dependabot::DependencyFileNotEvaluatable, /type/)
+        end
+      end
+    end
+  end
+end

--- a/bundler/spec/dependabot/bundler/file_parser_spec.rb
+++ b/bundler/spec/dependabot/bundler/file_parser_spec.rb
@@ -27,6 +27,147 @@ RSpec.describe Dependabot::Bundler::FileParser do
 
   it_behaves_like "a dependency file parser"
 
+  describe "helper-result boundaries" do
+    let(:gemfile) { Dependabot::DependencyFile.new(name: "Gemfile", content: "gem \"business\", \"~> 1.4.0\"\n") }
+    let(:dependency_files) { [gemfile] }
+    let(:operation) { "parsed_gemfile" }
+    let(:record) do
+      {
+        "name" => "business",
+        "requirement" => "~> 1.4.0",
+        "groups" => ["default"],
+        "source" => nil,
+        "type" => "runtime"
+      }
+    end
+    let(:result) { [record] }
+
+    before do
+      allow(Dependabot::Bundler::NativeHelpers).to receive(:run_bundler_subprocess).and_call_original
+      allow(Dependabot::Bundler::NativeHelpers).to receive(:run_bundler_subprocess)
+        .with(hash_including(function: operation)).and_return(result)
+    end
+
+    it "uses typed Gemfile records without changing group representation" do
+      expect(parser.parse.first.requirements).to eq(
+        [{ requirement: "~> 1.4.0", file: "Gemfile", source: nil, groups: [:default] }]
+      )
+    end
+
+    context "with the same dependency declared in two files" do
+      let(:dependency_files) do
+        [gemfile, Dependabot::DependencyFile.new(name: "other.rb", content: gemfile.content)]
+      end
+      let(:record) { super().merge("source" => { "type" => "rubygems", "url" => "https://gems.example/" }) }
+
+      it "keeps each requirement's source independent" do
+        requirements = parser.parse.first.requirements
+        expect(requirements.length).to eq(2)
+
+        requirements.first.source_hash[:url] = "https://other.example/"
+        expect(requirements.last.source_string("url")).to eq("https://gems.example/")
+      end
+    end
+
+    ["2.7.2", "4.0.20"].each do |version|
+      context "with BUNDLED WITH #{version}" do
+        let(:dependency_files) do
+          [
+            gemfile,
+            Dependabot::DependencyFile.new(
+              name: "Gemfile.lock",
+              content: <<~LOCK
+                GEM
+                  remote: https://rubygems.org/
+                  specs:
+                    business (1.4.0)
+
+                PLATFORMS
+                  ruby
+
+                DEPENDENCIES
+                  business (~> 1.4.0)
+
+                BUNDLED WITH
+                   #{version}
+              LOCK
+            )
+          ]
+        end
+
+        it "selects the matching helper while retaining the locked version" do
+          expect(parser.parse.first.version).to eq("1.4.0")
+          expect(Dependabot::Bundler::NativeHelpers).to have_received(:run_bundler_subprocess)
+            .with(hash_including(function: "parsed_gemfile", bundler_version: version.split(".").first))
+        end
+      end
+    end
+
+    context "with a malformed entry that is not declared in the file" do
+      let(:result) { [record, record.merge("name" => "undeclared", "groups" => [1])] }
+
+      it "decodes the complete result before declaration filtering" do
+        expect { parser.parse }.to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
+          expect(error.message).to include(operation, gemfile.path, "[1]", "groups")
+        end
+      end
+    end
+
+    context "when the helper raises an unrelated type error" do
+      before do
+        allow(Dependabot::Bundler::NativeHelpers).to receive(:run_bundler_subprocess)
+          .with(hash_including(function: operation)).and_raise(TypeError, "helper execution failed")
+      end
+
+      it "does not classify the exception as malformed output" do
+        expect { parser.parse }.to raise_error(TypeError, "helper execution failed")
+      end
+    end
+
+    context "with gemspec results" do
+      let(:operation) { "parsed_gemspec" }
+      let(:dependency_files) do
+        [
+          Dependabot::DependencyFile.new(
+            name: "example.gemspec",
+            content: <<~GEMSPEC
+              Gem::Specification.new do |spec|
+                spec.name = "example"
+                spec.version = "1.0.0"
+                spec.add_dependency "business", "~> 1.4.0"
+              end
+            GEMSPEC
+          )
+        ]
+      end
+      let(:record) { super().merge("groups" => nil) }
+
+      it "preserves runtime gemspec groups" do
+        expect(parser.parse.first.requirements).to eq(
+          [{ requirement: "~> 1.4.0", file: "example.gemspec", source: nil, groups: ["runtime"] }]
+        )
+      end
+
+      context "with another string dependency type" do
+        let(:record) { super().merge("type" => "other") }
+
+        it "preserves the development-group fallback" do
+          expect(parser.parse.first.requirements.first.groups).to eq(["development"])
+        end
+      end
+
+      context "with a malformed undeclared entry" do
+        let(:result) { [record, record.merge("name" => "undeclared", "requirement" => 1)] }
+
+        it "reports the operation, file, and field before filtering" do
+          expect { parser.parse }.to raise_error(Dependabot::DependencyFileNotEvaluatable) do |error|
+            expect(error.message).to include(operation, "example.gemspec", "[1]", "requirement")
+          end
+        end
+      end
+    end
+  end
+
   describe "parse" do
     subject(:dependencies) { parser.parse }
 

--- a/bundler/spec/dependabot/bundler/native_helpers_spec.rb
+++ b/bundler/spec/dependabot/bundler/native_helpers_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "dependabot/bundler/file_parser/helper_dependencies"
 require "dependabot/bundler/native_helpers"
 
 RSpec.describe Dependabot::Bundler::NativeHelpers do
@@ -148,6 +149,180 @@ RSpec.describe Dependabot::Bundler::NativeHelpers do
       yield
     ensure
       ENV[key] = previous_value
+    end
+  end
+
+  describe ".run_bundler_subprocess parser protocol" do
+    %w(2 4).each do |bundler_version|
+      context "with Bundler #{bundler_version}" do
+        it "activates the selected helper's Bundler major version" do
+          version = native_helper.run_bundler_subprocess(
+            function: "bundler_raw_version",
+            args: {},
+            bundler_version: bundler_version
+          )
+
+          expect(version).to start_with("#{bundler_version}.")
+        end
+
+        context "when parsing a Gemfile" do
+          subject(:parsed_gemfile) do
+            Dependabot::SharedHelpers.in_a_temporary_repo_directory do |directory|
+              File.write(gemfile.name, gemfile.content)
+              native_helper.run_bundler_subprocess(
+                function: "parsed_gemfile",
+                args: { dir: directory.to_s, gemfile_name: gemfile.name, lockfile_name: "Gemfile.lock" },
+                bundler_version: bundler_version
+              )
+            end
+          end
+
+          let(:gemfile) do
+            Dependabot::DependencyFile.new(
+              name: "Gemfile",
+              content: <<~GEMFILE
+                source "https://rubygems.org"
+
+                gem "default_gem", "~> 1.0"
+                group :development, :test do
+                  gem "git_gem", git: "https://git.example.test/git_gem.git"
+                end
+                source "https://gems.example.test" do
+                  gem "private_gem", ">= 2.0"
+                end
+              GEMFILE
+            )
+          end
+
+          let(:expected_dependencies) do
+            [
+              {
+                "name" => "default_gem",
+                "requirement" => "~> 1.0",
+                "groups" => ["default"],
+                "source" => nil,
+                "type" => "runtime"
+              },
+              {
+                "name" => "git_gem",
+                "requirement" => ">= 0",
+                "groups" => %w(development test),
+                "source" => {
+                  "type" => "git",
+                  "url" => "https://git.example.test/git_gem.git",
+                  "branch" => nil,
+                  "ref" => nil
+                },
+                "type" => "runtime"
+              },
+              {
+                "name" => "private_gem",
+                "requirement" => ">= 2.0",
+                "groups" => ["default"],
+                "source" => {
+                  "type" => "rubygems",
+                  "url" => "https://gems.example.test/"
+                },
+                "type" => "runtime"
+              }
+            ]
+          end
+
+          it "preserves JSON value types, explicit nil Git keys, and omitted registry keys" do
+            expect(parsed_gemfile).to eq(expected_dependencies)
+          end
+
+          it "decodes the real response into typed Gemfile dependencies" do
+            dependencies = Dependabot::Bundler::FileParser::HelperDependencies.from_gemfile_result(
+              parsed_gemfile,
+              file: gemfile
+            )
+
+            expected = expected_dependencies.map do |dependency|
+              be_a(Dependabot::Bundler::FileParser::HelperDependencies::GemfileDependency).and(
+                have_attributes(
+                  name: dependency.fetch("name"),
+                  requirement: dependency.fetch("requirement"),
+                  groups: dependency.fetch("groups"),
+                  source: dependency.fetch("source")&.transform_keys(&:to_sym)
+                )
+              )
+            end
+            expect(dependencies).to match(expected)
+          end
+        end
+
+        context "when parsing a gemspec" do
+          subject(:parsed_gemspec) do
+            Dependabot::SharedHelpers.in_a_temporary_repo_directory do |directory|
+              File.write(gemspec.name, gemspec.content)
+              native_helper.run_bundler_subprocess(
+                function: "parsed_gemspec",
+                args: { dir: directory.to_s, gemspec_name: gemspec.name, lockfile_name: "Gemfile.lock" },
+                bundler_version: bundler_version
+              )
+            end
+          end
+
+          let(:gemspec) do
+            Dependabot::DependencyFile.new(
+              name: "example.gemspec",
+              content: <<~GEMSPEC
+                Gem::Specification.new do |spec|
+                  spec.name = "example"
+                  spec.version = "1.0.0"
+                  spec.summary = "Parser protocol fixture"
+                  spec.authors = ["Dependabot"]
+                  spec.add_dependency "runtime_gem", "~> 1.0"
+                  spec.add_development_dependency "development_gem", ">= 2.0"
+                end
+              GEMSPEC
+            )
+          end
+
+          let(:expected_dependencies) do
+            [
+              {
+                "name" => "runtime_gem",
+                "requirement" => "~> 1.0",
+                "groups" => nil,
+                "source" => nil,
+                "type" => "runtime"
+              },
+              {
+                "name" => "development_gem",
+                "requirement" => ">= 2.0",
+                "groups" => nil,
+                "source" => nil,
+                "type" => "development"
+              }
+            ]
+          end
+
+          it "serializes requirement and dependency type strings with nil groups and sources" do
+            expect(parsed_gemspec).to eq(expected_dependencies)
+          end
+
+          it "decodes the real response into typed gemspec dependencies" do
+            dependencies = Dependabot::Bundler::FileParser::HelperDependencies.from_gemspec_result(
+              parsed_gemspec,
+              file: gemspec
+            )
+
+            expected = expected_dependencies.map do |dependency|
+              be_a(Dependabot::Bundler::FileParser::HelperDependencies::GemspecDependency).and(
+                have_attributes(
+                  name: dependency.fetch("name"),
+                  requirement: dependency.fetch("requirement"),
+                  type: dependency.fetch("type"),
+                  source: dependency.fetch("source")&.transform_keys(&:to_sym)
+                )
+              )
+            end
+            expect(dependencies).to match(expected)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Decode Bundler's Gemfile and gemspec responses into operation-specific records and pass typed values to the declaration finders. This removes the parser's three remaining `T.untyped` annotations.

### Anything you want to highlight for special attention from reviewers?

Malformed consumed fields raise `DependencyFileNotEvaluatable` before declaration filtering. Each declaration keeps its own source hash, with source-key presence and the helper protocol unchanged.

### How will you know you've accomplished your goal?

The targeted Ruby suites pass with 204 examples, plus three native parser examples under each Bundler helper runtime. Sorbet, RuboCop, and the existing strictness checks pass.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
